### PR TITLE
Ignore Wrangler runtime cache in deploy digest

### DIFF
--- a/apps/worker/scripts/production-deploy.check.mjs
+++ b/apps/worker/scripts/production-deploy.check.mjs
@@ -26,6 +26,7 @@ import {
   PRODUCTION_DEPLOY_CONFIRMATION,
   PRODUCTION_MIGRATION_LEDGER_SQL,
   createImmutableSourceSnapshot,
+  dependencyTreeDigest,
   determinePendingProductionMigrations,
   runProductionDeployment,
   recheckProductionHealth,
@@ -198,6 +199,40 @@ function options(overrides = {}) {
     ...overrides,
   };
 }
+
+test("dependency digest ignores only root Wrangler runtime state", async (t) => {
+  const root = await mkdtemp(join(tmpdir(), "usage-monitor-dependency-digest-"));
+  t.after(() => rm(root, { recursive: true, force: true }));
+  const installedPackage = join(root, "installed-package");
+  await mkdir(installedPackage, { recursive: true });
+  await writeFile(join(installedPackage, "index.js"), "export const value = 1;\n");
+
+  const installedDigest = await dependencyTreeDigest(root);
+  await mkdir(join(root, ".cache", "wrangler"), { recursive: true });
+  await writeFile(
+    join(root, ".cache", "wrangler", "wrangler-account.json"),
+    '{"account":"first-run-cache"}\n',
+  );
+  await mkdir(join(root, ".mf"), { recursive: true });
+  await writeFile(join(root, ".mf", "cf.json"), '{"runtime":"local"}\n');
+  assert.equal(await dependencyTreeDigest(root), installedDigest);
+
+  await writeFile(
+    join(root, ".cache", "wrangler", "wrangler-account.json"),
+    '{"account":"refreshed-cache"}\n',
+  );
+  assert.equal(await dependencyTreeDigest(root), installedDigest);
+
+  // The exception is root-scoped. Package content, including a nested path
+  // with the same name as a runtime cache, remains integrity-bound.
+  await mkdir(join(installedPackage, ".cache"), { recursive: true });
+  await writeFile(join(installedPackage, ".cache", "package-state"), "bound\n");
+  const nestedCacheDigest = await dependencyTreeDigest(root);
+  assert.notEqual(nestedCacheDigest, installedDigest);
+
+  await writeFile(join(installedPackage, "index.js"), "export const value = 2;\n");
+  assert.notEqual(await dependencyTreeDigest(root), nestedCacheDigest);
+});
 
 // Re-pin: this end-to-end path previously required an injected containment
 // proof; it now exercises the real migration gate against the snapshot's

--- a/apps/worker/scripts/production-deploy.mjs
+++ b/apps/worker/scripts/production-deploy.mjs
@@ -37,6 +37,12 @@ import { runReleasePreflight } from "./release-preflight.mjs";
 export const PRODUCTION_DEPLOY_CONFIRMATION =
   "DEPLOY_PRODUCTION";
 const PRODUCTION_HEALTH_RECHECK_TIMEOUT_MS = 10_000;
+// Wrangler creates these runtime-state directories at the node_modules root
+// while release preflight runs. They contain account/Miniflare cache data, not
+// installed package code, and can legitimately appear after the dependency
+// snapshot is taken. Skip only these root entries: identically named paths
+// inside an installed package remain covered by the integrity digest.
+const DEPENDENCY_RUNTIME_STATE_DIRECTORIES = new Set([".cache", ".mf"]);
 const PRODUCTION_PUBLIC_SURFACE_FORBIDDEN_PATHS = Object.freeze([
   "/app.js",
   "/data-client.js",
@@ -397,9 +403,11 @@ async function requireAbsent(path, label) {
  * is realpath-resolved, so a symlinked node_modules digests the bytes of its
  * target. Entries are visited in a fixed sorted order and file content, symlink
  * targets, sizes, and directory structure all contribute, so any post-snapshot
- * mutation of the mutable dependency tree produces a different digest. Symlinks
- * are recorded by target string rather than followed, so internal `.bin` links
- * and cycles neither escape the tree nor double-count content.
+ * mutation of installed dependency content produces a different digest. Known
+ * Wrangler runtime-state directories at the root are excluded because preflight
+ * legitimately creates them after the snapshot. Symlinks are recorded by target
+ * string rather than followed, so internal `.bin` links and cycles neither
+ * escape the tree nor double-count content.
  *
  * This is the mitigation for the ignored-node_modules gap: the snapshot records
  * this digest, and the deploy path reverifies it immediately before and after
@@ -415,6 +423,10 @@ export async function dependencyTreeDigest(rootPath) {
       left.name < right.name ? -1 : left.name > right.name ? 1 : 0
     ));
     for (const entry of entries) {
+      if (relativePath === ""
+          && DEPENDENCY_RUNTIME_STATE_DIRECTORIES.has(entry.name)) {
+        continue;
+      }
       const childAbsolute = join(absolute, entry.name);
       const childRelative = relativePath === ""
         ? entry.name


### PR DESCRIPTION
## Summary
- exclude only root-level Wrangler runtime state (`node_modules/.cache` and `node_modules/.mf`) from the production dependency digest
- continue hashing identically named paths inside installed packages and all other dependency content
- add regression coverage for first-run cache creation, cache refresh, nested cache content, and package mutation

## Why
A fresh production install writes `wrangler-account.json` and Miniflare `cf.json` during release preflight, after the dependency snapshot. That caused a false `PRODUCTION_DEPENDENCY_TREE_DIGEST_MISMATCH` before Wrangler deploy.

## Validation
- focused production deploy tests: 22/22
- Worker script suite: 148/148
- fresh-install end-to-end gate simulation passed with real remote migration reads and local D1 preflight; only the final Wrangler deploy command was intercepted
- production was not changed by this PR validation