### PR TITLE
Retire legacy local accounting index behind rollback

### DIFF
--- a/apps/local/server.js
+++ b/apps/local/server.js
@@ -2017,6 +2017,23 @@ export function resolveClaudeDesktopShadowConfiguration({
   });
 }
 
+// Accounting authority is a composition-root choice. The shipped default is
+// the generation-bound unified index; legacy remains an explicit rollback only.
+// Either mode is selected here and there is no implicit fallback between them.
+export function configuredAccountingSourceMode(environment) {
+  if (!environment || typeof environment !== "object"
+      || Array.isArray(environment)) {
+    throw new TypeError("environment must be an object");
+  }
+  const selected = environment.USAGE_MONITOR_ACCOUNTING_SOURCE_MODE ?? "unified";
+  if (!new Set(["legacy", "unified"]).has(selected)) {
+    throw new TypeError(
+      "USAGE_MONITOR_ACCOUNTING_SOURCE_MODE must be legacy or unified",
+    );
+  }
+  return selected;
+}
+
 function parentWatchdogConfigurationError() {
   const error = new TypeError(
     "Parent watchdog configuration is invalid",
@@ -2257,6 +2274,10 @@ function createPreparedLocalCompanionServer({
   claudeProjectDirectory,
   diagnosticsLogFile,
   parentWatchdogPid,
+  // Explicit reversible authority switch. Unified is the normal authority;
+  // legacy is retained only for an explicit rollback selection.
+  accountingSourceMode =
+    configuredAccountingSourceMode(environment),
   fastModePreference = createFastModePreferenceController({
     settingsFile: statePaths.fastModePreferenceFile,
   }),
@@ -2273,9 +2294,12 @@ function createPreparedLocalCompanionServer({
     builder: async () => buildLocalCompanionSnapshot({
       root: resourceRoot,
       collectorStateFile: statePaths.collectorStateFile,
-      archiveIndexFile: statePaths.archiveAccountingIndexFile,
+      archiveIndexFile: accountingSourceMode === "legacy"
+        ? statePaths.archiveAccountingIndexFile
+        : null,
       unifiedIndexFile: statePaths.unifiedIndexFile,
       codexHome,
+      accountingSourceMode,
       allowDevelopmentArtifactFallback:
         environment.USAGE_MONITOR_DEVELOPMENT_ARTIFACT_FALLBACK === "1",
       includeDevelopmentSideChatEstimates:
@@ -2348,9 +2372,22 @@ function createPreparedLocalCompanionServer({
     refreshClaudeUsageShadow: claudeShadowEnabled
       ? ({ signal }) => claudeShadowController.refresh({ signal })
       : null,
-    refreshArchiveIndex: refreshLocalArchiveAccountingIndex,
-    archiveIndexFile: statePaths.archiveAccountingIndexFile,
-    archiveIndexSecretFile: statePaths.archiveAccountingIndexSecretFile,
+    accountingSourceMode,
+    legacyAnalysisIndexFile: accountingSourceMode === "legacy"
+      ? statePaths.legacyAnalysisIndexFile
+      : null,
+    legacyAnalysisIndexSecretFile: accountingSourceMode === "legacy"
+      ? statePaths.legacyAnalysisIndexSecretFile
+      : null,
+    refreshArchiveIndex: accountingSourceMode === "legacy"
+      ? refreshLocalArchiveAccountingIndex
+      : null,
+    archiveIndexFile: accountingSourceMode === "legacy"
+      ? statePaths.archiveAccountingIndexFile
+      : null,
+    archiveIndexSecretFile: accountingSourceMode === "legacy"
+      ? statePaths.archiveAccountingIndexSecretFile
+      : null,
     // Advance the unified index by its cursors on every foreground refresh:
     // an ordinary pass reads only the bytes the rollout corpus grew.
     refreshUnifiedIndex: (options) => ingestLocalUnifiedIndexIncrement({

--- a/apps/local/server.test.mjs
+++ b/apps/local/server.test.mjs
@@ -48,6 +48,7 @@ import {
   SEMANTIC_OPEN_TARGET_PLACEHOLDER,
 } from "../../config/product-brand.js";
 import {
+  configuredAccountingSourceMode,
   createCentralOutboundFetch,
   createLocalCompanionServer,
   resolveClaudeDesktopShadowConfiguration,
@@ -200,6 +201,34 @@ async function fixture() {
   );
   return { root, resourceRoot, stateRoot, codexHome, staticRoot };
 }
+
+test("production authority defaults unified and keeps legacy as explicit rollback", () => {
+  assert.equal(configuredAccountingSourceMode({}), "unified");
+  assert.equal(
+    configuredAccountingSourceMode({
+      USAGE_MONITOR_ACCOUNTING_SOURCE_MODE: "unified",
+    }),
+    "unified",
+  );
+  assert.equal(
+    configuredAccountingSourceMode({
+      USAGE_MONITOR_ACCOUNTING_SOURCE_MODE: "legacy",
+    }),
+    "legacy",
+  );
+  assert.throws(
+    () => configuredAccountingSourceMode({
+      USAGE_MONITOR_ACCOUNTING_SOURCE_MODE: "automatic",
+    }),
+    /must be legacy or unified/u,
+  );
+  assert.throws(
+    () => configuredAccountingSourceMode({
+      USAGE_MONITOR_ACCOUNTING_SOURCE_MODE: "",
+    }),
+    /must be legacy or unified/u,
+  );
+});
 
 function rawRequest({ port, path, method = "GET", headers = {}, body = "" }) {
   return new Promise((resolveRequest, rejectRequest) => {

--- a/docs/plans/2026-08-17-local-analysis-index-retirement-plan.md
+++ b/docs/plans/2026-08-17-local-analysis-index-retirement-plan.md
@@ -1,0 +1,290 @@
+---
+title: Local Analysis Index Retirement Plan
+date: 2026-08-17
+type: plan
+status: implemented
+---
+
+# Local analysis index retirement plan
+
+## Outcome
+
+Make `local-unified-index-v1.sqlite` the only production fact index used for
+Codex accounting, history, dashboard projections, and contribution
+preparation. Keep the legacy analysis/archive code and files for one reversible
+rollback window; do not delete them in this change.
+
+The provider parser remains. This retires the duplicate durable index, not raw
+Codex discovery and parsing used by other tools.
+
+## Historical defect and current state
+
+Before this work, passing `unifiedIndexFile` changed only the weekly calibration
+corpus. The main accounting scan still constructed and refreshed
+`local-analysis-index-v2.sqlite`, and foreground refresh also wrote
+`local-archive-accounting-index-v1.sqlite`.
+
+That wiring defect is resolved in the implementation. Unified mode uses the
+generation-bound unified reader for recent accounting and history and does not
+read or advance either legacy database. The composition-root default is now
+`unified`; `USAGE_MONITOR_ACCOUNTING_SOURCE_MODE=legacy` is the explicit,
+observable rollback selector. Neither mode silently falls back to the other.
+
+## Decisions
+
+1. Unified facts retain source-native `NULL` context evidence. The production
+   compatibility adapter explicitly projects a missing total-input-context as
+   legacy zero during the cutover. The raw receipt keeps absence and zero
+   distinct so the compatibility behavior cannot hide a future correction.
+2. Accounting authority is explicit: `unified` or `legacy`. There is no error
+   fallback between them. Legacy is a reversible rollback selector.
+3. A published unified generation is the publication unit. Rebuilds and
+   increments are written to a staging database and atomically renamed over the
+   live file only after integrity validation and fsync. Global `complete`
+   still means every consumer fact is covered; a tool-only provenance gap is
+   published as `partial`, while its independently complete usage/quota
+   accounting remains eligible and tool totals are explicitly withheld.
+4. The unified schema persists exact source-local ordering, source offsets,
+   tier-observation time, source-scoped quota occurrences, source-scoped typed
+   tool facts, and bounded diagnostics. Migrated historical rows retain honest
+   `NULL` provenance; they do not receive fabricated values. A pre-tool source
+   that already rotated away is marked as missing tool history: usage remains
+   available, but the product never turns that gap into a zero tool count.
+5. Replay-safe caches record their reader/schema/parser/contract/generation and
+   compatibility tuple. Incomplete or mismatched coverage cannot be written or
+   reused as current accounting.
+6. Full-history accounting becomes a constant-memory aggregate in the same
+   collector-state cache transaction as the recent periods. Unified mode does
+   not read or advance the old archive database.
+7. Old databases, secrets, readers, and tests remain on disk for rollback until
+   a later deletion gate. This change performs no destructive cleanup.
+
+## Required invariants
+
+- Fork replay is excluded exactly once.
+- Usage components, model identity, speed/tier, surface, agent scope, lineage,
+  quota slot/duration/reset/plan/limit, event-time pricing, and stale-leading
+  quota gating remain semantically equivalent.
+- Global generation `complete` means the discovered source set and all admitted facts,
+  diagnostics, and provenance belong to one validated published generation.
+- Tool-only partial coverage cannot overstate a zero and cannot suppress
+  independently complete usage/quota accounting.
+- An abort, crash, parser change, active append, truncation, or callback failure
+  leaves the prior published database and prior valid accounting cache intact.
+- Readers never discover or open rollout JSONL.
+- No path, filename, source content, prompt, reply, arbitrary error text, or
+  raw identifier enters the new provenance, diagnostic, generation, or parity
+  surfaces.
+- A no-change accounting refresh reads zero rollout source-body bytes and does
+  not touch either legacy index.
+
+## Implementation sequence
+
+### 1. Characterization
+
+- Freeze a keyed, content-free usage/quota semantic receipt.
+- Compare legacy and unified callbacks plus replay-safe projections.
+- Preserve the known native mismatch: legacy emits context zero; unified stores
+  context unavailable.
+
+Status: complete in release-branch commit `dd82ef9` (patch-equivalent to the
+original characterization commit `408a8c5`).
+
+### 2. Unified publication contract
+
+- Widen the schema additively with source provenance, quota occurrences,
+  source diagnostics, generation membership, and coverage summaries.
+- Bump parser/storage versions for new rows.
+- Publish cold and incremental passes through staged atomic replacement.
+- Leave migrated provenance gaps partial until a v8 source rebuild can heal
+  them.
+
+Status: implemented and focused-test complete. Incremental replacement now
+deletes stale facts by source, preserves facts whose raw files merely rotate
+away, rebuilds unattested migrations, and publishes indexed retained sources
+in the new generation descriptor. Storage/parser v8 adds generation-bound
+typed tool facts, deterministic fingerprints, migration-safe diagnostic
+vocabulary widening, and honest rotated-source tool gaps.
+
+### 3. Read-only accounting source
+
+- Read one published generation only.
+- Emit deterministic usage and admitted quota occurrences with exact
+  provenance.
+- Support `source_native` and explicit `legacy_zero` context behavior.
+- Return a bounded generation/coverage/capability descriptor.
+- Preserve only a closed allowlist of resource error codes; collapse all other
+  callback failures to fixed content-free errors.
+
+Status: implemented and focused-test complete. The adapter binds canonical
+generation ID plus fingerprint before and after callbacks, supports explicit
+context compatibility, and exposes only fixed error codes.
+
+### 4. Cache and consumer cutover
+
+- Remove replay accounting's hidden legacy scanner construction.
+- Require explicit `unified` or `legacy` authority.
+- Bind the cache to the completed unified generation and enforce returned
+  coverage.
+- Add full-history aggregate and coverage to the cache.
+- In unified mode, stop normal analysis/archive writes and source history from
+  the cache. Keep the legacy mode code path intact.
+
+Status: implemented and focused-test complete. Direct cache builds fail closed
+without an injected scanner or explicit mode; unified caches and history are
+bound to both generation ID and fingerprint, require zero fallback use, and
+withhold incomplete evidence.
+
+### 5. Qualification
+
+- Prove native and legacy-compatible context receipts separately.
+- Cover equal-timestamp quota occurrences, fork replay, rotated sources,
+  corruption, cold/incremental interruption, no-change mtime, generation
+  mismatch, reader/writer overlap, and preservation of old DB files.
+- Benchmark the real production path separately for cold rebuild, increment,
+  no-change, cached read, and history projection. Report wall time, source
+  bytes, callback/fact counts, peak RSS, database bytes, median, and p95.
+- Run focused, affected, full, architecture, packaging, product-local, and
+  macOS gates. Installed-app validation remains separate from source tests.
+
+Status: cutover qualification is green on the synthetic production path and a
+real production-default server refresh. The fixture covers
+cold/no-change/append/relaunch, raw-source deletion, legacy-file non-touch,
+cache/history generation invalidation, and exact `legacy_zero` parity. The
+default flip has been exercised without setting the mode environment variable;
+the old analysis and archive files remained absent. The retained R7 decisions
+remain `release_open`; regenerating evidence does not promote a release. The
+source cutover is implemented, but final-source R7 evidence remains an open
+release/publishing gate as described below.
+
+The first read-only real-corpus unified pilot completed over 51,140,189,911
+source bytes in 2,145 sources and published 600,095 facts. Before the cold-path
+fixes below, it measured a 39.0-minute cold rebuild, 1.52 GB peak RSS, a 221 MB
+unified index, a 655 ms zero-byte no-change ingest with unchanged size/mtime, a
+56 ms generation-bound cache read, about 20.1 seconds for a full
+accounting/history cache rebuild, and about 4.8 seconds for the companion
+snapshot. This receipt exposed a real cold-publication defect; it is retained
+as the pre-fix baseline rather than presented as expected product performance.
+
+The 39-minute cold build and the 20.1-second accounting rebuild are different
+operations: the latter runs after a completed unified index already exists.
+Steady-state no-change work therefore did not regress from 20 seconds to 39
+minutes. The first-build/recovery path is nevertheless a release blocker. A
+10-worker real-corpus experiment was stopped after a 24-minute lower bound
+without publication. It disproved worker count as a complete explanation and
+exposed an unbounded worker-message queue around the single SQLite writer, so
+that configuration is not a production candidate and produced no qualifying
+receipt.
+
+The cold builder now defers its reader/proof secondary indexes until the
+brand-new staged fact load is complete. Primary and unique constraints remain
+active; the secondary indexes are created in fixed order before generation
+finalization, integrity validation, fsync, and atomic publication. Existing and
+incremental databases must already contain those indexes. Logical parity,
+index presence, staged failure rollback, reader compatibility, qualification,
+and benchmark-window contracts pass the latest focused regression (64/64).
+The generation proof includes a required index on
+`quota_occurrence(canonical_observation_id)`. Without that index, its
+correlated quota-coverage anti-join was effectively quadratic. Planner coverage
+proves the fixed query uses the index; writable migration repairs its absence
+while read-only validation rejects an incomplete index set.
+
+A finalized post-fix one-worker real-corpus pilot then completed successfully
+with explicit `2025-08-02T00:00:00.000Z` through
+`2026-08-02T00:00:00.000Z` bounds. Its 365-day live selection was larger than
+the first pilot: 65,187,367,357 source bytes, 3,333 sources, 429,257 usage
+events, 647,988 quota observations, 648,175 quota occurrences, and 1,077,245
+indexed usage/quota facts. The cold rebuild took 45.486 seconds, about 51 times
+faster than the pre-fix receipt; peak RSS was 2.393 GB, the published index was
+387.3 MB, and total isolated state was 396.4 MB. Zero-byte no-change ingest
+took 790 ms and preserved index size/mtime; a generation-bound cache read took
+56 ms; full accounting/history cache builds took 29.9 and 32.3 seconds;
+companion snapshots took 7.0 and 7.6 seconds. The whole qualification, which
+intentionally repeats cache and companion validation, took 123.7 seconds.
+Legacy paths remained absent and raw sources were read-only. An immediately
+preceding post-fix run over the same counts completed cold construction in 57.9
+seconds, providing a second consistent feasibility observation but not a
+predeclared statistical run.
+
+This fixes the observed catastrophic cold cost. The live-corpus receipts are
+not a frozen same-corpus A/B or a three-run median/p95, so they must not be used
+as a precise relative-speed claim. They are sufficient for the cutover's
+feasibility gate: steady-state work is incremental, no-change reads zero source
+bytes, and the recovery build completed in under a minute on a larger corpus.
+The roughly 2.4 GB cold-build peak remains a documented recovery-path cost.
+
+The retained legacy benchmark formatter and its callback-error classification
+were repaired. A real legacy index rebuild completed over the same live source
+family (3,333 sources, 65.2 GB, complete coverage, 408,142 usage events and
+636,717 quota observations). A cold legacy accounting-cache rebuild then hit
+the existing `accounting_transition_rss_limit_exceeded` guard, so there is no
+valid cold end-to-end legacy timing claim. Rollback was instead proven from a
+valid warm cache: explicit legacy mode reused the cache, invoked the archive
+path only in legacy mode, served the companion, and left collector-state
+size/mtime unchanged. This is a recovery proof, not a performance comparison.
+
+Focused evidence recorded during implementation:
+
+- Integrated cache/refresh/data/qualification regression passes, including the
+  exact-decimal half-boundary cache regression and pre-write cache validation.
+  The full local-product lane passes 214/214 with its
+  required loopback permissions.
+- Architecture boundaries, documentation links, tool inventory, package
+  export checks, and diff preflight pass at the verified stopping point.
+- Final-source R7 regeneration was attempted on exact Node 24.14.0 and Node
+  26.2.0. Node 24 completed its real-history lifecycle, but the Node 26
+  `source_scan` exceeded the preregistered 10-minute watchdog. Atomic recovery
+  removed the staging generation and preserved the prior complete receipt set;
+  those retained receipts are now stale against the final source-closure hash.
+  The timeout was not relaxed. Fresh exact-runtime R7 receipts therefore remain
+  an open release-evidence gate.
+- The final permission-correct root `npm test` run completed 2,564 tests: 2,542
+  passed, 17 were intentionally skipped, and five failed. Two failures are
+  checkout setup boundaries because the worker workspace's `jsonc-parser`
+  dependency is not installed; the cutover does not change the relevant
+  package or tests. The other two R7 assertions correctly reject retained
+  receipts whose exact source-closure hashes predate this cutover. The fifth
+  failure was an unchanged legacy-report TOCTOU scheduling test; it passed in
+  the preceding full run and again in an immediate focused 8/8 rerun. The
+  local-product lane remains 214/214 and the macOS product lane remains 53/53.
+- Real-corpus unified pilots: the pre-fix 39-minute receipt identified the
+  unindexed proof defect; the finalized post-fix one-worker receipt completed
+  the larger 365-day, 65.2 GB live selection in 45.5 seconds. Legacy production
+  files were absent from isolated unified state and raw sources were not
+  mutated. The unsafe
+  pre-fix 10-worker follow-up was stopped at a 24-minute lower bound, and the
+  current legacy cold cache still exceeds its existing transition RSS target.
+  A three-run frozen-corpus unified/legacy median and p95 remain useful future
+  characterization, not a precise claim made by this cutover; only 15 GB of
+  disk headroom was available at qualification start, so six additional cold
+  states were not created.
+- The package allowlists now match the locked `fast-uri` 3.1.5 dependency.
+  Packaging/export/review checks pass 17/17 and the permission-correct macOS
+  product lane passes 53/53.
+- The extracted local-review runtime smoke still fails to materialize the
+  `@app-usagemonitor/telemetry-contract` workspace package. The same command
+  fails identically on untouched `origin/main`; that inherited packaging fix
+  is deliberately not folded into this source-only cutover.
+- A production-default real refresh published generation 8 over the then-live
+  118.7 GB / 4,566-source corpus. It served complete generation-bound history
+  with zero fallback, no archive result, and no legacy files before or after.
+  The dormant collector's rollout and tool row counts were unchanged; one live
+  quota observation was added. A public-receipt double-projection bug found by
+  this smoke was fixed so source count, source bytes, and covered timestamps
+  remain lossless through the HTTP projection.
+
+## Cutover and rollback
+
+The composition root selects one authority. Unified-mode failure retains the
+last valid generation-bound cache or shows insufficient evidence; it never
+writes the old index as a fallback. Rollback explicitly selects `legacy`,
+reenabling the old accounting/archive readers without changing the unified
+database. Any rollback use is reported as a bounded mode receipt.
+
+The current branch defaults to unified. The rollback selector, legacy readers,
+tests, and dormant on-disk paths stay in place for the reversible release
+window. This implementation does not install, publish, or delete the old files.
+
+Do not remove old implementation or files until a later release has a durable
+dominance receipt showing semantic parity, complete unified coverage, installed
+refresh success, and acceptable production performance.

--- a/scripts/benchmark-local-analysis-pipeline.mjs
+++ b/scripts/benchmark-local-analysis-pipeline.mjs
@@ -6,13 +6,19 @@ import {
 import {
   refreshReplaySafeAccountingCache,
 } from "../src/replay-safe-accounting-cache.js";
+import {
+  deriveSupportedAccountingWindow,
+  LOCAL_INDEX_RETIREMENT_BENCHMARK_END_AT,
+  LOCAL_INDEX_RETIREMENT_BENCHMARK_START_AT,
+} from "./benchmark-local-index-retirement.mjs";
 
 function options(argv) {
   const result = {
     codexHome: null,
     stateDirectory: null,
-    endAt: null,
-    workers: 10,
+    startAt: LOCAL_INDEX_RETIREMENT_BENCHMARK_START_AT,
+    endAt: LOCAL_INDEX_RETIREMENT_BENCHMARK_END_AT,
+    workers: 1,
   };
   for (let index = 0; index < argv.length; index += 2) {
     const name = argv[index];
@@ -20,22 +26,45 @@ function options(argv) {
     if (value === undefined) throw new TypeError(`${name} needs a value`);
     if (name === "--codex-home") result.codexHome = resolve(value);
     else if (name === "--state") result.stateDirectory = resolve(value);
+    else if (name === "--start-at") result.startAt = value;
     else if (name === "--end-at") result.endAt = value;
     else if (name === "--workers") result.workers = Number(value);
     else throw new TypeError(`Unknown option: ${name}`);
   }
   if (result.codexHome === null
       || result.stateDirectory === null
-      || !Number.isFinite(Date.parse(result.endAt))
       || !Number.isSafeInteger(result.workers)
       || result.workers < 1
       || result.workers > 10) {
     throw new TypeError(
       "Required: --codex-home PATH --state EMPTY_DIR "
-      + "--end-at ISO [--workers 1..10]",
+      + "[--start-at ISO] --end-at ISO [--workers 1..10]",
     );
   }
+  result.accountingWindow = deriveSupportedAccountingWindow(
+    result.startAt,
+    result.endAt,
+  );
   return result;
+}
+
+function normalizeLegacyRefreshResult(result) {
+  if (result?.status === "accounting_rebuild_deferred") {
+    throw new Error("legacy_accounting_refresh_deferred");
+  }
+  const cache = result?.cache ?? result;
+  if (cache === null || typeof cache !== "object"
+      || Array.isArray(cache) || !Array.isArray(cache.periods)) {
+    throw new Error("legacy_accounting_cache_invalid");
+  }
+  if (cache.sourceDescriptor?.mode !== "legacy") {
+    throw new Error("legacy_accounting_source_mode_invalid");
+  }
+  const all = cache.periods.find((period) => period?.id === "all");
+  if (all === undefined) {
+    throw new Error("legacy_accounting_cache_missing_all_period");
+  }
+  return { all, cache };
 }
 
 const selected = options(process.argv.slice(2));
@@ -56,24 +85,34 @@ const secretFile = join(
   selected.stateDirectory,
   "local-analysis-index-secret-v2",
 );
-const fixedEndMs = Date.parse(selected.endAt);
+const fixedEndMs = Date.parse(selected.accountingWindow.endAt);
 const startedAt = performance.now();
-const cache = await refreshReplaySafeAccountingCache({
+const refreshed = await refreshReplaySafeAccountingCache({
   stateFile,
+  // This retained benchmark intentionally measures the rollback pipeline.
+  // Production refresh no longer infers legacy authority from old index
+  // paths, so the comparison must select it explicitly.
+  sourceMode: "legacy",
   indexFile,
   indexSecretFile: secretFile,
   codexHome: selected.codexHome,
   now: () => fixedEndMs,
   indexWorkerCount: selected.workers,
+  windowDays: selected.accountingWindow.durationDays,
 });
+const { all, cache } = normalizeLegacyRefreshResult(refreshed);
 const index = await inspectLocalAnalysisIndex({ indexFile });
-const all = cache.periods.find((period) => period.id === "all");
+if (index.coveredAt?.startAt !== selected.accountingWindow.startAt
+    || index.coveredAt?.endAt !== selected.accountingWindow.endAt) {
+  throw new Error("legacy_benchmark_window_mismatch");
+}
 
 process.stdout.write(`${JSON.stringify({
-  schemaVersion: "local-analysis-performance-receipt-v1",
+  schemaVersion: "local-analysis-performance-receipt-v2",
   node: process.version,
   elapsedMs: Number((performance.now() - startedAt).toFixed(3)),
   workers: selected.workers,
+  accountingWindow: selected.accountingWindow,
   coveredAt: index.coveredAt,
   sourceCount: index.sourceCount,
   sourceBytes: index.lastScan.bytes,
@@ -81,6 +120,7 @@ process.stdout.write(`${JSON.stringify({
   indexWallMs: index.lastScan.wallMs,
   phaseWallMs: index.lastScan.phases,
   accounting: {
+    sourceMode: cache.sourceDescriptor.mode,
     events: all.events,
     totalTokens: all.totalTokens,
     apiPriceEquivalentUsd: all.apiPriceEquivalentUsd,

--- a/scripts/benchmark-local-index-retirement.mjs
+++ b/scripts/benchmark-local-index-retirement.mjs
@@ -1,0 +1,1120 @@
+import {
+  appendFile,
+  mkdir,
+  readFile,
+  readdir,
+  stat,
+  writeFile,
+} from "node:fs/promises";
+import { fileURLToPath } from "node:url";
+import { join, resolve } from "node:path";
+
+import {
+  buildLocalCompanionSnapshot,
+} from "../src/local-companion-data.js";
+import {
+  rebuildLocalUnifiedIndex,
+} from "../src/local-unified-index-build.js";
+import {
+  ingestLocalUnifiedIndexIncrement,
+} from "../src/local-unified-index-ingest.js";
+import {
+  inspectLocalUnifiedIndex,
+  openLocalUnifiedIndex,
+  readUnifiedIndexGenerationDescriptor,
+} from "../src/local-unified-index.js";
+import {
+  createIndexedCodexLogScan,
+  inspectLocalAnalysisIndex,
+} from "../src/local-analysis-index.js";
+import {
+  readReplaySafeAccountingCache,
+  refreshReplaySafeAccountingCache,
+} from "../src/replay-safe-accounting-cache.js";
+import {
+  createLocalUnifiedAccountingSource,
+} from "../src/local-unified-accounting-source.js";
+
+export const LOCAL_INDEX_RETIREMENT_BENCHMARK_VERSION =
+  "local-index-retirement-qualification-v2";
+export const LOCAL_INDEX_RETIREMENT_BENCHMARK_CONTRACT =
+  "usage-event-v0.2";
+export const LOCAL_INDEX_RETIREMENT_BENCHMARK_START_AT =
+  "2025-08-02T00:00:00.000Z";
+export const LOCAL_INDEX_RETIREMENT_BENCHMARK_END_AT =
+  "2026-08-02T00:00:00.000Z";
+export const LOCAL_INDEX_RETIREMENT_ACCOUNTING_MIN_WINDOW_DAYS = 365;
+export const LOCAL_INDEX_RETIREMENT_ACCOUNTING_MAX_WINDOW_DAYS = 3_653;
+
+const MILLIS_PER_DAY = 24 * 60 * 60 * 1_000;
+
+function canonicalInstant(value) {
+  if (typeof value !== "string") return null;
+  const milliseconds = Date.parse(value);
+  if (!Number.isFinite(milliseconds)) return null;
+  const canonical = new Date(milliseconds).toISOString();
+  return canonical === value ? canonical : null;
+}
+
+// replay-safe accounting supports only whole-day windows from 365 through
+// 3,653 days. Derive that exact supported window from the benchmark caller's
+// interval so neither authority silently widens or shifts the comparison.
+export function deriveSupportedAccountingWindow(startAt, endAt) {
+  const canonicalStartAt = canonicalInstant(startAt);
+  const canonicalEndAt = canonicalInstant(endAt);
+  if (canonicalStartAt === null || canonicalEndAt === null) {
+    throw new TypeError("startAt/endAt must be canonical ISO instants");
+  }
+  const startMs = Date.parse(canonicalStartAt);
+  const endMs = Date.parse(canonicalEndAt);
+  const durationMs = endMs - startMs;
+  if (!Number.isSafeInteger(durationMs)
+      || durationMs < 0
+      || durationMs % MILLIS_PER_DAY !== 0) {
+    throw new TypeError("benchmark interval must contain whole days");
+  }
+  const durationDays = durationMs / MILLIS_PER_DAY;
+  if (durationDays < LOCAL_INDEX_RETIREMENT_ACCOUNTING_MIN_WINDOW_DAYS
+      || durationDays > LOCAL_INDEX_RETIREMENT_ACCOUNTING_MAX_WINDOW_DAYS) {
+    throw new TypeError(
+      "benchmark accounting window must be between 365 and 3653 days",
+    );
+  }
+  return Object.freeze({
+    startAt: canonicalStartAt,
+    endAt: canonicalEndAt,
+    durationDays,
+  });
+}
+
+// These are deliberately generous synthetic-fixture guardrails. They make a
+// runaway benchmark fail closed without turning a machine's absolute speed
+// into a product claim. The receipt reports measured values only.
+export const LOCAL_INDEX_RETIREMENT_BENCHMARK_LIMITS = Object.freeze({
+  maxPhaseMs: 60_000,
+  maxTotalMs: 180_000,
+  maxRssDeltaBytes: 1_024 * 1024 * 1024,
+  maxDiskBytes: 64 * 1024 * 1024,
+  maxSourceBytes: 4 * 1024 * 1024,
+});
+
+function sessionMeta(sessionId, timestamp) {
+  return JSON.stringify({
+    timestamp,
+    type: "session_meta",
+    payload: {
+      id: sessionId,
+      session_id: sessionId,
+      thread_source: "user",
+      originator: "codex_cli_rs",
+      cwd: "/private/synthetic-index-retirement",
+    },
+  });
+}
+
+function turnContext(timestamp) {
+  return JSON.stringify({
+    timestamp,
+    type: "turn_context",
+    payload: {
+      turn_id: "synthetic-turn",
+      cwd: "/private/synthetic-index-retirement",
+      model: "gpt-5.6-sol",
+      effort: "medium",
+    },
+  });
+}
+
+function threadSettings(timestamp) {
+  return JSON.stringify({
+    timestamp,
+    type: "event_msg",
+    payload: {
+      type: "thread_settings_applied",
+      thread_settings: {
+        service_tier: "priority",
+        reasoning_effort: "medium",
+      },
+    },
+  });
+}
+
+function tokenCount(timestamp, total, last, usedPercent = null) {
+  return JSON.stringify({
+    timestamp,
+    type: "event_msg",
+    payload: {
+      type: "token_count",
+      info: {
+        total_token_usage: total,
+        last_token_usage: last,
+      },
+      ...(usedPercent === null
+        ? {}
+        : {
+          rate_limits: {
+            limit_id: "codex",
+            plan_type: "pro",
+            primary: {
+              used_percent: usedPercent,
+              window_minutes: 10_080,
+              resets_at: Math.floor(
+                Date.parse("2026-08-08T00:00:00.000Z") / 1_000,
+              ),
+            },
+          },
+        }),
+    },
+  });
+}
+
+function usage(input, output, reasoning = 0) {
+  return {
+    input_tokens: input,
+    cached_input_tokens: 0,
+    cache_write_input_tokens: 0,
+    output_tokens: output,
+    reasoning_output_tokens: reasoning,
+    total_tokens: input + output + reasoning,
+  };
+}
+
+async function writeSyntheticSource(path, {
+  sessionId,
+  sessionAt,
+  events,
+}) {
+  const lines = [
+    sessionMeta(sessionId, sessionAt),
+    turnContext(sessionAt),
+    threadSettings(sessionAt),
+    ...events.map((event) => tokenCount(
+      event.timestamp,
+      event.total,
+      event.last,
+      event.usedPercent ?? null,
+    )),
+  ];
+  await writeFile(path, `${lines.join("\n")}\n`, { mode: 0o600 });
+}
+
+export async function createSyntheticLocalIndexRetirementCorpus(stateDirectory) {
+  const codexHome = join(stateDirectory, "synthetic-codex-home");
+  const firstDirectory = join(codexHome, "sessions", "2026", "07", "01");
+  const secondDirectory = join(codexHome, "sessions", "2026", "08", "01");
+  await mkdir(firstDirectory, { recursive: true, mode: 0o700 });
+  await mkdir(secondDirectory, { recursive: true, mode: 0o700 });
+  const firstSource = join(
+    firstDirectory,
+    "rollout-2026-07-01T12-00-00-qualification.jsonl",
+  );
+  const secondSource = join(
+    secondDirectory,
+    "rollout-2026-08-01T12-00-00-qualification.jsonl",
+  );
+  await writeSyntheticSource(firstSource, {
+    sessionId: "synthetic-qualification-history",
+    sessionAt: "2026-07-01T12:00:00.000Z",
+    events: [
+      {
+        timestamp: "2026-07-01T12:01:00.000Z",
+        total: usage(100, 10),
+        last: usage(100, 10),
+        usedPercent: 4,
+      },
+      {
+        timestamp: "2026-07-01T12:02:00.000Z",
+        total: usage(220, 25),
+        last: usage(120, 15),
+      },
+    ],
+  });
+  await writeSyntheticSource(secondSource, {
+    sessionId: "synthetic-qualification-current",
+    sessionAt: "2026-08-01T12:00:00.000Z",
+    events: [
+      {
+        timestamp: "2026-08-01T12:01:00.000Z",
+        total: usage(300, 30),
+        last: usage(300, 30),
+        usedPercent: 8,
+      },
+      {
+        timestamp: "2026-08-01T12:02:00.000Z",
+        total: usage(500, 55),
+        last: usage(200, 25),
+      },
+    ],
+  });
+  return { codexHome, firstSource, secondSource };
+}
+
+function phaseMeasure(name, action, state) {
+  return (async () => {
+    const started = performance.now();
+    const value = await action();
+    const elapsedMs = performance.now() - started;
+    state.phaseMs[name] = Number(elapsedMs.toFixed(3));
+    state.peakRssBytes = Math.max(state.peakRssBytes, process.memoryUsage.rss());
+    if (state.maxPhaseMs !== null
+        && elapsedMs > state.maxPhaseMs) {
+      throw new Error(`benchmark_phase_timeout:${name}`);
+    }
+    return value;
+  })();
+}
+
+async function directoryBytes(directory) {
+  let total = 0;
+  async function visit(path) {
+    for (const entry of await readdir(path, { withFileTypes: true })) {
+      const child = join(path, entry.name);
+      if (entry.isDirectory()) {
+        await visit(child);
+      } else if (entry.isFile()) {
+        total += (await stat(child)).size;
+      }
+    }
+  }
+  await visit(directory);
+  return total;
+}
+
+async function missing(path) {
+  try {
+    await stat(path);
+    return false;
+  } catch (error) {
+    if (error?.code === "ENOENT") return true;
+    throw error;
+  }
+}
+
+function assertBounded(value, limit, label) {
+  if (!Number.isFinite(value) || value < 0 || value > limit) {
+    throw new Error(`benchmark_bound_exceeded:${label}`);
+  }
+}
+
+function metadataSnapshot(path) {
+  return stat(path).then((value) => ({
+    size: value.size,
+    mtimeMs: value.mtimeMs,
+  }));
+}
+
+async function contentMetadataSnapshot(path) {
+  const [metadata, contents] = await Promise.all([
+    metadataSnapshot(path),
+    readFile(path),
+  ]);
+  return { ...metadata, contents };
+}
+
+async function unchangedContentMetadata(before, path) {
+  const after = await contentMetadataSnapshot(path);
+  return after.size === before.size
+    && after.mtimeMs === before.mtimeMs
+    && Buffer.compare(after.contents, before.contents) === 0;
+}
+
+function countedScanner(scanner, counters) {
+  return async function scanWithBoundedCounters({
+    onUsage,
+    onRateLimitSnapshot,
+    ...options
+  } = {}) {
+    return scanner({
+      ...options,
+      onUsage: async (event) => {
+        counters.usageCallbacks += 1;
+        return onUsage?.(event);
+      },
+      onRateLimitSnapshot: async (snapshot) => {
+        counters.quotaCallbacks += 1;
+        return onRateLimitSnapshot?.(snapshot);
+      },
+    });
+  };
+}
+
+function safeCount(value, label) {
+  if (value === null || value === undefined) {
+    throw new Error(`benchmark_count_invalid:${label}`);
+  }
+  const count = Number(value);
+  if (!Number.isSafeInteger(count) || count < 0) {
+    throw new Error(`benchmark_count_invalid:${label}`);
+  }
+  return count;
+}
+
+function rounded(value) {
+  return Number(value.toFixed(3));
+}
+
+function percentile(values, quantile) {
+  const sorted = [...values].sort((left, right) => left - right);
+  const index = Math.min(
+    sorted.length - 1,
+    Math.max(0, Math.ceil(sorted.length * quantile) - 1),
+  );
+  return sorted[index];
+}
+
+function summarizeNumbers(values) {
+  if (!Array.isArray(values) || values.length < 1
+      || values.some((value) => !Number.isFinite(value) || value < 0)) {
+    throw new Error("benchmark_statistics_invalid");
+  }
+  return {
+    min: rounded(Math.min(...values)),
+    median: rounded(percentile(values, 0.5)),
+    p95: rounded(percentile(values, 0.95)),
+    max: rounded(Math.max(...values)),
+  };
+}
+
+function summarizeRunReceipts(receipts) {
+  if (!Array.isArray(receipts) || receipts.length < 1) {
+    throw new Error("benchmark_runs_empty");
+  }
+  const timingNames = [...new Set(receipts.flatMap((receipt) => (
+    Object.keys(receipt.timings ?? {})
+  )))].sort();
+  const countNames = [...new Set(receipts.flatMap((receipt) => (
+    Object.keys(receipt.counts ?? {})
+  )))].sort();
+  return {
+    runCount: receipts.length,
+    timings: Object.fromEntries(timingNames.map((name) => [
+      name,
+      summarizeNumbers(receipts.map((receipt) => receipt.timings[name])),
+    ])),
+    counts: Object.fromEntries(countNames.map((name) => [
+      name,
+      summarizeNumbers(receipts.map((receipt) => receipt.counts[name])),
+    ])),
+  };
+}
+
+async function runSingleLocalIndexRetirementQualification({
+  stateDirectory,
+  codexHome = null,
+  endAt = LOCAL_INDEX_RETIREMENT_BENCHMARK_END_AT,
+  startAt = LOCAL_INDEX_RETIREMENT_BENCHMARK_START_AT,
+  seedLegacySentinels = false,
+  workerCount = 1,
+} = {}) {
+  if (typeof stateDirectory !== "string" || stateDirectory.length < 1) {
+    throw new TypeError("stateDirectory must be a non-empty path");
+  }
+  if (codexHome !== null
+      && (typeof codexHome !== "string" || codexHome.length < 1)) {
+    throw new TypeError("codexHome must be a non-empty path or null");
+  }
+  if (typeof seedLegacySentinels !== "boolean") {
+    throw new TypeError("seedLegacySentinels must be a boolean");
+  }
+  if (!Number.isSafeInteger(workerCount) || workerCount < 1 || workerCount > 10) {
+    throw new TypeError("workerCount must be an integer from 1 through 10");
+  }
+  const accountingWindow = deriveSupportedAccountingWindow(startAt, endAt);
+  const resolvedStateDirectory = resolve(stateDirectory);
+  await mkdir(resolvedStateDirectory, { recursive: true, mode: 0o700 });
+  if ((await readdir(resolvedStateDirectory)).length !== 0) {
+    throw new Error("Benchmark state directory must be empty");
+  }
+  const synthetic = codexHome === null;
+  const resolvedCodexHome = synthetic ? null : resolve(codexHome);
+  const parsedEndAt = Date.parse(accountingWindow.endAt);
+  const paths = {
+    indexFile: join(resolvedStateDirectory, "local-unified-index-v1.sqlite"),
+    secretFile: join(
+      resolvedStateDirectory,
+      "local-unified-index-device-salt-v1",
+    ),
+    accountingStateFile: join(
+      resolvedStateDirectory,
+      "local-collector-state-v1.sqlite",
+    ),
+    legacyAnalysisFile: join(
+      resolvedStateDirectory,
+      "local-analysis-index-v2.sqlite",
+    ),
+    legacyAnalysisSecretFile: join(
+      resolvedStateDirectory,
+      "local-analysis-index-secret-v2",
+    ),
+    legacyArchiveFile: join(
+      resolvedStateDirectory,
+      "local-archive-accounting-index-v1.sqlite",
+    ),
+    legacyArchiveSecretFile: join(
+      resolvedStateDirectory,
+      "local-archive-accounting-index-v1-secret",
+    ),
+  };
+  const corpus = synthetic
+    ? await createSyntheticLocalIndexRetirementCorpus(resolvedStateDirectory)
+    : { codexHome: resolvedCodexHome, firstSource: null, secondSource: null };
+  const legacySentinelContents = {
+    analysis: Buffer.from("legacy-analysis-index-sentinel\n", "utf8"),
+    secret: Buffer.from("legacy-analysis-secret-sentinel\n", "utf8"),
+  };
+  const legacySentinelBefore = seedLegacySentinels
+    ? {
+      analysis: await (async () => {
+        await writeFile(
+          paths.legacyAnalysisFile,
+          legacySentinelContents.analysis,
+          { mode: 0o600 },
+        );
+        return contentMetadataSnapshot(paths.legacyAnalysisFile);
+      })(),
+      secret: await (async () => {
+        await writeFile(
+          paths.legacyAnalysisSecretFile,
+          legacySentinelContents.secret,
+          { mode: 0o600 },
+        );
+        return contentMetadataSnapshot(paths.legacyAnalysisSecretFile);
+      })(),
+    }
+    : null;
+  const benchmarkState = {
+    phaseMs: {},
+    peakRssBytes: process.memoryUsage.rss(),
+    maxPhaseMs: synthetic
+      ? LOCAL_INDEX_RETIREMENT_BENCHMARK_LIMITS.maxPhaseMs
+      : null,
+  };
+  const initialRssBytes = benchmarkState.peakRssBytes;
+  const started = performance.now();
+  const cold = await phaseMeasure("coldRebuild", () => rebuildLocalUnifiedIndex({
+    codexHome: corpus.codexHome,
+    indexFile: paths.indexFile,
+    secretFile: paths.secretFile,
+    startAt: accountingWindow.startAt,
+    endAt: accountingWindow.endAt,
+    contractVersion: LOCAL_INDEX_RETIREMENT_BENCHMARK_CONTRACT,
+    workerCount,
+  }), benchmarkState);
+  if (cold.status !== "built" || cold.generation?.status !== "complete") {
+    throw new Error("benchmark_cold_rebuild_incomplete");
+  }
+  const initialIndex = await inspectLocalUnifiedIndex({
+    indexFile: paths.indexFile,
+  });
+  const coldGeneration = cold.generation;
+  const accountingCounters = {
+    usageCallbacks: 0,
+    quotaCallbacks: 0,
+  };
+  const unifiedAccountingScan = (generation) => countedScanner(
+    createLocalUnifiedAccountingSource({
+      indexFile: paths.indexFile,
+      requireComplete: true,
+      expectedGeneration: generation,
+      contextBehavior: "legacy_zero",
+    }),
+    accountingCounters,
+  );
+  const cache = await phaseMeasure("unifiedAccountingCache", () => (
+    refreshReplaySafeAccountingCache({
+      stateFile: paths.accountingStateFile,
+      codexHome: corpus.codexHome,
+      sourceMode: "unified",
+      scan: unifiedAccountingScan(coldGeneration),
+      unifiedIndexFile: paths.indexFile,
+      expectedGeneration: coldGeneration,
+      contextBehavior: "legacy_zero",
+      now: () => parsedEndAt,
+      windowDays: accountingWindow.durationDays,
+    })
+  ), benchmarkState);
+  if (cache.status === "accounting_rebuild_deferred"
+      || cache.weeklyCalibrationInput?.source !== "unified_index") {
+    throw new Error("benchmark_unified_cache_not_folded");
+  }
+  const companion = await phaseMeasure("unifiedCompanionSnapshot", () => (
+    buildLocalCompanionSnapshot({
+      root: resolvedStateDirectory,
+      collectorStateFile: paths.accountingStateFile,
+      archiveIndexFile: paths.legacyArchiveFile,
+      accountingSourceMode: "unified",
+      unifiedIndexFile: paths.indexFile,
+      now: () => parsedEndAt,
+    })
+  ), benchmarkState);
+  if (companion.overview?.timeline?.source !== "unified_local_index"
+      || companion.overview?.timeline?.history?.status !== "complete") {
+    throw new Error("benchmark_unified_companion_not_complete");
+  }
+
+  const beforeNoChange = await metadataSnapshot(paths.indexFile);
+  const noChange = await phaseMeasure("noChangeIngest", () => (
+    ingestLocalUnifiedIndexIncrement({
+      codexHome: corpus.codexHome,
+      indexFile: paths.indexFile,
+      secretFile: paths.secretFile,
+      startAt: accountingWindow.startAt,
+      endAt: accountingWindow.endAt,
+      contractVersion: LOCAL_INDEX_RETIREMENT_BENCHMARK_CONTRACT,
+    })
+  ), benchmarkState);
+  const afterNoChange = await metadataSnapshot(paths.indexFile);
+  if (noChange.unchanged !== true
+      || noChange.bytesScanned !== 0
+      || afterNoChange.size !== beforeNoChange.size
+      || afterNoChange.mtimeMs !== beforeNoChange.mtimeMs) {
+    throw new Error("benchmark_no_change_ingest_mutated_index");
+  }
+
+  let appendedBytes = 0;
+  let appendIngest;
+  let postAppendGeneration = coldGeneration;
+  if (synthetic) {
+    const appendedText = `${tokenCount(
+      "2026-08-01T12:03:00.000Z",
+      usage(680, 75),
+      usage(180, 20),
+    )}\n`;
+    await appendFile(corpus.secondSource, appendedText, { mode: 0o600 });
+    appendedBytes = Buffer.byteLength(appendedText);
+    appendIngest = await phaseMeasure("appendIngest", () => (
+      ingestLocalUnifiedIndexIncrement({
+        codexHome: corpus.codexHome,
+        indexFile: paths.indexFile,
+        secretFile: paths.secretFile,
+        startAt: accountingWindow.startAt,
+        endAt: accountingWindow.endAt,
+        contractVersion: LOCAL_INDEX_RETIREMENT_BENCHMARK_CONTRACT,
+      })
+    ), benchmarkState);
+    if (appendIngest.sourcesResumed !== 1
+        || appendIngest.bytesScanned !== appendedBytes
+        || appendIngest.insertedUsageEvents < 1) {
+      throw new Error("benchmark_append_ingest_incomplete");
+    }
+    postAppendGeneration = appendIngest.generation;
+    if (postAppendGeneration?.fingerprint === coldGeneration.fingerprint) {
+      throw new Error("benchmark_generation_did_not_advance");
+    }
+  } else {
+    // A real corpus is never mutated by this benchmark. The no-change
+    // incremental pass above is the safe increment qualification; an append
+    // pass is retained for the tiny synthetic CI fixture only.
+    appendIngest = {
+      status: "not_run",
+      reason: "real_corpus_is_read_only",
+      sourcesResumed: 0,
+      bytesScanned: 0,
+      insertedUsageEvents: 0,
+    };
+  }
+  const staleCache = await phaseMeasure("staleCacheGenerationCheck", () => (
+    readReplaySafeAccountingCache({
+      stateFile: paths.accountingStateFile,
+      now: () => parsedEndAt,
+      sourceMode: "unified",
+      expectedGeneration: postAppendGeneration,
+      contextBehavior: "legacy_zero",
+    })
+  ), benchmarkState);
+  if (synthetic && staleCache.status === "available") {
+    throw new Error("benchmark_stale_cache_was_not_rejected");
+  }
+  if (!synthetic && staleCache.status !== "available") {
+    throw new Error("benchmark_real_cache_was_not_reusable");
+  }
+  const postAppendCache = await phaseMeasure(
+    "unifiedAccountingCacheAfterAppend",
+    () => refreshReplaySafeAccountingCache({
+      stateFile: paths.accountingStateFile,
+      codexHome: corpus.codexHome,
+      sourceMode: "unified",
+      scan: unifiedAccountingScan(postAppendGeneration),
+      unifiedIndexFile: paths.indexFile,
+      expectedGeneration: postAppendGeneration,
+      contextBehavior: "legacy_zero",
+      now: () => parsedEndAt,
+      windowDays: accountingWindow.durationDays,
+    }),
+    benchmarkState,
+  );
+  if (postAppendCache.status === "accounting_rebuild_deferred"
+      || postAppendCache.weeklyCalibrationInput?.source !== "unified_index") {
+    throw new Error("benchmark_unified_append_cache_not_folded");
+  }
+  const relaunchedCache = await phaseMeasure("cacheRelaunchRead", () => (
+    readReplaySafeAccountingCache({
+      stateFile: paths.accountingStateFile,
+      now: () => parsedEndAt,
+      sourceMode: "unified",
+      expectedGeneration: postAppendGeneration,
+      contextBehavior: "legacy_zero",
+    })
+  ), benchmarkState);
+  if (relaunchedCache.status !== "available"
+      || relaunchedCache.cache?.sourceDescriptor?.mode !== "unified"
+      || relaunchedCache.cache?.weeklyCalibrationInput?.source
+        !== "unified_index") {
+    throw new Error("benchmark_cache_relaunch_validation_failed");
+  }
+  const postAppendCompanion = await phaseMeasure(
+    "unifiedCompanionSnapshotAfterAppend",
+    () => buildLocalCompanionSnapshot({
+      root: resolvedStateDirectory,
+      collectorStateFile: paths.accountingStateFile,
+      archiveIndexFile: paths.legacyArchiveFile,
+      accountingSourceMode: "unified",
+      unifiedIndexFile: paths.indexFile,
+      now: () => parsedEndAt,
+    }),
+    benchmarkState,
+  );
+  if (postAppendCompanion.overview?.timeline?.source
+      !== "unified_local_index"
+      || postAppendCompanion.overview?.timeline?.history?.status
+        !== "complete") {
+    throw new Error("benchmark_unified_companion_after_append_incomplete");
+  }
+  const finalIndex = await inspectLocalUnifiedIndex({
+    indexFile: paths.indexFile,
+  });
+  const finalDatabase = openLocalUnifiedIndex(paths.indexFile, {
+    readOnly: true,
+  });
+  let finalGeneration;
+  try {
+    finalGeneration = readUnifiedIndexGenerationDescriptor(finalDatabase);
+  } finally {
+    finalDatabase.close();
+  }
+  if (finalGeneration?.status !== "complete"
+      || finalGeneration?.id !== postAppendGeneration?.id) {
+    throw new Error("benchmark_final_generation_invalid");
+  }
+  const legacyPathsAbsent = await Promise.all([
+    missing(paths.legacyAnalysisFile),
+    missing(paths.legacyAnalysisSecretFile),
+    missing(paths.legacyArchiveFile),
+    missing(paths.legacyArchiveSecretFile),
+  ]);
+  const legacyArchiveFilesAbsent = legacyPathsAbsent.slice(2).every(Boolean);
+  const legacyAnalysisFilesPresent = legacyPathsAbsent.slice(0, 2)
+    .every((value) => value === false);
+  const legacyAnalysisSentinelsUnchanged = seedLegacySentinels
+    ? await Promise.all([
+      unchangedContentMetadata(
+        legacySentinelBefore.analysis,
+        paths.legacyAnalysisFile,
+      ),
+      unchangedContentMetadata(
+        legacySentinelBefore.secret,
+        paths.legacyAnalysisSecretFile,
+      ),
+    ]).then((values) => values.every(Boolean))
+    : true;
+  if (!legacyArchiveFilesAbsent
+      || (seedLegacySentinels
+        ? !legacyAnalysisFilesPresent || !legacyAnalysisSentinelsUnchanged
+        : !legacyPathsAbsent.every(Boolean))) {
+    throw new Error("benchmark_legacy_state_touched_in_unified_mode");
+  }
+  const legacyState = {
+    analysisSentinelsSeeded: seedLegacySentinels,
+    analysisSentinelsPresentAfter: legacyAnalysisFilesPresent,
+    analysisSentinelsUnchanged: legacyAnalysisSentinelsUnchanged,
+    archiveFilesAbsentAfter: legacyArchiveFilesAbsent,
+  };
+  const diskBytes = await directoryBytes(resolvedStateDirectory);
+  const totalMs = performance.now() - started;
+  const coldSourceBytes = safeCount(
+    cold.sourceBytes
+      ?? initialIndex.lastScan?.bytes
+      ?? 0,
+    "cold_source_bytes",
+  );
+  const finalSourceBytes = safeCount(
+    finalGeneration.indexedSourceBytes
+      ?? coldSourceBytes
+      ?? 0,
+    "final_source_bytes",
+  );
+  const rssDeltaBytes = Math.max(0, benchmarkState.peakRssBytes - initialRssBytes);
+  const counts = {
+    sourceCount: safeCount(finalGeneration.indexedSourceCount, "source_count"),
+    sourceBytes: finalSourceBytes,
+    coldSourceBytes,
+    finalSourceBytes,
+    usageEvents: safeCount(
+      finalGeneration.usageEvents ?? finalIndex.usageEvents,
+      "usage_events",
+    ),
+    quotaOccurrences: safeCount(
+      finalGeneration.quotaOccurrences ?? 0,
+      "quota_occurrences",
+    ),
+    quotaObservations: safeCount(
+      finalIndex.quotaObservations,
+      "quota_observations",
+    ),
+    usageCallbacks: safeCount(
+      accountingCounters.usageCallbacks,
+      "usage_callbacks",
+    ),
+    quotaCallbacks: safeCount(
+      accountingCounters.quotaCallbacks,
+      "quota_callbacks",
+    ),
+    totalCallbacks: safeCount(
+      accountingCounters.usageCallbacks + accountingCounters.quotaCallbacks,
+      "total_callbacks",
+    ),
+    usageFacts: safeCount(finalIndex.usageEvents, "usage_facts"),
+    quotaFacts: safeCount(finalIndex.quotaObservations, "quota_facts"),
+    indexedFacts: safeCount(
+      finalIndex.usageEvents + finalIndex.quotaObservations,
+      "indexed_facts",
+    ),
+  };
+  const diskBytesCount = safeCount(diskBytes, "disk_bytes");
+  const rssDeltaCount = safeCount(rssDeltaBytes, "rss_delta_bytes");
+  if (synthetic) {
+    assertBounded(totalMs, LOCAL_INDEX_RETIREMENT_BENCHMARK_LIMITS.maxTotalMs, "total_ms");
+    assertBounded(rssDeltaCount, LOCAL_INDEX_RETIREMENT_BENCHMARK_LIMITS.maxRssDeltaBytes, "rss_delta_bytes");
+    assertBounded(diskBytesCount, LOCAL_INDEX_RETIREMENT_BENCHMARK_LIMITS.maxDiskBytes, "disk_bytes");
+    assertBounded(coldSourceBytes, LOCAL_INDEX_RETIREMENT_BENCHMARK_LIMITS.maxSourceBytes, "cold_source_bytes");
+    assertBounded(finalSourceBytes, LOCAL_INDEX_RETIREMENT_BENCHMARK_LIMITS.maxSourceBytes, "final_source_bytes");
+    for (const [name, value] of Object.entries(benchmarkState.phaseMs)) {
+      assertBounded(value, LOCAL_INDEX_RETIREMENT_BENCHMARK_LIMITS.maxPhaseMs, name);
+    }
+  }
+  const receipt = {
+    schemaVersion: LOCAL_INDEX_RETIREMENT_BENCHMARK_VERSION,
+    synthetic,
+    node: process.version,
+    workerCount,
+    accountingWindow,
+    sourceCount: counts.sourceCount,
+    usageEvents: counts.usageEvents,
+    sourceBytes: coldSourceBytes,
+    finalSourceBytes,
+    appendedBytes,
+    indexBytes: safeCount(finalIndex.indexBytes, "index_bytes"),
+    diskBytes: diskBytesCount,
+    rssDeltaBytes: rssDeltaCount,
+    peakRssBytes: safeCount(benchmarkState.peakRssBytes, "peak_rss_bytes"),
+    counts,
+    timings: {
+      ...benchmarkState.phaseMs,
+      totalMs: Number(totalMs.toFixed(3)),
+    },
+    generations: {
+      cold: {
+        id: coldGeneration.id,
+        fingerprint: coldGeneration.fingerprint,
+        status: coldGeneration.status,
+      },
+      append: {
+        id: postAppendGeneration.id,
+        fingerprint: postAppendGeneration.fingerprint,
+        status: postAppendGeneration.status,
+      },
+    },
+    accounting: {
+      sourceMode: postAppendCache.sourceDescriptor.mode,
+      contextBehavior: postAppendCache.sourceDescriptor.contextBehavior,
+      weeklyCalibrationSource: postAppendCache.weeklyCalibrationInput.source,
+      retainedUsageEvents: postAppendCache.weeklyCalibrationInput.retainedUsageEvents,
+      staleGenerationStatus: staleCache.status,
+      relaunchedStatus: relaunchedCache.status,
+    },
+    companion: {
+      timelineSource: postAppendCompanion.overview.timeline.source,
+      historyStatus: postAppendCompanion.overview.timeline.history.status,
+      historyUsageEvents: postAppendCompanion.overview.timeline.history.usageEvents,
+    },
+    noChange: {
+      unchanged: noChange.unchanged === true,
+      bytesScanned: noChange.bytesScanned,
+      sizeUnchanged: afterNoChange.size === beforeNoChange.size,
+      mtimeUnchanged: afterNoChange.mtimeMs === beforeNoChange.mtimeMs,
+    },
+    append: {
+      status: appendIngest.status ?? "complete",
+      ...(appendIngest.reason === undefined ? {} : { reason: appendIngest.reason }),
+      sourcesResumed: appendIngest.sourcesResumed,
+      bytesScanned: appendIngest.bytesScanned,
+      insertedUsageEvents: appendIngest.insertedUsageEvents,
+    },
+    legacyPathsAbsent: legacyPathsAbsent.every(Boolean),
+    legacyState,
+  };
+  return {
+    receipt,
+    codexHome: corpus.codexHome,
+  };
+}
+
+async function runLegacyComparison({
+  stateDirectory,
+  codexHome,
+  startAt,
+  endAt,
+  synthetic,
+  workerCount = 1,
+}) {
+  const accountingWindow = deriveSupportedAccountingWindow(startAt, endAt);
+  const resolvedStateDirectory = resolve(stateDirectory);
+  await mkdir(resolvedStateDirectory, { recursive: true, mode: 0o700 });
+  if ((await readdir(resolvedStateDirectory)).length !== 0) {
+    throw new Error("Legacy comparison state directory must be empty");
+  }
+  const indexFile = join(
+    resolvedStateDirectory,
+    "local-analysis-index-v2.sqlite",
+  );
+  const indexSecretFile = join(
+    resolvedStateDirectory,
+    "local-analysis-index-secret-v2",
+  );
+  const stateFile = join(
+    resolvedStateDirectory,
+    "local-collector-state-v1.sqlite",
+  );
+  const counters = { usageCallbacks: 0, quotaCallbacks: 0 };
+  const benchmarkState = {
+    phaseMs: {},
+    peakRssBytes: process.memoryUsage.rss(),
+    maxPhaseMs: synthetic
+      ? LOCAL_INDEX_RETIREMENT_BENCHMARK_LIMITS.maxPhaseMs
+      : null,
+  };
+  const initialRssBytes = benchmarkState.peakRssBytes;
+  const started = performance.now();
+  const cache = await phaseMeasure("legacyAccountingCache", () => (
+    refreshReplaySafeAccountingCache({
+      stateFile,
+      codexHome,
+      sourceMode: "legacy",
+      scan: countedScanner(
+        createIndexedCodexLogScan({
+          indexFile,
+          secretFile: indexSecretFile,
+          workerCount,
+        }),
+        counters,
+      ),
+      indexFile,
+      indexSecretFile,
+      now: () => Date.parse(accountingWindow.endAt),
+      windowDays: accountingWindow.durationDays,
+    })
+  ), benchmarkState);
+  const index = await inspectLocalAnalysisIndex({ indexFile });
+  const diskBytes = await directoryBytes(resolvedStateDirectory);
+  const totalMs = performance.now() - started;
+  const counts = {
+    sourceCount: safeCount(index.sourceCount, "legacy_source_count"),
+    sourceBytes: safeCount(index.lastScan?.bytes, "legacy_source_bytes"),
+    usageEvents: safeCount(index.usageFacts, "legacy_usage_events"),
+    quotaOccurrences: safeCount(index.quotaFacts, "legacy_quota_occurrences"),
+    quotaObservations: safeCount(index.quotaFacts, "legacy_quota_observations"),
+    usageCallbacks: safeCount(counters.usageCallbacks, "legacy_usage_callbacks"),
+    quotaCallbacks: safeCount(counters.quotaCallbacks, "legacy_quota_callbacks"),
+    totalCallbacks: safeCount(
+      counters.usageCallbacks + counters.quotaCallbacks,
+      "legacy_total_callbacks",
+    ),
+    usageFacts: safeCount(index.usageFacts, "legacy_usage_facts"),
+    quotaFacts: safeCount(index.quotaFacts, "legacy_quota_facts"),
+    indexedFacts: safeCount(
+      index.usageFacts + index.quotaFacts,
+      "legacy_indexed_facts",
+    ),
+  };
+  const rssDeltaBytes = Math.max(
+    0,
+    benchmarkState.peakRssBytes - initialRssBytes,
+  );
+  if (synthetic) {
+    assertBounded(totalMs, LOCAL_INDEX_RETIREMENT_BENCHMARK_LIMITS.maxTotalMs, "legacy_total_ms");
+    assertBounded(rssDeltaBytes, LOCAL_INDEX_RETIREMENT_BENCHMARK_LIMITS.maxRssDeltaBytes, "legacy_rss_delta_bytes");
+    assertBounded(diskBytes, LOCAL_INDEX_RETIREMENT_BENCHMARK_LIMITS.maxDiskBytes, "legacy_disk_bytes");
+    assertBounded(counts.sourceBytes, LOCAL_INDEX_RETIREMENT_BENCHMARK_LIMITS.maxSourceBytes, "legacy_source_bytes");
+    for (const [name, value] of Object.entries(benchmarkState.phaseMs)) {
+      assertBounded(value, LOCAL_INDEX_RETIREMENT_BENCHMARK_LIMITS.maxPhaseMs, `legacy_${name}`);
+    }
+  }
+  return {
+    schemaVersion: "local-index-retirement-legacy-comparison-v2",
+    mode: "legacy",
+    selection: "explicit",
+    node: process.version,
+    workerCount,
+    accountingWindow,
+    sourceCount: counts.sourceCount,
+    sourceBytes: counts.sourceBytes,
+    usageEvents: counts.usageEvents,
+    quotaObservations: counts.quotaObservations,
+    quotaFacts: counts.quotaFacts,
+    indexBytes: safeCount(index.indexBytes, "legacy_index_bytes"),
+    diskBytes: safeCount(diskBytes, "legacy_disk_bytes"),
+    rssDeltaBytes: safeCount(rssDeltaBytes, "legacy_rss_delta_bytes"),
+    counts,
+    timings: {
+      ...benchmarkState.phaseMs,
+      totalMs: rounded(totalMs),
+    },
+    accounting: {
+      sourceMode: cache.sourceDescriptor?.mode ?? "legacy",
+      weeklyStatus: cache.weeklyCalibration?.status ?? null,
+    },
+  };
+}
+
+export async function runLocalIndexRetirementQualification({
+  stateDirectory,
+  codexHome = null,
+  startAt = LOCAL_INDEX_RETIREMENT_BENCHMARK_START_AT,
+  endAt = LOCAL_INDEX_RETIREMENT_BENCHMARK_END_AT,
+  runs = 1,
+  workerCount = 1,
+  compareLegacy = false,
+  seedLegacySentinels = false,
+} = {}) {
+  if (typeof stateDirectory !== "string" || stateDirectory.length < 1) {
+    throw new TypeError("stateDirectory must be a non-empty path");
+  }
+  if (codexHome !== null
+      && (typeof codexHome !== "string" || codexHome.length < 1)) {
+    throw new TypeError("codexHome must be a non-empty path or null");
+  }
+  if (!Number.isSafeInteger(runs) || runs < 1 || runs > 20) {
+    throw new TypeError("runs must be an integer from 1 through 20");
+  }
+  if (!Number.isSafeInteger(workerCount) || workerCount < 1 || workerCount > 10) {
+    throw new TypeError("workerCount must be an integer from 1 through 10");
+  }
+  if (typeof compareLegacy !== "boolean"
+      || typeof seedLegacySentinels !== "boolean") {
+    throw new TypeError("benchmark flags must be booleans");
+  }
+  const accountingWindow = deriveSupportedAccountingWindow(startAt, endAt);
+  const resolvedStateDirectory = resolve(stateDirectory);
+  await mkdir(resolvedStateDirectory, { recursive: true, mode: 0o700 });
+  if ((await readdir(resolvedStateDirectory)).length !== 0) {
+    throw new Error("Benchmark state directory must be empty");
+  }
+  const runResults = [];
+  for (let index = 0; index < runs; index += 1) {
+    const runStateDirectory = runs === 1
+      ? resolvedStateDirectory
+      : join(resolvedStateDirectory, `unified-run-${index + 1}`);
+    runResults.push(await runSingleLocalIndexRetirementQualification({
+      stateDirectory: runStateDirectory,
+      codexHome,
+      startAt: accountingWindow.startAt,
+      endAt: accountingWindow.endAt,
+      seedLegacySentinels,
+      workerCount,
+    }));
+  }
+  const receipts = runResults.map((result) => result.receipt);
+  const legacyResults = [];
+  if (compareLegacy) {
+    for (let index = 0; index < runs; index += 1) {
+      const legacyResult = await runLegacyComparison({
+        stateDirectory: join(resolvedStateDirectory, `legacy-run-${index + 1}`),
+        codexHome: runResults[index].codexHome,
+        startAt: accountingWindow.startAt,
+        endAt: accountingWindow.endAt,
+        synthetic: codexHome === null,
+        workerCount,
+      });
+      if (legacyResult.workerCount !== workerCount
+          || legacyResult.accountingWindow.startAt !== accountingWindow.startAt
+          || legacyResult.accountingWindow.endAt !== accountingWindow.endAt
+          || legacyResult.accountingWindow.durationDays
+            !== accountingWindow.durationDays) {
+        throw new Error("benchmark_legacy_parity_window_mismatch");
+      }
+      legacyResults.push(legacyResult);
+    }
+  }
+  const representative = receipts[0];
+  return {
+    ...representative,
+    runCount: receipts.length,
+    statistics: summarizeRunReceipts(receipts),
+    runs: receipts,
+    legacyComparison: compareLegacy
+      ? {
+        mode: "legacy",
+        selection: "explicit",
+        accountingWindow,
+        invocation: {
+          unifiedCommandTemplate:
+            "node scripts/benchmark-local-index-retirement.mjs --codex-home <codex-home> --state <empty-state> --start-at <ISO> --end-at <ISO> --runs <RUNS> --workers <WORKERS> --compare-legacy",
+          legacyCommandTemplate:
+            "node scripts/benchmark-local-analysis-pipeline.mjs --codex-home <codex-home> --state <empty-state> --start-at <ISO> --end-at <ISO> --workers <WORKERS>",
+        },
+        runCount: legacyResults.length,
+        statistics: summarizeRunReceipts(legacyResults),
+        runs: legacyResults,
+      }
+      : null,
+  };
+}
+
+function parseOptions(argv) {
+  const options = {
+    stateDirectory: null,
+    codexHome: null,
+    startAt: LOCAL_INDEX_RETIREMENT_BENCHMARK_START_AT,
+    endAt: LOCAL_INDEX_RETIREMENT_BENCHMARK_END_AT,
+    runs: 1,
+    workerCount: 1,
+    compareLegacy: false,
+    seedLegacySentinels: false,
+  };
+  for (let index = 0; index < argv.length;) {
+    const name = argv[index];
+    if (name === "--compare-legacy" || name === "--seed-legacy-sentinels") {
+      options[name === "--compare-legacy"
+        ? "compareLegacy"
+        : "seedLegacySentinels"] = true;
+      index += 1;
+      continue;
+    }
+    const value = argv[index + 1];
+    if (value === undefined) throw new TypeError(`${name} needs a value`);
+    if (name === "--state") options.stateDirectory = resolve(value);
+    else if (name === "--codex-home") options.codexHome = resolve(value);
+    else if (name === "--start-at") options.startAt = value;
+    else if (name === "--end-at") options.endAt = value;
+    else if (name === "--runs") options.runs = Number(value);
+    else if (name === "--workers") options.workerCount = Number(value);
+    else throw new TypeError(`Unknown option: ${name}`);
+    index += 2;
+  }
+  if (options.stateDirectory === null) {
+    throw new TypeError(
+      "Required: --state EMPTY_DIR [--codex-home CODEX_HOME] "
+      + "[--start-at ISO] [--end-at ISO] [--runs N] "
+      + "[--workers N] [--compare-legacy] [--seed-legacy-sentinels]",
+    );
+  }
+  return options;
+}
+
+const isMain = process.argv[1] !== undefined
+  && resolve(process.argv[1]) === resolve(fileURLToPath(import.meta.url));
+if (isMain) {
+  const options = parseOptions(process.argv.slice(2));
+  const receipt = await runLocalIndexRetirementQualification(options);
+  process.stdout.write(`${JSON.stringify(receipt)}\n`);
+}

--- a/scripts/export-tibotattle.mjs
+++ b/scripts/export-tibotattle.mjs
@@ -196,6 +196,7 @@ export const CLIENT_RUNTIME_FILES = Object.freeze([
   "src/local-installation-diagnostics.js",
   "src/local-companion-usage-model.js",
   "src/local-legacy-report-storage.js",
+  "src/local-unified-accounting-source.js",
   "src/local-unified-companion-source.js",
   // Reviewed 2026-08-10: pure windowed repricing over the local index for
   // the divergence panel's per-period cost mix — no content, paths, or

--- a/src/local-accounting-parity-receipt.js
+++ b/src/local-accounting-parity-receipt.js
@@ -1,0 +1,613 @@
+import { createHmac } from "node:crypto";
+
+import { isValidQuotaWindowDuration } from "@app-usagemonitor/quota-analysis";
+
+import {
+  COMPONENT_KEYS,
+  KNOWN_AGENT_SCOPES,
+  KNOWN_API_TIERS,
+  KNOWN_LINEAGE,
+  KNOWN_LIMITS,
+  KNOWN_PLANS,
+  KNOWN_SLOTS,
+  KNOWN_SPEEDS,
+  KNOWN_SURFACES,
+} from "./local-companion-usage-model.js";
+import { recognizedCodexModelId } from "./export/index.js";
+import { validAbortSignal } from "./valid-abort-signal.js";
+
+// This receipt is deliberately a content-free, pre-calibration callback
+// characterization boundary. It records only normalized usage/quota callback
+// inputs; it is not a pricing, declared-speed, or final-accounting proof.
+// Keyed multiset checksums make the result useful for comparing two scanners
+// without retaining their rows or source identifiers.
+export const LOCAL_ACCOUNTING_PARITY_RECEIPT_VERSION =
+  "local-accounting-semantic-receipt-v1";
+export const LOCAL_ACCOUNTING_PARITY_RECEIPT_SCOPE =
+  "pre_calibration_callback_semantics";
+export const LOCAL_ACCOUNTING_PARITY_RECEIPT_SCOPE_VERSION = "v1";
+
+export const LOCAL_ACCOUNTING_PARITY_MISMATCH_CATEGORIES = Object.freeze([
+  "receipt_schema",
+  "window",
+  "usage_count",
+  "usage_tokens",
+  "usage_components",
+  "usage_digest",
+  "usage_dimensions",
+  "quota_count",
+  "quota_digest",
+  "quota_dimensions",
+]);
+
+const ERROR_CODES = Object.freeze({
+  options: "accounting_parity_options_invalid",
+  window: "accounting_parity_window_invalid",
+  byteKey: "accounting_parity_byte_key_invalid",
+  signal: "accounting_parity_signal_invalid",
+  scanner: "accounting_parity_scanner_invalid",
+  usage: "accounting_parity_usage_callback_invalid",
+  quota: "accounting_parity_quota_callback_invalid",
+  aborted: "accounting_parity_aborted",
+  scan: "accounting_parity_scan_failed",
+  receipt: "accounting_parity_receipt_invalid",
+  overflow: "accounting_parity_total_overflow",
+});
+const PARITY_ERROR = Symbol("local-accounting-parity-error");
+
+const DIGEST_PATTERN = /^hmac-sha256-multiset-v1:[0-9a-f]{64}:[0-9a-f]{64}$/u;
+const MODULUS = 1n << 256n;
+
+const USAGE_DIMENSIONS = Object.freeze([
+  "model",
+  "speed",
+  "apiServiceTier",
+  "surface",
+  "agentScope",
+  "lineage",
+]);
+const QUOTA_DIMENSIONS = Object.freeze([
+  "provider",
+  "planType",
+  "limitId",
+  "slot",
+  "durationMinutes",
+]);
+const KNOWN_PROVIDERS = new Set(["openai_codex", "unknown"]);
+
+function fixedError(code, name = "Error") {
+  const error = new Error(code);
+  error.name = name;
+  error.code = code;
+  error[PARITY_ERROR] = true;
+  return error;
+}
+
+function isParityError(error) {
+  return error?.[PARITY_ERROR] === true;
+}
+
+function canonicalInstant(value) {
+  if (typeof value !== "string") return null;
+  const timestamp = Date.parse(value);
+  return Number.isFinite(timestamp)
+    && new Date(timestamp).toISOString() === value
+    ? value
+    : null;
+}
+
+function validateWindow(startAt, endAt) {
+  const start = canonicalInstant(startAt);
+  const end = canonicalInstant(endAt);
+  if (start === null || end === null || Date.parse(start) > Date.parse(end)) {
+    throw fixedError(ERROR_CODES.window, "TypeError");
+  }
+  return { startAt: start, endAt: end };
+}
+
+function validateByteKey(value) {
+  if (!(value instanceof Uint8Array)
+      || value.byteLength < 32
+      || value.byteLength > 256) {
+    throw fixedError(ERROR_CODES.byteKey, "TypeError");
+  }
+  return Buffer.from(value);
+}
+
+function throwIfAborted(signal) {
+  if (!signal?.aborted) return;
+  throw fixedError(ERROR_CODES.aborted, "AbortError");
+}
+
+function isPlainObject(value) {
+  return value !== null
+    && typeof value === "object"
+    && !Array.isArray(value);
+}
+
+function closedEnum(value, allowed) {
+  return allowed.has(value) ? value : "unknown";
+}
+
+function closedModel(value) {
+  return recognizedCodexModelId(value) ?? "unknown";
+}
+
+function nonNegativeSafeInteger(value) {
+  return Number.isSafeInteger(value) && value >= 0;
+}
+
+function checkedAdd(left, right) {
+  const result = left + right;
+  if (!Number.isSafeInteger(result)) {
+    throw fixedError(ERROR_CODES.overflow);
+  }
+  return result;
+}
+
+function componentTotals() {
+  return Object.fromEntries(COMPONENT_KEYS.map((key) => [key, 0]));
+}
+
+function normalizeUsage(raw) {
+  if (!isPlainObject(raw)
+      || typeof raw.model !== "string"
+      || !isPlainObject(raw.components)) {
+    throw fixedError(ERROR_CODES.usage);
+  }
+  const timestamp = canonicalInstant(raw.timestamp);
+  if (timestamp === null) throw fixedError(ERROR_CODES.usage);
+
+  const components = {};
+  for (const key of COMPONENT_KEYS) {
+    const value = raw.components[key];
+    if (value !== undefined && !nonNegativeSafeInteger(value)) {
+      throw fixedError(ERROR_CODES.usage);
+    }
+    // The legacy indexed reader omits the combined-output alias. Replay-safe
+    // accounting's component normalizer treats that omission as zero.
+    components[key] = value ?? 0;
+  }
+
+  // Preserve the distinction between a reported zero and an omitted database
+  // value. The replay pricer uses input components when this field is absent,
+  // so normalizing absence to zero can silently change long-context pricing.
+  const totalInputContextTokens = raw.totalInputContextTokens === undefined
+    || raw.totalInputContextTokens === null
+    ? null
+    : raw.totalInputContextTokens;
+  if (totalInputContextTokens !== null
+      && !nonNegativeSafeInteger(totalInputContextTokens)) {
+    throw fixedError(ERROR_CODES.usage);
+  }
+
+  const tier = raw.tierSemantics;
+  const surface = raw.surfaceClassification;
+  if (tier !== undefined && !isPlainObject(tier)) {
+    throw fixedError(ERROR_CODES.usage);
+  }
+  if (surface !== undefined && !isPlainObject(surface)) {
+    throw fixedError(ERROR_CODES.usage);
+  }
+
+  const projection = {
+    timestamp,
+    model: closedModel(raw.model),
+    totalInputContextTokens,
+    components,
+    speed: closedEnum(tier?.codexSpeedMode, KNOWN_SPEEDS),
+    apiServiceTier: closedEnum(tier?.apiServiceTier, KNOWN_API_TIERS),
+    surface: closedEnum(surface?.surface, KNOWN_SURFACES),
+    agentScope: closedEnum(surface?.agentScope, KNOWN_AGENT_SCOPES),
+    lineage: closedEnum(
+      surface?.lineageDisposition,
+      KNOWN_LINEAGE,
+    ),
+  };
+  const inputTokens = components.input_uncached_tokens
+    + components.input_cache_read_tokens
+    + components.input_cache_write_tokens;
+  const separatedOutput = components.output_text_tokens
+    + components.output_reasoning_tokens;
+  // Mirror eventProjection: a non-empty separated output split is more
+  // informative than the overlapping combined alias.
+  if (components.output_combined_tokens > 0 && separatedOutput > 0) {
+    components.output_combined_tokens = 0;
+  }
+  const outputTokens = separatedOutput > 0
+    ? separatedOutput
+    : components.output_combined_tokens;
+  projection.totalTokens = checkedAdd(inputTokens, outputTokens);
+  return projection;
+}
+
+function normalizeQuota(raw) {
+  if (!isPlainObject(raw) || typeof raw.timestamp !== "string") {
+    throw fixedError(ERROR_CODES.quota);
+  }
+  const timestamp = canonicalInstant(raw.timestamp);
+  const window = raw.window;
+  if (timestamp === null || !isPlainObject(window)) {
+    throw fixedError(ERROR_CODES.quota);
+  }
+  const durationMinutes = window.windowDurationMins;
+  const resetsAt = window.resetsAt;
+  const usedPercent = window.usedPercent;
+  if (!Number.isSafeInteger(durationMinutes)
+      || !isValidQuotaWindowDuration(durationMinutes)
+      || !Number.isFinite(usedPercent)
+      || usedPercent < 0
+      || usedPercent > 100
+      || !Number.isSafeInteger(resetsAt)
+      || resetsAt <= 0
+      || !Number.isFinite(new Date(resetsAt * 1_000).getTime())) {
+    throw fixedError(ERROR_CODES.quota);
+  }
+  return {
+    timestamp,
+    provider: closedEnum(window.provider, KNOWN_PROVIDERS),
+    planType: closedEnum(window.planType, KNOWN_PLANS),
+    limitId: closedEnum(window.limitId, KNOWN_LIMITS),
+    slot: closedEnum(window.slot, KNOWN_SLOTS),
+    usedPercent,
+    durationMinutes,
+    resetsAt,
+  };
+}
+
+function bytesToBigInt(bytes) {
+  return BigInt(`0x${bytes.toString("hex")}`);
+}
+
+function formatBigInt(value) {
+  return value.toString(16).padStart(64, "0");
+}
+
+// An internal characterization checksum. Keeping only two 256-bit sums and a
+// count makes this order-independent and multiplicity-sensitive without
+// retaining rows (or even their individual digests). The modular sums are
+// algebraically collisionable, so this is not an adversarial proof; callers
+// must pair it with the shadow final-projection comparison before cutover.
+class MultisetAccumulator {
+  #key;
+  #domain;
+  #sum = 0n;
+  #secondary = 0n;
+
+  constructor(key, domain) {
+    this.#key = key;
+    this.#domain = domain;
+  }
+
+  add(serialized) {
+    const first = createHmac("sha256", this.#key)
+      .update(`${this.#domain}\0${serialized}`)
+      .digest();
+    const second = createHmac("sha256", this.#key)
+      .update(`${this.#domain}\0secondary\0${serialized}`)
+      .digest();
+    this.#sum = (this.#sum + bytesToBigInt(first)) % MODULUS;
+    this.#secondary = (this.#secondary + bytesToBigInt(second)) % MODULUS;
+  }
+
+  digest() {
+    return [
+      "hmac-sha256-multiset-v1",
+      formatBigInt(this.#sum),
+      formatBigInt(this.#secondary),
+    ].join(":");
+  }
+}
+
+function newDimensionState(kind) {
+  return Object.fromEntries(kind === "usage"
+    ? USAGE_DIMENSIONS.map((dimension) => [dimension, new Map()])
+    : QUOTA_DIMENSIONS.map((dimension) => [dimension, new Map()]));
+}
+
+function dimensionValueKey(value) {
+  return typeof value === "number" ? String(value) : value;
+}
+
+function addDimensionRow({
+  state,
+  key,
+  domain,
+  value,
+  serialized,
+  count,
+  totalTokens = 0,
+}) {
+  const dimension = state[domain];
+  const valueKey = dimensionValueKey(value);
+  let row = dimension.get(valueKey);
+  if (!row) {
+    row = {
+      count: 0,
+      totalTokens: 0,
+      digest: new MultisetAccumulator(
+        key,
+        `${domain}\0${valueKey}`,
+      ),
+    };
+    dimension.set(valueKey, row);
+  }
+  row.count = checkedAdd(row.count, count);
+  row.totalTokens = checkedAdd(row.totalTokens, totalTokens);
+  row.digest.add(serialized);
+}
+
+function sortedDimensionDigests(state, includeTokens = true) {
+  const result = {};
+  for (const dimension of Object.keys(state).sort()) {
+    const rows = state[dimension];
+    result[dimension] = {};
+    for (const value of [...rows.keys()].sort()) {
+      const row = rows.get(value);
+      result[dimension][value] = {
+        count: row.count,
+        ...(includeTokens ? { totalTokens: row.totalTokens } : {}),
+        digest: row.digest.digest(),
+      };
+    }
+  }
+  return result;
+}
+
+function createUsageState(key) {
+  return {
+    count: 0,
+    totalTokens: 0,
+    totalInputContextTokens: 0,
+    missingTotalInputContextCount: 0,
+    components: componentTotals(),
+    digest: new MultisetAccumulator(key, "usage"),
+    dimensions: newDimensionState("usage"),
+  };
+}
+
+function addUsage(state, raw, startMs, endMs) {
+  const row = normalizeUsage(raw);
+  const observedMs = Date.parse(row.timestamp);
+  if (observedMs < startMs || observedMs > endMs) return;
+  // Replay-safe accounting suppresses zero-token usage callbacks before they
+  // affect counts, totals, dimensions, or digests.
+  if (row.totalTokens === 0) return;
+  const serialized = JSON.stringify(row);
+  state.count = checkedAdd(state.count, 1);
+  state.totalTokens = checkedAdd(state.totalTokens, row.totalTokens);
+  if (row.totalInputContextTokens === null) {
+    state.missingTotalInputContextCount = checkedAdd(
+      state.missingTotalInputContextCount,
+      1,
+    );
+  } else {
+    state.totalInputContextTokens = checkedAdd(
+      state.totalInputContextTokens,
+      row.totalInputContextTokens,
+    );
+  }
+  for (const key of COMPONENT_KEYS) {
+    state.components[key] = checkedAdd(state.components[key], row.components[key]);
+  }
+  state.digest.add(serialized);
+  for (const dimension of USAGE_DIMENSIONS) {
+    addDimensionRow({
+      state: state.dimensions,
+      key: state.key,
+      domain: dimension,
+      value: row[dimension],
+      serialized,
+      count: 1,
+      totalTokens: row.totalTokens,
+    });
+  }
+}
+
+function createQuotaState(key) {
+  return {
+    count: 0,
+    digest: new MultisetAccumulator(key, "quota"),
+    dimensions: newDimensionState("quota"),
+  };
+}
+
+function addQuota(state, raw, startMs, endMs) {
+  // This is the raw normalized callback semantics. Final replay-safe quota
+  // acceptance/projection remains a separate shadow-cache comparison.
+  const row = normalizeQuota(raw);
+  const observedMs = Date.parse(row.timestamp);
+  if (observedMs < startMs || observedMs > endMs) return;
+  const serialized = JSON.stringify(row);
+  state.count = checkedAdd(state.count, 1);
+  state.digest.add(serialized);
+  for (const dimension of QUOTA_DIMENSIONS) {
+    addDimensionRow({
+      state: state.dimensions,
+      key: state.key,
+      domain: dimension,
+      value: row[dimension],
+      serialized,
+      count: 1,
+    });
+  }
+}
+
+function finalizeState(state) {
+  return {
+    count: state.count,
+    ...(state.totalTokens === undefined
+      ? {}
+      : {
+        totalTokens: state.totalTokens,
+        totalInputContextTokens: state.totalInputContextTokens,
+        missingTotalInputContextCount: state.missingTotalInputContextCount,
+        components: state.components,
+      }),
+    digest: state.digest.digest(),
+    dimensionDigests: sortedDimensionDigests(
+      state.dimensions,
+      state.totalTokens !== undefined,
+    ),
+  };
+}
+
+function validateReceiptDigest(value) {
+  return typeof value === "string" && DIGEST_PATTERN.test(value);
+}
+
+function validateReceiptDimensionMap(value, includeTokens) {
+  if (!isPlainObject(value)) return false;
+  for (const dimension of Object.values(value)) {
+    if (!isPlainObject(dimension)) return false;
+    for (const row of Object.values(dimension)) {
+      if (!isPlainObject(row)
+          || !nonNegativeSafeInteger(row.count)
+          || (includeTokens && !nonNegativeSafeInteger(row.totalTokens))
+          || !validateReceiptDigest(row.digest)) return false;
+    }
+  }
+  return true;
+}
+
+function validReceipt(value) {
+  if (!isPlainObject(value)
+      || typeof value.version !== "string"
+      || !/^[a-z][a-z0-9._-]{0,63}$/u.test(value.version)
+      || value.scope !== LOCAL_ACCOUNTING_PARITY_RECEIPT_SCOPE
+      || value.scopeVersion !== LOCAL_ACCOUNTING_PARITY_RECEIPT_SCOPE_VERSION
+      || !isPlainObject(value.window)
+      || canonicalInstant(value.window.startAt) !== value.window.startAt
+      || canonicalInstant(value.window.endAt) !== value.window.endAt
+      || Date.parse(value.window.startAt) > Date.parse(value.window.endAt)
+      || !isPlainObject(value.usage)
+      || !isPlainObject(value.quota)) return false;
+  const usage = value.usage;
+  const quota = value.quota;
+  if (!nonNegativeSafeInteger(usage.count)
+      || !nonNegativeSafeInteger(usage.totalTokens)
+      || !nonNegativeSafeInteger(usage.totalInputContextTokens)
+      || !nonNegativeSafeInteger(usage.missingTotalInputContextCount)
+      || !isPlainObject(usage.components)
+      || COMPONENT_KEYS.some((key) => !nonNegativeSafeInteger(usage.components[key]))
+      || !validateReceiptDigest(usage.digest)
+      || !validateReceiptDimensionMap(usage.dimensionDigests, true)) {
+    return false;
+  }
+  return nonNegativeSafeInteger(quota.count)
+    && validateReceiptDigest(quota.digest)
+    && validateReceiptDimensionMap(quota.dimensionDigests, false);
+}
+
+function sameValue(left, right) {
+  return JSON.stringify(left) === JSON.stringify(right);
+}
+
+function addMismatch(categories, category) {
+  if (!categories.includes(category)) categories.push(category);
+}
+
+/**
+ * Stream one scanner-shaped source into a content-free semantic receipt.
+ * `scan` receives only the pinned inclusive window and the callbacks used by
+ * replay-safe accounting; scanner return values and diagnostics are ignored
+ * so paths, source names, and error text cannot enter the receipt. The result
+ * is explicitly scoped to pre-calibration callback semantics and must not be
+ * read as pricing, declared-speed, or final-accounting evidence.
+ */
+export async function createLocalAccountingSemanticReceipt({
+  scan,
+  scanner,
+  startAt,
+  endAt,
+  byteKey,
+  signal = null,
+} = {}) {
+  const selectedScan = scan ?? scanner;
+  if (typeof selectedScan !== "function") {
+    throw fixedError(ERROR_CODES.scanner, "TypeError");
+  }
+  if (!validAbortSignal(signal)) {
+    throw fixedError(ERROR_CODES.signal, "TypeError");
+  }
+  const window = validateWindow(startAt, endAt);
+  const key = validateByteKey(byteKey);
+  throwIfAborted(signal);
+
+  // `key` is kept only by the short-lived accumulators. It is never copied to
+  // the returned object, and raw scanner rows are reduced before the next
+  // callback returns.
+  const usage = createUsageState(key);
+  const quota = createQuotaState(key);
+  const startMs = Date.parse(window.startAt);
+  const endMs = Date.parse(window.endAt);
+  usage.key = key;
+  quota.key = key;
+  try {
+    await selectedScan({
+      startAt: window.startAt,
+      endAt: window.endAt,
+      signal,
+      onUsage: (row) => {
+        throwIfAborted(signal);
+        addUsage(usage, row, startMs, endMs);
+      },
+      onRateLimitSnapshot: (row) => {
+        throwIfAborted(signal);
+        addQuota(quota, row, startMs, endMs);
+      },
+    });
+    throwIfAborted(signal);
+  } catch (error) {
+    if (isParityError(error)) throw error;
+    if (signal?.aborted) throw fixedError(ERROR_CODES.aborted, "AbortError");
+    throw fixedError(ERROR_CODES.scan);
+  }
+
+  return {
+    version: LOCAL_ACCOUNTING_PARITY_RECEIPT_VERSION,
+    scope: LOCAL_ACCOUNTING_PARITY_RECEIPT_SCOPE,
+    scopeVersion: LOCAL_ACCOUNTING_PARITY_RECEIPT_SCOPE_VERSION,
+    window,
+    usage: finalizeState(usage),
+    quota: finalizeState(quota),
+  };
+}
+
+/**
+ * Compare two receipts without exposing differing values. The result is
+ * intentionally a fixed category set, suitable for a durable parity report
+ * that must not contain source paths, row content, or scanner error text.
+ */
+export function compareLocalAccountingSemanticReceipts(left, right) {
+  if (!validReceipt(left) || !validReceipt(right)) {
+    throw fixedError(ERROR_CODES.receipt, "TypeError");
+  }
+  const categories = [];
+  if (left.version !== right.version) addMismatch(categories, "receipt_schema");
+  if (!sameValue(left.window, right.window)) addMismatch(categories, "window");
+  if (left.usage.count !== right.usage.count) addMismatch(categories, "usage_count");
+  if (left.usage.totalTokens !== right.usage.totalTokens
+      || left.usage.totalInputContextTokens
+        !== right.usage.totalInputContextTokens
+      || left.usage.missingTotalInputContextCount
+        !== right.usage.missingTotalInputContextCount) {
+    addMismatch(categories, "usage_tokens");
+  }
+  if (!sameValue(left.usage.components, right.usage.components)) {
+    addMismatch(categories, "usage_components");
+  }
+  if (left.usage.digest !== right.usage.digest) addMismatch(categories, "usage_digest");
+  if (!sameValue(left.usage.dimensionDigests, right.usage.dimensionDigests)) {
+    addMismatch(categories, "usage_dimensions");
+  }
+  if (left.quota.count !== right.quota.count) addMismatch(categories, "quota_count");
+  if (left.quota.digest !== right.quota.digest) addMismatch(categories, "quota_digest");
+  if (!sameValue(left.quota.dimensionDigests, right.quota.dimensionDigests)) {
+    addMismatch(categories, "quota_dimensions");
+  }
+  return {
+    equal: categories.length === 0,
+    mismatchCategories: categories,
+  };
+}

--- a/src/local-analysis-index.js
+++ b/src/local-analysis-index.js
@@ -100,6 +100,24 @@ const COVERAGE_BLOCK_REASONS = new Set([
   "disk_space",
   "storage_unavailable",
 ]);
+// Accounting callbacks can stop an otherwise valid legacy scan at a fixed,
+// bounded resource or transition limit. Preserve those codes so the
+// accounting owner can retain/defer its cache; wrapping one as the generic
+// local-index failure would turn a recoverable budget miss into a false
+// rollback failure. This is an explicit allowlist: arbitrary callback errors
+// remain content-free local_analysis_index_failed failures.
+const BOUNDED_ACCOUNTING_CALLBACK_ERROR_CODES = new Set([
+  "accounting_refresh_aborted",
+  "accounting_scan_rss_limit_exceeded",
+  "accounting_scan_source_bytes_limit_exceeded",
+  "accounting_transition_rss_measurement_invalid",
+  "accounting_transition_rss_limit_exceeded",
+  "accounting_transition_memory_budget_exceeded",
+  "accounting_transition_usage_limit_exceeded",
+  "accounting_transition_snapshot_limit_exceeded",
+  "accounting_transition_input_limit_exceeded",
+  "accounting_transition_derivation_limit_exceeded",
+]);
 
 function canonicalInstant(value) {
   if (typeof value !== "string") return null;
@@ -113,6 +131,38 @@ function fixedError(code) {
   const error = new Error(code);
   error.code = code;
   return error;
+}
+
+function boundedFailureCategory(error) {
+  const code = typeof error?.code === "string" ? error.code : "";
+  if (code === "ENOSPC") return "storage_full";
+  if (code === "EMFILE" || code === "ENFILE") return "file_handle_limit";
+  if (code === "SQLITE_BUSY" || code === "SQLITE_LOCKED") {
+    return "sqlite_lock";
+  }
+  if (code === "SQLITE_FULL") return "storage_full";
+  if (code === "ENOENT") return "missing_resource";
+  if (code === "EACCES" || code === "EPERM") return "permission";
+  if (error?.name === "TypeError") return "type_error";
+  if (error?.name === "RangeError") return "range_error";
+  return "unknown";
+}
+
+function fixedRefreshFailure(phase, error) {
+  const fixed = fixedError("local_analysis_index_failed");
+  // Keep diagnostic evidence bounded and non-enumerable. Public callers still
+  // receive only the fixed content-free error code.
+  Object.defineProperties(fixed, {
+    failurePhase: {
+      value: phase,
+      enumerable: false,
+    },
+    failureCategory: {
+      value: boundedFailureCategory(error),
+      enumerable: false,
+    },
+  });
+  return fixed;
 }
 
 function throwIfAborted(signal) {
@@ -2611,6 +2661,7 @@ export async function refreshLocalAnalysisIndex({
   let shardDirectory = null;
   let attachedSchemas = [];
   let streamedScanResult = null;
+  let failurePhase = "stage_open";
   try {
     if (existing === null) {
       database = createFreshIndex(stageFile);
@@ -2623,6 +2674,7 @@ export async function refreshLocalAnalysisIndex({
         requireComplete: false,
       }).database;
     }
+    failurePhase = "source_update";
     database.exec("BEGIN IMMEDIATE");
     try {
       const deleteSource = database.prepare(
@@ -2676,6 +2728,7 @@ export async function refreshLocalAnalysisIndex({
         0,
       );
       if (slice.length > 0) {
+        failurePhase = "extraction";
         const extracted = await extractTasks({
           tasks: slice,
           workerCount,
@@ -2688,6 +2741,7 @@ export async function refreshLocalAnalysisIndex({
           + extracted.extractWallMs;
         phaseWallMs.shardMerge = (phaseWallMs.shardMerge ?? 0)
           + extracted.mergeWallMs;
+        failurePhase = "shard_attach";
         attachedSchemas = attachExtractedShards(
           database,
           extracted.shardFiles,
@@ -2704,6 +2758,7 @@ export async function refreshLocalAnalysisIndex({
           [...resetPending].filter((key) => selectedKeys.has(key)),
         );
         const derivationStartedAt = performance.now();
+        failurePhase = "derivation";
         database.exec("BEGIN IMMEDIATE");
         try {
           await deriveChangedSources({
@@ -2731,9 +2786,11 @@ export async function refreshLocalAnalysisIndex({
           + performance.now() - derivationStartedAt;
         detachExtractedShards(database, attachedSchemas);
         attachedSchemas = [];
+        failurePhase = "shard_cleanup";
         await rm(shardDirectory, { recursive: true, force: true });
         shardDirectory = null;
         const factIndexStartedAt = performance.now();
+        failurePhase = "fact_indexes";
         database.exec(`
           CREATE INDEX IF NOT EXISTS usage_facts_time
             ON usage_facts(timestamp_ms, source_key, source_offset);
@@ -2754,6 +2811,7 @@ export async function refreshLocalAnalysisIndex({
           throw error;
         }
       }
+      failurePhase = "coverage_meta";
       coverage = indexCoverage(database, sources);
       updateMeta(database, {
         startAt: new Date(startAt).toISOString(),
@@ -2768,6 +2826,7 @@ export async function refreshLocalAnalysisIndex({
         phaseWallMs,
       });
       const finalizeStartedAt = performance.now();
+      failurePhase = "finalize";
       database.exec("PRAGMA optimize");
       const integrity = database.prepare("PRAGMA quick_check").get();
       if (integrity?.quick_check !== "ok") {
@@ -2795,6 +2854,7 @@ export async function refreshLocalAnalysisIndex({
         serverBillableUnits: {},
       };
     }
+    failurePhase = "close";
     database.close();
     database = null;
     return {
@@ -2829,10 +2889,21 @@ export async function refreshLocalAnalysisIndex({
       }
     }
     if (database?.isOpen) database.close();
-    if (error?.name === "AbortError"
-        || (typeof error?.code === "string"
-          && error.code.startsWith("local_analysis_"))) throw error;
-    throw fixedError("local_analysis_index_failed");
+    const code = typeof error?.code === "string" ? error.code : null;
+    if (error?.name === "AbortError") {
+      const boundedCode = code !== null
+          && (code.startsWith("local_analysis_")
+            || BOUNDED_ACCOUNTING_CALLBACK_ERROR_CODES.has(code))
+        ? code
+        : "local_analysis_index_aborted";
+      throw fixedError(boundedCode, "AbortError");
+    }
+    if (code?.startsWith("local_analysis_")) throw fixedError(code);
+    if (code !== null
+        && BOUNDED_ACCOUNTING_CALLBACK_ERROR_CODES.has(code)) {
+      throw fixedError(code);
+    }
+    throw fixedRefreshFailure(failurePhase, error);
   } finally {
     if (shardDirectory !== null) {
       await rm(shardDirectory, { recursive: true, force: true })

--- a/src/local-collector-state.js
+++ b/src/local-collector-state.js
@@ -23,6 +23,9 @@ import { readBoundedUtf8LineEntries } from "./platform/index.js";
 // Raw Codex rollout JSONL is input owned by Codex, not application state.
 export const LOCAL_COLLECTOR_STATE_SCHEMA_VERSION =
   "local-collector-state-v1";
+export const LOCAL_COLLECTOR_LEGACY_REFRESH_USE_SCHEMA_VERSION =
+  "local-collector-legacy-refresh-use-v1";
+export const LOCAL_COLLECTOR_LEGACY_REFRESH_USE_MAX = 1_000_000;
 
 const STATE_APPLICATION_ID = 0x554d4353;
 const STATE_USER_VERSION = 1;
@@ -82,6 +85,40 @@ function validIso(value) {
   const milliseconds = Date.parse(value);
   return Number.isFinite(milliseconds)
     && new Date(milliseconds).toISOString() === value;
+}
+
+function emptyLegacyRefreshUse() {
+  return {
+    schemaVersion: LOCAL_COLLECTOR_LEGACY_REFRESH_USE_SCHEMA_VERSION,
+    sourceMode: "legacy",
+    attempts: 0,
+    saturated: false,
+    lastAttemptedAt: null,
+  };
+}
+
+function normalizeLegacyRefreshUse(value) {
+  if (value === null) return emptyLegacyRefreshUse();
+  if (!value || typeof value !== "object" || Array.isArray(value)
+      || value.schemaVersion
+        !== LOCAL_COLLECTOR_LEGACY_REFRESH_USE_SCHEMA_VERSION
+      || value.sourceMode !== "legacy"
+      || !Number.isSafeInteger(value.attempts)
+      || value.attempts < 0
+      || value.attempts > LOCAL_COLLECTOR_LEGACY_REFRESH_USE_MAX
+      || typeof value.saturated !== "boolean"
+      || value.saturated
+        !== (value.attempts === LOCAL_COLLECTOR_LEGACY_REFRESH_USE_MAX)
+      || (value.lastAttemptedAt !== null && !validIso(value.lastAttemptedAt))) {
+    throw fixedError("local_collector_state_corrupt");
+  }
+  return {
+    schemaVersion: LOCAL_COLLECTOR_LEGACY_REFRESH_USE_SCHEMA_VERSION,
+    sourceMode: "legacy",
+    attempts: value.attempts,
+    saturated: value.saturated,
+    lastAttemptedAt: value.lastAttemptedAt,
+  };
 }
 
 function sha256(value) {
@@ -678,6 +715,7 @@ export async function readLocalCollectorState({
       status: "missing",
       checkpoint: null,
       accountingCache: null,
+      legacyRefreshUse: emptyLegacyRefreshUse(),
       migration: null,
       records: includeRecords ? [] : null,
     };
@@ -689,12 +727,73 @@ export async function readLocalCollectorState({
       status: "available",
       checkpoint: readMeta(database, "checkpoint"),
       accountingCache: readMeta(database, "accounting_cache"),
+      legacyRefreshUse: normalizeLegacyRefreshUse(
+        readMeta(database, "legacy_refresh_use"),
+      ),
       migration: readMeta(database, "legacy_migration"),
       records: includeRecords ? readRecords(database) : null,
     };
   } finally {
     database?.close();
   }
+}
+
+export async function recordLocalCollectorLegacyRefreshAttempt({
+  stateFile = defaultLocalCollectorStatePath(),
+  clock = () => Date.now(),
+} = {}) {
+  if (typeof stateFile !== "string" || stateFile.length < 1
+      || typeof clock !== "function") {
+    throw new TypeError("Local legacy refresh receipt request is invalid");
+  }
+  const nowMs = clock();
+  if (!Number.isFinite(nowMs)) {
+    throw new TypeError("clock must return a finite epoch timestamp");
+  }
+  const lastAttemptedAt = new Date(nowMs).toISOString();
+  await ensureDatabase(stateFile);
+  let database;
+  let receipt;
+  try {
+    database = openDatabase(stateFile, { readOnly: false });
+    receipt = transaction(database, () => {
+      const current = normalizeLegacyRefreshUse(
+        readMeta(database, "legacy_refresh_use"),
+      );
+      const attempts = Math.min(
+        LOCAL_COLLECTOR_LEGACY_REFRESH_USE_MAX,
+        current.attempts + 1,
+      );
+      const next = {
+        schemaVersion: LOCAL_COLLECTOR_LEGACY_REFRESH_USE_SCHEMA_VERSION,
+        sourceMode: "legacy",
+        attempts,
+        saturated: attempts === LOCAL_COLLECTOR_LEGACY_REFRESH_USE_MAX,
+        lastAttemptedAt,
+      };
+      writeMeta(database, "legacy_refresh_use", next);
+      return next;
+    });
+    database.exec("PRAGMA optimize");
+  } finally {
+    database?.close();
+  }
+  await chmod(stateFile, 0o600);
+  await syncStateFile(stateFile);
+  return receipt;
+}
+
+export async function readLocalCollectorLegacyRefreshUse({
+  stateFile = defaultLocalCollectorStatePath(),
+} = {}) {
+  const state = await readLocalCollectorState({
+    stateFile,
+    includeRecords: false,
+  });
+  return {
+    status: state.status,
+    receipt: state.legacyRefreshUse,
+  };
 }
 
 export async function readLocalCollectorCheckpoint({

--- a/src/local-companion-data.js
+++ b/src/local-companion-data.js
@@ -2060,10 +2060,123 @@ function timelineAllowanceWeightingEncoding(preference) {
   };
 }
 
+function completeUnifiedGeneration(value) {
+  const accountingStatus = value?.status === "complete"
+    || (value?.status === "partial"
+      && value?.blockReason === "tool_provenance_incomplete"
+      && value?.toolProvenanceComplete === false);
+  return value
+    && typeof value === "object"
+    && !Array.isArray(value)
+    && Number.isSafeInteger(value.id)
+    && value.id >= 1
+    && accountingStatus
+    && value.discoveryComplete === true
+    && value.diagnosticsComplete === true
+    && value.usageProvenanceComplete === true
+    && value.sourceOrderComplete === true
+    && value.quotaProvenanceComplete === true;
+}
+
+function safeHistoryCoveredAt(value) {
+  const startAt = typeof value?.startAt === "string" ? value.startAt : null;
+  const endAt = typeof value?.endAt === "string" ? value.endAt : null;
+  return Number.isFinite(Date.parse(startAt ?? ""))
+      && Number.isFinite(Date.parse(endAt ?? ""))
+      && Date.parse(startAt) <= Date.parse(endAt)
+    ? { startAt, endAt }
+    : { startAt: null, endAt: null };
+}
+
+function insufficientEvidenceUsagePeriods() {
+  return [
+    ["24h", "Last 24 hours"],
+    ["7d", "Last 7 days"],
+    ["30d", "Last 30 days"],
+    ["all", RECENT_COLLECTOR_PERIOD_LABEL],
+  ].map(([id, label]) => finalizeUsagePeriod(newUsagePeriod(id, label)));
+}
+
+function unifiedPartialReason(unified) {
+  return unified?.indexStatus === "partial"
+    ? "unified_index_partial"
+    : "unified_index_generation_incomplete";
+}
+
+function unifiedHistoryState({ cache, unified, cacheErrorCode }) {
+  const history = cache?.history;
+  const descriptor = cache?.sourceDescriptor;
+  const generationMatched = descriptor?.generationMatched === true;
+  const available = history?.status === "available"
+    && history.period !== null
+    && history.coverage?.status === "complete"
+    && descriptor?.coverageStatus === "complete"
+    && generationMatched;
+  const sourceCount = Number.isSafeInteger(unified?.discoveredSourceCount)
+    && unified.discoveredSourceCount >= 0
+    ? unified.discoveredSourceCount
+    : 0;
+  const sourceBytes = Number.isSafeInteger(unified?.discoveredSourceBytes)
+    && unified.discoveredSourceBytes >= 0
+    ? unified.discoveredSourceBytes
+    : 0;
+  const indexedSourceCount = Number.isSafeInteger(unified?.indexedSourceCount)
+    && unified.indexedSourceCount >= 0
+    ? unified.indexedSourceCount
+    : 0;
+  const indexedSourceBytes = Number.isSafeInteger(unified?.indexedSourceBytes)
+    && unified.indexedSourceBytes >= 0
+    ? unified.indexedSourceBytes
+    : 0;
+  const coveredAt = safeHistoryCoveredAt(history?.coverage?.coveredAt);
+  const errorCode = available
+    ? null
+    : typeof history?.errorCode === "string"
+      ? history.errorCode
+      : typeof cacheErrorCode === "string"
+        ? cacheErrorCode
+        : "accounting_unified_history_unavailable";
+  return {
+    accounting: available
+      ? {
+        status: "available",
+        errorCode: null,
+        generatedAt: history.coverage.generatedAt,
+        coveredAt,
+        period: history.period,
+      }
+      : {
+        status: "unavailable",
+        errorCode,
+        generatedAt: null,
+        coveredAt,
+        period: null,
+      },
+    coverage: {
+      status: available ? "complete" : "partial",
+      phase: available ? "complete" : cache === null ? "not_started" : "unavailable",
+      errorCode,
+      generatedAt: available ? history.coverage.generatedAt : null,
+      coveredAt,
+      sourceCount,
+      indexedSourceCount,
+      pendingSourceCount: Math.max(0, sourceCount - indexedSourceCount),
+      sourceBytes,
+      indexedBytes: indexedSourceBytes,
+      sourceMode: "unified",
+      generationMatched,
+    },
+  };
+}
+
 export async function buildLocalCompanionSnapshot({
   root = process.cwd(),
   collectorStateFile = defaultLocalCollectorStatePath(root),
   archiveIndexFile = defaultLocalArchiveAccountingIndexPath(root),
+  // The legacy default is a direct compatibility/test seam; production always
+  // passes its composition-root selection. Unified mode sources history from
+  // the generation-bound cache and never touches the old archive database.
+  accountingSourceMode = "legacy",
   // The unified local index. When it is present the "All" period and the
   // timelines draw from its whole fork-replay-suppressed history; when it is
   // absent the snapshot says so and stays on the bounded recent window.
@@ -2090,6 +2203,9 @@ export async function buildLocalCompanionSnapshot({
 } = {}) {
   const nowMs = now();
   if (!Number.isFinite(nowMs)) throw new TypeError("now must return a finite epoch timestamp");
+  if (!["unified", "legacy"].includes(accountingSourceMode)) {
+    throw new TypeError("accountingSourceMode must be unified or legacy");
+  }
   // Make a legacy installation converge before any snapshot readers race to
   // inspect it. Once complete this is a cheap receipt check; it never revives
   // JSON as an active state backend.
@@ -2149,21 +2265,37 @@ export async function buildLocalCompanionSnapshot({
       ))
     : Promise.resolve(null);
   const [
-    replaySafeAccounting,
+    initialReplaySafeAccounting,
     archiveCoverage,
     archiveAccounting,
     unified,
     retainedSideChatEstimates,
     sideChatHistoricalGapProbe,
-  ] =
-    await Promise.all([
+  ] = await Promise.all([
       readReplaySafeAccountingCache({
         stateFile: collectorStateFile,
         now: () => nowMs,
         maximumAgeMs: MAX_REPLAY_SAFE_CACHE_AGE_MS,
+        // Unified authority is bound only after the parallel index projection
+        // supplies its immutable generation below. This first read is merely a
+        // cheap cache-presence probe; never label it as a bound unified read.
+        ...(accountingSourceMode === "legacy"
+          ? { sourceMode: "legacy" }
+          : {}),
+        ...(accountingSourceMode === "unified"
+          ? { contextBehavior: "legacy_zero" }
+          : {}),
       }),
-      inspectLocalArchiveAccountingIndex({ indexFile: archiveIndexFile }),
-      readLocalArchiveAccountingPeriod({ indexFile: archiveIndexFile }),
+      accountingSourceMode === "legacy"
+        ? inspectLocalArchiveAccountingIndex({ indexFile: archiveIndexFile })
+        : Promise.resolve({
+          status: "dormant",
+          indexedSourceCount: 0,
+          sourceCount: 0,
+        }),
+      accountingSourceMode === "legacy"
+        ? readLocalArchiveAccountingPeriod({ indexFile: archiveIndexFile })
+        : Promise.resolve({ status: "unavailable", period: null }),
       readLocalUnifiedCompanionProjection({
         indexFile: unifiedIndexFile,
         nowMs,
@@ -2180,12 +2312,78 @@ export async function buildLocalCompanionSnapshot({
         ...retainedSideChatEstimates,
         historicalGapProbe: sideChatHistoricalGapProbe,
       };
-  const replaySafeCache = ["available", "stale"].includes(
+  const unifiedProjectionAvailable = unified.status === "available";
+  const unifiedGenerationReady = unifiedProjectionAvailable
+    && (unified.indexStatus === "complete"
+      || (unified.indexStatus === "partial"
+        && unified.generation?.blockReason === "tool_provenance_incomplete"
+        && unified.generation?.toolProvenanceComplete === false))
+    && completeUnifiedGeneration(unified.generation);
+  let replaySafeAccounting = initialReplaySafeAccounting;
+  if (accountingSourceMode === "unified"
+      && ["available", "stale"].includes(replaySafeAccounting.status)) {
+    if (!unifiedGenerationReady) {
+      replaySafeAccounting = {
+        status: "unavailable",
+        errorCode: "cache_generation_unavailable",
+        cache: null,
+      };
+    } else {
+      // The first cache read overlaps the potentially large companion index
+      // projection. Once that projection has supplied its immutable
+      // generation descriptor, this cheap second SQLite read binds the cache
+      // to exactly that publication before any totals are selected.
+      replaySafeAccounting = await readReplaySafeAccountingCache({
+        stateFile: collectorStateFile,
+        now: () => nowMs,
+        maximumAgeMs: MAX_REPLAY_SAFE_CACHE_AGE_MS,
+        sourceMode: "unified",
+        contextBehavior: "legacy_zero",
+        expectedGeneration: unified.generation,
+      });
+    }
+  }
+  let replaySafeCache = ["available", "stale"].includes(
     replaySafeAccounting.status,
   )
     ? replaySafeAccounting.cache
     : null;
-  const unifiedAvailable = unified.status === "available";
+  if (accountingSourceMode === "unified"
+      && replaySafeCache !== null
+      && (!Number.isSafeInteger(replaySafeCache.sourceDescriptor?.fallbackCount)
+        || replaySafeCache.sourceDescriptor.fallbackCount !== 0)) {
+    // A cache that cannot prove zero fallback use is not a valid unified
+    // authority, even if its periods happen to be structurally readable.
+    replaySafeAccounting = {
+      status: "unavailable",
+      errorCode: "cache_fallback_disallowed",
+      cache: null,
+    };
+    replaySafeCache = null;
+  }
+  // Legacy rollback mode may continue to use a readable pre-v2 unified file
+  // for broad display history. Unified authority requires the complete,
+  // attested generation above; a merely readable legacy file is insufficient.
+  const unifiedAvailable = unifiedProjectionAvailable
+    && (accountingSourceMode === "legacy" || unifiedGenerationReady);
+  const unifiedAuthorityPartial = accountingSourceMode === "unified"
+    && unifiedProjectionAvailable
+    && !unifiedGenerationReady;
+  const unifiedAccountingWithheld = accountingSourceMode === "unified"
+    && replaySafeCache === null
+    && !unifiedAvailable;
+  const selectedHistory = accountingSourceMode === "unified"
+    ? unifiedHistoryState({
+      cache: replaySafeCache,
+      unified,
+      cacheErrorCode: replaySafeAccounting.errorCode,
+    })
+    : {
+      accounting: archiveAccounting,
+      coverage: archiveCoverage,
+    };
+  const historyAccounting = selectedHistory.accounting;
+  const historyCoverage = selectedHistory.coverage;
   if (typeof allowDevelopmentArtifactFallback !== "boolean") {
     throw new TypeError("allowDevelopmentArtifactFallback must be a boolean");
   }
@@ -2197,7 +2395,10 @@ export async function buildLocalCompanionSnapshot({
       // re-summarizing 600k+ JSON rows here was the old startup cost, and the
       // raw collector projection also counts fork replay the owner has ruled
       // is not real spend.
-      summarizeUsageEvents: replaySafeCache === null && !unifiedAvailable,
+      summarizeUsageEvents:
+        accountingSourceMode !== "unified"
+        && replaySafeCache === null
+        && !unifiedAvailable,
       declaredSpeedBaselines,
     }),
     reportProjection(root),
@@ -2223,9 +2424,22 @@ export async function buildLocalCompanionSnapshot({
     ...weeklyBase,
     paceForecast: collector.paceForecast,
   };
-  const latestRecordAt = collector.latestRecordAt;
+  const collectorLatestRecordAt = collector.latestRecordAt;
+  const unifiedLatestExportableMs = accountingSourceMode === "unified"
+      && unifiedAvailable
+      && typeof unified.latestExportableRecordAt === "string"
+    ? Date.parse(unified.latestExportableRecordAt)
+    : Number.NaN;
+  const latestRecordAt = Number.isSafeInteger(unifiedLatestExportableMs)
+    ? collectorLatestRecordAt === null
+      ? unifiedLatestExportableMs
+      : Math.max(collectorLatestRecordAt, unifiedLatestExportableMs)
+    : collectorLatestRecordAt;
   const indexing = await readCollectorIndexProjection(collectorStateFile, collector);
   const latestEvidenceAt = latestRecordAt === null ? null : new Date(latestRecordAt).toISOString();
+  const collectorLatestEvidenceAt = collectorLatestRecordAt === null
+    ? null
+    : new Date(collectorLatestRecordAt).toISOString();
   const evidenceAgeSeconds = latestRecordAt === null ? null : Math.max(0, Math.round((nowMs - latestRecordAt) / 1_000));
   const collectorFreshnessStatus = evidenceAgeSeconds === null
     ? "unavailable"
@@ -2258,9 +2472,18 @@ export async function buildLocalCompanionSnapshot({
   const accountingCoverageEndMs = replaySafeCache === null
     ? Number.NaN
     : Date.parse(replaySafeCache.coveredAt.endAt);
+  // Unified refreshes deliberately skip legacy rollout ingestion. When the
+  // published unified projection is authoritative, its newest typed usage
+  // timestamp is the exportable-evidence clock; consulting the dormant
+  // collector ledger here would make cache/index freshness appear frozen.
+  const latestExportableRecordAt = Number.isSafeInteger(unifiedLatestExportableMs)
+    ? unifiedLatestExportableMs
+    : accountingSourceMode === "unified" && unifiedAvailable
+      ? null
+      : collector.latestExportableRecordAt;
   const accountingCoversKnownEvidence = Number.isFinite(accountingCoverageEndMs)
-    && (collector.latestExportableRecordAt === null
-      || collector.latestExportableRecordAt - accountingCoverageEndMs
+    && (latestExportableRecordAt === null
+      || latestExportableRecordAt - accountingCoverageEndMs
         <= MAX_REPLAY_SAFE_CACHE_AGE_MS);
   const accountingStatus =
     replaySafeAccounting.status === "stale" && accountingCoversKnownEvidence
@@ -2270,7 +2493,11 @@ export async function buildLocalCompanionSnapshot({
   // unified index (also replay-suppressed), and fall back to the raw collector
   // projection — which counts fork replay — only when neither exists.
   const recentUsage = replaySafeCache?.periods
-    ?? (unifiedAvailable ? unified.usage : collector.usage);
+    ?? (unifiedAvailable
+      ? unified.usage
+      : unifiedAccountingWithheld
+        ? insufficientEvidenceUsagePeriods()
+        : collector.usage);
   // The unified index owns the broadest period whenever it is present: its
   // "all" spans the whole suppressed corpus rather than a bounded recent
   // window, which is what removes the 31-day ceiling.
@@ -2280,10 +2507,10 @@ export async function buildLocalCompanionSnapshot({
       unified.usage.find((period) => period.id === "all"),
     ]
     : recentUsage;
-  const usage = archiveAccounting.status === "available"
+  const usage = historyAccounting.status === "available"
     ? [
       ...broadUsage.filter((period) => period.id !== "history"),
-      archiveAccounting.period,
+      historyAccounting.period,
     ]
     : broadUsage;
   const displayUsage = usage.find((period) => period.id === "7d" && period.events > 0)
@@ -2330,15 +2557,19 @@ export async function buildLocalCompanionSnapshot({
     : Array.isArray(replaySafeCache?.sparkQuotaTimeline)
       ? replaySafeCache.sparkQuotaTimeline
       : collector.timeline.sparkQuota;
-  const sparkUsageTimeline = unifiedAvailable
-    ? unified.timeline.sparkUsage
-    : Array.isArray(replaySafeCache?.sparkUsageTimeline)
-      ? replaySafeCache.sparkUsageTimeline
-      : collector.timeline.sparkUsage;
-  const exactUsageTimelineWithSpeed = unifiedAvailable
-    ? unified.timeline.usage
-    : replaySafeCache?.timeline
-      ?? collector.timeline.usage;
+  const sparkUsageTimeline = unifiedAccountingWithheld
+    ? []
+    : unifiedAvailable
+      ? unified.timeline.sparkUsage
+      : Array.isArray(replaySafeCache?.sparkUsageTimeline)
+        ? replaySafeCache.sparkUsageTimeline
+        : collector.timeline.sparkUsage;
+  const exactUsageTimelineWithSpeed = unifiedAccountingWithheld
+    ? []
+    : unifiedAvailable
+      ? unified.timeline.usage
+      : replaySafeCache?.timeline
+        ?? collector.timeline.usage;
   const calibrationUsageTimelineWithSpeed =
     sideChatEstimates?.status === "available"
       && sideChatEstimates.methodology?.includedInCalibrationTimeline === true
@@ -2355,13 +2586,21 @@ export async function buildLocalCompanionSnapshot({
     calibrationUsageTimelineWithSpeed,
     fastModeContext,
   );
+  const timelineCoveredAt = unifiedAccountingWithheld
+    ? { startAt: null, endAt: null }
+    : unifiedAvailable
+      ? unified.timeline.coveredAt
+      : replaySafeCache?.coveredAt
+        ?? collector.timeline.coveredAt;
   // What span the timelines honestly cover, and out of which source. When the
   // unified index is absent this names the bound instead of hiding it.
   const timelineSource = unifiedAvailable
     ? "unified_local_index"
     : replaySafeCache !== null
       ? "replay_safe_cache"
-      : "recent_collector_window";
+      : unifiedAccountingWithheld
+        ? "insufficient_evidence"
+        : "recent_collector_window";
   const timelineHistory = unifiedAvailable
     ? {
       status: unified.indexStatus === "complete" ? "complete" : "partial",
@@ -2371,6 +2610,16 @@ export async function buildLocalCompanionSnapshot({
       sourceCount: unified.sourceCount,
       indexBytes: unified.indexBytes,
     }
+    : unifiedAuthorityPartial
+      ? {
+        status: "partial",
+        reason: unifiedPartialReason(unified),
+        coveredAt: unified.coveredAt,
+        usageEvents: unified.usageEvents,
+        generatedAt: unified.generatedAt,
+        sourceCount: unified.sourceCount,
+        indexBytes: unified.indexBytes,
+      }
     : {
       status: "unavailable",
       reason: unified.status === "missing"
@@ -2379,7 +2628,27 @@ export async function buildLocalCompanionSnapshot({
       boundedDays: RECENT_TIMELINE_DAYS,
       coveredAt: null,
     };
-  const tools = collector.tools;
+  // Tool-class counts are durable typed facts in the unified index. Prefer
+  // them only in unified authority mode; legacy rollback keeps its collector
+  // projection exactly as before.
+  const tools = accountingSourceMode === "unified"
+    ? unifiedAvailable ? unified.tools : summarizeToolClasses([])
+    : collector.tools;
+  const exportableCoveredAt = accountingSourceMode === "unified"
+    ? unifiedAvailable
+      ? {
+        startAt: unified.coveredAt.startAt,
+        endAt: unified.latestExportableRecordAt ?? unified.coveredAt.endAt,
+      }
+      : { startAt: null, endAt: null }
+    : {
+      startAt: collector.firstExportableRecordAt === null
+        ? null
+        : new Date(collector.firstExportableRecordAt).toISOString(),
+      endAt: collector.latestExportableRecordAt === null
+        ? null
+        : new Date(collector.latestExportableRecordAt).toISOString(),
+    };
   const pricedEvents = (displayUsage?.pricingCoverage.fullyPricedEvents ?? 0)
     + (displayUsage?.pricingCoverage.partiallyPricedEvents ?? 0);
   const pricingCoveragePercent = (displayUsage?.events ?? 0) === 0
@@ -2414,13 +2683,23 @@ export async function buildLocalCompanionSnapshot({
       "Recent cost accounting is using the live collector projection. It may include inherited snapshots from forked child rollouts until the replay-safe cache is refreshed.",
     );
   }
-  if (!unifiedAvailable) {
+  if (unifiedAccountingWithheld) {
+    warnings.push(unifiedAuthorityPartial
+      ? "The unified local index is readable but only partially covered. Usage totals and timelines are withheld until a complete generation-bound publication is available."
+      : unified.status === "missing"
+        ? "The unified local index has not been built yet. Usage totals and timelines remain unavailable until a complete generation-bound publication is available."
+        : "The unified local index is unavailable. Usage totals and timelines remain unavailable until a complete generation-bound publication is available.");
+  } else if (!unifiedAvailable) {
     warnings.push(unified.status === "missing"
       ? `The unified local index has not been built yet. Usage history and the broadest period are bounded to the recent ${RECENT_TIMELINE_DAYS}-day collector window until it is.`
       : `The unified local index is unreadable. Usage history and the broadest period are bounded to the recent ${RECENT_TIMELINE_DAYS}-day collector window until it recovers.`);
   } else {
     const indexEndMs = Date.parse(unified.coveredAt.endAt ?? "");
-    const newestUsageMs = collector.latestExportableRecordAt;
+    // In unified authority mode rollout ingestion is deliberately skipped in
+    // the legacy collector. Compare against the typed index clock so a
+    // current publication is not reported as lagging behind a dormant
+    // collector ledger.
+    const newestUsageMs = latestExportableRecordAt;
     if (Number.isFinite(indexEndMs)
         && Number.isSafeInteger(newestUsageMs)
         && newestUsageMs - indexEndMs > MAX_COLLECTOR_LIVE_AGE_MS) {
@@ -2428,6 +2707,11 @@ export async function buildLocalCompanionSnapshot({
         `The unified local index is ${Math.round((newestUsageMs - indexEndMs) / 60_000)} minutes behind the newest collector evidence and catches up on the next refresh.`,
       );
     }
+  }
+  if (unifiedAvailable && unified.toolCoverageStatus === "partial") {
+    warnings.push(
+      "Usage accounting is complete, but typed tool history is partial. Tool totals are withheld rather than reported as zero.",
+    );
   }
   if (indexing.status === "prospective_only") {
     warnings.push("The retained collector state began prospectively and does not prove recent-history coverage.");
@@ -2450,11 +2734,11 @@ export async function buildLocalCompanionSnapshot({
       `Verified OpenAI price evidence was reviewed beginning ${OPENAI_PRICE_EVIDENCE_START_DATE}; events without a recognized or separately evidenced card remain unpriced.`,
     );
   }
-  if (archiveCoverage.status !== "complete") {
-    warnings.push(archiveAccounting.status === "available"
-      ? `Indexed-history totals currently cover ${archiveCoverage.indexedSourceCount}/${archiveCoverage.sourceCount} discovered sources and expand as later foreground refreshes advance the index.`
+  if (historyCoverage.status !== "complete") {
+    warnings.push(historyAccounting.status === "available"
+      ? `Indexed-history totals currently cover ${historyCoverage.indexedSourceCount}/${historyCoverage.sourceCount} discovered sources and expand as later foreground refreshes advance the index.`
       : "History indexing is still advancing. Complete historical totals stay hidden until an indexed aggregate is available.");
-  } else if (archiveAccounting.status !== "available") {
+  } else if (historyAccounting.status !== "available") {
     warnings.push(
       "Historical sources are indexed, but their aggregate is temporarily unavailable and is not substituted with a recent-window total.",
     );
@@ -2470,13 +2754,30 @@ export async function buildLocalCompanionSnapshot({
     ? displayUsage.priceCardBreakdown
     : [];
   const mixedPriceCardWindows = priceCardIds.length > 1;
+  const accountingDescriptor = replaySafeCache?.sourceDescriptor ?? null;
+  const accountingGeneration = accountingDescriptor?.generation
+    ?? unified.generation?.id
+    ?? null;
+  const accountingGenerationFingerprint =
+    accountingDescriptor?.generationFingerprint
+      ?? unified.generation?.fingerprint
+      ?? null;
+  const accountingSource = replaySafeCache !== null
+    ? replaySafeCache.accountingMethod
+    : unifiedAvailable
+      ? "unified_local_index_replay_suppressed"
+      : unifiedAccountingWithheld
+        ? "insufficient_evidence"
+        : "collector_projection_unverified";
   return {
     schemaVersion: LOCAL_COMPANION_SCHEMA_VERSION,
     mode: "real_local_evidence",
     generatedAt: new Date(nowMs).toISOString(),
     overview: {
       status: freshnessStatus,
-      evidenceStatus: collector.recordCount > 0 ? "available" : "unavailable",
+      evidenceStatus: collector.recordCount > 0 || unifiedAvailable
+        ? "available"
+        : "unavailable",
       latestEvidenceAt,
       latestObservedAt: latestEvidenceAt,
         freshness: {
@@ -2492,7 +2793,7 @@ export async function buildLocalCompanionSnapshot({
         records: collector.recordCount,
         recordCounts: collector.recordCounts,
         malformedLines: collector.malformedLines,
-        lastScanAt: latestEvidenceAt,
+        lastScanAt: collectorLatestEvidenceAt,
         safeRecordCount: collector.recordCount,
         identityMode: "prospective_pseudonymous_not_exposed",
         sourceMode: "content_free_collector_state",
@@ -2502,16 +2803,9 @@ export async function buildLocalCompanionSnapshot({
           startAt: collector.firstRecordAt === null
             ? null
             : new Date(collector.firstRecordAt).toISOString(),
-          endAt: latestEvidenceAt,
+          endAt: collectorLatestEvidenceAt,
         },
-        exportableCoveredAt: {
-          startAt: collector.firstExportableRecordAt === null
-            ? null
-            : new Date(collector.firstExportableRecordAt).toISOString(),
-          endAt: collector.latestExportableRecordAt === null
-            ? null
-            : new Date(collector.latestExportableRecordAt).toISOString(),
-        },
+        exportableCoveredAt,
       },
       quota,
       quotaWindows: quota.windows.map((window) => ({
@@ -2527,10 +2821,7 @@ export async function buildLocalCompanionSnapshot({
           ? unified.timeline.bucketMinutes
           : replaySafeCache?.bucketMinutes
             ?? collector.timeline.bucketMinutes,
-        coveredAt: unifiedAvailable
-          ? unified.timeline.coveredAt
-          : replaySafeCache?.coveredAt
-            ?? collector.timeline.coveredAt,
+        coveredAt: timelineCoveredAt,
         allowanceWeightingEncoding: timelineAllowanceWeightingEncoding(
           selectedFastModePreference,
         ),
@@ -2546,6 +2837,23 @@ export async function buildLocalCompanionSnapshot({
         history: timelineHistory,
       },
       accounting: {
+        sourceMode: accountingSourceMode,
+        readerVersion: accountingDescriptor?.readerVersion ?? null,
+        compatibilityBehavior:
+          accountingDescriptor?.contextBehavior ?? null,
+        sourceCoverageStatus:
+          accountingDescriptor?.coverageStatus ?? "unavailable",
+        generation: accountingGeneration,
+        generationFingerprint: accountingGenerationFingerprint,
+        generationMatched: accountingSourceMode === "unified"
+          ? accountingDescriptor?.generationMatched === true
+          : null,
+        fallbackCount: Number.isSafeInteger(accountingDescriptor?.fallbackCount)
+          ? accountingDescriptor.fallbackCount
+          : 0,
+        diagnosticsAvailable:
+          accountingDescriptor?.diagnosticsAvailable === true,
+        sourceCapabilities: accountingDescriptor?.capabilities ?? null,
         periodId: displayUsage?.id ?? "all",
         periodLabel: displayUsage?.label ?? RECENT_COLLECTOR_PERIOD_LABEL,
         events: displayUsage?.events ?? 0,
@@ -2584,11 +2892,7 @@ export async function buildLocalCompanionSnapshot({
         // narrower read from the unified index and reports only known adjacent
         // configuration transitions.
         reasoningEffortAvailable: false,
-        accountingSource: replaySafeCache !== null
-          ? replaySafeCache.accountingMethod
-          : unifiedAvailable
-            ? "unified_local_index_replay_suppressed"
-            : "collector_projection_unverified",
+        accountingSource,
         accountingCacheStatus: accountingStatus,
         replayExclusionDiagnostics: replaySafeCache?.diagnostics ?? null,
         cacheSwitchImpact,
@@ -2597,10 +2901,10 @@ export async function buildLocalCompanionSnapshot({
           ? { sideChatEstimates }
           : {}),
         evidenceStartDate: OPENAI_PRICE_EVIDENCE_START_DATE,
-        historyCoverage: archiveCoverage,
-        historyPeriodStatus: archiveAccounting.status,
-        historyGeneratedAt: archiveAccounting.generatedAt ?? null,
-        historyCoveredAt: archiveAccounting.coveredAt ?? null,
+        historyCoverage,
+        historyPeriodStatus: historyAccounting.status,
+        historyGeneratedAt: historyAccounting.generatedAt ?? null,
+        historyCoveredAt: historyAccounting.coveredAt ?? null,
         generatedAt: replaySafeCache?.generatedAt ?? null,
         coveredAt: replaySafeCache?.coveredAt ?? null,
         unknownModelEvents: displayUsage?.byModel
@@ -2641,6 +2945,11 @@ export async function buildLocalCompanionSnapshot({
         lastScanAt: latestEvidenceAt,
       },
       pricing: {
+        accountingSourceMode,
+        accountingGeneration,
+        accountingGenerationMatched: accountingSourceMode === "unified"
+          ? accountingDescriptor?.generationMatched === true
+          : null,
         basis: "official_api_price_equivalent_not_subscription_allowance",
         totalCostUsd: displayUsage?.apiPriceEquivalentUsd ?? 0,
         spark: displayUsage?.spark ?? null,
@@ -2692,19 +3001,15 @@ export async function buildLocalCompanionSnapshot({
         // at that event's timestamp; a reset may therefore contain mixed
         // historical card windows.
         priceEpochBasis: "event_time_when_registry_has_effective_evidence",
-        accountingSource: replaySafeCache !== null
-          ? replaySafeCache.accountingMethod
-          : unifiedAvailable
-            ? "unified_local_index_replay_suppressed"
-            : "collector_projection_unverified",
+        accountingSource,
         accountingCacheStatus: accountingStatus,
         replayExclusionDiagnostics: replaySafeCache?.diagnostics ?? null,
-        historyCoverage: archiveCoverage,
-        historyPeriodStatus: archiveAccounting.status,
+        historyCoverage,
+        historyPeriodStatus: historyAccounting.status,
       },
       coverage: {
         overallPercent: pricingCoveragePercent,
-        history: archiveCoverage,
+        history: historyCoverage,
       },
       warnings,
       monitoringGaps: [

--- a/src/local-companion-refresh.js
+++ b/src/local-companion-refresh.js
@@ -5,6 +5,11 @@ import {
   isValidQuotaWindowDuration,
 } from "@app-usagemonitor/quota-analysis";
 import { selectProductionAccountObservationSecret } from "./account-observation-production.js";
+import {
+  LOCAL_COLLECTOR_LEGACY_REFRESH_USE_MAX,
+  LOCAL_COLLECTOR_LEGACY_REFRESH_USE_SCHEMA_VERSION,
+  recordLocalCollectorLegacyRefreshAttempt,
+} from "./local-collector-state.js";
 import { runCollectorOnce } from "./passive-collector.js";
 import {
   REPLAY_SAFE_ACCOUNTING_SCHEMA_VERSION,
@@ -77,6 +82,71 @@ const INDEXING_PHASES = new Set([
   "prospective",
 ]);
 const ACCOUNTING_REFRESH_STATUSES = new Set(["reused", "rebuilt", "deferred"]);
+const GENERATION_TOKEN_PATTERN = /^[A-Za-z0-9._:-]{1,256}$/u;
+// Accounting reader failures are deliberately closed over a fixed vocabulary.
+// A caller-controlled `accounting_*` string must never become a public
+// diagnostic or an implicit promise that an unreviewed failure is safe to
+// expose.
+const ACCOUNTING_UNAVAILABLE_CODES = new Set([
+  "accounting_unified_source_unavailable",
+  "accounting_unified_coverage_incomplete",
+  "accounting_unified_coverage_unavailable",
+  "accounting_unified_index_missing",
+  "accounting_unified_index_unavailable",
+  "accounting_unified_generation_changed",
+  "accounting_unified_generation_mismatch",
+  "accounting_unified_generation_required",
+  "accounting_unified_generation_unavailable",
+  "accounting_unified_index_incompatible",
+  "accounting_unified_index_invalid",
+  "accounting_unified_read_failed",
+  "accounting_unified_callback_failed",
+  "accounting_unified_history_unavailable",
+  "accounting_calibration_corpus_unavailable",
+  "accounting_history_unavailable",
+  "accounting_refresh_aborted",
+]);
+const ACCOUNTING_RESOURCE_LIMIT_CODES = new Set([
+  "accounting_scan_source_bytes_limit_exceeded",
+  "accounting_scan_rss_limit_exceeded",
+  "accounting_transition_rss_limit_exceeded",
+  "accounting_transition_memory_budget_exceeded",
+  "accounting_transition_usage_limit_exceeded",
+  "accounting_transition_snapshot_limit_exceeded",
+  "accounting_transition_input_limit_exceeded",
+  "accounting_transition_derivation_limit_exceeded",
+  "accounting_archive_rss_limit_exceeded",
+]);
+const ACCOUNTING_TERMINAL_FAILURE_CODES = new Set([
+  "accounting_transition_rss_measurement_invalid",
+  "accounting_archive_rss_measurement_invalid",
+]);
+// Only reviewed, content-free unified-index failures may cross the public
+// refresh boundary. Prefix/shape validation is insufficient here: an
+// arbitrary internal string can still be well formed while carrying an
+// unreviewed diagnostic promise.
+const UNIFIED_INDEX_PUBLIC_ERROR_CODES = new Set([
+  "local_unified_index_aborted",
+  "local_unified_index_directory_sync_failed",
+  "local_unified_index_file_changed",
+  "local_unified_index_file_invalid",
+  "local_unified_index_generation_invalid",
+  "local_unified_index_generation_mismatch",
+  "local_unified_index_integrity_failed",
+  "local_unified_index_journal_mode_refused",
+  "local_unified_index_meta_invalid",
+  "local_unified_index_missing",
+  "local_unified_index_publication_durability_uncertain",
+  "local_unified_index_schema_invalid",
+  "local_unified_index_secondary_indexes_failed",
+  "local_unified_index_secondary_indexes_missing",
+  "local_unified_index_secret_invalid",
+  "local_unified_index_secret_unavailable",
+  "local_unified_index_unavailable",
+  "local_unified_index_worker_failed",
+]);
+const DEFAULT_UNIFIED_INDEX_PUBLIC_ERROR_CODE =
+  "local_unified_index_refresh_failed";
 const ARCHIVE_INDEX_STATUSES = new Set(["complete", "partial"]);
 const ARCHIVE_INDEX_PHASES = new Set(["complete", "awaiting_resume"]);
 const ARCHIVE_INDEX_ERROR_CODES = new Set([
@@ -108,6 +178,12 @@ const QUOTA_NOTIFICATION_EVIDENCE_SCHEMA =
 const QUOTA_NOTIFICATION_LANES = new Set(["primary", "secondary"]);
 const QUOTA_NOTIFICATION_CONTINUITY_KEY = /^[A-Za-z0-9_-]{43}$/u;
 const MAX_NOTIFICATION_EVIDENCE_AGE_MS = 5 * 60 * 1_000;
+
+function safeUnifiedIndexPublicErrorCode(value) {
+  return UNIFIED_INDEX_PUBLIC_ERROR_CODES.has(value)
+    ? value
+    : DEFAULT_UNIFIED_INDEX_PUBLIC_ERROR_CODE;
+}
 
 // A five-hour refresh_resource_limited loop once wrote NOTHING to
 // diagnostics-v0.1.log: the terminal classification lived only in the
@@ -267,8 +343,7 @@ function isResourceLimitedRefreshError(error) {
   const code = error?.code;
   return typeof code === "string"
     && (
-      code.startsWith("accounting_scan_")
-      || code.startsWith("accounting_transition_")
+      ACCOUNTING_RESOURCE_LIMIT_CODES.has(code)
       || code.startsWith("export_resource_")
       || code.startsWith("collector_resource_")
       || code.startsWith("codex_log_discovery_")
@@ -299,6 +374,144 @@ function safeCount(value) {
   return Number.isSafeInteger(value) && value >= 0 ? value : 0;
 }
 
+function safeGenerationToken(value) {
+  if (typeof value === "string" && GENERATION_TOKEN_PATTERN.test(value)) {
+    return value;
+  }
+  if (Number.isSafeInteger(value) && value >= 1) return String(value);
+  return null;
+}
+
+function publicUnifiedGeneration(value) {
+  const source = value?.generationDescriptor ?? value?.generation;
+  if (!source || typeof source !== "object" || Array.isArray(source)) {
+    return null;
+  }
+  const id = Number(source.id ?? source.generationId);
+  const fingerprint = safeGenerationToken(
+    source.fingerprint ?? source.generationFingerprint,
+  );
+  const status = ["complete", "partial"].includes(source.status)
+    ? source.status
+    : null;
+  if (!Number.isSafeInteger(id) || id < 1 || fingerprint === null
+      || status === null) {
+    return null;
+  }
+  const token = (candidate) => safeGenerationToken(candidate);
+  // The runner projects the ingest descriptor before it uses the generation
+  // as accounting authority, and the controller projects the complete runner
+  // result once more for the HTTP receipt. Accept both the internal
+  // millisecond/count names and that already-bounded public shape so the
+  // second pass is lossless rather than replacing real coverage with zeros.
+  const publicCoveredStart = source.coveredAt?.startAt;
+  const publicCoveredEnd = source.coveredAt?.endAt;
+  const coveredStart = Number.isSafeInteger(source.coveredStartMs)
+    ? new Date(source.coveredStartMs).toISOString()
+    : publicCoveredStart === null || publicCoveredStart === undefined
+      ? null
+      : safeCanonicalInstant(publicCoveredStart);
+  const coveredEnd = Number.isSafeInteger(source.coveredEndMs)
+    ? new Date(source.coveredEndMs).toISOString()
+    : publicCoveredEnd === null || publicCoveredEnd === undefined
+      ? null
+      : safeCanonicalInstant(publicCoveredEnd);
+  if ((publicCoveredStart !== null && publicCoveredStart !== undefined
+        && coveredStart === null)
+      || (publicCoveredEnd !== null && publicCoveredEnd !== undefined
+        && coveredEnd === null)) {
+    return null;
+  }
+  const discoveredSourceCount = safeCount(
+    source.discoveredSourceCount ?? source.sourceCount,
+  );
+  const discoveredSourceBytes = safeCount(
+    source.discoveredSourceBytes ?? source.sourceBytes,
+  );
+  const indexedSourceCount = safeCount(
+    source.indexedSourceCount ?? source.sourceCount
+      ?? source.discoveredSourceCount,
+  );
+  const indexedSourceBytes = safeCount(
+    source.indexedSourceBytes ?? source.sourceBytes
+      ?? source.discoveredSourceBytes,
+  );
+  return {
+    id,
+    fingerprint,
+    status,
+    blockReason: token(source.blockReason),
+    schemaVersion: token(source.schemaVersion),
+    parserVersion: token(source.parserVersion),
+    contractVersion: token(source.contractVersion),
+    coveredAt: {
+      startAt: coveredStart,
+      endAt: coveredEnd,
+    },
+    sourceCount: indexedSourceCount,
+    sourceBytes: indexedSourceBytes,
+    discoveredSourceCount,
+    discoveredSourceBytes,
+    indexedSourceCount,
+    indexedSourceBytes,
+    usageEvents: safeCount(source.usageEvents),
+    quotaOccurrences: safeCount(source.quotaOccurrences),
+    toolFacts: safeCount(source.toolFacts),
+    toolFactFingerprint: safeGenerationToken(source.toolFactFingerprint),
+    discoveryComplete: source.discoveryComplete === true,
+    diagnosticsComplete: source.diagnosticsComplete === true,
+    usageProvenanceComplete: source.usageProvenanceComplete === true,
+    sourceOrderComplete: source.sourceOrderComplete === true,
+    quotaProvenanceComplete: source.quotaProvenanceComplete === true,
+    toolProvenanceComplete: source.toolProvenanceComplete === true,
+  };
+}
+
+function unifiedGenerationAuthoritative(value) {
+  const generation = value?.generation;
+  const accountingStatus = generation?.status === "complete"
+    || (generation?.status === "partial"
+      && generation?.blockReason === "tool_provenance_incomplete"
+      && generation?.toolProvenanceComplete === false);
+  return value?.status === "ingested"
+    && accountingStatus
+    && generation.discoveryComplete === true
+    && generation.diagnosticsComplete === true
+    && generation.usageProvenanceComplete === true
+    && generation.sourceOrderComplete === true
+    && generation.quotaProvenanceComplete === true;
+}
+
+function safeAccountingUnavailableCode(value) {
+  return typeof value === "string"
+      && ACCOUNTING_UNAVAILABLE_CODES.has(value)
+    ? value
+    : "accounting_unified_source_unavailable";
+}
+
+function unifiedAccountingCacheHasZeroFallback(cache) {
+  const fallbackCount = cache?.sourceDescriptor?.fallbackCount;
+  return Number.isSafeInteger(fallbackCount) && fallbackCount === 0;
+}
+
+function publicAccountingCapabilities(value) {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return null;
+  const result = {};
+  for (const key of [
+    "readsRawSources",
+    "deterministicCanonicalOrder",
+    "sourceOrderingProvenance",
+    "sourceOffsetProvenance",
+    "sourceScopedQuotaOccurrences",
+    "durableDiagnostics",
+    "crashSafeGenerationPublication",
+  ]) {
+    if (typeof value[key] !== "boolean") return null;
+    result[key] = value[key];
+  }
+  return result;
+}
+
 function addReportedCounts(left, right) {
   if (!Number.isSafeInteger(left) || left < 0
       || !Number.isSafeInteger(right) || right < 0) return null;
@@ -318,6 +531,30 @@ function safeCanonicalInstant(value) {
   return Number.isFinite(milliseconds) && new Date(milliseconds).toISOString() === value
     ? value
     : null;
+}
+
+function publicLegacyRefreshUse(value) {
+  if (!value || typeof value !== "object" || Array.isArray(value)
+      || value.schemaVersion
+        !== LOCAL_COLLECTOR_LEGACY_REFRESH_USE_SCHEMA_VERSION
+      || value.sourceMode !== "legacy"
+      || !Number.isSafeInteger(value.attempts)
+      || value.attempts < 0
+      || value.attempts > LOCAL_COLLECTOR_LEGACY_REFRESH_USE_MAX
+      || typeof value.saturated !== "boolean"
+      || value.saturated
+        !== (value.attempts === LOCAL_COLLECTOR_LEGACY_REFRESH_USE_MAX)
+      || (value.lastAttemptedAt !== null
+        && safeCanonicalInstant(value.lastAttemptedAt) === null)) {
+    return null;
+  }
+  return {
+    schemaVersion: LOCAL_COLLECTOR_LEGACY_REFRESH_USE_SCHEMA_VERSION,
+    sourceMode: "legacy",
+    attempts: value.attempts,
+    saturated: value.saturated,
+    lastAttemptedAt: value.lastAttemptedAt,
+  };
 }
 
 function hasExactKeys(value, keys) {
@@ -603,6 +840,12 @@ export function createLocalCollectorRefreshRunner({
   // injected. Its result is intentionally not part of the public refresh
   // projection; only its provider-isolated local stores are advanced.
   refreshClaudeUsageShadow = null,
+  // Explicit source authority. The legacy default is retained only for direct
+  // compatibility/test callers; the production composition root always passes
+  // its selected mode. Neither path is ever entered as an error fallback.
+  accountingSourceMode = "legacy",
+  legacyAnalysisIndexFile = null,
+  legacyAnalysisIndexSecretFile = null,
   refreshArchiveIndex = null,
   archiveIndexFile = null,
   archiveIndexSecretFile = null,
@@ -639,6 +882,9 @@ export function createLocalCollectorRefreshRunner({
       && typeof refreshClaudeUsageShadow !== "function") {
     throw new TypeError("refreshClaudeUsageShadow must be a function or null");
   }
+  if (!["unified", "legacy"].includes(accountingSourceMode)) {
+    throw new TypeError("accountingSourceMode must be unified or legacy");
+  }
   if (refreshArchiveIndex !== null && typeof refreshArchiveIndex !== "function") {
     throw new TypeError("refreshArchiveIndex must be a function or null");
   }
@@ -652,6 +898,8 @@ export function createLocalCollectorRefreshRunner({
   for (const [name, value] of Object.entries({
     stateFile,
     accountObservationOperationLockFile,
+    legacyAnalysisIndexFile,
+    legacyAnalysisIndexSecretFile,
     archiveIndexFile,
     archiveIndexSecretFile,
     unifiedIndexFile,
@@ -698,6 +946,24 @@ export function createLocalCollectorRefreshRunner({
     };
     try {
       return await (async () => {
+    // Legacy is an explicit rollback authority, never an error fallback. Stamp
+    // the attempted use before any collector/accounting work so a later
+    // failure still leaves a durable, bounded receipt in owner-only state.
+    let legacyRefreshUse = null;
+    if (accountingSourceMode === "legacy" && stateFile !== null) {
+      try {
+        legacyRefreshUse = await recordLocalCollectorLegacyRefreshAttempt({
+          stateFile,
+          clock,
+        });
+      } catch (error) {
+        // Test/injected runners may deliberately point at a non-writable
+        // placeholder path. Do not turn that unrelated setup failure into a
+        // refresh failure; malformed existing receipt metadata still fails
+        // closed so a real owner-state corruption is not hidden.
+        if (error?.code !== "local_collector_state_unavailable") throw error;
+      }
+    }
     // Record the declared baseline before the pass reads any usage, so the
     // reading is stamped no later than the turns it may attribute. A failure
     // here is never allowed to block collection: it simply leaves those turns
@@ -734,8 +1000,17 @@ export function createLocalCollectorRefreshRunner({
       ...(stateFile === null ? {} : { stateFile }),
       staleAfterMs: 0,
       refreshStale: true,
-      backfill: true,
-      backfillSinceAt: new Date(clock() - recentIndexWindowMs).toISOString(),
+      // Usage facts are authoritative in the unified index. In that mode the
+      // collector remains responsible for the provider quota/quick headline,
+      // but must not resume an inherited legacy recent-7d rollout backfill.
+      // Legacy mode keeps the historical two-pass collector unchanged.
+      backfill: accountingSourceMode === "legacy",
+      ...(accountingSourceMode === "legacy"
+        ? { backfillSinceAt: new Date(clock() - recentIndexWindowMs).toISOString() }
+        : {}),
+      ...(accountingSourceMode === "unified"
+        ? { skipRolloutIngestion: true }
+        : {}),
       signal,
       onProgress: async (value) => {
         const progress = publicIndexingResult(value);
@@ -775,7 +1050,13 @@ export function createLocalCollectorRefreshRunner({
     if (earlyIndex?.status === "bounded_pause"
         && signal?.aborted !== true) {
       const earlyLimit = collectorResourceLimit(result);
-      if (earlyLimit !== null
+      if (accountingSourceMode === "unified") {
+        // A custom/injected collector may still report its own bounded pause
+        // even though unified production collection opts out of rollout
+        // ingestion. Remember the fixed limit for the assemble decision, but
+        // never launch a second legacy continuation in unified mode.
+        collectorResourceLimitDeferred = earlyLimit !== null;
+      } else if (earlyLimit !== null
           && earlyLimit.dimension !== "source_bytes") {
         // Preserve the foreground resource-limit receipt, but let the
         // independent archive pass use this same bounded refresh to advance
@@ -793,12 +1074,25 @@ export function createLocalCollectorRefreshRunner({
     }
     const completedIndex = publicIndexingResult(result?.indexing);
     await publishHeadline(completedIndex);
-    const accountingMayRun = completedIndex === null
-      || ["recent_7d_complete", "recent_7d_partial", "prospective_only"]
-        .includes(completedIndex.status);
+    const accountingMayRun = accountingSourceMode === "unified"
+      ? completedIndex === null
+        || [
+          "recent_7d_complete",
+          "recent_7d_partial",
+          "prospective_only",
+          // Unified accounting reads the published index, not the bounded
+          // collector ledger, so a collector-only pause must not suppress a
+          // complete-generation accounting pass.
+          "bounded_pause",
+        ].includes(completedIndex.status)
+      : completedIndex === null
+        || ["recent_7d_complete", "recent_7d_partial", "prospective_only"]
+          .includes(completedIndex.status);
     let unifiedIndex = null;
     refreshStep = "unified_index";
-    if (refreshUnifiedIndex !== null && signal?.aborted !== true) {
+    if (accountingSourceMode === "unified"
+        && refreshUnifiedIndex !== null
+        && signal?.aborted !== true) {
       // The unified index advances by its cursors, so this ordinarily reads
       // only appended bytes. It runs BEFORE accounting so the full-history
       // calibration corpus the accounting rebuild reads from the index
@@ -817,18 +1111,25 @@ export function createLocalCollectorRefreshRunner({
       } catch (error) {
         unifiedIndex = {
           status: "failed",
-          errorCode: typeof error?.code === "string"
-              && error.code.startsWith("local_unified_index_")
-            ? error.code
-            : "local_unified_index_refresh_failed",
+          errorCode: safeUnifiedIndexPublicErrorCode(error?.code),
         };
       }
     }
+    const unifiedAccountingReady = accountingSourceMode === "legacy"
+      || unifiedGenerationAuthoritative(unifiedIndex);
     let accounting = null;
     let accountingRefreshStatus = null;
     let accountingRebuildDeferred = null;
+    let accountingUnavailableCode = accountingSourceMode === "unified"
+        && !unifiedAccountingReady
+      ? unifiedIndex?.status === "failed"
+        ? "accounting_unified_source_unavailable"
+        : "accounting_unified_coverage_incomplete"
+      : null;
     refreshStep = "accounting";
-    if (refreshAccounting !== null && accountingMayRun) {
+    if (refreshAccounting !== null
+        && accountingMayRun
+        && unifiedAccountingReady) {
       // A provider quota observation does not alter replay-safe token
       // accounting. Reuse a current cache when no rollout usage record was
       // added, while the collector state continues to supply the fresh quota
@@ -845,6 +1146,13 @@ export function createLocalCollectorRefreshRunner({
           const existing = await readAccountingCache({
             ...(stateFile === null ? {} : { stateFile }),
             now: clock,
+            sourceMode: accountingSourceMode,
+            ...(accountingSourceMode === "unified"
+              ? {
+                contextBehavior: "legacy_zero",
+                expectedGeneration: unifiedIndex.generation,
+              }
+              : {}),
             // During backoff a labelled estimate beats a blank surface, so the
             // ordinary reuse-age gate is lifted (a valid cache then reads
             // "available" regardless of age). Outside backoff the gate stays,
@@ -856,7 +1164,9 @@ export function createLocalCollectorRefreshRunner({
           if (signal?.aborted !== true
               && existing?.status === "available"
               && existing.cache?.schemaVersion
-                === REPLAY_SAFE_ACCOUNTING_SCHEMA_VERSION) {
+                === REPLAY_SAFE_ACCOUNTING_SCHEMA_VERSION
+              && (accountingSourceMode !== "unified"
+                || unifiedAccountingCacheHasZeroFallback(existing.cache))) {
             accounting = existing.cache;
             // No new usage -> the reused cache still covers every event, so it
             // is exact ("reused"). Otherwise it is served only because the
@@ -871,21 +1181,56 @@ export function createLocalCollectorRefreshRunner({
         }
       }
       if (accounting === null && !withinRebuildBackoff) {
-        const rebuilt = await refreshAccounting({
-          codexHome,
-          ...(stateFile === null ? {} : { stateFile }),
-          now: clock,
-          // The scan window bounds only the periods/timeline scan and obeys
-          // the standing rule above: extreme, never convenience-sized. The
-          // calibration corpus does not follow this window at all when the
-          // unified index is present — the rebuild reads the full indexed
-          // history through `unifiedIndexFile` and falls back to this window
-          // only when the index is missing or unreadable.
-          windowDays: ACCOUNTING_SCAN_WINDOW_DAYS,
-          ...(unifiedIndexFile === null ? {} : { unifiedIndexFile }),
-          declaredSpeedBaselines,
-          signal,
-        });
+        let rebuilt = null;
+        try {
+          rebuilt = await refreshAccounting({
+            codexHome,
+            ...(stateFile === null ? {} : { stateFile }),
+            now: clock,
+            sourceMode: accountingSourceMode,
+            // The scan window bounds only the periods/timeline scan and obeys
+            // the standing rule above: extreme, never convenience-sized. The
+            // calibration corpus does not follow this window at all when the
+            // unified index is present.
+            windowDays: ACCOUNTING_SCAN_WINDOW_DAYS,
+            ...(unifiedIndexFile === null ? {} : { unifiedIndexFile }),
+            ...(accountingSourceMode === "legacy"
+                && legacyAnalysisIndexFile !== null
+              ? { indexFile: legacyAnalysisIndexFile }
+              : {}),
+            ...(accountingSourceMode === "legacy"
+                && legacyAnalysisIndexSecretFile !== null
+              ? { indexSecretFile: legacyAnalysisIndexSecretFile }
+              : {}),
+            ...(accountingSourceMode === "unified"
+              ? { expectedGeneration: unifiedIndex.generation }
+              : {}),
+            ...(accountingSourceMode === "unified"
+              ? { contextBehavior: "legacy_zero" }
+              : {}),
+            declaredSpeedBaselines,
+            signal,
+          });
+        } catch (error) {
+          if (accountingSourceMode !== "unified"
+              || error?.name === "AbortError") {
+            throw error;
+          }
+          // Resource limits are terminal refresh safety stops, not ordinary
+          // unavailable evidence. Let the controller classify the fixed code
+          // as refresh_resource_limited; swallowing it here would report a
+          // misleading successful refresh with an unavailable cache.
+          if (ACCOUNTING_RESOURCE_LIMIT_CODES.has(error?.code)
+              || ACCOUNTING_TERMINAL_FAILURE_CODES.has(error?.code)) {
+            throw error;
+          }
+          // Unified mode never falls back to raw logs or the old index. Keep
+          // the last cache on disk untouched and return a bounded unavailable
+          // receipt; a later complete generation can validate and reuse it.
+          accountingUnavailableCode = safeAccountingUnavailableCode(
+            error?.code,
+          );
+        }
         if (rebuilt?.status === "accounting_rebuild_deferred") {
           // Memory-budget miss soft-failed inside the rebuild: the prior
           // on-disk cache was retained untouched. Do NOT fail the refresh —
@@ -905,23 +1250,46 @@ export function createLocalCollectorRefreshRunner({
               const existing = await readAccountingCache({
                 ...(stateFile === null ? {} : { stateFile }),
                 now: clock,
+                sourceMode: accountingSourceMode,
+                ...(accountingSourceMode === "unified"
+                  ? {
+                    contextBehavior: "legacy_zero",
+                    expectedGeneration: unifiedIndex.generation,
+                  }
+                  : {}),
               });
               if (existing?.status === "available"
                   && existing.cache?.schemaVersion
-                    === REPLAY_SAFE_ACCOUNTING_SCHEMA_VERSION) {
+                    === REPLAY_SAFE_ACCOUNTING_SCHEMA_VERSION
+                  && (accountingSourceMode !== "unified"
+                    || unifiedAccountingCacheHasZeroFallback(existing.cache))) {
                 accounting = existing.cache;
                 accountingRefreshStatus = "deferred";
+              } else if (accountingSourceMode === "unified") {
+                accountingUnavailableCode =
+                  "accounting_unified_source_unavailable";
               }
             } catch {
               // Retained-cache read failed; the surface shows honest
               // insufficient-evidence rather than a fabricated total.
             }
           }
-        } else {
-          accounting = rebuilt;
-          accountingRefreshStatus = "rebuilt";
-          // A successful rebuild clears any prior budget-miss backoff.
-          accountingRebuildDeferUntilMs = 0;
+        } else if (rebuilt !== null) {
+          if (accountingSourceMode === "unified"
+              && !unifiedAccountingCacheHasZeroFallback(rebuilt)) {
+            // A unified cache is authoritative only when its source receipt
+            // proves that no legacy/raw fallback was used. Do not publish a
+            // plausible-looking result when the attestation is absent or
+            // non-zero.
+            accountingUnavailableCode = "accounting_unified_source_unavailable";
+          } else {
+            accounting = rebuilt;
+          }
+          if (accounting !== null) {
+            accountingRefreshStatus = "rebuilt";
+            // A successful rebuild clears any prior budget-miss backoff.
+            accountingRebuildDeferUntilMs = 0;
+          }
         }
       }
     }
@@ -931,7 +1299,8 @@ export function createLocalCollectorRefreshRunner({
     );
     let archiveIndex = null;
     refreshStep = "archive_index";
-    if (refreshArchiveIndex !== null
+    if (accountingSourceMode === "legacy"
+        && refreshArchiveIndex !== null
         && signal?.aborted !== true) {
       // Archive coverage is independent of the recent collector's accounting
       // gate. A bounded recent pass may remain paused while this one foreground
@@ -956,7 +1325,12 @@ export function createLocalCollectorRefreshRunner({
     refreshStep = "assemble";
     const claudeQuota = await claudeQuotaPromise;
     await claudeUsageShadowPromise;
-    if (collectorResourceLimitDeferred) throwCollectorResourceLimit();
+    const unifiedCollectorPauseSoftened = accountingSourceMode === "unified"
+      && unifiedAccountingReady
+      && accounting !== null;
+    if (collectorResourceLimitDeferred && !unifiedCollectorPauseSoftened) {
+      throwCollectorResourceLimit();
+    }
     return {
       rolloutRecordsWritten: Number.isSafeInteger(result?.rolloutRecordsWritten)
         ? result.rolloutRecordsWritten
@@ -970,19 +1344,54 @@ export function createLocalCollectorRefreshRunner({
           : null,
       },
       ...(notificationEvidence === null ? {} : { notificationEvidence }),
-      ...(accounting === null
-        ? {}
-        : {
+      ...(legacyRefreshUse === null ? {} : { legacyRefreshUse }),
+      ...(accounting !== null
+        ? {
           accounting: {
             status: "replay_safe",
+            sourceMode: accountingSourceMode,
             refreshStatus: accountingRefreshStatus,
+            readerVersion: accounting.sourceDescriptor?.readerVersion ?? null,
+            compatibilityBehavior:
+              accounting.sourceDescriptor?.contextBehavior ?? null,
+            coverageStatus:
+              accounting.sourceDescriptor?.coverageStatus ?? null,
+            generation: accounting.sourceDescriptor?.generation ?? null,
+            generationFingerprint:
+              accounting.sourceDescriptor?.generationFingerprint ?? null,
+            generationMatched:
+              accounting.sourceDescriptor?.generationMatched === true,
+            fallbackCount:
+              safeCount(accounting.sourceDescriptor?.fallbackCount),
+            diagnosticsAvailable:
+              accounting.sourceDescriptor?.diagnosticsAvailable === true,
+            capabilities: accounting.sourceDescriptor?.capabilities ?? null,
             generatedAt: accounting.generatedAt,
             events: accounting.periods
               ?.find((period) => period.id === "7d")?.events ?? 0,
             forkReplayEventsExcluded:
               accounting.diagnostics?.forkReplayEventsExcluded ?? 0,
           },
-        }),
+        }
+        : accountingSourceMode === "unified"
+          ? {
+            accounting: {
+              status: "unavailable",
+              sourceMode: "unified",
+              errorCode: safeAccountingUnavailableCode(
+                accountingUnavailableCode,
+              ),
+              compatibilityBehavior: "legacy_zero",
+              coverageStatus: unifiedIndex?.generation?.status ?? "unavailable",
+              generation: unifiedIndex?.generation?.id ?? null,
+              generationFingerprint:
+                unifiedIndex?.generation?.fingerprint ?? null,
+              generationMatched: false,
+              fallbackCount: 0,
+              diagnosticsAvailable: false,
+            },
+          }
+          : {}),
       ...(publicArchiveIndexResult(archiveIndex) === null
         ? {}
         : { archiveIndex: publicArchiveIndexResult(archiveIndex) }),
@@ -1007,7 +1416,17 @@ export function createLocalCollectorRefreshRunner({
 // rather than leaking whatever shape the ingest returned.
 function publicUnifiedIndexResult(value) {
   if (value?.status !== "ingested") {
-    return { status: "failed", errorCode: "local_unified_index_refresh_failed" };
+    return {
+      status: "failed",
+      errorCode: DEFAULT_UNIFIED_INDEX_PUBLIC_ERROR_CODE,
+    };
+  }
+  const generation = publicUnifiedGeneration(value);
+  if (generation === null) {
+    return {
+      status: "failed",
+      errorCode: "local_unified_index_generation_invalid",
+    };
   }
   const counts = {};
   for (const key of [
@@ -1029,6 +1448,8 @@ function publicUnifiedIndexResult(value) {
   }
   return {
     status: "ingested",
+    unchanged: value.unchanged === true,
+    generation,
     ...counts,
     wallMs: Number.isFinite(value.wallMs) && value.wallMs >= 0
       ? Math.round(value.wallMs)
@@ -1167,17 +1588,81 @@ function publicRefreshResult(result, now = Date.now()) {
   if (result?.claudeQuota !== undefined) {
     projected.claudeQuota = publicClaudeQuotaResult(result.claudeQuota);
   }
+  const legacyRefreshUse = publicLegacyRefreshUse(result?.legacyRefreshUse);
+  if (legacyRefreshUse !== null) {
+    projected.legacyRefreshUse = legacyRefreshUse;
+  }
+  if (result?.unifiedIndex?.status === "ingested") {
+    projected.unifiedIndex = publicUnifiedIndexResult(result.unifiedIndex);
+  } else if (result?.unifiedIndex?.status === "failed") {
+    projected.unifiedIndex = {
+      status: "failed",
+      errorCode: safeUnifiedIndexPublicErrorCode(
+        result.unifiedIndex.errorCode,
+      ),
+    };
+  }
   if (result?.accounting?.status === "replay_safe"
-      && safeCanonicalInstant(result.accounting.generatedAt) !== null) {
+      && safeCanonicalInstant(result.accounting.generatedAt) !== null
+      && (result.accounting.sourceMode !== "unified"
+        || (Number.isSafeInteger(result.accounting.fallbackCount)
+          && result.accounting.fallbackCount === 0))) {
+    const capabilities = publicAccountingCapabilities(
+      result.accounting.capabilities,
+    );
     projected.accounting = {
       status: "replay_safe",
+      sourceMode: ["unified", "legacy"].includes(result.accounting.sourceMode)
+        ? result.accounting.sourceMode
+        : "legacy",
       ...(ACCOUNTING_REFRESH_STATUSES.has(result.accounting.refreshStatus)
         ? { refreshStatus: result.accounting.refreshStatus }
         : {}),
+      readerVersion: safeGenerationToken(result.accounting.readerVersion),
+      compatibilityBehavior:
+        ["legacy_zero", "source_native"].includes(
+          result.accounting.compatibilityBehavior,
+        )
+          ? result.accounting.compatibilityBehavior
+          : null,
+      coverageStatus: ["complete", "partial"].includes(
+        result.accounting.coverageStatus,
+      ) ? result.accounting.coverageStatus : null,
+      generation: safeGenerationToken(result.accounting.generation),
+      generationFingerprint: safeGenerationToken(
+        result.accounting.generationFingerprint,
+      ),
+      generationMatched: result.accounting.generationMatched === true,
+      fallbackCount: safeCount(result.accounting.fallbackCount),
+      diagnosticsAvailable:
+        result.accounting.diagnosticsAvailable === true,
+      ...(capabilities === null ? {} : { capabilities }),
       generatedAt: result.accounting.generatedAt,
       events: safeCount(result.accounting.events),
       forkReplayEventsExcluded:
         safeCount(result.accounting.forkReplayEventsExcluded),
+    };
+  } else if (result?.accounting?.sourceMode === "unified"
+      && ["unavailable", "replay_safe"].includes(result.accounting.status)) {
+    projected.accounting = {
+      status: "unavailable",
+      sourceMode: "unified",
+      errorCode: safeAccountingUnavailableCode(
+        result.accounting.status === "replay_safe"
+          ? "accounting_unified_source_unavailable"
+          : result.accounting.errorCode,
+      ),
+      compatibilityBehavior: "legacy_zero",
+      coverageStatus: ["complete", "partial"].includes(
+        result.accounting.coverageStatus,
+      ) ? result.accounting.coverageStatus : "unavailable",
+      generation: safeGenerationToken(result.accounting.generation),
+      generationFingerprint: safeGenerationToken(
+        result.accounting.generationFingerprint,
+      ),
+      generationMatched: false,
+      fallbackCount: 0,
+      diagnosticsAvailable: false,
     };
   }
   const archiveIndex = publicArchiveIndexResult(result?.archiveIndex);

--- a/src/local-installation-diagnostics.js
+++ b/src/local-installation-diagnostics.js
@@ -147,6 +147,17 @@ export function localCompanionStatePaths(stateRoot) {
     // legacy JSON/JSONL files are discovered privately by the migration code
     // and removed only after its parity receipt is durable.
     collectorStateFile: join(selected, "local-collector-state-v1.sqlite"),
+    // Dormant rollback-only state. Unified mode never reads or advances these
+    // files, but their exact locations remain stable for one reversible
+    // release so selecting legacy authority is explicit and diagnosable.
+    legacyAnalysisIndexFile: join(
+      selected,
+      "local-analysis-index-v2.sqlite",
+    ),
+    legacyAnalysisIndexSecretFile: join(
+      selected,
+      "local-analysis-index-secret-v2",
+    ),
     archiveAccountingIndexFile: join(
       selected,
       "local-archive-accounting-index-v1.sqlite",

--- a/src/local-unified-accounting-source.js
+++ b/src/local-unified-accounting-source.js
@@ -5,28 +5,50 @@ import { isValidQuotaWindowDuration } from "@app-usagemonitor/quota-analysis";
 import {
   LOCAL_UNIFIED_INDEX_SCHEMA_VERSION,
   openLocalUnifiedIndex,
+  readUnifiedIndexGenerationDescriptor,
+  readUnifiedIndexToolFactFingerprint,
 } from "./local-unified-index.js";
 import { validAbortSignal } from "./valid-abort-signal.js";
 
-// Read-only characterization adapter from the current unified fact store to
-// the callback contract consumed by replay-safe accounting. This module never
-// discovers or opens rollout JSONL. It deliberately reports accounting
-// coverage as partial until source ordering, source-scoped quota occurrences,
-// durable diagnostics, and crash-safe generation publication are persisted.
+// Read-only adapter from the current unified fact store to the callback
+// contract consumed by replay-safe accounting. This module never discovers
+// or opens rollout JSONL. Coverage is complete only for an attested staged
+// generation whose persisted provenance, quota occurrences, diagnostics, and
+// publication state prove the reader contract.
 export const LOCAL_UNIFIED_ACCOUNTING_SOURCE_VERSION =
-  "local-unified-accounting-source-v1";
+  "local-unified-accounting-source-v2";
 
 const SAFE_TOKEN = /^[A-Za-z0-9._:-]{1,64}$/u;
+const GENERATION_FINGERPRINT = /^generation-v2-[a-f0-9]{64}$/u;
+const TOOL_FACT_FINGERPRINT = /^tool-facts-v1-[a-f0-9]{64}$/u;
 const QUOTA_SLOTS = new Set(["primary", "secondary"]);
 const REQUIRED_META_KEYS = Object.freeze([
   "schema_version",
   "status",
-  "generated_at",
-  "source_count",
-  "source_bytes",
-  "usage_events",
   "contract_version",
+  "current_generation_id",
 ]);
+const CALLBACK_RESOURCE_CODES = new Set([
+  "accounting_refresh_aborted",
+  "accounting_scan_source_bytes_limit_exceeded",
+  "accounting_scan_rss_limit_exceeded",
+  "accounting_transition_rss_measurement_invalid",
+  "accounting_transition_rss_limit_exceeded",
+  "accounting_transition_memory_budget_exceeded",
+  "accounting_transition_usage_limit_exceeded",
+  "accounting_transition_snapshot_limit_exceeded",
+  "accounting_transition_input_limit_exceeded",
+  "accounting_transition_derivation_limit_exceeded",
+  "accounting_archive_rss_measurement_invalid",
+  "accounting_archive_rss_limit_exceeded",
+]);
+const GENERATION_STATUSES = new Set([
+  "in_progress",
+  "complete",
+  "partial",
+  "failed",
+]);
+const CONTEXT_BEHAVIORS = new Set(["source_native", "legacy_zero"]);
 const ADAPTER_ABORT = Symbol("local-unified-accounting-source-abort");
 
 function fixedError(code, name = "Error") {
@@ -93,6 +115,14 @@ function safeText(value, { nullable = false } = {}) {
   return value;
 }
 
+function safeDigest(value, { nullable = false } = {}) {
+  if (value === null && nullable) return null;
+  if (!(value instanceof Uint8Array) || value.byteLength !== 32) {
+    throw fixedError("local_unified_index_row_invalid");
+  }
+  return Buffer.from(value);
+}
+
 function readMeta(database) {
   const result = {};
   for (const row of database.prepare(
@@ -127,12 +157,113 @@ function metaCount(meta, key) {
   return numeric;
 }
 
-function parserCompatibility(database, contractVersion) {
+function metaCountOptional(meta, key) {
+  if (!Object.hasOwn(meta, key)) return null;
+  return metaCount(meta, key);
+}
+
+function generationIdFromValue(value) {
+  if (typeof value === "number" || typeof value === "bigint") {
+    const id = Number(value);
+    if (Number.isSafeInteger(id) && id > 0) return id;
+    return null;
+  }
+  if (typeof value !== "string" || !/^\d+(?:\.0+)?$/u.test(value)) return null;
+  const id = Number(value);
+  return Number.isSafeInteger(id) && id > 0 ? id : null;
+}
+
+function validateStoredGenerationFingerprint(meta, canonicalFingerprint) {
+  for (const key of [
+    "current_generation_fingerprint",
+    "generation_fingerprint",
+  ]) {
+    if (!Object.hasOwn(meta, key)) continue;
+    if (meta[key] !== canonicalFingerprint) {
+      throw fixedError("local_unified_index_generation_invalid");
+    }
+  }
+}
+
+function expectedGenerationDescriptor(value) {
+  if (value === null || value === undefined) return null;
+  if (typeof value === "number" || typeof value === "bigint") {
+    const id = generationIdFromValue(value);
+    if (id === null) {
+      throw fixedError(
+        "local_unified_index_generation_request_invalid",
+        "TypeError",
+      );
+    }
+    return { id, fingerprint: null };
+  }
+  if (typeof value === "string") {
+    const id = generationIdFromValue(value);
+    if (id !== null) return { id, fingerprint: null };
+    if (!SAFE_TOKEN.test(value) && !GENERATION_FINGERPRINT.test(value)) {
+      throw fixedError(
+        "local_unified_index_generation_request_invalid",
+        "TypeError",
+      );
+    }
+    return { id: null, fingerprint: value };
+  }
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw fixedError(
+      "local_unified_index_generation_request_invalid",
+      "TypeError",
+    );
+  }
+  const id = generationIdFromValue(
+    value.id ?? value.generationId ?? value.currentGenerationId,
+  );
+  const fingerprint = value.fingerprint
+    ?? value.generationFingerprint
+    ?? value.currentGenerationFingerprint
+    ?? null;
+  if (fingerprint !== null
+      && (typeof fingerprint !== "string"
+        || (!SAFE_TOKEN.test(fingerprint)
+          && !GENERATION_FINGERPRINT.test(fingerprint)))) {
+    throw fixedError(
+      "local_unified_index_generation_request_invalid",
+      "TypeError",
+    );
+  }
+  if (id === null && (typeof fingerprint !== "string"
+      || (!SAFE_TOKEN.test(fingerprint)
+        && !GENERATION_FINGERPRINT.test(fingerprint)))) {
+    throw fixedError(
+      "local_unified_index_generation_request_invalid",
+      "TypeError",
+    );
+  }
+  return { id, fingerprint };
+}
+
+function boundedCount(value) {
+  const numeric = Number(value);
+  return Number.isSafeInteger(numeric) && numeric >= 0 ? numeric : null;
+}
+
+function parserCompatibility(database, contractVersion, generationId) {
+  // Dimension history is retained across additive migrations. Only parser
+  // versions referenced by facts (plus the current generation for an empty
+  // index) describe the published generation; an orphaned old dimension row
+  // must not make every read look mixed forever.
   const rows = database.prepare(`
-    SELECT DISTINCT parser_version, contract_version
-    FROM parser_version
-    ORDER BY parser_version, contract_version
-  `).all();
+    SELECT DISTINCT p.parser_version, p.contract_version
+    FROM parser_version p
+    JOIN (
+      SELECT DISTINCT parser_version_id
+      FROM usage_event
+      UNION
+      SELECT parser_version_id
+      FROM index_generation
+      WHERE id = ?
+    ) referenced ON referenced.parser_version_id = p.id
+    ORDER BY p.parser_version, p.contract_version
+  `).all(generationId);
   if (rows.length === 0) {
     throw fixedError("local_unified_index_compatibility_invalid");
   }
@@ -159,56 +290,400 @@ function parserCompatibility(database, contractVersion) {
   };
 }
 
-function accountingCoverage(database, meta, requestedWindow) {
+function queryCount(database, sql, ...parameters) {
+  const value = database.prepare(sql).get(...parameters)?.count;
+  const count = boundedCount(value ?? 0);
+  if (count === null) throw fixedError("local_unified_index_meta_invalid");
+  return count;
+}
+
+function readCurrentGeneration(
+  database,
+  meta,
+  requestedWindow,
+  { verifyPublishedGeneration = false } = {},
+) {
   for (const key of REQUIRED_META_KEYS) requiredMetaText(meta, key);
   const schemaVersion = requiredMetaText(meta, "schema_version");
+  if (schemaVersion !== LOCAL_UNIFIED_INDEX_SCHEMA_VERSION) {
+    throw fixedError("local_unified_index_meta_invalid");
+  }
   const indexStatus = requiredMetaText(meta, "status");
-  if (schemaVersion !== LOCAL_UNIFIED_INDEX_SCHEMA_VERSION
-      || !new Set(["complete", "partial"]).has(indexStatus)) {
+  if (!["complete", "partial"].includes(indexStatus)) {
     throw fixedError("local_unified_index_meta_invalid");
   }
-  const generatedAtText = requiredMetaText(meta, "generated_at");
-  const generatedAt = canonicalInstant(generatedAtText);
-  if (generatedAt === null) {
-    throw fixedError("local_unified_index_meta_invalid");
+  const currentGenerationId = generationIdFromValue(
+    requiredMetaText(meta, "current_generation_id"),
+  );
+  if (currentGenerationId === null) {
+    throw fixedError("local_unified_index_generation_invalid");
   }
-  const sourceCount = metaCount(meta, "source_count");
-  const sourceBytes = metaCount(meta, "source_bytes");
-  // Do not compare these totals to source_cursor here: rotated rollout files
-  // can vanish while their durable facts and retained cursors remain, and the
-  // current schema has no generation-scoped coverage record that distinguishes
-  // that history from an in-progress discovery set.
-  const declaredUsageEvents = metaCount(meta, "usage_events");
-  const usageEvents = Number(database.prepare(
-    "SELECT COUNT(*) AS count FROM usage_event",
-  ).get()?.count ?? 0);
-  const quotaObservations = Number(database.prepare(
-    "SELECT COUNT(*) AS count FROM quota_observation",
-  ).get()?.count ?? 0);
-  if (![usageEvents, quotaObservations].every(
-    (value) => Number.isSafeInteger(value) && value >= 0,
-  ) || usageEvents !== declaredUsageEvents) {
-    throw fixedError("local_unified_index_meta_invalid");
+  let generation;
+  try {
+    generation = database.prepare(`
+      SELECT id, started_at_ms, completed_at_ms, parser_version_id,
+             contract_version, status, block_reason,
+             discovered_source_count, discovered_source_bytes,
+             indexed_source_count, indexed_source_bytes, usage_events,
+             quota_occurrences, covered_start_ms, covered_end_ms,
+             discovery_complete, diagnostics_complete,
+             usage_provenance_complete, source_order_complete,
+             quota_provenance_complete, tool_facts,
+             tool_fact_fingerprint, tool_provenance_complete
+      FROM index_generation
+      WHERE id = ?
+    `).get(currentGenerationId);
+  } catch {
+    throw fixedError("local_unified_index_generation_invalid");
   }
+  if (!generation || Number(generation.id) !== currentGenerationId
+      || !GENERATION_STATUSES.has(generation.status)) {
+    throw fixedError("local_unified_index_generation_invalid");
+  }
+  const contractVersion = requiredMetaText(meta, "contract_version");
+  if (generation.contract_version !== contractVersion
+      || !SAFE_TOKEN.test(contractVersion)) {
+    throw fixedError("local_unified_index_compatibility_invalid");
+  }
+  // The fingerprint is derived only from the published generation row. Meta
+  // values are compatibility breadcrumbs, not an authority that can replace
+  // the canonical identity handed to downstream accounting.
+  const descriptor = readUnifiedIndexGenerationDescriptor(
+    database,
+    currentGenerationId,
+  );
+  if (!descriptor || descriptor.id !== currentGenerationId
+      || !GENERATION_FINGERPRINT.test(descriptor.fingerprint)) {
+    throw fixedError("local_unified_index_generation_invalid");
+  }
+  validateStoredGenerationFingerprint(meta, descriptor.fingerprint);
+  const fingerprint = descriptor.fingerprint;
+  const generatedAtMs = boundedCount(
+    generation.completed_at_ms ?? generation.started_at_ms,
+  );
+  if (generatedAtMs === null) {
+    throw fixedError("local_unified_index_generation_invalid");
+  }
+  const generatedAt = new Date(generatedAtMs).toISOString();
+  const coveredStartMs = boundedCount(generation.covered_start_ms);
+  const coveredEndMs = boundedCount(generation.covered_end_ms);
+  const coveredAt = coveredStartMs !== null && coveredEndMs !== null
+    && coveredEndMs >= coveredStartMs
+    ? {
+      startAt: new Date(coveredStartMs).toISOString(),
+      endAt: new Date(coveredEndMs).toISOString(),
+    }
+    : null;
+
+  const declaredUsageEvents = boundedCount(generation.usage_events);
+  const declaredQuotaOccurrences = boundedCount(generation.quota_occurrences);
+  const declaredToolFacts = boundedCount(generation.tool_facts);
+  const declaredToolFactFingerprint = typeof generation.tool_fact_fingerprint
+      === "string" && TOOL_FACT_FINGERPRINT.test(
+        generation.tool_fact_fingerprint,
+      )
+    ? generation.tool_fact_fingerprint
+    : null;
+  const declaredSourceCount = boundedCount(generation.indexed_source_count);
+  const declaredSourceBytes = boundedCount(generation.indexed_source_bytes);
+  const usageProvenanceAttested = generation.usage_provenance_complete === 1;
+  const sourceOrderAttested = generation.source_order_complete === 1;
+  const quotaProvenanceAttested = generation.quota_provenance_complete === 1;
+  const toolProvenanceAttested = generation.tool_provenance_complete === 1;
+  const generationAttestationComplete = usageProvenanceAttested
+    && sourceOrderAttested
+    && quotaProvenanceAttested;
+  if (declaredUsageEvents === null
+      || declaredQuotaOccurrences === null
+      || declaredToolFacts === null
+      || declaredToolFactFingerprint === null
+      || declaredSourceCount === null
+      || declaredSourceBytes === null) {
+    // A completed generation without its immutable count attestation is not a
+    // safe publication. The optional full verifier below can explain the
+    // mismatch, but the normal reader must fail closed immediately.
+    return {
+      status: "partial",
+      indexStatus,
+      blockReason: "generation_attestation_incomplete",
+      generatedAt,
+      coveredAt,
+      generationId: currentGenerationId,
+      generationFingerprint: fingerprint,
+      generationProof: false,
+      requestedWindow,
+      sourceCount: declaredSourceCount ?? 0,
+      sourceBytes: declaredSourceBytes ?? 0,
+      usageEvents: declaredUsageEvents ?? 0,
+      quotaObservations: metaCountOptional(meta, "quota_observations"),
+      quotaOccurrences: declaredQuotaOccurrences ?? 0,
+      toolFacts: declaredToolFacts ?? 0,
+      toolFactFingerprint: declaredToolFactFingerprint,
+      admittedQuotaOccurrences: metaCountOptional(
+        meta,
+        "admitted_quota_occurrences",
+      ),
+      provenanceComplete: false,
+      quotaOccurrencesComplete: false,
+      toolFactsComplete: false,
+      diagnosticsComplete: false,
+      usageProvenanceAttested,
+      sourceOrderAttested,
+      quotaProvenanceAttested,
+      toolProvenanceAttested,
+      currentGeneration: generation,
+    };
+  }
+
+  // Staged publication persists these values before the rename. Keep the hot
+  // accounting path on the generation attestation; the explicit verifier is
+  // available for migration audits and tests that need to prove every row.
+  let usageEvents = declaredUsageEvents;
+  let quotaOccurrences = declaredQuotaOccurrences;
+  let toolFacts = declaredToolFacts;
+  let admittedQuotaOccurrences = metaCountOptional(
+    meta,
+    "admitted_quota_occurrences",
+  );
+  let quotaObservations = metaCountOptional(meta, "quota_observations");
+  let sourceCount = declaredSourceCount;
+  let sourceBytes = declaredSourceBytes;
+  let countsMatch = true;
+  let sourceIncomplete = false;
+  let sourceOrdinalMissing = false;
+  let usageProvenanceMissing = false;
+  let quotaProvenanceMissing = false;
+  let toolProvenanceMissing = false;
+  let toolFactFingerprintMatches = true;
+
+  if (verifyPublishedGeneration) {
+    // These checks deliberately inspect the facts themselves. A generation's
+    // summary is not proof when a migrated row still has NULL provenance or
+    // when an occurrence was lost between a source cursor and publication.
+    usageEvents = queryCount(database, `
+      SELECT COUNT(*) AS count FROM usage_event
+    `);
+    quotaOccurrences = queryCount(database, `
+      SELECT COUNT(*) AS count FROM quota_occurrence
+    `);
+    toolFacts = queryCount(database, `
+      SELECT COUNT(*) AS count FROM tool_class_fact
+      WHERE generation_id = ?
+    `, currentGenerationId);
+    admittedQuotaOccurrences = queryCount(database, `
+      SELECT COUNT(*) AS count FROM quota_occurrence
+      WHERE admission = 'admitted'
+    `);
+    quotaObservations = queryCount(database, `
+      SELECT COUNT(*) AS count FROM quota_observation
+    `);
+    sourceCount = queryCount(database, `
+      SELECT COUNT(*) AS count FROM generation_source
+      WHERE generation_id = ?
+    `, currentGenerationId);
+    const sourceBytesValue = database.prepare(`
+      SELECT COALESCE(SUM(discovered_size_bytes), 0) AS bytes
+      FROM generation_source WHERE generation_id = ?
+    `).get(currentGenerationId)?.bytes;
+    sourceBytes = boundedCount(sourceBytesValue);
+    if (sourceBytes === null) {
+      throw fixedError("local_unified_index_meta_invalid");
+    }
+    sourceIncomplete = queryCount(database, `
+      SELECT COUNT(*) AS count FROM generation_source
+      WHERE generation_id = ?
+        AND (status IN ('pending', 'failed') OR diagnostics_complete <> 1)
+    `, currentGenerationId) > 0;
+    sourceOrdinalMissing = queryCount(database, `
+      SELECT COUNT(*) AS count FROM generation_source
+      WHERE generation_id = ? AND source_ordinal IS NULL
+    `, currentGenerationId) > 0;
+    sourceOrdinalMissing = sourceOrdinalMissing || queryCount(database, `
+      SELECT COUNT(*) AS count
+      FROM (
+        SELECT source_ordinal
+        FROM generation_source
+        WHERE generation_id = ?
+        GROUP BY source_ordinal
+        HAVING COUNT(*) > 1
+      )
+    `, currentGenerationId) > 0;
+    sourceOrdinalMissing = sourceOrdinalMissing || queryCount(database, `
+      SELECT (
+        (SELECT COUNT(*) FROM source_cursor sc
+         WHERE NOT EXISTS (
+           SELECT 1 FROM generation_source gs
+           WHERE gs.generation_id = ? AND gs.source_local = sc.source_local
+             AND gs.source_ordinal = sc.source_ordinal))
+        +
+        (SELECT COUNT(*) FROM generation_source gs
+         LEFT JOIN source_cursor sc ON sc.source_local = gs.source_local
+         WHERE gs.generation_id = ?
+           AND (sc.source_local IS NULL OR sc.source_ordinal IS NULL
+             OR sc.source_ordinal != gs.source_ordinal))
+      ) AS count
+    `, currentGenerationId, currentGenerationId) > 0;
+    usageProvenanceMissing = queryCount(database, `
+      SELECT COUNT(*) AS count FROM usage_event
+      WHERE source_local IS NULL OR source_offset IS NULL
+        OR source_ordinal IS NULL
+        OR NOT EXISTS (
+          SELECT 1 FROM generation_source gs
+          WHERE gs.generation_id = ?
+            AND gs.source_local = usage_event.source_local
+            AND gs.source_ordinal = usage_event.source_ordinal)
+    `, currentGenerationId) > 0;
+    quotaProvenanceMissing = queryCount(database, `
+      SELECT COUNT(*) AS count FROM quota_occurrence
+      WHERE source_local IS NULL OR source_offset IS NULL
+        OR source_ordinal IS NULL OR slot_order IS NULL
+        OR surface_id IS NULL OR admission IS NULL
+        OR NOT EXISTS (
+          SELECT 1 FROM generation_source gs
+          WHERE gs.generation_id = ?
+            AND gs.source_local = quota_occurrence.source_local
+            AND gs.source_ordinal = quota_occurrence.source_ordinal)
+    `, currentGenerationId) > 0 || queryCount(database, `
+      SELECT COUNT(*) AS count
+      FROM quota_observation q
+      WHERE NOT EXISTS (
+        SELECT 1
+        FROM quota_occurrence o
+        WHERE o.canonical_observation_id = q.id
+      )
+    `) > 0;
+    toolProvenanceMissing = queryCount(database, `
+      SELECT COUNT(*) AS count FROM tool_class_fact f
+      WHERE f.generation_id = ?
+        AND (f.source_local IS NULL OR f.source_offset IS NULL
+          OR f.source_ordinal IS NULL OR f.session_local IS NULL
+          OR f.tool_class IS NULL OR f.source_kind IS NULL
+          OR NOT EXISTS (
+            SELECT 1 FROM generation_source gs
+            WHERE gs.generation_id = ?
+              AND gs.source_local = f.source_local
+              AND gs.source_ordinal = f.source_ordinal))
+    `, currentGenerationId, currentGenerationId) > 0;
+    toolFactFingerprintMatches = readUnifiedIndexToolFactFingerprint(
+      database,
+      currentGenerationId,
+    ) === declaredToolFactFingerprint;
+    countsMatch = declaredUsageEvents === usageEvents
+      && declaredQuotaOccurrences === quotaOccurrences
+      && declaredToolFacts === toolFacts
+      && declaredSourceCount === sourceCount
+      && declaredSourceBytes === sourceBytes;
+  } else {
+    // Range-scoped checks catch a legacy nullable row before it can be
+    // emitted, without turning every short history read into a full-table
+    // audit. The generation attestation remains the source of whole-index
+    // counts and publication capabilities.
+    const startMs = Date.parse(requestedWindow.startAt);
+    const endMs = Date.parse(requestedWindow.endAt);
+    usageProvenanceMissing = queryCount(database, `
+      SELECT COUNT(*) AS count FROM usage_event
+      WHERE observed_at_ms >= ? AND observed_at_ms <= ?
+        AND (source_local IS NULL OR source_offset IS NULL
+          OR source_ordinal IS NULL OR NOT EXISTS (
+            SELECT 1 FROM generation_source gs
+            WHERE gs.generation_id = ?
+              AND gs.source_local = usage_event.source_local
+              AND gs.source_ordinal = usage_event.source_ordinal))
+    `, startMs, endMs, currentGenerationId) > 0;
+    quotaProvenanceMissing = queryCount(database, `
+      SELECT COUNT(*) AS count FROM quota_occurrence
+      WHERE observed_at_ms >= ? AND observed_at_ms <= ?
+        AND (source_local IS NULL OR source_offset IS NULL
+          OR source_ordinal IS NULL OR slot_order IS NULL
+          OR surface_id IS NULL OR admission IS NULL OR NOT EXISTS (
+            SELECT 1 FROM generation_source gs
+            WHERE gs.generation_id = ?
+              AND gs.source_local = quota_occurrence.source_local
+              AND gs.source_ordinal = quota_occurrence.source_ordinal))
+    `, startMs, endMs, currentGenerationId) > 0;
+  }
+  const toolOnlyPartial = generation.status === "partial"
+    && indexStatus === "partial"
+    && generation.block_reason === "tool_provenance_incomplete"
+    && !toolProvenanceAttested;
+  const generationComplete = ((generation.status === "complete"
+      && indexStatus === "complete") || toolOnlyPartial)
+    && generation.discovery_complete === 1
+    && generation.diagnostics_complete === 1;
+  const diagnosticsComplete = !sourceIncomplete
+    && generation.diagnostics_complete === 1;
+  const provenanceComplete = !usageProvenanceMissing
+    && !quotaProvenanceMissing
+    && !sourceOrdinalMissing
+    && generationAttestationComplete;
+  const quotaOccurrencesComplete = declaredQuotaOccurrences !== null
+    && quotaOccurrences === declaredQuotaOccurrences
+    && quotaProvenanceAttested
+    && !quotaProvenanceMissing;
+  const toolFactsComplete = declaredToolFacts !== null
+    && toolFacts === declaredToolFacts
+    && toolProvenanceAttested
+    && !toolProvenanceMissing
+    && toolFactFingerprintMatches;
+  let blockReason = null;
+  if (!generationComplete) {
+    blockReason = typeof generation.block_reason === "string"
+      && SAFE_TOKEN.test(generation.block_reason)
+      ? generation.block_reason
+      : "generation_incomplete";
+  } else if (!generationAttestationComplete) {
+    blockReason = "generation_attestation_incomplete";
+  }
+  else if (!countsMatch) blockReason = "generation_counts_mismatch";
+  else if (!provenanceComplete) blockReason = "legacy_nullable_rows";
+  else if (!quotaOccurrencesComplete) {
+    blockReason = "quota_occurrences_incomplete";
+  } else if (!diagnosticsComplete) {
+    blockReason = "source_diagnostics_incomplete";
+  }
+  const generationProof = blockReason === null;
   return {
-    // Even a source-complete current index is not yet accounting-complete: the
-    // current schema cannot prove the contracts named in `capabilities`.
-    status: indexStatus === "unavailable" ? "unavailable" : "partial",
+    status: generationProof ? "complete" : "partial",
     indexStatus,
-    blockReason: indexStatus === "complete"
-      ? "accounting_contract_incomplete"
-      : "unified_index_incomplete",
+    blockReason,
     generatedAt,
-    generationProof: false,
+    coveredAt,
+    generationId: currentGenerationId,
+    generationFingerprint: fingerprint,
+    generationProof,
     requestedWindow,
     sourceCount,
     sourceBytes,
     usageEvents,
     quotaObservations,
+    quotaOccurrences,
+    toolFacts,
+    toolFactFingerprint: declaredToolFactFingerprint,
+    admittedQuotaOccurrences,
+    provenanceComplete,
+    quotaOccurrencesComplete,
+    toolFactsComplete,
+    diagnosticsComplete,
+    usageProvenanceAttested,
+    sourceOrderAttested,
+    quotaProvenanceAttested,
+    toolProvenanceAttested,
+    currentGeneration: generation,
   };
 }
 
-function validateUsageJoins(database, usageEvents) {
+function validateUsageJoins(
+  database,
+  { startAt, endAt, verifyPublishedGeneration = false } = {},
+) {
+  const where = verifyPublishedGeneration ? "" : `
+    WHERE u.observed_at_ms >= ? AND u.observed_at_ms <= ?`;
+  const parameters = verifyPublishedGeneration
+    ? []
+    : [Date.parse(startAt), Date.parse(endAt)];
+  const usageCount = Number(database.prepare(`
+    SELECT COUNT(*) AS count FROM usage_event u${where}
+  `).get(...parameters)?.count ?? 0);
   const joinedEvents = Number(database.prepare(`
     SELECT COUNT(*) AS count
     FROM usage_event u
@@ -216,8 +691,11 @@ function validateUsageJoins(database, usageEvents) {
     JOIN tier_semantics t ON t.id = u.tier_id
     JOIN surface_class s ON s.id = u.surface_id
     JOIN account_scope a ON a.id = u.account_scope_id
-  `).get()?.count ?? 0);
-  if (!Number.isSafeInteger(joinedEvents) || joinedEvents !== usageEvents) {
+    ${where}
+  `).get(...parameters)?.count ?? 0);
+  if (!Number.isSafeInteger(usageCount)
+      || !Number.isSafeInteger(joinedEvents)
+      || joinedEvents !== usageCount) {
     throw fixedError("local_unified_index_row_invalid");
   }
 }
@@ -275,14 +753,43 @@ function hasUsage(components) {
   return Object.values(components).some((value) => value > 0);
 }
 
-async function invoke(callback, value) {
+async function invoke(callback, value, signal) {
   if (callback === undefined) return;
   try {
     const result = callback(value);
     if (result && typeof result.then === "function") await result;
-  } catch {
+  } catch (error) {
+    if (error?.name === "AbortError"
+        || error?.code === "ABORT_ERR"
+        || signal?.aborted) {
+      const aborted = fixedError(
+        "local_unified_index_read_aborted",
+        "AbortError",
+      );
+      aborted[ADAPTER_ABORT] = true;
+      throw aborted;
+    }
+    if (CALLBACK_RESOURCE_CODES.has(error?.code)) {
+      throw fixedError(error.code);
+    }
     throw fixedError("local_unified_index_callback_failed");
   }
+}
+
+function readDiagnostics(database, generationId) {
+  const diagnostics = {};
+  for (const row of database.prepare(`
+    SELECT code, SUM(count) AS count
+    FROM source_diagnostic
+    WHERE generation_id = ?
+    GROUP BY code
+    ORDER BY code
+  `).iterate(generationId)) {
+    const code = safeText(row.code);
+    const count = safeNonNegativeInteger(row.count);
+    diagnostics[code] = count;
+  }
+  return diagnostics;
 }
 
 function sameOpenedFile(before, after) {
@@ -291,6 +798,50 @@ function sameOpenedFile(before, after) {
     .every((value) => value !== undefined && value !== null);
   return !canCompareIdentity
     || (before.dev === after.dev && before.ino === after.ino);
+}
+
+async function revalidatePublishedSnapshot({
+  indexFile,
+  metadata,
+  database,
+  coverage,
+  requestedWindow,
+  verifyPublishedGeneration,
+}) {
+  let finalMetadata;
+  try {
+    finalMetadata = await lstat(indexFile);
+  } catch {
+    throw fixedError("local_unified_index_file_changed");
+  }
+  if (!sameOpenedFile(metadata, finalMetadata)) {
+    throw fixedError("local_unified_index_file_changed");
+  }
+
+  const finalCoverage = readCurrentGeneration(
+    database,
+    readMeta(database),
+    requestedWindow,
+    { verifyPublishedGeneration },
+  );
+  if (finalCoverage.generationId !== coverage.generationId
+      || finalCoverage.generationFingerprint
+        !== coverage.generationFingerprint) {
+    throw fixedError("local_unified_index_generation_mismatch");
+  }
+
+  // Close the race between the final lstat and the generation read. A
+  // copy-on-write publisher must leave the same inode at the path for the
+  // entire callback/read boundary.
+  let settledMetadata;
+  try {
+    settledMetadata = await lstat(indexFile);
+  } catch {
+    throw fixedError("local_unified_index_file_changed");
+  }
+  if (!sameOpenedFile(finalMetadata, settledMetadata)) {
+    throw fixedError("local_unified_index_file_changed");
+  }
 }
 
 function validateRequest({
@@ -319,11 +870,20 @@ function validateRequest({
 export function createLocalUnifiedAccountingSource({
   indexFile,
   requireComplete = false,
+  expectedGeneration = null,
+  contextBehavior = "source_native",
+  verifyPublishedGeneration = false,
+  fullIntegrity = false,
 } = {}) {
   if (typeof indexFile !== "string" || indexFile.length < 1
-      || typeof requireComplete !== "boolean") {
+      || typeof requireComplete !== "boolean"
+      || typeof verifyPublishedGeneration !== "boolean"
+      || typeof fullIntegrity !== "boolean"
+      || !CONTEXT_BEHAVIORS.has(contextBehavior)) {
     throw fixedError("local_unified_index_source_options_invalid", "TypeError");
   }
+  const verifyGeneration = verifyPublishedGeneration || fullIntegrity;
+  const expected = expectedGenerationDescriptor(expectedGeneration);
   return async function scanLocalUnifiedAccountingSource({
     startAt,
     endAt,
@@ -353,7 +913,6 @@ export function createLocalUnifiedAccountingSource({
     }
 
     let database;
-    let snapshotOpen = false;
     try {
       database = openLocalUnifiedIndex(indexFile, { readOnly: true });
       let reopenedMetadata;
@@ -365,22 +924,39 @@ export function createLocalUnifiedAccountingSource({
       if (!sameOpenedFile(metadata, reopenedMetadata)) {
         throw fixedError("local_unified_index_file_changed");
       }
-      // Keep metadata, row counts and both callback streams on one SQLite
-      // snapshot. Without this deferred transaction a foreground ingest could
-      // publish additional facts between the validation and the callbacks.
-      database.exec("BEGIN");
-      snapshotOpen = true;
       const meta = readMeta(database);
-      const coverage = accountingCoverage(database, meta, window);
+      const coverage = readCurrentGeneration(database, meta, window, {
+        verifyPublishedGeneration: verifyGeneration,
+      });
+      if (expected !== null
+          && ((expected.id !== null && expected.id !== coverage.generationId)
+            || (expected.fingerprint !== null
+              && expected.fingerprint !== coverage.generationFingerprint))) {
+        throw fixedError("local_unified_index_generation_mismatch");
+      }
       const contractVersion = requiredMetaText(meta, "contract_version");
       if (!SAFE_TOKEN.test(contractVersion)) {
         throw fixedError("local_unified_index_meta_invalid");
       }
-      validateUsageJoins(database, coverage.usageEvents);
+      validateUsageJoins(database, {
+        ...window,
+        verifyPublishedGeneration: verifyGeneration,
+      });
+      const compatibility = parserCompatibility(
+        database,
+        contractVersion,
+        coverage.generationId,
+      );
+      if (compatibility.status !== "compatible"
+          && coverage.status === "complete") {
+        coverage.status = "partial";
+        coverage.generationProof = false;
+        coverage.blockReason = "mixed_parser_versions";
+      }
       if (requireComplete && coverage.status !== "complete") {
         throw fixedError("local_unified_index_accounting_coverage_incomplete");
       }
-      const compatibility = parserCompatibility(database, contractVersion);
+      const diagnostics = readDiagnostics(database, coverage.generationId);
       const startMs = Date.parse(window.startAt);
       const endMs = Date.parse(window.endAt);
       let sequence = 0;
@@ -394,6 +970,10 @@ export function createLocalUnifiedAccountingSource({
                u.tokens_out_text,
                u.tokens_out_reasoning,
                u.tokens_out_combined,
+               u.source_local,
+               u.source_offset,
+               u.source_ordinal,
+               u.tier_observed_at_ms,
                m.model_id,
                t.billing_surface,
                t.codex_speed_mode,
@@ -409,7 +989,11 @@ export function createLocalUnifiedAccountingSource({
         JOIN surface_class s ON s.id = u.surface_id
         JOIN account_scope a ON a.id = u.account_scope_id
         WHERE u.observed_at_ms >= ? AND u.observed_at_ms <= ?
-        ORDER BY u.observed_at_ms, u.event_key
+        ORDER BY u.observed_at_ms,
+                 COALESCE(u.source_ordinal, 2147483647),
+                 COALESCE(u.source_local, zeroblob(32)),
+                 COALESCE(u.source_offset, 9223372036854775807),
+                 u.event_key
       `);
       for (const row of usageStatement.iterate(startMs, endMs)) {
         throwIfAborted(signal);
@@ -421,6 +1005,22 @@ export function createLocalUnifiedAccountingSource({
           row.total_input_context,
           { nullable: true, nullValue: null },
         );
+        const sourceLocal = safeDigest(row.source_local, { nullable: true });
+        const sourceOffset = safeNonNegativeInteger(
+          row.source_offset,
+          { nullable: true },
+        );
+        const sourceOrdinal = safeNonNegativeInteger(
+          row.source_ordinal,
+          { nullable: true },
+        );
+        const tierObservedAtMs = safeNonNegativeInteger(
+          row.tier_observed_at_ms,
+          { nullable: true },
+        );
+        const tierObservedAt = tierObservedAtMs === null
+          ? null
+          : timestampForMs(tierObservedAtMs).timestamp;
         const usage = {
           timestamp,
           timestampMs: observedAtMs,
@@ -431,7 +1031,7 @@ export function createLocalUnifiedAccountingSource({
             codexSpeedMode: safeText(row.codex_speed_mode),
             apiServiceTier: safeText(row.api_service_tier),
             tierSource: safeText(row.tier_source),
-            tierObservedAt: null,
+            tierObservedAt,
           },
           surfaceClassification: {
             surface: safeText(row.surface),
@@ -440,27 +1040,51 @@ export function createLocalUnifiedAccountingSource({
             lineageDisposition: safeText(row.lineage_disposition),
           },
         };
-        if (totalInputContextTokens !== null) {
-          usage.totalInputContextTokens = totalInputContextTokens;
+        if (totalInputContextTokens !== null
+            || contextBehavior === "legacy_zero") {
+          usage.totalInputContextTokens = totalInputContextTokens ?? 0;
+        }
+        if (sourceLocal !== null) usage.sourceLocal = sourceLocal;
+        if (sourceOffset !== null) {
+          usage.sourceRecordOrdinal = sourceOffset;
+          usage.sourceOffset = sourceOffset;
+        }
+        if (sourceOrdinal !== null) {
+          usage.sourceRolloutOrdinal = sourceOrdinal;
+          usage.sourceOrdinal = sourceOrdinal;
         }
         if (onUsage !== undefined) {
           usage.sequence = sequence++;
-          await invoke(onUsage, usage);
+          await invoke(onUsage, usage, signal);
         }
       }
 
       const quotaStatement = database.prepare(`
-        SELECT id, observed_at_ms, limit_id, slot, plan_type, used_percent,
-               resets_at_ms, duration_mins
-        FROM quota_observation
-        WHERE observed_at_ms >= ? AND observed_at_ms <= ?
-        ORDER BY observed_at_ms, limit_id, slot, id
+        SELECT q.id, q.observed_at_ms, q.provider, q.limit_id, q.slot,
+               q.plan_type, q.used_percent, q.resets_at_ms,
+               q.duration_mins, q.source_local, q.source_offset,
+               q.source_ordinal, q.slot_order,
+               s.surface, s.thread_source, s.agent_scope,
+               s.lineage_disposition
+        FROM quota_occurrence q
+        JOIN surface_class s ON s.id = q.surface_id
+        WHERE q.admission = 'admitted'
+          AND q.observed_at_ms >= ? AND q.observed_at_ms <= ?
+        ORDER BY q.observed_at_ms,
+                 q.source_ordinal,
+                 q.source_local,
+                 q.source_offset,
+                 q.slot_order,
+                 q.id
       `);
       for (const row of quotaStatement.iterate(startMs, endMs)) {
         throwIfAborted(signal);
         const { observedAtMs, timestamp } = timestampForMs(row.observed_at_ms);
         const durationMins = safeNonNegativeInteger(row.duration_mins);
-        const resetsAtMs = safeNonNegativeInteger(row.resets_at_ms);
+        const resetsAtMs = safeNonNegativeInteger(row.resets_at_ms, {
+          nullable: true,
+          nullValue: null,
+        });
         if (row.used_percent === null
             || (typeof row.used_percent !== "number"
               && typeof row.used_percent !== "bigint")) {
@@ -468,7 +1092,12 @@ export function createLocalUnifiedAccountingSource({
         }
         const usedPercent = Number(row.used_percent);
         const slot = safeText(row.slot);
+        const sourceLocal = safeDigest(row.source_local);
+        const sourceOffset = safeNonNegativeInteger(row.source_offset);
+        const sourceOrdinal = safeNonNegativeInteger(row.source_ordinal);
+        const slotOrder = safeNonNegativeInteger(row.slot_order);
         if (!isValidQuotaWindowDuration(durationMins)
+            || resetsAtMs === null
             || resetsAtMs <= 0
             || resetsAtMs % 1_000 !== 0
             || !Number.isFinite(usedPercent)
@@ -481,7 +1110,7 @@ export function createLocalUnifiedAccountingSource({
           timestamp,
           timestampMs: observedAtMs,
           window: {
-            provider: "openai_codex",
+            provider: safeText(row.provider),
             planType: safeText(row.plan_type, { nullable: true }),
             limitId: safeText(row.limit_id),
             slot,
@@ -489,13 +1118,42 @@ export function createLocalUnifiedAccountingSource({
             windowDurationMins: durationMins,
             resetsAt: resetsAtMs / 1_000,
           },
+          surfaceClassification: {
+            surface: safeText(row.surface),
+            threadSource: safeText(row.thread_source),
+            agentScope: safeText(row.agent_scope),
+            lineageDisposition: safeText(row.lineage_disposition),
+          },
+          sourceRolloutOrdinal: sourceOrdinal,
+          sourceRecordOrdinal: sourceOffset,
+          sourceLocal,
+          sourceOrdinal,
+          sourceOffset,
+          slotOrder,
         };
         if (onRateLimitSnapshot !== undefined) {
           quota.sequence = sequence++;
-          await invoke(onRateLimitSnapshot, quota);
+          await invoke(onRateLimitSnapshot, quota, signal);
         }
       }
       throwIfAborted(signal);
+      await revalidatePublishedSnapshot({
+        indexFile,
+        metadata,
+        database,
+        coverage,
+        requestedWindow: window,
+        verifyPublishedGeneration: verifyGeneration,
+      });
+      const capabilities = {
+        readsRawSources: false,
+        deterministicCanonicalOrder: coverage.generationProof,
+        sourceOrderingProvenance: coverage.provenanceComplete,
+        sourceOffsetProvenance: coverage.provenanceComplete,
+        sourceScopedQuotaOccurrences: coverage.quotaOccurrencesComplete,
+        durableDiagnostics: coverage.diagnosticsComplete,
+        crashSafeGenerationPublication: coverage.generationProof,
+      };
       return {
         readerVersion: LOCAL_UNIFIED_ACCOUNTING_SOURCE_VERSION,
         schemaVersion: LOCAL_UNIFIED_INDEX_SCHEMA_VERSION,
@@ -505,18 +1163,12 @@ export function createLocalUnifiedAccountingSource({
         contractVersion,
         compatibility,
         coverage,
-        capabilities: {
-          readsRawSources: false,
-          deterministicCanonicalOrder: true,
-          sourceOrderingProvenance: false,
-          sourceOffsetProvenance: false,
-          sourceScopedQuotaOccurrences: false,
-          durableDiagnostics: false,
-          crashSafeGenerationPublication: false,
-        },
-        diagnosticCoverage: "unavailable",
-        diagnosticsAvailable: false,
-        diagnostics: {},
+        capabilities,
+        diagnosticCoverage: coverage.diagnosticsComplete
+          ? "complete"
+          : "partial",
+        diagnosticsAvailable: coverage.diagnosticsComplete,
+        diagnostics,
         toolCallsByClass: {},
         toolObservationsBySource: {},
         serverBillableUnits: {},
@@ -524,18 +1176,12 @@ export function createLocalUnifiedAccountingSource({
     } catch (error) {
       if (typeof error?.code === "string"
           && (error.code.startsWith("local_unified_index_")
+            || CALLBACK_RESOURCE_CODES.has(error.code)
             || error[ADAPTER_ABORT] === true)) {
         throw error;
       }
       throw fixedError("local_unified_index_read_failed");
     } finally {
-      if (snapshotOpen) {
-        try {
-          database?.exec("ROLLBACK");
-        } catch {
-          // The connection is closing; no error detail is safe or actionable.
-        }
-      }
       database?.close();
     }
   };

--- a/src/local-unified-accounting-source.js
+++ b/src/local-unified-accounting-source.js
@@ -1,0 +1,542 @@
+import { lstat } from "node:fs/promises";
+
+import { isValidQuotaWindowDuration } from "@app-usagemonitor/quota-analysis";
+
+import {
+  LOCAL_UNIFIED_INDEX_SCHEMA_VERSION,
+  openLocalUnifiedIndex,
+} from "./local-unified-index.js";
+import { validAbortSignal } from "./valid-abort-signal.js";
+
+// Read-only characterization adapter from the current unified fact store to
+// the callback contract consumed by replay-safe accounting. This module never
+// discovers or opens rollout JSONL. It deliberately reports accounting
+// coverage as partial until source ordering, source-scoped quota occurrences,
+// durable diagnostics, and crash-safe generation publication are persisted.
+export const LOCAL_UNIFIED_ACCOUNTING_SOURCE_VERSION =
+  "local-unified-accounting-source-v1";
+
+const SAFE_TOKEN = /^[A-Za-z0-9._:-]{1,64}$/u;
+const QUOTA_SLOTS = new Set(["primary", "secondary"]);
+const REQUIRED_META_KEYS = Object.freeze([
+  "schema_version",
+  "status",
+  "generated_at",
+  "source_count",
+  "source_bytes",
+  "usage_events",
+  "contract_version",
+]);
+const ADAPTER_ABORT = Symbol("local-unified-accounting-source-abort");
+
+function fixedError(code, name = "Error") {
+  const error = new Error(code);
+  error.name = name;
+  error.code = code;
+  return error;
+}
+
+function canonicalInstant(value) {
+  if (typeof value !== "string") return null;
+  const timestamp = Date.parse(value);
+  return Number.isFinite(timestamp)
+      && new Date(timestamp).toISOString() === value
+    ? value
+    : null;
+}
+
+function throwIfAborted(signal) {
+  if (!signal?.aborted) return;
+  const error = fixedError("local_unified_index_read_aborted", "AbortError");
+  error[ADAPTER_ABORT] = true;
+  throw error;
+}
+
+function ownerOnlyRegularFile(metadata) {
+  return metadata.isFile()
+    && !metadata.isSymbolicLink()
+    && metadata.nlink === 1
+    && (typeof process.getuid !== "function" || metadata.uid === process.getuid())
+    && (process.platform === "win32" || (metadata.mode & 0o077) === 0);
+}
+
+function safeInteger(value, { nullable = false, nullValue = null } = {}) {
+  if (value === null && nullable) return nullValue;
+  if (value === undefined
+      || (typeof value !== "number" && typeof value !== "bigint")) {
+    throw fixedError("local_unified_index_row_invalid");
+  }
+  const numeric = Number(value);
+  if (!Number.isSafeInteger(numeric)) {
+    throw fixedError("local_unified_index_row_invalid");
+  }
+  return numeric;
+}
+
+function safeNonNegativeInteger(value, options = {}) {
+  const numeric = safeInteger(value, {
+    nullValue: 0,
+    ...options,
+  });
+  if (numeric === null) return null;
+  if (!Number.isSafeInteger(numeric) || numeric < 0) {
+    throw fixedError("local_unified_index_row_invalid");
+  }
+  return numeric;
+}
+
+function safeText(value, { nullable = false } = {}) {
+  if (value === null && nullable) return "unknown";
+  if (typeof value !== "string" || !SAFE_TOKEN.test(value)) {
+    throw fixedError("local_unified_index_row_invalid");
+  }
+  return value;
+}
+
+function readMeta(database) {
+  const result = {};
+  for (const row of database.prepare(
+    "SELECT key, value FROM meta ORDER BY key",
+  ).iterate()) {
+    if (typeof row.key !== "string" || typeof row.value !== "string") {
+      throw fixedError("local_unified_index_meta_invalid");
+    }
+    result[row.key] = row.value;
+  }
+  return result;
+}
+
+function requiredMetaText(meta, key) {
+  if (!Object.hasOwn(meta, key)
+      || typeof meta[key] !== "string"
+      || meta[key].length < 1) {
+    throw fixedError("local_unified_index_meta_invalid");
+  }
+  return meta[key];
+}
+
+function metaCount(meta, key) {
+  const value = requiredMetaText(meta, key);
+  if (!/^\d+$/u.test(value)) {
+    throw fixedError("local_unified_index_meta_invalid");
+  }
+  const numeric = Number(value);
+  if (!Number.isSafeInteger(numeric) || numeric < 0) {
+    throw fixedError("local_unified_index_meta_invalid");
+  }
+  return numeric;
+}
+
+function parserCompatibility(database, contractVersion) {
+  const rows = database.prepare(`
+    SELECT DISTINCT parser_version, contract_version
+    FROM parser_version
+    ORDER BY parser_version, contract_version
+  `).all();
+  if (rows.length === 0) {
+    throw fixedError("local_unified_index_compatibility_invalid");
+  }
+  const parserVersions = [];
+  const contractVersions = [];
+  for (const row of rows) {
+    const parserVersion = safeText(row.parser_version);
+    const rowContractVersion = safeText(row.contract_version);
+    if (rowContractVersion !== contractVersion) {
+      throw fixedError("local_unified_index_compatibility_invalid");
+    }
+    parserVersions.push(parserVersion);
+    contractVersions.push(rowContractVersion);
+  }
+  const uniqueParserVersions = [...new Set(parserVersions)];
+  const uniqueContractVersions = [...new Set(contractVersions)];
+  return {
+    status: uniqueParserVersions.length === 1
+      ? "compatible"
+      : "mixed_parser_versions",
+    parserVersions: uniqueParserVersions,
+    contractVersions: uniqueContractVersions,
+    contractVersion,
+  };
+}
+
+function accountingCoverage(database, meta, requestedWindow) {
+  for (const key of REQUIRED_META_KEYS) requiredMetaText(meta, key);
+  const schemaVersion = requiredMetaText(meta, "schema_version");
+  const indexStatus = requiredMetaText(meta, "status");
+  if (schemaVersion !== LOCAL_UNIFIED_INDEX_SCHEMA_VERSION
+      || !new Set(["complete", "partial"]).has(indexStatus)) {
+    throw fixedError("local_unified_index_meta_invalid");
+  }
+  const generatedAtText = requiredMetaText(meta, "generated_at");
+  const generatedAt = canonicalInstant(generatedAtText);
+  if (generatedAt === null) {
+    throw fixedError("local_unified_index_meta_invalid");
+  }
+  const sourceCount = metaCount(meta, "source_count");
+  const sourceBytes = metaCount(meta, "source_bytes");
+  // Do not compare these totals to source_cursor here: rotated rollout files
+  // can vanish while their durable facts and retained cursors remain, and the
+  // current schema has no generation-scoped coverage record that distinguishes
+  // that history from an in-progress discovery set.
+  const declaredUsageEvents = metaCount(meta, "usage_events");
+  const usageEvents = Number(database.prepare(
+    "SELECT COUNT(*) AS count FROM usage_event",
+  ).get()?.count ?? 0);
+  const quotaObservations = Number(database.prepare(
+    "SELECT COUNT(*) AS count FROM quota_observation",
+  ).get()?.count ?? 0);
+  if (![usageEvents, quotaObservations].every(
+    (value) => Number.isSafeInteger(value) && value >= 0,
+  ) || usageEvents !== declaredUsageEvents) {
+    throw fixedError("local_unified_index_meta_invalid");
+  }
+  return {
+    // Even a source-complete current index is not yet accounting-complete: the
+    // current schema cannot prove the contracts named in `capabilities`.
+    status: indexStatus === "unavailable" ? "unavailable" : "partial",
+    indexStatus,
+    blockReason: indexStatus === "complete"
+      ? "accounting_contract_incomplete"
+      : "unified_index_incomplete",
+    generatedAt,
+    generationProof: false,
+    requestedWindow,
+    sourceCount,
+    sourceBytes,
+    usageEvents,
+    quotaObservations,
+  };
+}
+
+function validateUsageJoins(database, usageEvents) {
+  const joinedEvents = Number(database.prepare(`
+    SELECT COUNT(*) AS count
+    FROM usage_event u
+    JOIN model m ON m.id = u.model_id
+    JOIN tier_semantics t ON t.id = u.tier_id
+    JOIN surface_class s ON s.id = u.surface_id
+    JOIN account_scope a ON a.id = u.account_scope_id
+  `).get()?.count ?? 0);
+  if (!Number.isSafeInteger(joinedEvents) || joinedEvents !== usageEvents) {
+    throw fixedError("local_unified_index_row_invalid");
+  }
+}
+
+function validateEventKey(value) {
+  if (!(value instanceof Uint8Array) || value.byteLength !== 32) {
+    throw fixedError("local_unified_index_row_invalid");
+  }
+}
+
+function timestampForMs(value) {
+  const observedAtMs = safeInteger(value);
+  try {
+    const timestamp = new Date(observedAtMs).toISOString();
+    if (canonicalInstant(timestamp) === null) {
+      throw fixedError("local_unified_index_row_invalid");
+    }
+    return { observedAtMs, timestamp };
+  } catch (error) {
+    if (error?.code === "local_unified_index_row_invalid") throw error;
+    throw fixedError("local_unified_index_row_invalid");
+  }
+}
+
+function usageComponents(row) {
+  return {
+    input_uncached_tokens: safeNonNegativeInteger(
+      row.tokens_in_uncached,
+      { nullable: true },
+    ),
+    input_cache_read_tokens: safeNonNegativeInteger(
+      row.tokens_in_cache_read,
+      { nullable: true },
+    ),
+    input_cache_write_tokens: safeNonNegativeInteger(
+      row.tokens_in_cache_write,
+      { nullable: true },
+    ),
+    output_text_tokens: safeNonNegativeInteger(
+      row.tokens_out_text,
+      { nullable: true },
+    ),
+    output_reasoning_tokens: safeNonNegativeInteger(
+      row.tokens_out_reasoning,
+      { nullable: true },
+    ),
+    output_combined_tokens: safeNonNegativeInteger(
+      row.tokens_out_combined,
+      { nullable: true },
+    ),
+  };
+}
+
+function hasUsage(components) {
+  return Object.values(components).some((value) => value > 0);
+}
+
+async function invoke(callback, value) {
+  if (callback === undefined) return;
+  try {
+    const result = callback(value);
+    if (result && typeof result.then === "function") await result;
+  } catch {
+    throw fixedError("local_unified_index_callback_failed");
+  }
+}
+
+function sameOpenedFile(before, after) {
+  if (!ownerOnlyRegularFile(after)) return false;
+  const canCompareIdentity = [before.dev, before.ino, after.dev, after.ino]
+    .every((value) => value !== undefined && value !== null);
+  return !canCompareIdentity
+    || (before.dev === after.dev && before.ino === after.ino);
+}
+
+function validateRequest({
+  startAt,
+  endAt,
+  signal,
+  onUsage,
+  onRateLimitSnapshot,
+}) {
+  const start = canonicalInstant(startAt);
+  const end = canonicalInstant(endAt);
+  if (start === null || end === null || Date.parse(start) > Date.parse(end)
+      || !validAbortSignal(signal)
+      || (onUsage !== undefined && typeof onUsage !== "function")
+      || (onRateLimitSnapshot !== undefined
+        && typeof onRateLimitSnapshot !== "function")) {
+    throw fixedError("local_unified_index_read_request_invalid", "TypeError");
+  }
+  return { startAt: start, endAt: end };
+}
+
+/**
+ * Return a scanner-shaped function over one already-published unified index.
+ * The connection is always read-only and is closed after callbacks settle.
+ */
+export function createLocalUnifiedAccountingSource({
+  indexFile,
+  requireComplete = false,
+} = {}) {
+  if (typeof indexFile !== "string" || indexFile.length < 1
+      || typeof requireComplete !== "boolean") {
+    throw fixedError("local_unified_index_source_options_invalid", "TypeError");
+  }
+  return async function scanLocalUnifiedAccountingSource({
+    startAt,
+    endAt,
+    signal = null,
+    onUsage,
+    onRateLimitSnapshot,
+  } = {}) {
+    const window = validateRequest({
+      startAt,
+      endAt,
+      signal,
+      onUsage,
+      onRateLimitSnapshot,
+    });
+    throwIfAborted(signal);
+    let metadata;
+    try {
+      metadata = await lstat(indexFile);
+    } catch (error) {
+      if (error?.code === "ENOENT") {
+        throw fixedError("local_unified_index_missing");
+      }
+      throw fixedError("local_unified_index_unavailable");
+    }
+    if (!ownerOnlyRegularFile(metadata)) {
+      throw fixedError("local_unified_index_file_invalid");
+    }
+
+    let database;
+    let snapshotOpen = false;
+    try {
+      database = openLocalUnifiedIndex(indexFile, { readOnly: true });
+      let reopenedMetadata;
+      try {
+        reopenedMetadata = await lstat(indexFile);
+      } catch {
+        throw fixedError("local_unified_index_file_changed");
+      }
+      if (!sameOpenedFile(metadata, reopenedMetadata)) {
+        throw fixedError("local_unified_index_file_changed");
+      }
+      // Keep metadata, row counts and both callback streams on one SQLite
+      // snapshot. Without this deferred transaction a foreground ingest could
+      // publish additional facts between the validation and the callbacks.
+      database.exec("BEGIN");
+      snapshotOpen = true;
+      const meta = readMeta(database);
+      const coverage = accountingCoverage(database, meta, window);
+      const contractVersion = requiredMetaText(meta, "contract_version");
+      if (!SAFE_TOKEN.test(contractVersion)) {
+        throw fixedError("local_unified_index_meta_invalid");
+      }
+      validateUsageJoins(database, coverage.usageEvents);
+      if (requireComplete && coverage.status !== "complete") {
+        throw fixedError("local_unified_index_accounting_coverage_incomplete");
+      }
+      const compatibility = parserCompatibility(database, contractVersion);
+      const startMs = Date.parse(window.startAt);
+      const endMs = Date.parse(window.endAt);
+      let sequence = 0;
+      const usageStatement = database.prepare(`
+        SELECT u.event_key,
+               u.observed_at_ms,
+               u.total_input_context,
+               u.tokens_in_uncached,
+               u.tokens_in_cache_read,
+               u.tokens_in_cache_write,
+               u.tokens_out_text,
+               u.tokens_out_reasoning,
+               u.tokens_out_combined,
+               m.model_id,
+               t.billing_surface,
+               t.codex_speed_mode,
+               t.api_service_tier,
+               t.tier_source,
+               s.surface,
+               s.thread_source,
+               s.agent_scope,
+               s.lineage_disposition
+        FROM usage_event u
+        JOIN model m ON m.id = u.model_id
+        JOIN tier_semantics t ON t.id = u.tier_id
+        JOIN surface_class s ON s.id = u.surface_id
+        JOIN account_scope a ON a.id = u.account_scope_id
+        WHERE u.observed_at_ms >= ? AND u.observed_at_ms <= ?
+        ORDER BY u.observed_at_ms, u.event_key
+      `);
+      for (const row of usageStatement.iterate(startMs, endMs)) {
+        throwIfAborted(signal);
+        validateEventKey(row.event_key);
+        const { observedAtMs, timestamp } = timestampForMs(row.observed_at_ms);
+        const components = usageComponents(row);
+        if (!hasUsage(components)) continue;
+        const totalInputContextTokens = safeNonNegativeInteger(
+          row.total_input_context,
+          { nullable: true, nullValue: null },
+        );
+        const usage = {
+          timestamp,
+          timestampMs: observedAtMs,
+          model: safeText(row.model_id),
+          components,
+          tierSemantics: {
+            billingSurface: safeText(row.billing_surface),
+            codexSpeedMode: safeText(row.codex_speed_mode),
+            apiServiceTier: safeText(row.api_service_tier),
+            tierSource: safeText(row.tier_source),
+            tierObservedAt: null,
+          },
+          surfaceClassification: {
+            surface: safeText(row.surface),
+            threadSource: safeText(row.thread_source),
+            agentScope: safeText(row.agent_scope),
+            lineageDisposition: safeText(row.lineage_disposition),
+          },
+        };
+        if (totalInputContextTokens !== null) {
+          usage.totalInputContextTokens = totalInputContextTokens;
+        }
+        if (onUsage !== undefined) {
+          usage.sequence = sequence++;
+          await invoke(onUsage, usage);
+        }
+      }
+
+      const quotaStatement = database.prepare(`
+        SELECT id, observed_at_ms, limit_id, slot, plan_type, used_percent,
+               resets_at_ms, duration_mins
+        FROM quota_observation
+        WHERE observed_at_ms >= ? AND observed_at_ms <= ?
+        ORDER BY observed_at_ms, limit_id, slot, id
+      `);
+      for (const row of quotaStatement.iterate(startMs, endMs)) {
+        throwIfAborted(signal);
+        const { observedAtMs, timestamp } = timestampForMs(row.observed_at_ms);
+        const durationMins = safeNonNegativeInteger(row.duration_mins);
+        const resetsAtMs = safeNonNegativeInteger(row.resets_at_ms);
+        if (row.used_percent === null
+            || (typeof row.used_percent !== "number"
+              && typeof row.used_percent !== "bigint")) {
+          throw fixedError("local_unified_index_row_invalid");
+        }
+        const usedPercent = Number(row.used_percent);
+        const slot = safeText(row.slot);
+        if (!isValidQuotaWindowDuration(durationMins)
+            || resetsAtMs <= 0
+            || resetsAtMs % 1_000 !== 0
+            || !Number.isFinite(usedPercent)
+            || usedPercent < 0
+            || usedPercent > 100
+            || !QUOTA_SLOTS.has(slot)) {
+          throw fixedError("local_unified_index_row_invalid");
+        }
+        const quota = {
+          timestamp,
+          timestampMs: observedAtMs,
+          window: {
+            provider: "openai_codex",
+            planType: safeText(row.plan_type, { nullable: true }),
+            limitId: safeText(row.limit_id),
+            slot,
+            usedPercent,
+            windowDurationMins: durationMins,
+            resetsAt: resetsAtMs / 1_000,
+          },
+        };
+        if (onRateLimitSnapshot !== undefined) {
+          quota.sequence = sequence++;
+          await invoke(onRateLimitSnapshot, quota);
+        }
+      }
+      throwIfAborted(signal);
+      return {
+        readerVersion: LOCAL_UNIFIED_ACCOUNTING_SOURCE_VERSION,
+        schemaVersion: LOCAL_UNIFIED_INDEX_SCHEMA_VERSION,
+        parserVersion: compatibility.parserVersions.length === 1
+          ? compatibility.parserVersions[0]
+          : null,
+        contractVersion,
+        compatibility,
+        coverage,
+        capabilities: {
+          readsRawSources: false,
+          deterministicCanonicalOrder: true,
+          sourceOrderingProvenance: false,
+          sourceOffsetProvenance: false,
+          sourceScopedQuotaOccurrences: false,
+          durableDiagnostics: false,
+          crashSafeGenerationPublication: false,
+        },
+        diagnosticCoverage: "unavailable",
+        diagnosticsAvailable: false,
+        diagnostics: {},
+        toolCallsByClass: {},
+        toolObservationsBySource: {},
+        serverBillableUnits: {},
+      };
+    } catch (error) {
+      if (typeof error?.code === "string"
+          && (error.code.startsWith("local_unified_index_")
+            || error[ADAPTER_ABORT] === true)) {
+        throw error;
+      }
+      throw fixedError("local_unified_index_read_failed");
+    } finally {
+      if (snapshotOpen) {
+        try {
+          database?.exec("ROLLBACK");
+        } catch {
+          // The connection is closing; no error detail is safe or actionable.
+        }
+      }
+      database?.close();
+    }
+  };
+}

--- a/src/local-unified-companion-source.js
+++ b/src/local-unified-companion-source.js
@@ -5,6 +5,7 @@ import {
   addUsageToPeriod,
   finalizeTimelineBuckets,
   finalizeUsagePeriod,
+  KNOWN_TOOL_CLASSES,
   MAX_QUOTA_TIMELINE_POINTS,
   newUsagePeriod,
   quotaWindowProjection,
@@ -15,7 +16,9 @@ import {
   usageProjection,
 } from "./local-companion-usage-model.js";
 import {
+  createUnifiedIndexToolFactFingerprintAccumulator,
   openLocalUnifiedIndex,
+  readUnifiedIndexGenerationDescriptor,
 } from "./local-unified-index.js";
 import {
   createAccountingPricer,
@@ -57,12 +60,21 @@ function unavailable(status, errorCode = null) {
     errorCode,
     generatedAt: null,
     indexStatus: null,
+    generation: null,
     coveredAt: { startAt: null, endAt: null },
     usageEvents: 0,
     quotaObservations: 0,
     sourceCount: 0,
     sourceBytes: 0,
+    discoveredSourceCount: 0,
+    discoveredSourceBytes: 0,
+    indexedSourceCount: 0,
+    indexedSourceBytes: 0,
     indexBytes: 0,
+    latestExportableRecordAt: null,
+    tools: emptyToolProjection(),
+    toolCoverageStatus: "unavailable",
+    toolCoverageBlockReason: null,
     usage: [],
     timeline: null,
     cacheSwitchImpact: unavailableCacheSwitchImpact(
@@ -77,6 +89,123 @@ function unavailable(status, errorCode = null) {
     ),
     readWallMs: null,
   };
+}
+
+function emptyToolProjection() {
+  return {
+    total: 0,
+    counts: Object.fromEntries([...KNOWN_TOOL_CLASSES].map((toolClass) => [
+      toolClass,
+      0,
+    ])),
+  };
+}
+
+function tableExists(database, tableName) {
+  return database.prepare(
+    "SELECT 1 AS present FROM sqlite_master WHERE type = 'table' AND name = ?",
+  ).get(tableName)?.present === 1;
+}
+
+function isDigest(value) {
+  return value instanceof Uint8Array && value.byteLength === 32;
+}
+
+function sameOpenedFile(before, after) {
+  if (!after?.isFile?.() || after.isSymbolicLink()) return false;
+  const canCompareIdentity = [before.dev, before.ino, after.dev, after.ino]
+    .every((value) => value !== undefined && value !== null);
+  return !canCompareIdentity
+    || (before.dev === after.dev && before.ino === after.ino);
+}
+
+async function revalidatePublishedPath(indexFile, metadata) {
+  let first;
+  let second;
+  try {
+    first = await lstat(indexFile);
+    second = await lstat(indexFile);
+  } catch {
+    throw fixedError("local_unified_index_file_changed");
+  }
+  if (!sameOpenedFile(metadata, first) || !sameOpenedFile(first, second)) {
+    throw fixedError("local_unified_index_file_changed");
+  }
+}
+
+function toolProjection(database, generation) {
+  const projection = emptyToolProjection();
+  if (tableExists(database, "tool_class_fact")) {
+    if (generation?.toolProvenanceComplete !== true) {
+      // The rest of a readable partial publication still supplies honest
+      // coverage metadata. Withhold only the un-attested tool projection; the
+      // companion's generation gate prevents it from becoming unified
+      // authority.
+      return projection;
+    }
+    const expectedCount = Number(generation.toolFacts);
+    if (!Number.isSafeInteger(expectedCount) || expectedCount < 0) {
+      throw fixedError("local_unified_index_tool_attestation_mismatch");
+    }
+    let count = 0;
+    const fingerprint = createUnifiedIndexToolFactFingerprintAccumulator();
+    for (const row of database.prepare(`
+      SELECT f.event_key, f.source_local, f.source_offset, f.source_ordinal,
+             f.session_local, f.observed_at_ms, f.tool_ordinal,
+             f.tool_class, f.source_kind, gs.source_ordinal AS attested_ordinal
+      FROM tool_class_fact f
+      LEFT JOIN generation_source gs
+        ON gs.generation_id = f.generation_id
+       AND gs.source_local = f.source_local
+      WHERE f.generation_id = ?
+      ORDER BY f.event_key`).iterate(generation.id)) {
+      if (!isDigest(row.event_key)
+          || !isDigest(row.source_local)
+          || !isDigest(row.session_local)
+          || !Number.isSafeInteger(Number(row.source_offset))
+          || Number(row.source_offset) < 0
+          || !Number.isSafeInteger(Number(row.source_ordinal))
+          || Number(row.source_ordinal) < 0
+          || Number(row.attested_ordinal) !== Number(row.source_ordinal)
+          || !Number.isSafeInteger(Number(row.observed_at_ms))
+          || !Number.isSafeInteger(Number(row.tool_ordinal))
+          || Number(row.tool_ordinal) < 0
+          || typeof row.tool_class !== "string"
+          || !/^[a-z0-9._:-]{1,64}$/u.test(row.tool_class)
+          || typeof row.source_kind !== "string"
+          || !/^[a-z0-9._:-]{1,64}$/u.test(row.source_kind)) {
+        throw fixedError("local_unified_index_tool_attestation_mismatch");
+      }
+      const toolClass = KNOWN_TOOL_CLASSES.has(row.tool_class)
+        ? row.tool_class
+        : "other";
+      projection.counts[toolClass] += 1;
+      projection.total += 1;
+      count += 1;
+      fingerprint.add(row);
+    }
+    if (count !== expectedCount
+        || fingerprint.digest() !== generation.toolFactFingerprint) {
+      throw fixedError("local_unified_index_tool_attestation_mismatch");
+    }
+    return projection;
+  }
+  // A pre-v8 read-only index can still be displayed in explicit legacy mode.
+  // It is never accepted as the unified authority because its generation has
+  // no tool attestation fields.
+  if (!tableExists(database, "tool_class_count")) return projection;
+  for (const row of database.prepare(
+    "SELECT tool_class, SUM(count) AS count FROM tool_class_count GROUP BY tool_class",
+  ).iterate()) {
+    const count = Number(row.count);
+    if (!Number.isSafeInteger(count) || count < 0) continue;
+    const toolClass = KNOWN_TOOL_CLASSES.has(row.tool_class)
+      ? row.tool_class
+      : "other";
+    projection.counts[toolClass] += count;
+    projection.total += count;
+  }
+  return projection;
 }
 
 function isoOrNull(milliseconds) {
@@ -301,6 +430,17 @@ export async function readLocalUnifiedCompanionProjection({
     );
   }
   try {
+    await revalidatePublishedPath(indexFile, metadata);
+    // A legacy read-only file may still satisfy the projection queries, but
+    // only v2 publications carry the immutable generation proof accounting
+    // needs. Keep that distinction explicit instead of upgrading a legacy
+    // projection into authority merely because its rows are readable.
+    let generation = null;
+    try {
+      generation = readUnifiedIndexGenerationDescriptor(database);
+    } catch {
+      generation = null;
+    }
     const periods = [
       { summary: newUsagePeriod("24h", "Last 24 hours"), start: nowMs - 24 * 60 * 60 * 1_000 },
       { summary: newUsagePeriod("7d", "Last 7 days"), start: nowMs - 7 * 24 * 60 * 60 * 1_000 },
@@ -391,11 +531,18 @@ export async function readLocalUnifiedCompanionProjection({
       : Math.max(...timelineBuckets.keys()) + TIMELINE_BUCKET_MS;
     const sourceCount = Number(readMeta(database, "source_count"));
     const sourceBytes = Number(readMeta(database, "source_bytes"));
-    return {
+    const discoveredSourceCount = generation?.discoveredSourceCount
+      ?? (Number.isSafeInteger(sourceCount) ? sourceCount : 0);
+    const discoveredSourceBytes = generation?.discoveredSourceBytes
+      ?? (Number.isSafeInteger(sourceBytes) ? sourceBytes : 0);
+    const indexedSourceCount = generation?.indexedSourceCount;
+    const indexedSourceBytes = generation?.indexedSourceBytes;
+    const result = {
       status: "available",
       errorCode: null,
       generatedAt: readMeta(database, "generated_at"),
       indexStatus: readMeta(database, "status") ?? "unknown",
+      generation,
       coveredAt: {
         startAt: isoOrNull(firstObservedMs),
         endAt: isoOrNull(lastObservedMs),
@@ -404,7 +551,23 @@ export async function readLocalUnifiedCompanionProjection({
       quotaObservations,
       sourceCount: Number.isSafeInteger(sourceCount) ? sourceCount : 0,
       sourceBytes: Number.isSafeInteger(sourceBytes) ? sourceBytes : 0,
+      discoveredSourceCount: Number.isSafeInteger(discoveredSourceCount)
+        ? discoveredSourceCount : 0,
+      discoveredSourceBytes: Number.isSafeInteger(discoveredSourceBytes)
+        ? discoveredSourceBytes : 0,
+      indexedSourceCount: Number.isSafeInteger(indexedSourceCount)
+        ? indexedSourceCount : 0,
+      indexedSourceBytes: Number.isSafeInteger(indexedSourceBytes)
+        ? indexedSourceBytes : 0,
       indexBytes: metadata.size,
+      latestExportableRecordAt: isoOrNull(lastObservedMs),
+      tools: toolProjection(database, generation),
+      toolCoverageStatus: generation?.toolProvenanceComplete === true
+        ? "complete"
+        : generation === null ? "unavailable" : "partial",
+      toolCoverageBlockReason: generation?.toolProvenanceComplete === true
+        ? null
+        : generation?.blockReason ?? "tool_provenance_incomplete",
       usage: periods.map((period) => finalizeUsagePeriod(period.summary)),
       cacheSwitchImpact,
       cacheContinuityImpact,
@@ -421,6 +584,19 @@ export async function readLocalUnifiedCompanionProjection({
       },
       readWallMs: performance.now() - startedAt,
     };
+    let settledGeneration = null;
+    try {
+      settledGeneration = readUnifiedIndexGenerationDescriptor(database);
+    } catch {
+      settledGeneration = null;
+    }
+    if ((generation?.id ?? null) !== (settledGeneration?.id ?? null)
+        || (generation?.fingerprint ?? null)
+          !== (settledGeneration?.fingerprint ?? null)) {
+      throw fixedError("local_unified_index_generation_mismatch");
+    }
+    await revalidatePublishedPath(indexFile, metadata);
+    return result;
   } catch (error) {
     if (error?.code?.startsWith("local_unified_index_")) {
       return unavailable("unavailable", error.code);

--- a/src/local-unified-index-build.js
+++ b/src/local-unified-index-build.js
@@ -2,7 +2,10 @@ import { availableParallelism } from "node:os";
 import { basename, dirname, resolve } from "node:path";
 import { Worker } from "node:worker_threads";
 
-import { discoverCodexRolloutInfos } from "./codex-log-scan.js";
+import {
+  createLeadingRateLimitGate,
+  discoverCodexRolloutInfos,
+} from "./codex-log-scan.js";
 import { recognizedExportModelId } from "./export/index.js";
 import {
   createLineageSnapshots,
@@ -11,7 +14,11 @@ import {
   ownObservedTier,
 } from "./local-unified-index-extract.js";
 import {
+  assertSafeLocalUnifiedIndexTarget,
   createUnifiedIndexWriter,
+  createLocalUnifiedIndexSecondaryIndexes,
+  beginUnifiedIndexGeneration,
+  recoverUnifiedIndexGenerations,
   defaultLocalUnifiedIndexPath,
   defaultLocalUnifiedIndexSecretPath,
   localDigest,
@@ -19,6 +26,7 @@ import {
   outcomeOrdinal,
   publishStagedUnifiedIndex,
   readOrCreateDeviceSalt,
+  readUnifiedIndexGenerationDescriptor,
   reasoningEffortOrdinal,
   removeIfPresent,
   sessionLocal,
@@ -197,6 +205,7 @@ export function writeCursorForOutcome(writer, deviceSalt, info, state, {
 }) {
   writer.writeSourceCursor({
     sourceLocal: sourceLocal(deviceSalt, info.rolloutKey),
+    sourceOrdinal: state.sourceOrdinal ?? null,
     sessionLocal: state.sessionLocal,
     scannedBytes: nextOffset,
     sizeBytes: Number(info.size ?? 0),
@@ -240,19 +249,57 @@ function eventKeyFor(deviceSalt, sessionLocalKey, sourceOffset, observedAtMs) {
   return localDigest(
     deviceSalt,
     "unified-index-event",
-    `${sessionLocalKey.toString("hex")} ${sourceOffset} ${observedAtMs}`,
+    `${sessionLocalKey.toString("hex")}\0${sourceOffset}\0${observedAtMs}`,
   );
 }
 
-export function createEventSink({ writer, deviceSalt, accountScopeId, onCounts }) {
+function toolFactKey(deviceSalt, sourceLocalKey, sourceOffset, toolOrdinal) {
+  return localDigest(
+    deviceSalt,
+    "unified-index-tool-event",
+    `${Buffer.from(sourceLocalKey).toString("hex")}\0${sourceOffset}\0${toolOrdinal}`,
+  );
+}
+
+export function createEventSink({
+  writer,
+  deviceSalt,
+  accountScopeId,
+  generationId = null,
+  onCounts,
+}) {
   const counts = {
     usageEvents: 0,
     boundaryLinks: 0,
     quotaObservations: 0,
+    quotaOccurrences: 0,
+    contradictedLeadingSnapshotsSkipped: 0,
+    toolEvents: 0,
     modelMissing: 0,
     modelUnrecognized: 0,
     partialEvents: 0,
   };
+  const gates = new Map();
+  const settled = new Map();
+  const sourceSuppressed = new Map();
+
+  function gateFor(source) {
+    const key = source.sourceLocal.toString("hex");
+    let gate = gates.get(key);
+    if (gate !== undefined) return gate;
+    const windows = settled.get(key)
+      ?? writer.loadSettledQuotaWindows(source.sourceLocal);
+    settled.set(key, windows);
+    gate = createLeadingRateLimitGate(windows);
+    gates.set(key, gate);
+    return gate;
+  }
+
+  function occurrence(entry, admission) {
+    writer.writeQuotaOccurrence({ ...entry, generationId, admission });
+    if (admission === "admitted") counts.quotaOccurrences += 1;
+  }
+
   return {
     counts,
     write(source, event) {
@@ -261,14 +308,54 @@ export function createEventSink({ writer, deviceSalt, accountScopeId, onCounts }
       if (declaration.recognition === "unrecognized") counts.modelUnrecognized += 1;
       if (event.partial) counts.partialEvents += 1;
       let quotaObservationId = null;
-      for (const window of event.quota) {
+      const gate = gateFor(source);
+      for (const [slotOrder, window] of event.quota.entries()) {
         const id = writer.internQuota(window);
         counts.quotaObservations += 1;
-        // A token_count record can report a primary and a secondary window.
-        // The event references the primary pairing, which is the one the
-        // calibration reads; both remain in the quota series.
         if (quotaObservationId === null || window.slot === "primary") {
           quotaObservationId = id;
+        }
+        const entry = {
+          sourceLocal: source.sourceLocal,
+          sourceOffset: event.sourceOffset,
+          sourceOrdinal: source.sourceOrdinal,
+          surfaceId: source.surfaceId,
+          canonicalObservationId: id,
+          observedAtMs: window.observedAtMs,
+          provider: "openai_codex",
+          planType: window.planType ?? null,
+          limitId: window.limitId,
+          slot: window.slot,
+          slotOrder,
+          usedPercent: window.usedPercent,
+          resetsAtMs: window.resetsAtMs ?? null,
+          durationMins: window.durationMins,
+        };
+        // The replay callback contract requires a positive reset epoch. Keep
+        // the canonical observation for diagnostics, but never admit a
+        // reset-less window into the source-scoped callback series.
+        if (entry.resetsAtMs === null || entry.resetsAtMs <= 0) {
+          occurrence(entry, "suppressed");
+          continue;
+        }
+        const decision = gate.offer({
+          provider: entry.provider,
+          planType: entry.planType,
+          limitId: entry.limitId,
+          slot: entry.slot,
+          usedPercent: entry.usedPercent,
+          resetsAt: entry.resetsAtMs,
+          windowDurationMins: entry.durationMins,
+        }, entry.observedAtMs, entry);
+        for (const withheld of decision.withheld) {
+          counts.contradictedLeadingSnapshotsSkipped += 1;
+          const key = source.sourceLocal.toString("hex");
+          sourceSuppressed.set(key, (sourceSuppressed.get(key) ?? 0) + 1);
+          occurrence(withheld, "suppressed");
+        }
+        for (const released of decision.released) occurrence(released, "admitted");
+        if (decision.released.length === 0 && decision.withheld.length === 0) {
+          occurrence(entry, "held");
         }
       }
       const components = event.components;
@@ -282,33 +369,27 @@ export function createEventSink({ writer, deviceSalt, accountScopeId, onCounts }
         sourceId: source.sourceId,
         sourceOffset: event.sourceOffset,
         observedAtMs: event.observedAtMs,
+        generationId,
+        sourceLocal: source.sourceLocal,
+        sourceOffset: event.sourceOffset,
+        sourceOrdinal: source.sourceOrdinal,
+        tierObservedAtMs: event.tier?.observedAtMs ?? null,
         sessionLocal: source.sessionLocal,
         accountScopeId,
         modelId: writer.internModel(declaration.modelId, declaration.recognition),
         tierId: writer.internTier(tierRow(event.tier)),
-        surfaceId: writer.internSurface(source.surface),
+        surfaceId: source.surfaceId,
         quotaObservationId,
         reasoningEffort: reasoningEffortOrdinal(event.reasoningEffort ?? "unknown"),
-        // Codex rollout logs do not report a turn outcome. `unknown` is the
-        // contract's own member for that, and is not a stand-in for failure.
         outcome: outcomeOrdinal("unknown"),
         tokensInUncached: components?.inputUncachedTokens ?? null,
         tokensInCacheRead: components?.inputCacheReadTokens ?? null,
         tokensInCacheWrite: components?.inputCacheWriteTokens ?? null,
-        // Codex does not split cache writes by TTL and does not report a
-        // combined output figure. NULL is the honest value; a zero here would
-        // be indistinguishable from an observed zero, and the pricing tests
-        // deliberately pin the missing-TTL-split failure mode.
         tokensInCacheWrite5m: null,
         tokensInCacheWrite1h: null,
         tokensOutText: components?.outputTextTokens ?? null,
         tokensOutReasoning: components?.outputReasoningTokens ?? null,
         tokensOutCombined: null,
-        // Provider-reported only. Codex reports `model_context_window` (a
-        // property of the model, not of the turn) and the component counts
-        // whose sum we must never promote into a pricing band. Decision 1 of
-        // the agreed design requires NULL to stay distinguishable from a real
-        // provider total, so NULL is what it gets.
         totalInputContext: null,
         partial: event.partial === true,
       });
@@ -329,6 +410,37 @@ export function createEventSink({ writer, deviceSalt, accountScopeId, onCounts }
         sessionLocal: source.sessionLocal,
       });
       counts.boundaryLinks += 1;
+    },
+    writeTool(source, event) {
+      const inserted = writer.writeToolClassFact({
+        eventKey: toolFactKey(
+          deviceSalt,
+          source.sourceLocal,
+          event.sourceOffset,
+          event.toolOrdinal,
+        ),
+        generationId,
+        sourceLocal: source.sourceLocal,
+        sourceOffset: event.sourceOffset,
+        sourceOrdinal: source.sourceOrdinal,
+        sessionLocal: source.sessionLocal,
+        observedAtMs: event.observedAtMs,
+        toolOrdinal: event.toolOrdinal,
+        toolClass: event.toolClass,
+        sourceKind: event.sourceKind,
+      });
+      counts.toolEvents += inserted;
+    },
+    finishSource(source) {
+      const gate = gates.get(source.sourceLocal.toString("hex"));
+      if (gate === undefined) return;
+      for (const entry of gate.flush()) occurrence(entry, "admitted");
+    },
+    diagnosticsForSource(source) {
+      return {
+        contradictedLeadingSnapshotsSkipped:
+          sourceSuppressed.get(source.sourceLocal.toString("hex")) ?? 0,
+      };
     },
   };
 }
@@ -404,6 +516,7 @@ export async function rebuildLocalUnifiedIndex({
   contractVersion,
   workerCount = 1,
   commitRows = 10_000,
+  deferSecondaryIndexes = true,
   maximumLineBytes,
   signal = null,
   onProgress = null,
@@ -419,8 +532,14 @@ export async function rebuildLocalUnifiedIndex({
       || workerCount > MAXIMUM_WORKERS) {
     throw new TypeError(`workerCount must be between 1 and ${MAXIMUM_WORKERS}`);
   }
+  if (typeof deferSecondaryIndexes !== "boolean") {
+    throw new TypeError("deferSecondaryIndexes must be a boolean");
+  }
   const startedAt = performance.now();
   const resolvedIndexFile = resolve(indexFile);
+  await assertSafeLocalUnifiedIndexTarget(resolvedIndexFile, {
+    allowMissing: true,
+  });
   const deviceSalt = await readOrCreateDeviceSalt(
     secretFile ?? defaultLocalUnifiedIndexSecretPath(resolvedIndexFile),
   );
@@ -436,27 +555,57 @@ export async function rebuildLocalUnifiedIndex({
 
   const stageFile = `${resolvedIndexFile}.building-${process.pid}-${Date.now().toString(36)}`;
   await removeIfPresent(stageFile);
-  const database = openLocalUnifiedIndex(stageFile, {
-    readOnly: false,
-    create: true,
-    staging: true,
-  });
-  const writer = createUnifiedIndexWriter(database, {
-    commitRows,
-    contractVersion,
-  });
+  let database = null;
+  let generation = null;
+  let writer = null;
+  let sink = null;
+  try {
+    database = openLocalUnifiedIndex(stageFile, {
+      readOnly: false,
+      create: true,
+      staging: true,
+      deferSecondaryIndexes,
+    });
+    recoverUnifiedIndexGenerations(database);
+    generation = beginUnifiedIndexGeneration(database, {
+      contractVersion,
+      discoveredSourceCount: infos.length,
+      discoveredSourceBytes: sourceBytes,
+    });
+    writer = createUnifiedIndexWriter(database, {
+      commitRows,
+      contractVersion,
+      generationId: generation.generationId,
+      parserVersionId: generation.parserVersionId,
+      ingestRunId: generation.ingestRunId,
+    });
 
-  // Rollout logs carry no account identity at all; the account scope the
-  // collector attaches comes from a contemporaneous app-server marker, which a
-  // historical rebuild has no honest way to reconstruct.
-  const accountScopeId = writer.internAccountScope({
-    status: "unavailable",
-    reason: "missing_account",
-    planType: null,
-    scopeLocal: null,
-  });
+    // Rollout logs carry no account identity at all; the account scope the
+    // collector attaches comes from a contemporaneous app-server marker, which a
+    // historical rebuild has no honest way to reconstruct.
+    const accountScopeId = writer.internAccountScope({
+      status: "unavailable",
+      reason: "missing_account",
+      planType: null,
+      scopeLocal: null,
+    });
 
-  const sink = createEventSink({ writer, deviceSalt, accountScopeId, onCounts: null });
+    sink = createEventSink({
+      writer,
+      deviceSalt,
+      accountScopeId,
+      generationId: generation.generationId,
+      onCounts: null,
+    });
+  } catch (error) {
+    try {
+      database?.close();
+    } catch {
+      // Preserve the setup failure; the incomplete stage is discarded below.
+    }
+    await removeIfPresent(stageFile);
+    throw error;
+  }
   const diagnostics = {
     sources: infos.length,
     sourceBytes,
@@ -474,18 +623,24 @@ export async function rebuildLocalUnifiedIndex({
     peakRetainedSnapshotKeys: 0,
   };
 
+  const sourceOrdinals = new Map(
+    infos.map((info, ordinal) => [info.rolloutKey, ordinal]),
+  );
   const sourceState = new Map();
   function stateFor(info) {
     const key = info.rolloutKey;
     let state = sourceState.get(key);
     if (state === undefined) {
       const sessionId = info.lineage?.sessionId ?? info.rolloutKey;
-      const sourceKey = sourceLocal(deviceSalt, info.rolloutKey);
+      const local = sourceLocal(deviceSalt, info.rolloutKey);
+      const surface = surfaceRow(info.lineage?.surfaceClassification);
       state = {
         sessionLocal: sessionLocal(deviceSalt, sessionId),
-        sourceLocal: sourceKey,
-        sourceId: writer.internSource(sourceKey),
-        surface: surfaceRow(info.lineage?.surfaceClassification),
+        sourceLocal: local,
+        sourceId: writer.internSource(local),
+        sourceOrdinal: sourceOrdinals.get(info.rolloutKey),
+        surface,
+        surfaceId: writer.internSurface(surface),
         finalModel: null,
         finalEffort: null,
         finalTier: null,
@@ -494,6 +649,16 @@ export async function rebuildLocalUnifiedIndex({
       // decision). The writer refuses anything that is not UUID-shaped, so a
       // rollout-key fallback id is never recorded.
       writer.recordSessionIdentity(state.sessionLocal, sessionId);
+      writer.writeGenerationSource({
+        sourceLocal: local,
+        sourceOrdinal: state.sourceOrdinal,
+        sessionLocal: state.sessionLocal,
+        surfaceId: state.surfaceId,
+        status: "pending",
+        discoveredSizeBytes: Number(info.size ?? 0),
+        scannedBytes: 0,
+        mtimeMs: Math.floor(Number(info.mtimeMs ?? 0)),
+      });
       sourceState.set(key, state);
     }
     return state;
@@ -553,10 +718,12 @@ export async function rebuildLocalUnifiedIndex({
               signal,
               onEvent: (event) => sink.write(state, event),
               onBoundary: (event) => sink.writeBoundary(state, event),
+              onTool: (event) => sink.writeTool(state, event),
             });
             state.finalModel = outcome.finalModel;
             state.finalEffort = outcome.finalEffort;
             state.finalTier = outcome.finalTier;
+            sink.finishSource(state);
             writeCursorForOutcome(writer, deviceSalt, info, state, {
               nextOffset: outcome.read.nextOffset,
               finalModel: outcome.finalModel,
@@ -571,6 +738,22 @@ export async function rebuildLocalUnifiedIndex({
               finalTurnContextPending: outcome.finalTurnContextPending,
               turnContextSeen: outcome.finalTurnContextSeen,
               snapshotsPersisted: collector !== null,
+            });
+            writer.writeSourceDiagnostics(state.sourceLocal, {
+              ...outcome.diagnostics,
+              oversizedLines: outcome.read.oversizedLines,
+              ...sink.diagnosticsForSource(state),
+            });
+            writer.writeGenerationSource({
+              sourceLocal: state.sourceLocal,
+              sourceOrdinal: state.sourceOrdinal,
+              sessionLocal: state.sessionLocal,
+              surfaceId: state.surfaceId,
+              status: "complete",
+              discoveredSizeBytes: Number(info.size ?? 0),
+              scannedBytes: outcome.read.nextOffset,
+              mtimeMs: Math.floor(Number(info.mtimeMs ?? 0)),
+              diagnosticsComplete: true,
             });
             diagnostics.sourcesScanned += 1;
             diagnostics.bytesScanned += Number(info.size ?? 0);
@@ -599,6 +782,9 @@ export async function rebuildLocalUnifiedIndex({
           for (const event of message.boundaries ?? []) {
             sink.writeBoundary(state, event);
           }
+          for (const event of message.tools ?? []) {
+            sink.writeTool(state, event);
+          }
           for (const key of message.snapshotKeys ?? []) {
             writer.addLineageSnapshot(
               state.sessionLocal,
@@ -606,6 +792,7 @@ export async function rebuildLocalUnifiedIndex({
             );
           }
           if (message.final === true) {
+            sink.finishSource(state);
             if (message.cursor) {
               writeCursorForOutcome(
                 writer,
@@ -615,6 +802,22 @@ export async function rebuildLocalUnifiedIndex({
                 message.cursor,
               );
             }
+            writer.writeSourceDiagnostics(state.sourceLocal, {
+              ...message.diagnostics,
+              oversizedLines: message.diagnostics.oversizedLines,
+              ...sink.diagnosticsForSource(state),
+            });
+            writer.writeGenerationSource({
+              sourceLocal: state.sourceLocal,
+              sourceOrdinal: state.sourceOrdinal,
+              sessionLocal: state.sessionLocal,
+              surfaceId: state.surfaceId,
+              status: "complete",
+              discoveredSizeBytes: Number(info.size ?? 0),
+              scannedBytes: Number(message.cursor?.nextOffset ?? info.size ?? 0),
+              mtimeMs: Math.floor(Number(info.mtimeMs ?? 0)),
+              diagnosticsComplete: true,
+            });
             diagnostics.sourcesScanned += 1;
             diagnostics.bytesScanned += Number(info.size ?? 0);
             accumulate(
@@ -633,18 +836,43 @@ export async function rebuildLocalUnifiedIndex({
     }
 
     const scannedAt = performance.now();
+    if (signal?.aborted) throw fixedError("local_unified_index_aborted");
+    if (deferSecondaryIndexes) {
+      // All fact writes are settled before SQLite builds the reader-only
+      // indexes in one fixed-order operation. Primary/UNIQUE indexes remain
+      // online throughout the load because the writer's conflict semantics
+      // depend on them.
+      writer.flush();
+      createLocalUnifiedIndexSecondaryIndexes(database);
+    }
     writer.writeMeta("source_count", infos.length);
     writer.writeMeta("source_bytes", sourceBytes);
     writer.writeMeta("usage_events", sink.counts.usageEvents);
     writer.writeMeta("boundary_links", sink.counts.boundaryLinks);
     writer.writeMeta("generated_at", new Date().toISOString());
     writer.writeMeta("contract_version", contractVersion);
-    writer.writeMeta("status", signal?.aborted ? "partial" : "complete");
+    if (signal?.aborted) throw fixedError("local_unified_index_aborted");
+    writer.writeMeta("status", "complete");
+    writer.finalizeGeneration({
+      status: "complete",
+      discoveredSourceCount: infos.length,
+      discoveredSourceBytes: sourceBytes,
+      indexedSourceCount: infos.length,
+      indexedSourceBytes: sourceBytes,
+      discoveryComplete: true,
+      diagnosticsComplete: true,
+    });
+    const generationDescriptor = readUnifiedIndexGenerationDescriptor(
+      database,
+      generation.generationId,
+    );
     const closed = await writer.close({ integrityCheck: true, fsyncPath: null });
     await publishStagedUnifiedIndex(stageFile, resolvedIndexFile);
     return {
       status: "built",
       indexFile: resolvedIndexFile,
+      generation: generationDescriptor,
+      generationDescriptor,
       ...diagnostics,
       ...sink.counts,
       batches: closed.batches,
@@ -656,7 +884,15 @@ export async function rebuildLocalUnifiedIndex({
     };
   } catch (error) {
     try {
-      database.close();
+      writer?.failGeneration(error?.code === "local_unified_index_aborted"
+        ? "aborted"
+        : "exception");
+    } catch {
+      // The staging file is discarded below; an uncommitted generation cannot
+      // affect the live publication.
+    }
+    try {
+      database?.close();
     } catch {
       // The connection may already be closed by the writer.
     }

--- a/src/local-unified-index-extract.js
+++ b/src/local-unified-index-extract.js
@@ -1,4 +1,7 @@
-import { cumulativeSnapshotKey } from "./providers/codex/logs.js";
+import {
+  cumulativeSnapshotKey,
+  extractToolObservations,
+} from "./providers/codex/logs.js";
 import { forEachRolloutLine, ROLLOUT_LINE_BYTES } from "./rollout-line-reader.js";
 
 // Projection from one Codex rollout file to typed usage facts.
@@ -8,25 +11,27 @@ import { forEachRolloutLine, ROLLOUT_LINE_BYTES } from "./rollout-line-reader.js
 // one owner-area import is the reviewed `cumulativeSnapshotKey`, measured at
 // 5.1 ms to load per thread.
 //
-// Only three JSON record types are read: `turn_context`, `token_count` and
-// `thread_settings_applied`. A fourth boundary, top-level `compacted`, is
-// recognised from its bounded header without ever parsing its payload. No
-// prompt, reply, reasoning or file content is parsed — and the fields taken
-// from the three JSON records are enumerated by hand below rather than copied
-// wholesale, so a new content-bearing field appearing upstream cannot leak in
-// by default. Note in particular that `turn_context` carries `cwd`,
+// The accounting records are `turn_context`, `token_count` and
+// `thread_settings_applied`; typed `response_item` tool descriptors are also
+// classified through the reviewed privacy-safe normalizer. A fourth boundary,
+// top-level `compacted`, is recognised from its bounded header without ever
+// parsing its payload. No prompt, reply, reasoning, tool name, tool input or
+// file content is retained — the normalizer returns only fixed classes. The
+// fields taken from accounting records are enumerated by hand below rather
+// than copied wholesale, so a new content-bearing field appearing upstream
+// cannot leak in by default. Note in particular that `turn_context` carries `cwd`,
 // `workspace_roots` and a
 // `collaboration_mode.settings.developer_instructions` block: all three are
 // content or filesystem paths, and none of them is read here.
 
 // Byte-level needles. Matching on the raw Buffer avoids decoding the ~99% of
-// lines that are irrelevant. `"custom_tool_call"` is deliberately absent: a
-// loose `tool_call` marker matched large response records and cost measurable
-// time, and tool classification is not one of the three permitted record
-// types.
+// lines that are irrelevant. The response-item marker is exact and is decoded
+// only far enough for typed tool classification; arbitrary response content
+// never becomes an index value.
 const NEEDLE_TURN_CONTEXT = Buffer.from('"turn_context"');
 const NEEDLE_TOKEN_COUNT = Buffer.from('"token_count"');
 const NEEDLE_THREAD_SETTINGS = Buffer.from('"thread_settings_applied"');
+const NEEDLE_RESPONSE_ITEM = Buffer.from('"type":"response_item"');
 const COMPACTION_TIMESTAMP_PREFIX = Buffer.from('{"timestamp":"');
 const COMPACTION_TYPE_SUFFIX = Buffer.from(',"type":"compacted"');
 const COMPACTION_TYPE_PREFIX = Buffer.from('{"type":"compacted","timestamp":"');
@@ -104,7 +109,8 @@ const TOKEN_KEYS = [
 function relevant(line) {
   return line.includes(NEEDLE_TOKEN_COUNT)
     || line.includes(NEEDLE_TURN_CONTEXT)
-    || line.includes(NEEDLE_THREAD_SETTINGS);
+    || line.includes(NEEDLE_THREAD_SETTINGS)
+    || line.includes(NEEDLE_RESPONSE_ITEM);
 }
 
 function normalizeUsage(value) {
@@ -312,12 +318,16 @@ export async function extractRolloutUsage(path, {
   signal = null,
   onEvent,
   onBoundary = null,
+  onTool = null,
 } = {}) {
   if (typeof onEvent !== "function") {
     throw new TypeError("onEvent must be a function");
   }
   if (onBoundary !== null && typeof onBoundary !== "function") {
     throw new TypeError("onBoundary must be a function or null");
+  }
+  if (onTool !== null && typeof onTool !== "function") {
+    throw new TypeError("onTool must be a function or null");
   }
   let currentModel = seedModel;
   let currentEffort = seedEffort;
@@ -409,6 +419,9 @@ export async function extractRolloutUsage(path, {
     modelSeededFromLineage: 0,
     tierSeededFromLineage: 0,
     modelMissing: 0,
+    toolRecords: 0,
+    toolEvents: 0,
+    toolRecordsSkipped: 0,
   };
   if (seedModel !== null) diagnostics.modelSeededFromLineage = 1;
   if (seedTier?.inherited === true) diagnostics.tierSeededFromLineage = 1;
@@ -442,6 +455,9 @@ export async function extractRolloutUsage(path, {
           record = JSON.parse(text);
         } catch {
           diagnostics.malformedLines += 1;
+          if (text.includes(NEEDLE_RESPONSE_ITEM)) {
+            diagnostics.toolRecordsSkipped += 1;
+          }
           return;
         }
       }
@@ -460,6 +476,13 @@ export async function extractRolloutUsage(path, {
             currentEffort = effort;
           }
           diagnostics.salvagedRecords += 1;
+          return;
+        }
+        if (text.includes(NEEDLE_RESPONSE_ITEM)) {
+          // A response item that exceeds the bounded line cap cannot be
+          // classified without decoding its payload. Withhold it and let the
+          // generation attestation mark tool evidence incomplete.
+          diagnostics.toolRecordsSkipped += 1;
           return;
         }
         if (!text.includes('"token_count"')) return;
@@ -518,6 +541,23 @@ export async function extractRolloutUsage(path, {
         const effort = record.payload?.effort;
         if (typeof effort === "string" && REASONING_EFFORT_VALUES.has(effort)) {
           currentEffort = effort;
+        }
+        return;
+      }
+      if (record.type === "response_item") {
+        const observations = extractToolObservations(record.payload);
+        if (observations.length === 0) return;
+        diagnostics.toolRecords += 1;
+        for (const [toolOrdinal, observation] of observations.entries()) {
+          const event = {
+            observedAtMs,
+            sourceOffset: lineEndOffset,
+            toolOrdinal,
+            toolClass: observation.toolClass,
+            sourceKind: observation.sourceKind,
+          };
+          diagnostics.toolEvents += 1;
+          await onTool?.(event);
         }
         return;
       }

--- a/src/local-unified-index-ingest.js
+++ b/src/local-unified-index-ingest.js
@@ -1,3 +1,5 @@
+import { constants } from "node:fs";
+import { copyFile } from "node:fs/promises";
 import { resolve } from "node:path";
 
 import { discoverCodexRolloutInfos } from "./codex-log-scan.js";
@@ -11,16 +13,25 @@ import {
   createEventSink,
   lineageComponents,
   persistingCollector,
+  rebuildLocalUnifiedIndex,
   surfaceRow,
   writeCursorForOutcome,
 } from "./local-unified-index-build.js";
 import {
+  assertSafeLocalUnifiedIndexTarget,
   createUnifiedIndexWriter,
+  beginUnifiedIndexGeneration,
   defaultLocalUnifiedIndexPath,
   defaultLocalUnifiedIndexSecretPath,
   LOCAL_UNIFIED_INDEX_PARSER_VERSION,
+  LOCAL_UNIFIED_INDEX_SCHEMA_VERSION,
+  LOCAL_UNIFIED_INDEX_USER_VERSION,
   openLocalUnifiedIndex,
+  publishStagedUnifiedIndex,
+  recoverUnifiedIndexGenerations,
   readOrCreateDeviceSalt,
+  readUnifiedIndexGenerationDescriptor,
+  removeIfPresent,
   sessionLocal,
   snapshotLocal,
   sourceLocal,
@@ -64,7 +75,8 @@ function loadCursors(database) {
   // missing; a NULL parser_version then reads as "unknown", which classifies
   // as a forced rescan — the safe direction.
   const rows = database.prepare(`
-    SELECT sc.source_local, sc.session_local, sc.scanned_bytes, sc.size_bytes,
+    SELECT sc.source_local, sc.source_ordinal, sc.session_local,
+           sc.scanned_bytes, sc.size_bytes,
            sc.mtime_ms, sc.snapshots_persisted, sc.turn_context_seen,
            sc.carry_model, sc.carry_effort, sc.carry_tier_raw,
            sc.carry_tier_observed_at_ms, sc.carry_total_input,
@@ -152,7 +164,9 @@ export function classifySource(info, cursor, expectedParserVersion = null) {
   const cursorSize = Number(cursor.size_bytes);
   const cursorMtime = Number(cursor.mtime_ms);
   if (size === cursorSize) {
-    return mtimeMs === cursorMtime ? { mode: "skip" } : { mode: "touch" };
+    return mtimeMs === cursorMtime
+      ? { mode: "skip" }
+      : { mode: "rescan", reason: "same_size_changed" };
   }
   if (size > cursorSize) return { mode: "resume" };
   return { mode: "rescan", reason: "shrink" };
@@ -183,6 +197,9 @@ export async function ingestLocalUnifiedIndexIncrement({
   }
   const startedAt = performance.now();
   const resolvedIndexFile = resolve(indexFile);
+  await assertSafeLocalUnifiedIndexTarget(resolvedIndexFile, {
+    allowMissing: true,
+  });
   const deviceSalt = await readOrCreateDeviceSalt(
     secretFile ?? defaultLocalUnifiedIndexSecretPath(resolvedIndexFile),
   );
@@ -194,13 +211,227 @@ export async function ingestLocalUnifiedIndexIncrement({
     discoveryLimits,
   });
   const discoveredAt = performance.now();
-
-  const database = openLocalUnifiedIndex(resolvedIndexFile, {
-    readOnly: false,
-    create: true,
-  });
+  const sourceBytes = infos.reduce(
+    (total, info) => total + Number(info.size ?? 0),
+    0,
+  );
+  let coldRebuildReason = null;
+  // Read-only preflight avoids cloning/publishing when every current source
+  // is byte-for-byte unchanged. A same-size mtime change is deliberately a
+  // rescan (classifySource's conservative race policy), so this reads no
+  // rollout body bytes and still catches replacement files.
+  if (!signal?.aborted) {
+    let unchangedDatabase = null;
+    try {
+      unchangedDatabase = openLocalUnifiedIndex(resolvedIndexFile, { readOnly: true });
+      const schema = unchangedDatabase.prepare(
+        "SELECT value FROM meta WHERE key = 'schema_version'",
+      ).get()?.value;
+      const userVersion = Number(
+        unchangedDatabase.prepare("PRAGMA user_version").get()?.user_version,
+      );
+      if (schema !== LOCAL_UNIFIED_INDEX_SCHEMA_VERSION
+          || userVersion !== LOCAL_UNIFIED_INDEX_USER_VERSION) {
+        coldRebuildReason = "legacy_schema";
+      }
+      const storedContract = unchangedDatabase.prepare(
+        "SELECT value FROM meta WHERE key = 'contract_version'",
+      ).get()?.value;
+      if (coldRebuildReason === null && storedContract !== contractVersion) {
+        coldRebuildReason = "contract_changed";
+      }
+      if (coldRebuildReason === null
+          && schema === LOCAL_UNIFIED_INDEX_SCHEMA_VERSION
+          && storedContract === contractVersion) {
+        const cursors = loadCursors(unchangedDatabase);
+        const descriptor = readUnifiedIndexGenerationDescriptor(
+          unchangedDatabase,
+        );
+        if (descriptor !== null && (
+          descriptor.status !== "complete"
+          || descriptor.discoveryComplete !== true
+          || descriptor.diagnosticsComplete !== true
+          || descriptor.usageProvenanceComplete !== true
+          || descriptor.sourceOrderComplete !== true
+          || descriptor.quotaProvenanceComplete !== true
+          || descriptor.toolProvenanceComplete !== true
+        )) {
+          coldRebuildReason = "incomplete_generation";
+        }
+        if (coldRebuildReason === null && descriptor !== null) {
+          const unattestedSources = Number(unchangedDatabase.prepare(`
+            SELECT (
+              (SELECT COUNT(*) FROM source_cursor sc
+               WHERE NOT EXISTS (
+                 SELECT 1 FROM generation_source gs
+                 WHERE gs.generation_id = ?
+                   AND gs.source_local = sc.source_local))
+              +
+              (SELECT COUNT(*) FROM usage_event u
+               WHERE u.source_local IS NOT NULL AND NOT EXISTS (
+                 SELECT 1 FROM generation_source gs
+                 WHERE gs.generation_id = ?
+                   AND gs.source_local = u.source_local))
+              +
+              (SELECT COUNT(*) FROM quota_occurrence q
+               WHERE NOT EXISTS (
+                 SELECT 1 FROM generation_source gs
+                 WHERE gs.generation_id = ?
+                   AND gs.source_local = q.source_local))
+              +
+              (SELECT COUNT(*) FROM usage_event u
+               WHERE u.source_local IS NOT NULL AND NOT EXISTS (
+                 SELECT 1 FROM source_cursor sc
+                 WHERE sc.source_local = u.source_local))
+              +
+              (SELECT COUNT(*) FROM quota_occurrence q
+               WHERE NOT EXISTS (
+                 SELECT 1 FROM source_cursor sc
+                 WHERE sc.source_local = q.source_local))
+            ) AS count`).get(
+            descriptor.id,
+            descriptor.id,
+            descriptor.id,
+          )?.count ?? 0);
+          if (unattestedSources > 0) {
+            coldRebuildReason = "source_attestation_incomplete";
+          }
+        }
+        const generationAuthoritative = descriptor?.status === "complete"
+          && descriptor.discoveryComplete === true
+          && descriptor.diagnosticsComplete === true
+          && descriptor.usageProvenanceComplete === true
+          && descriptor.sourceOrderComplete === true
+          && descriptor.quotaProvenanceComplete === true
+          && descriptor.toolProvenanceComplete === true;
+        const sourceSetUnchanged = descriptor?.discoveredSourceCount
+            === infos.length
+          && descriptor?.discoveredSourceBytes === sourceBytes;
+        const unchanged = generationAuthoritative
+          && sourceSetUnchanged
+          && infos.every((info) => classifySource(
+            info,
+            cursors.get(
+              sourceLocal(deviceSalt, info.rolloutKey).toString("hex"),
+            ),
+            LOCAL_UNIFIED_INDEX_PARSER_VERSION,
+          ).mode === "skip");
+        if (unchanged) {
+          const totalBoundaryLinks = Number(
+            unchangedDatabase.prepare(
+              "SELECT COUNT(*) AS count FROM usage_event_boundary",
+            ).get()?.count ?? 0,
+          );
+          return {
+            status: "ingested",
+            unchanged: true,
+            indexFile: resolvedIndexFile,
+            generation: descriptor,
+            generationDescriptor: descriptor,
+            sources: infos.length,
+            sourceBytes,
+            sourcesSkipped: infos.length,
+            sourcesTouched: 0,
+            sourcesResumed: 0,
+            sourcesRescanned: 0,
+            sourcesReparsedForParserVersion: 0,
+            usageRowsDeletedForReparse: 0,
+            sourcesScanned: 0,
+            bytesScanned: 0,
+            insertedUsageEvents: 0,
+            insertedBoundaryLinks: 0,
+            totalUsageEvents: descriptor.usageEvents ?? 0,
+            totalBoundaryLinks,
+            quotaOccurrences: descriptor.quotaOccurrences ?? 0,
+            discoveryWallMs: discoveredAt - startedAt,
+            scanWallMs: 0,
+            wallMs: performance.now() - startedAt,
+            peakRssBytes: process.memoryUsage.rss(),
+          };
+        }
+      }
+    } catch {
+      // The normal staged path handles missing/legacy indexes and any cursor
+      // shape mismatch. Preflight is an optimization, never a gate.
+    } finally {
+      unchangedDatabase?.close();
+    }
+  }
+  if (coldRebuildReason !== null) {
+    const rebuilt = await rebuildLocalUnifiedIndex({
+      codexHome,
+      indexFile: resolvedIndexFile,
+      secretFile: secretFile
+        ?? defaultLocalUnifiedIndexSecretPath(resolvedIndexFile),
+      startAt,
+      endAt,
+      contractVersion,
+      workerCount: 1,
+      commitRows,
+      maximumLineBytes,
+      signal,
+      onProgress,
+      discoveryLimits,
+    });
+    return {
+      ...rebuilt,
+      status: "ingested",
+      unchanged: false,
+      rebuilt: true,
+      rebuildReason: coldRebuildReason,
+      sourcesSkipped: 0,
+      sourcesTouched: 0,
+      sourcesResumed: 0,
+      sourcesRescanned: rebuilt.sourcesScanned,
+      sourcesReparsedForParserVersion: 0,
+      usageRowsDeletedForReparse: 0,
+      quotaOccurrenceRowsDeletedForRescan: 0,
+      insertedUsageEvents: rebuilt.usageEvents,
+      insertedBoundaryLinks: rebuilt.boundaryLinks ?? 0,
+      totalUsageEvents: rebuilt.usageEvents,
+      totalBoundaryLinks: rebuilt.boundaryLinks ?? 0,
+    };
+  }
+  const stageFile = `${resolvedIndexFile}.incremental-${process.pid}-${Date.now().toString(36)}`;
+  await removeIfPresent(stageFile);
+  let database = null;
   let writer = null;
+  let generation = null;
   try {
+    const liveExists = await assertSafeLocalUnifiedIndexTarget(
+      resolvedIndexFile,
+      { allowMissing: true },
+    ) !== null;
+    if (liveExists) {
+      try {
+        await copyFile(
+          resolvedIndexFile,
+          stageFile,
+          constants.COPYFILE_FICLONE ?? 0,
+        );
+      } catch {
+        // APFS clone is the cheap path, but not every filesystem supports it.
+        // A regular copy preserves the same atomic publication boundary.
+        await copyFile(resolvedIndexFile, stageFile);
+      }
+    }
+    database = openLocalUnifiedIndex(stageFile, {
+      readOnly: false,
+      create: !liveExists,
+      staging: true,
+    });
+    const previousGenerationValue = database.prepare(
+      "SELECT value FROM meta WHERE key = 'current_generation_id'",
+    ).get()?.value;
+    const previousGenerationId = previousGenerationValue === undefined
+      ? null
+      : Number(previousGenerationValue);
+    recoverUnifiedIndexGenerations(database);
+    generation = beginUnifiedIndexGeneration(database, {
+      contractVersion,
+      discoveredSourceCount: infos.length,
+      discoveredSourceBytes: sourceBytes,
+    });
     const cursors = loadCursors(database);
     const selectLineageSnapshot = database.prepare(`
       SELECT 1 AS present FROM lineage_snapshot
@@ -208,6 +439,9 @@ export async function ingestLocalUnifiedIndexIncrement({
     writer = createUnifiedIndexWriter(database, {
       commitRows,
       contractVersion,
+      generationId: generation.generationId,
+      parserVersionId: generation.parserVersionId,
+      ingestRunId: generation.ingestRunId,
     });
     const accountScopeId = writer.internAccountScope({
       status: "unavailable",
@@ -219,6 +453,7 @@ export async function ingestLocalUnifiedIndexIncrement({
       writer,
       deviceSalt,
       accountScopeId,
+      generationId: generation.generationId,
       onCounts: null,
     });
     const countSourceBoundaries = database.prepare(`
@@ -226,9 +461,7 @@ export async function ingestLocalUnifiedIndexIncrement({
       FROM usage_event_boundary boundary
       JOIN usage_event event
         ON event.event_key = boundary.current_event_key
-      WHERE event.source_id = ?`);
-    const deleteSourceUsage = database.prepare(`
-      DELETE FROM usage_event WHERE source_id = ?`);
+      WHERE event.source_local = ?`);
 
     const diagnostics = {
       sources: infos.length,
@@ -241,6 +474,7 @@ export async function ingestLocalUnifiedIndexIncrement({
       boundaryRowsDeletedForReparse: 0,
       usageRowsDeletedForSourceRescan: 0,
       boundaryRowsDeletedForSourceRescan: 0,
+      quotaOccurrenceRowsDeletedForRescan: 0,
       sourcesScanned: 0,
       bytesScanned: 0,
       relevantLines: 0,
@@ -276,44 +510,172 @@ export async function ingestLocalUnifiedIndexIncrement({
     // Final carried state for sources scanned in THIS pass, keyed by session
     // id, so a child scanned after its parent seeds from the freshest values.
     const finalBySessionId = new Map();
-
-    // Parser-version healing. A cursor stamped by an older parser version
-    // names a source whose stored rows were derived by the old (possibly
-    // poisoned) logic. Re-derived rows share their event keys with the old
-    // ones — the key is (session, byte offset, observed-at), not the token
-    // values — so `ON CONFLICT DO NOTHING` would silently keep the poison.
-    // Delete those sessions' rows up front, before anything is scanned, so
-    // the forced whole-file rescans below re-insert clean values. Rows whose
-    // rollout files have rotated away have no discovered source here and are
-    // untouched, exactly as the parser-version design records.
-    {
-      const deleteSessionUsage = database.prepare(
-        "DELETE FROM usage_event WHERE session_local = ?",
-      );
-      const deleteSessionBoundaries = database.prepare(
-        "DELETE FROM usage_event_boundary WHERE session_local = ?",
-      );
-      const healedSessions = new Set();
-      for (const info of infos) {
-        const cursor = cursors.get(
-          sourceLocal(deviceSalt, info.rolloutKey).toString("hex"),
-        );
-        if (cursor === undefined) continue;
-        if (cursor.parser_version === LOCAL_UNIFIED_INDEX_PARSER_VERSION) {
-          continue;
-        }
-        diagnostics.sourcesReparsedForParserVersion += 1;
-        const sessionKey = cursor.session_local === null
-          ? localForSession(info.lineage?.sessionId ?? info.rolloutKey)
-          : Buffer.from(cursor.session_local);
-        const sessionHex = sessionKey.toString("hex");
-        if (healedSessions.has(sessionHex)) continue;
-        healedSessions.add(sessionHex);
-        diagnostics.boundaryRowsDeletedForReparse +=
-          Number(deleteSessionBoundaries.run(sessionKey).changes ?? 0);
-        diagnostics.usageRowsDeletedForReparse +=
-          Number(deleteSessionUsage.run(sessionKey).changes ?? 0);
+    const sourceOrdinals = new Map();
+    let nextSourceOrdinal = -1;
+    for (const cursor of cursors.values()) {
+      const ordinal = Number(cursor.source_ordinal);
+      if (Number.isSafeInteger(ordinal) && ordinal >= 0) {
+        nextSourceOrdinal = Math.max(nextSourceOrdinal, ordinal);
       }
+    }
+    for (const info of infos) {
+      const sourceKey = sourceLocal(deviceSalt, info.rolloutKey).toString("hex");
+      const existing = cursors.get(sourceKey);
+      const stored = Number(existing?.source_ordinal);
+      if (Number.isSafeInteger(stored) && stored >= 0) {
+        sourceOrdinals.set(info.rolloutKey, stored);
+      } else {
+        // Allocate missing ordinals in deterministic discovery order. The
+        // ordinal is only a local ordering token; no path is persisted.
+        sourceOrdinals.set(info.rolloutKey, ++nextSourceOrdinal);
+      }
+    }
+    const currentSourceKeys = new Set(infos.map((info) => (
+      sourceLocal(deviceSalt, info.rolloutKey).toString("hex")
+    )));
+    const previousRetainedSource = previousGenerationId === null
+      ? null
+      : database.prepare(`
+        SELECT source_ordinal, session_local, surface_id, status,
+               discovered_size_bytes, scanned_bytes, mtime_ms,
+               diagnostics_complete
+        FROM generation_source
+        WHERE generation_id = ? AND source_local = ?`);
+    for (const [sourceHex, cursor] of cursors) {
+      if (currentSourceKeys.has(sourceHex) || previousRetainedSource === null) {
+        continue;
+      }
+      const sourceKey = Buffer.from(sourceHex, "hex");
+      const retained = previousRetainedSource.get(previousGenerationId, sourceKey);
+      if (retained === undefined) continue;
+      writer.copySourceDiagnostics(sourceKey, previousGenerationId);
+      if (cursor.parser_version !== LOCAL_UNIFIED_INDEX_PARSER_VERSION) {
+        // This source rotated away before the v8 typed-tool pass could rescan
+        // it. Preserve its usage/quota facts, but permanently attest the tool
+        // history gap instead of publishing a false zero.
+        writer.writeSourceDiagnostics(sourceKey, {
+          toolSourceHistoryUnavailable: 1,
+        });
+      }
+      writer.rebindToolFactsForSource(sourceKey);
+      writer.writeGenerationSource({
+        sourceLocal: sourceKey,
+        sourceOrdinal: Number(retained.source_ordinal),
+        sessionLocal: retained.session_local === null
+          ? cursor.session_local
+          : Buffer.from(retained.session_local),
+        surfaceId: Number(retained.surface_id),
+        status: "skipped",
+        discoveredSizeBytes: Number(retained.discovered_size_bytes),
+        scannedBytes: Number(retained.scanned_bytes),
+        mtimeMs: Number(retained.mtime_ms),
+        diagnosticsComplete: Number(retained.diagnostics_complete) === 1,
+      });
+    }
+
+    const deleteUsageForSource = database.prepare(
+      "DELETE FROM usage_event WHERE source_local = ?",
+    );
+    const affectedQuotaForSource = database.prepare(`
+      SELECT DISTINCT canonical_observation_id AS id
+      FROM quota_occurrence WHERE source_local = ?`);
+    const deleteQuotaForSource = database.prepare(
+      "DELETE FROM quota_occurrence WHERE source_local = ?",
+    );
+    const replacementQuota = database.prepare(`
+      SELECT plan_type, used_percent, resets_at_ms, duration_mins
+      FROM quota_occurrence WHERE canonical_observation_id = ?
+      ORDER BY used_percent DESC, COALESCE(resets_at_ms, -1) DESC, id ASC
+      LIMIT 1`);
+    const updateCanonicalQuota = database.prepare(`
+      UPDATE quota_observation SET plan_type = ?, used_percent = ?,
+        resets_at_ms = ?, duration_mins = ? WHERE id = ?`);
+    const deleteOrphanQuota = database.prepare(`
+      DELETE FROM quota_observation WHERE id = ?
+        AND NOT EXISTS (
+          SELECT 1 FROM quota_occurrence WHERE canonical_observation_id = ?)
+        AND NOT EXISTS (
+          SELECT 1 FROM usage_event WHERE quota_observation_id = ?)`);
+    const deleteLineageSnapshots = database.prepare(
+      "DELETE FROM lineage_snapshot WHERE session_local = ?",
+    );
+    const deleteToolCounts = database.prepare(
+      "DELETE FROM tool_class_count WHERE session_local = ?",
+    );
+    const deleteToolFactsForSource = database.prepare(
+      "DELETE FROM tool_class_fact WHERE source_local = ?",
+    );
+    const resetSessions = new Set();
+
+    function replaceSourceFacts(sourceKey, sessionKey, { parserReparse }) {
+      const deletedBoundaries = Number(
+        countSourceBoundaries.get(sourceKey)?.count ?? 0,
+      );
+      const affectedQuotaIds = affectedQuotaForSource.all(sourceKey)
+        .map((row) => Number(row.id));
+      const deletedUsage = Number(
+        deleteUsageForSource.run(sourceKey).changes ?? 0,
+      );
+      diagnostics.quotaOccurrenceRowsDeletedForRescan += Number(
+        deleteQuotaForSource.run(sourceKey).changes ?? 0,
+      );
+      deleteToolFactsForSource.run(sourceKey);
+      for (const quotaId of affectedQuotaIds) {
+        const replacement = replacementQuota.get(quotaId);
+        if (replacement === undefined) {
+          deleteOrphanQuota.run(quotaId, quotaId, quotaId);
+        } else {
+          updateCanonicalQuota.run(
+            replacement.plan_type,
+            replacement.used_percent,
+            replacement.resets_at_ms,
+            replacement.duration_mins,
+            quotaId,
+          );
+        }
+      }
+      if (parserReparse) {
+        diagnostics.sourcesReparsedForParserVersion += 1;
+        diagnostics.usageRowsDeletedForReparse += deletedUsage;
+        diagnostics.boundaryRowsDeletedForReparse += deletedBoundaries;
+      } else {
+        diagnostics.usageRowsDeletedForSourceRescan += deletedUsage;
+        diagnostics.boundaryRowsDeletedForSourceRescan += deletedBoundaries;
+      }
+      const sessionHex = sessionKey.toString("hex");
+      if (!resetSessions.has(sessionHex)) {
+        resetSessions.add(sessionHex);
+        deleteLineageSnapshots.run(sessionKey);
+        deleteToolCounts.run(sessionKey);
+      }
+    }
+
+    const replacementReasons = new Set([
+      "parser_version",
+      "same_size_changed",
+      "shrink",
+    ]);
+    const replacementSessionIds = new Set();
+    for (const info of infos) {
+      const cursor = cursors.get(
+        sourceLocal(deviceSalt, info.rolloutKey).toString("hex"),
+      );
+      const classification = classifySource(
+        info,
+        cursor,
+        LOCAL_UNIFIED_INDEX_PARSER_VERSION,
+      );
+      if (cursor !== undefined && replacementReasons.has(classification.reason)) {
+        replacementSessionIds.add(
+          info.lineage?.sessionId ?? info.rolloutKey,
+        );
+      }
+    }
+    for (const sessionId of replacementSessionIds) {
+      const sessionKey = localForSession(sessionId);
+      resetSessions.add(sessionKey.toString("hex"));
+      deleteLineageSnapshots.run(sessionKey);
+      deleteToolCounts.run(sessionKey);
     }
 
     function seedForNew(info) {
@@ -401,7 +763,13 @@ export async function ingestLocalUnifiedIndexIncrement({
           plan.cursor,
           LOCAL_UNIFIED_INDEX_PARSER_VERSION,
         ),
-      }));
+      })).map((plan) => (
+        replacementSessionIds.has(
+          plan.info.lineage?.sessionId ?? plan.info.rolloutKey,
+        ) && plan.mode !== "rescan"
+          ? { ...plan, mode: "rescan", reason: "session_rescan" }
+          : plan
+      ));
       const planBySessionId = new Map();
       for (const plan of plans) {
         if (plan.info.lineage?.sessionId) {
@@ -428,35 +796,83 @@ export async function ingestLocalUnifiedIndexIncrement({
                 && ["skip", "touch", "resume"].includes(ancestor.mode)
                 && Number(ancestor.cursor?.snapshots_persisted ?? 0) !== 1) {
               ancestor.mode = "rescan";
+              ancestor.reason = "snapshot_persistence";
               changed = true;
             }
             parentId = bySessionId.get(parentId)?.lineage?.parentId ?? null;
           }
         }
-      }
-      if (plans.every((plan) => plan.mode === "skip")) {
-        diagnostics.sourcesSkipped += plans.length;
-        continue;
+        const rescanSessions = new Set(plans
+          .filter((plan) => plan.mode === "rescan")
+          .map((plan) => plan.info.lineage?.sessionId ?? plan.info.rolloutKey));
+        for (const plan of plans) {
+          const sessionId = plan.info.lineage?.sessionId ?? plan.info.rolloutKey;
+          if (plan.mode !== "rescan" && rescanSessions.has(sessionId)) {
+            plan.mode = "rescan";
+            plan.reason = "session_rescan";
+            changed = true;
+          }
+        }
       }
       const snapshots = createLineageSnapshots(component.members);
       try {
         for (const plan of plans) {
           if (signal?.aborted) throw fixedError("local_unified_index_aborted");
-          const { info, cursor, mode } = plan;
+          const {
+            info,
+            cursor,
+            mode,
+            reason,
+          } = plan;
+          const sourceKey = sourceLocal(deviceSalt, info.rolloutKey);
+          const sourceOrdinal = sourceOrdinals.get(info.rolloutKey);
+          const sessionId = info.lineage?.sessionId ?? info.rolloutKey;
+          const surface = surfaceRow(info.lineage?.surfaceClassification);
+          const surfaceId = writer.internSurface(surface);
+          const sessionKey = localForSession(sessionId);
+          const previousSource = writer.previousGenerationSource(
+            sourceKey,
+            previousGenerationId,
+          );
+          writer.writeGenerationSource({
+            sourceLocal: sourceKey,
+            sourceOrdinal,
+            sessionLocal: sessionKey,
+            surfaceId,
+            status: "pending",
+            discoveredSizeBytes: Number(info.size ?? 0),
+            scannedBytes: Number(cursor?.scanned_bytes ?? 0),
+            mtimeMs: Math.floor(Number(info.mtimeMs ?? 0)),
+            diagnosticsComplete: false,
+          });
           if (mode === "skip") {
             diagnostics.sourcesSkipped += 1;
+            writer.rebindToolFactsForSource(sourceKey);
+            writer.copySourceDiagnostics(sourceKey, previousGenerationId);
+            writer.writeGenerationSource({
+              sourceLocal: sourceKey,
+              sourceOrdinal,
+              sessionLocal: sessionKey,
+              surfaceId,
+              status: "skipped",
+              discoveredSizeBytes: Number(info.size ?? 0),
+              scannedBytes: Number(cursor?.scanned_bytes ?? 0),
+              mtimeMs: Math.floor(Number(info.mtimeMs ?? 0)),
+              diagnosticsComplete: previousSource?.diagnosticsComplete === true,
+            });
             continue;
           }
-          const sessionId = info.lineage?.sessionId ?? info.rolloutKey;
-          const sourceKey = sourceLocal(deviceSalt, info.rolloutKey);
           const state = {
-            sessionLocal: localForSession(sessionId),
+            sessionLocal: sessionKey,
             sourceLocal: sourceKey,
             sourceId: writer.internSource(sourceKey),
-            surface: surfaceRow(info.lineage?.surfaceClassification),
+            sourceOrdinal,
+            surface,
+            surfaceId,
           };
           if (mode === "touch") {
             diagnostics.sourcesTouched += 1;
+            writer.rebindToolFactsForSource(sourceKey);
             writeCursorForOutcome(writer, deviceSalt, info, state, {
               nextOffset: Number(cursor.scanned_bytes),
               finalModel: cursor.carry_model ?? null,
@@ -471,24 +887,32 @@ export async function ingestLocalUnifiedIndexIncrement({
               turnContextSeen: Number(cursor.turn_context_seen) === 1,
               snapshotsPersisted: Number(cursor.snapshots_persisted) === 1,
             });
+            writer.copySourceDiagnostics(sourceKey, previousGenerationId);
+            writer.writeGenerationSource({
+              sourceLocal: sourceKey,
+              sourceOrdinal,
+              sessionLocal: sessionKey,
+              surfaceId,
+              status: "touched",
+              discoveredSizeBytes: Number(info.size ?? 0),
+              scannedBytes: Number(cursor.scanned_bytes),
+              mtimeMs: Math.floor(Number(info.mtimeMs ?? 0)),
+              diagnosticsComplete: previousSource?.diagnosticsComplete === true,
+            });
             continue;
           }
-          // A same-parser shrink means bytes previously indexed from this
-          // exact source no longer exist. Deterministic re-insertion replaces
-          // rows that remain, but it cannot collide with (and therefore
-          // remove) a truncated tail. Delete only rows owned by this interned
-          // salted source before the whole-file rescan; boundary links cascade
-          // from usage_event. Parser-version healing is session-wide
-          // above and therefore does not enter this branch.
-          if (plan.reason === "shrink") {
-            diagnostics.boundaryRowsDeletedForSourceRescan += Number(
-              countSourceBoundaries.get(state.sourceId)?.count ?? 0,
-            );
-            diagnostics.usageRowsDeletedForSourceRescan += Number(
-              deleteSourceUsage.run(state.sourceId).changes ?? 0,
-            );
-          }
           const resuming = mode === "resume";
+          if (resuming) {
+            // Existing facts from the scanned prefix remain authoritative;
+            // bind them to this publication before appending the new tail.
+            writer.rebindToolFactsForSource(sourceKey);
+          }
+          if (!resuming && cursor !== undefined
+              && replacementReasons.has(reason)) {
+            replaceSourceFacts(sourceKey, sessionKey, {
+              parserReparse: reason === "parser_version",
+            });
+          }
           const seed = resuming
             ? {
               seedModel: cursor.carry_model ?? null,
@@ -545,7 +969,9 @@ export async function ingestLocalUnifiedIndexIncrement({
             signal,
             onEvent: (event) => sink.write(state, event),
             onBoundary: (event) => sink.writeBoundary(state, event),
+            onTool: (event) => sink.writeTool(state, event),
           });
+          sink.finishSource(state);
           if (info.lineage?.sessionId) {
             finalBySessionId.set(info.lineage.sessionId, {
               model: outcome.finalModel,
@@ -572,6 +998,22 @@ export async function ingestLocalUnifiedIndexIncrement({
             snapshotsPersisted: collector !== null
               && (startOffset === 0
                 || Number(cursor?.snapshots_persisted ?? 0) === 1),
+          });
+          writer.writeSourceDiagnostics(state.sourceLocal, {
+            ...outcome.diagnostics,
+            oversizedLines: outcome.read.oversizedLines,
+            ...sink.diagnosticsForSource(state),
+          });
+          writer.writeGenerationSource({
+            sourceLocal: state.sourceLocal,
+            sourceOrdinal: state.sourceOrdinal,
+            sessionLocal: state.sessionLocal,
+            surfaceId: state.surfaceId,
+            status: resuming ? "resumed" : "rescanned",
+            discoveredSizeBytes: Number(info.size ?? 0),
+            scannedBytes: outcome.read.nextOffset,
+            mtimeMs: Math.floor(Number(info.mtimeMs ?? 0)),
+            diagnosticsComplete: true,
           });
           diagnostics[resuming ? "sourcesResumed" : "sourcesRescanned"] += 1;
           diagnostics.sourcesScanned += 1;
@@ -611,9 +1053,11 @@ export async function ingestLocalUnifiedIndexIncrement({
     const totalBoundaryLinks = Number(
       database.prepare("SELECT COUNT(*) AS events FROM usage_event_boundary").get().events,
     );
-    const sourceBytes = infos.reduce(
-      (total, info) => total + Number(info.size ?? 0),
-      0,
+    const indexedSources = database.prepare(`
+      SELECT COUNT(*) AS count,
+             COALESCE(SUM(discovered_size_bytes), 0) AS bytes
+      FROM generation_source WHERE generation_id = ?`).get(
+      generation.generationId,
     );
     writer.writeMeta("source_count", infos.length);
     writer.writeMeta("source_bytes", sourceBytes);
@@ -621,15 +1065,32 @@ export async function ingestLocalUnifiedIndexIncrement({
     writer.writeMeta("boundary_links", totalBoundaryLinks);
     writer.writeMeta("generated_at", new Date().toISOString());
     writer.writeMeta("contract_version", contractVersion);
-    writer.writeMeta("status", signal?.aborted ? "partial" : "complete");
+    if (signal?.aborted) throw fixedError("local_unified_index_aborted");
+    writer.writeMeta("status", "complete");
+    writer.finalizeGeneration({
+      status: "complete",
+      discoveredSourceCount: infos.length,
+      discoveredSourceBytes: sourceBytes,
+      indexedSourceCount: Number(indexedSources.count),
+      indexedSourceBytes: Number(indexedSources.bytes),
+      discoveryComplete: true,
+      diagnosticsComplete: true,
+    });
+    const generationDescriptor = readUnifiedIndexGenerationDescriptor(
+      database,
+      generation.generationId,
+    );
     const closed = await writer.close({
       integrityCheck: true,
-      fsyncPath: resolvedIndexFile,
+      fsyncPath: stageFile,
     });
     writer = null;
+    await publishStagedUnifiedIndex(stageFile, resolvedIndexFile);
     return {
       status: "ingested",
       indexFile: resolvedIndexFile,
+      generation: generationDescriptor,
+      generationDescriptor,
       ...diagnostics,
       ...sink.counts,
       // `usageEvents` above counts write attempts; a resumed pass can re-scan
@@ -646,14 +1107,23 @@ export async function ingestLocalUnifiedIndexIncrement({
       peakRssBytes: process.memoryUsage.rss(),
     };
   } catch (error) {
-    if (writer === null && database.isOpen) database.close();
-    else if (writer !== null) {
+    if (writer !== null) {
+      try {
+        writer.failGeneration(error?.code === "local_unified_index_aborted"
+          ? "aborted"
+          : "exception");
+      } catch {
+        // If the stage is already closed or storage failed, it is discarded.
+      }
+    }
+    if (database?.isOpen) {
       try {
         database.close();
       } catch {
         // The connection may already be closed.
       }
     }
+    await removeIfPresent(stageFile);
     throw error;
   }
 }

--- a/src/local-unified-index-worker.js
+++ b/src/local-unified-index-worker.js
@@ -62,6 +62,7 @@ async function run() {
           : finalBySessionId.get(source.parentId) ?? null;
         let events = [];
         let boundaries = [];
+        let tools = [];
         let snapshotKeys = [];
         const flush = (rolloutKey, final, diagnostics, cursor = null) => {
           parentPort.postMessage({
@@ -69,6 +70,7 @@ async function run() {
             rolloutKey,
             events,
             boundaries,
+            tools,
             // Snapshot keys collected for descendants — "|"-joined token
             // counters, nothing that can hold content. The host persists them
             // so a later incremental ingest can answer for this ancestor.
@@ -79,6 +81,7 @@ async function run() {
           });
           events = [];
           boundaries = [];
+          tools = [];
           snapshotKeys = [];
         };
         const collector = snapshots.collectorFor(source);
@@ -100,13 +103,19 @@ async function run() {
           ...(maximumLineBytes === undefined ? {} : { maximumLineBytes }),
           onEvent: (event) => {
             events.push(event);
-            if (events.length + boundaries.length >= BATCH_EVENTS) {
+            if (events.length + boundaries.length + tools.length >= BATCH_EVENTS) {
               flush(source.rolloutKey, false, null);
             }
           },
           onBoundary: (event) => {
             boundaries.push(event);
-            if (events.length + boundaries.length >= BATCH_EVENTS) {
+            if (events.length + boundaries.length + tools.length >= BATCH_EVENTS) {
+              flush(source.rolloutKey, false, null);
+            }
+          },
+          onTool: (event) => {
+            tools.push(event);
+            if (events.length + boundaries.length + tools.length >= BATCH_EVENTS) {
               flush(source.rolloutKey, false, null);
             }
           },
@@ -127,6 +136,9 @@ async function run() {
           forkReplayEventsSkipped: outcome.diagnostics.forkReplayEventsSkipped,
           unattributedForkReplayEventsSkipped:
             outcome.diagnostics.unattributedForkReplayEventsSkipped,
+          toolRecords: outcome.diagnostics.toolRecords,
+          toolEvents: outcome.diagnostics.toolEvents,
+          toolRecordsSkipped: outcome.diagnostics.toolRecordsSkipped,
           oversizedLines: outcome.read.oversizedLines,
           retainedSnapshotKeys: snapshots.retainedKeys,
           seeded: seed?.model != null,

--- a/src/local-unified-index.js
+++ b/src/local-unified-index.js
@@ -1,5 +1,5 @@
-import { createHmac, randomBytes } from "node:crypto";
-import { constants } from "node:fs";
+import { createHash, createHmac, randomBytes } from "node:crypto";
+import { constants, lstatSync } from "node:fs";
 import { chmod, lstat, mkdir, open, rename, unlink } from "node:fs/promises";
 import { dirname, resolve } from "node:path";
 import { DatabaseSync } from "node:sqlite";
@@ -26,7 +26,8 @@ import { DatabaseSync } from "node:sqlite";
 //     under the old shape each rotation invalidated the whole index.
 //   * `scope_local` is the same construction over the local account scope id.
 
-export const LOCAL_UNIFIED_INDEX_SCHEMA_VERSION = "local-unified-index-v1";
+export const LOCAL_UNIFIED_INDEX_SCHEMA_VERSION = "local-unified-index-v2";
+const LEGACY_LOCAL_UNIFIED_INDEX_SCHEMA_VERSION = "local-unified-index-v1";
 
 // Stamped onto every row. A parser change re-scans only the affected rows'
 // source files; rows whose rollout files have rotated away keep their
@@ -69,7 +70,15 @@ export const LOCAL_UNIFIED_INDEX_SCHEMA_VERSION = "local-unified-index-v1";
 // cursor over NULL order state. Rows retained from rotated older-parser
 // sources remain distinguishable by provenance and are withheld from
 // adjacency analysis rather than guessed into an order.
-export const LOCAL_UNIFIED_INDEX_PARSER_VERSION = "unified-rollout-typed-v6";
+//
+// v7 (2026-08-17): every current usage and quota fact is bound to a staged,
+// attested publication generation with exact source-local ordering and
+// source-scoped quota admission. This composes the v6 boundary/order contract
+// with the unified accounting cutover's provenance contract.
+// v8 (2026-08-17): typed response-item tool observations are source-scoped and
+// generation-bound. Existing v7 cursors must rescan so a complete generation
+// cannot silently publish an empty tool projection for already indexed files.
+export const LOCAL_UNIFIED_INDEX_PARSER_VERSION = "unified-rollout-typed-v8";
 
 // A row salvaged from a line that exceeded the bounded-line cap carries this
 // parser version instead. The agreed schema has no "partial" column and the
@@ -78,7 +87,7 @@ export const LOCAL_UNIFIED_INDEX_PARSER_VERSION = "unified-rollout-typed-v6";
 // degraded row is recorded. Kept in lockstep with the main constant: salvaged
 // rows run the same delta derivation.
 export const LOCAL_UNIFIED_INDEX_PARTIAL_PARSER_VERSION =
-  "unified-rollout-typed-v6-partial";
+  "unified-rollout-typed-v8-partial";
 
 const INDEX_APPLICATION_ID = 0x554d5549;
 // Version 2 (2026-08-07) widens version 1 with the two incremental-ingest
@@ -90,16 +99,39 @@ const INDEX_APPLICATION_ID = 0x554d5549;
 // adds local-only, content-free usage-boundary state and relation tables.
 // Version 5 (2026-08-16) adds the exact content-free source order of each
 // usage event. Version 6 stores that order compactly as two nullable integer
-// columns on usage_event plus one interned local-source dimension. Each
-// widening is purely additive, so an older index opened writable is migrated
-// in place. Its rows survive, which matters because rows whose rollout files
-// have rotated away can never be rebuilt. An older index opened read-only stays
-// valid as it is: readers never touch the new tables.
-const INDEX_USER_VERSION = 6;
-const MIGRATABLE_USER_VERSIONS = new Set([1, 2, 3, 4, 5, 6]);
+// columns on usage_event plus one interned local-source dimension. Version 7
+// adds generation-bound usage/quota provenance. Version 8 adds source-scoped,
+// generation-bound tool facts and widens the closed diagnostic vocabulary.
+// Each widening is additive except that closed diagnostic CHECK widening,
+// which is rebuilt transactionally while preserving every existing row.
+export const LOCAL_UNIFIED_INDEX_USER_VERSION = 8;
+const INDEX_USER_VERSION = LOCAL_UNIFIED_INDEX_USER_VERSION;
+const MIGRATABLE_USER_VERSIONS = new Set([1, 2, 3, 4, 5, 6, 7, 8]);
 const SECRET_BYTES = 32;
 const MAX_SECRET_BYTES = 256;
 const DEFAULT_COMMIT_ROWS = 10_000;
+const DIAGNOSTIC_CODES = new Set([
+  "relevantLines",
+  "malformedLines",
+  "malformedTimestamps",
+  "partialLines",
+  "salvagedRecords",
+  "turnContexts",
+  "tokenCounts",
+  "forkReplayEventsSkipped",
+  "unattributedForkReplayEventsSkipped",
+  "cumulativeCounterRegressions",
+  "tierEvents",
+  "modelSeededFromLineage",
+  "tierSeededFromLineage",
+  "modelMissing",
+  "oversizedLines",
+  "contradictedLeadingSnapshotsSkipped",
+  "toolRecords",
+  "toolEvents",
+  "toolRecordsSkipped",
+  "toolSourceHistoryUnavailable",
+]);
 // The one shape a stored raw session identity may take: the provider-issued
 // UUID. Deliberately narrower than the transport regex so a filename-shaped
 // rollout-key fallback can never be recorded as an identity.
@@ -167,6 +199,41 @@ const SCHEMA = `
     received_at_ms INTEGER NOT NULL,
     parser_version_id INTEGER NOT NULL REFERENCES parser_version) STRICT;
 
+  -- A generation is the publication unit. Facts may be committed in batches,
+  -- but only a generation whose final transaction says complete may become
+  -- the reader's current publication.
+  CREATE TABLE IF NOT EXISTS index_generation(
+    id INTEGER PRIMARY KEY,
+    started_at_ms INTEGER NOT NULL,
+    completed_at_ms INTEGER,
+    parser_version_id INTEGER NOT NULL REFERENCES parser_version,
+    contract_version TEXT NOT NULL,
+    status TEXT NOT NULL CHECK(status IN
+      ('in_progress', 'complete', 'partial', 'failed')),
+    block_reason TEXT,
+    discovered_source_count INTEGER,
+    discovered_source_bytes INTEGER,
+    indexed_source_count INTEGER,
+    indexed_source_bytes INTEGER,
+    usage_events INTEGER,
+    quota_occurrences INTEGER,
+    covered_start_ms INTEGER,
+    covered_end_ms INTEGER,
+    discovery_complete INTEGER NOT NULL DEFAULT 0
+      CHECK(discovery_complete IN (0, 1)),
+    diagnostics_complete INTEGER NOT NULL DEFAULT 0
+      CHECK(diagnostics_complete IN (0, 1)),
+    usage_provenance_complete INTEGER NOT NULL DEFAULT 0
+      CHECK(usage_provenance_complete IN (0, 1)),
+    source_order_complete INTEGER NOT NULL DEFAULT 0
+      CHECK(source_order_complete IN (0, 1)),
+    quota_provenance_complete INTEGER NOT NULL DEFAULT 0
+      CHECK(quota_provenance_complete IN (0, 1)),
+    tool_facts INTEGER,
+    tool_fact_fingerprint TEXT,
+    tool_provenance_complete INTEGER NOT NULL DEFAULT 0
+      CHECK(tool_provenance_complete IN (0, 1))) STRICT;
+
   CREATE TABLE IF NOT EXISTS model(
     id INTEGER PRIMARY KEY,
     model_id TEXT NOT NULL UNIQUE,
@@ -219,22 +286,50 @@ const SCHEMA = `
     duration_mins INTEGER,
     UNIQUE(observed_at_ms, limit_id, slot)) STRICT;
 
+  -- Source-scoped quota occurrences preserve the readings that canonical
+  -- quota_observation deliberately deduplicates. admission is the closed
+  -- leading-window gate result; readers emit only admitted rows.
+  CREATE TABLE IF NOT EXISTS quota_occurrence(
+    id INTEGER PRIMARY KEY,
+    generation_id INTEGER REFERENCES index_generation,
+    source_local BLOB NOT NULL CHECK(length(source_local) = 32),
+    source_offset INTEGER NOT NULL CHECK(source_offset >= 0),
+    source_ordinal INTEGER NOT NULL CHECK(source_ordinal >= 0),
+    surface_id INTEGER NOT NULL REFERENCES surface_class,
+    canonical_observation_id INTEGER NOT NULL REFERENCES quota_observation,
+    observed_at_ms INTEGER NOT NULL,
+    provider TEXT NOT NULL,
+    plan_type TEXT,
+    limit_id TEXT NOT NULL,
+    slot TEXT NOT NULL,
+    slot_order INTEGER NOT NULL CHECK(slot_order >= 0),
+    used_percent REAL NOT NULL CHECK(used_percent >= 0 AND used_percent <= 100),
+    resets_at_ms INTEGER,
+    duration_mins INTEGER NOT NULL CHECK(duration_mins >= 1),
+    admission TEXT NOT NULL CHECK(admission IN
+      ('admitted', 'held', 'suppressed')),
+    UNIQUE(source_local, source_offset, slot_order)) STRICT;
+
   -- Facts. Fixed width, typed, no JSON.
   CREATE TABLE IF NOT EXISTS usage_event(
     event_key BLOB PRIMARY KEY,
     observed_at_ms INTEGER NOT NULL,
+    generation_id INTEGER REFERENCES index_generation,
     ingest_run_id INTEGER NOT NULL REFERENCES ingest_run,
     parser_version_id INTEGER NOT NULL REFERENCES parser_version,
     -- NULL only on retained rows from a parser/schema that predates exact
     -- source ordering. Current-parser writers always set both fields.
     source_id INTEGER REFERENCES source_dimension,
-    source_offset INTEGER,
     session_local BLOB NOT NULL,
     account_scope_id INTEGER NOT NULL REFERENCES account_scope,
     model_id INTEGER NOT NULL REFERENCES model,
     tier_id INTEGER NOT NULL REFERENCES tier_semantics,
     surface_id INTEGER NOT NULL REFERENCES surface_class,
     quota_observation_id INTEGER REFERENCES quota_observation,
+    source_local BLOB CHECK(source_local IS NULL OR length(source_local) = 32),
+    source_offset INTEGER CHECK(source_offset IS NULL OR source_offset >= 0),
+    source_ordinal INTEGER CHECK(source_ordinal IS NULL OR source_ordinal >= 0),
+    tier_observed_at_ms INTEGER,
     reasoning_effort INTEGER NOT NULL,
     outcome INTEGER NOT NULL,
     -- Token counts. Integers only. No prompt, reply, reasoning or file content
@@ -273,6 +368,23 @@ const SCHEMA = `
     count INTEGER NOT NULL,
     PRIMARY KEY(session_local, tool_class)) STRICT, WITHOUT ROWID;
 
+  -- Source-scoped, generation-bound tool observations. The compatibility
+  -- aggregate above remains for older contribution readers, but this table is
+  -- the authoritative unified projection: one deterministic fact per typed
+  -- response item and no raw tool name or input.
+  CREATE TABLE IF NOT EXISTS tool_class_fact(
+    event_key BLOB PRIMARY KEY CHECK(length(event_key) = 32),
+    generation_id INTEGER NOT NULL REFERENCES index_generation ON DELETE CASCADE,
+    source_local BLOB NOT NULL CHECK(length(source_local) = 32),
+    source_offset INTEGER NOT NULL CHECK(source_offset >= 0),
+    source_ordinal INTEGER NOT NULL CHECK(source_ordinal >= 0),
+    session_local BLOB NOT NULL CHECK(length(session_local) = 32),
+    observed_at_ms INTEGER NOT NULL,
+    tool_ordinal INTEGER NOT NULL CHECK(tool_ordinal >= 0),
+    tool_class TEXT NOT NULL CHECK(length(tool_class) BETWEEN 1 AND 64),
+    source_kind TEXT NOT NULL CHECK(length(source_kind) BETWEEN 1 AND 64),
+    UNIQUE(source_local, source_offset, tool_ordinal)) STRICT;
+
   -- Incremental ingest state (schema widening of 2026-08-07).
   --
   -- One row per rollout source: how far it has been scanned and the carried
@@ -281,6 +393,7 @@ const SCHEMA = `
   -- six cumulative token counters. No path, no content.
   CREATE TABLE IF NOT EXISTS source_cursor(
     source_local BLOB PRIMARY KEY,     -- HMAC(device_salt, rollout key)
+    source_ordinal INTEGER CHECK(source_ordinal IS NULL OR source_ordinal >= 0),
     session_local BLOB,
     scanned_bytes INTEGER NOT NULL,
     size_bytes INTEGER NOT NULL,
@@ -341,13 +454,81 @@ const SCHEMA = `
     session_local BLOB PRIMARY KEY,
     session_uuid TEXT NOT NULL) STRICT;
 
+  -- One row per discovered source in a generation. No path or rollout text is
+  -- retained; source_local is the device-local HMAC of the rollout key.
+  CREATE TABLE IF NOT EXISTS generation_source(
+    generation_id INTEGER NOT NULL REFERENCES index_generation ON DELETE CASCADE,
+    source_local BLOB NOT NULL CHECK(length(source_local) = 32),
+    source_ordinal INTEGER NOT NULL CHECK(source_ordinal >= 0),
+    session_local BLOB,
+    surface_id INTEGER NOT NULL REFERENCES surface_class,
+    status TEXT NOT NULL CHECK(status IN
+      ('pending', 'skipped', 'touched', 'resumed', 'rescanned', 'complete', 'failed')),
+    discovered_size_bytes INTEGER NOT NULL CHECK(discovered_size_bytes >= 0),
+    scanned_bytes INTEGER NOT NULL CHECK(scanned_bytes >= 0),
+    mtime_ms INTEGER NOT NULL,
+    diagnostics_complete INTEGER NOT NULL DEFAULT 0
+      CHECK(diagnostics_complete IN (0, 1)),
+    PRIMARY KEY(generation_id, source_local)) STRICT, WITHOUT ROWID;
+
+  -- Diagnostic names are deliberately a closed set. Counts contain no source
+  -- path, message or content and are only meaningful when the owning source
+  -- row says diagnostics_complete=1.
+  CREATE TABLE IF NOT EXISTS source_diagnostic(
+    generation_id INTEGER NOT NULL REFERENCES index_generation ON DELETE CASCADE,
+    source_local BLOB NOT NULL CHECK(length(source_local) = 32),
+    code TEXT NOT NULL CHECK(code IN (
+      'relevantLines', 'malformedLines', 'malformedTimestamps',
+      'partialLines', 'salvagedRecords', 'turnContexts', 'tokenCounts',
+      'forkReplayEventsSkipped', 'unattributedForkReplayEventsSkipped',
+      'cumulativeCounterRegressions', 'tierEvents', 'modelSeededFromLineage',
+      'tierSeededFromLineage', 'modelMissing', 'oversizedLines',
+      'contradictedLeadingSnapshotsSkipped', 'toolRecords', 'toolEvents',
+      'toolRecordsSkipped', 'toolSourceHistoryUnavailable')),
+    count INTEGER NOT NULL CHECK(count >= 0),
+    PRIMARY KEY(generation_id, source_local, code)) STRICT, WITHOUT ROWID;
+
+`;
+
+// These indexes accelerate readers or generation attestation but are not
+// needed by the writer's primary/UNIQUE conflict paths. A cold rebuild may
+// omit them while loading facts and build them once, after the load, so
+// SQLite does not maintain these secondary b-trees for every inserted row.
+// Keep this list fixed and ordered: it is part of the staged-publication
+// contract, not a caller-provided SQL surface. In particular,
+// quota_occurrence_canonical must exist before finalizeGeneration runs its
+// quota-observation coverage proof.
+const SECONDARY_INDEX_SCHEMA = `
   CREATE INDEX IF NOT EXISTS usage_event_observed
     ON usage_event(observed_at_ms);
   CREATE INDEX IF NOT EXISTS usage_event_session
     ON usage_event(session_local);
   CREATE INDEX IF NOT EXISTS usage_event_boundary_session
     ON usage_event_boundary(session_local);
+  CREATE INDEX IF NOT EXISTS usage_event_replay_order
+    ON usage_event(observed_at_ms, source_ordinal, source_local,
+                   source_offset, event_key);
+  CREATE INDEX IF NOT EXISTS quota_occurrence_canonical
+    ON quota_occurrence(canonical_observation_id);
+  CREATE INDEX IF NOT EXISTS quota_occurrence_replay_order
+    ON quota_occurrence(observed_at_ms, source_ordinal, source_local,
+                        source_offset, slot_order, id);
+  CREATE INDEX IF NOT EXISTS tool_class_fact_generation
+    ON tool_class_fact(generation_id, event_key);
+  CREATE INDEX IF NOT EXISTS tool_class_fact_source
+    ON tool_class_fact(source_local);
 `;
+
+const SECONDARY_INDEX_NAMES = Object.freeze([
+  "usage_event_observed",
+  "usage_event_session",
+  "usage_event_boundary_session",
+  "usage_event_replay_order",
+  "quota_occurrence_canonical",
+  "quota_occurrence_replay_order",
+  "tool_class_fact_generation",
+  "tool_class_fact_source",
+]);
 
 function fixedError(code) {
   const error = new Error(code);
@@ -371,6 +552,24 @@ function ownerOnlyRegularFile(metadata) {
     && metadata.nlink === 1
     && (typeof process.getuid !== "function" || metadata.uid === process.getuid())
     && (process.platform === "win32" || (metadata.mode & 0o077) === 0);
+}
+
+export async function assertSafeLocalUnifiedIndexTarget(
+  indexFile,
+  { allowMissing = true } = {},
+) {
+  let metadata;
+  try {
+    metadata = await lstat(resolve(indexFile));
+  } catch (error) {
+    if (allowMissing && error?.code === "ENOENT") return null;
+    if (error?.code?.startsWith("local_unified_index_")) throw error;
+    throw fixedError("local_unified_index_unavailable");
+  }
+  if (!ownerOnlyRegularFile(metadata)) {
+    throw fixedError("local_unified_index_file_invalid");
+  }
+  return metadata;
 }
 
 /**
@@ -512,17 +711,123 @@ function configureDatabase(database, { readOnly = false, staging = false } = {})
   database.enableDefensive?.(true);
 }
 
-function initializeSchema(database) {
+function schemaSql({ deferSecondaryIndexes = false } = {}) {
+  return deferSecondaryIndexes
+    ? SCHEMA
+    : `${SCHEMA}\n${SECONDARY_INDEX_SCHEMA}`;
+}
+
+function assertSecondaryIndexes(database) {
+  const placeholders = SECONDARY_INDEX_NAMES.map(() => "?").join(", ");
+  const present = new Set(database.prepare(
+    `SELECT name FROM sqlite_master
+     WHERE type = 'index' AND name IN (${placeholders})`,
+  ).all(...SECONDARY_INDEX_NAMES).map((row) => row.name));
+  const missing = SECONDARY_INDEX_NAMES.filter((name) => !present.has(name));
+  if (missing.length > 0) {
+    throw fixedError("local_unified_index_secondary_indexes_missing");
+  }
+}
+
+/**
+ * Build the reader-only secondary indexes on a fully loaded staging database.
+ * The transaction makes a partial index set invisible to any caller that
+ * keeps the stage open, and the caller publishes only after this succeeds.
+ */
+export function createLocalUnifiedIndexSecondaryIndexes(database) {
+  try {
+    database.exec("BEGIN IMMEDIATE");
+    database.exec(SECONDARY_INDEX_SCHEMA);
+    assertSecondaryIndexes(database);
+    database.exec("COMMIT");
+  } catch (error) {
+    try {
+      database.exec("ROLLBACK");
+    } catch {
+      // Preserve the index-creation failure; the staging owner discards the
+      // connection and file below.
+    }
+    if (error?.code?.startsWith("local_unified_index_")) throw error;
+    throw fixedError("local_unified_index_secondary_indexes_failed");
+  }
+}
+
+function initializeSchema(database, { deferSecondaryIndexes = false } = {}) {
   database.exec(`
     PRAGMA application_id=${INDEX_APPLICATION_ID};
     PRAGMA user_version=${INDEX_USER_VERSION};
-    ${SCHEMA}
+    ${schemaSql({ deferSecondaryIndexes })}
   `);
   database.prepare("INSERT OR IGNORE INTO meta(key, value) VALUES (?, ?)")
     .run("schema_version", LOCAL_UNIFIED_INDEX_SCHEMA_VERSION);
 }
 
-function validateDatabase(database, { readOnly = false } = {}) {
+function tableColumns(database, tableName) {
+  return new Set(database.prepare(`PRAGMA table_info(${tableName})`).all()
+    .map((row) => row.name));
+}
+
+function tableExists(database, tableName) {
+  return database.prepare(
+    "SELECT 1 AS present FROM sqlite_master WHERE type = 'table' AND name = ?",
+  ).get(tableName) !== undefined;
+}
+
+function addColumnIfMissing(database, tableName, columnName, definition) {
+  if (tableColumns(database, tableName).has(columnName)) return;
+  database.exec(`ALTER TABLE ${tableName} ADD COLUMN ${columnName} ${definition}`);
+}
+
+function ensureGenerationAttestationColumns(database) {
+  addColumnIfMissing(database, "index_generation", "usage_provenance_complete",
+    "INTEGER NOT NULL DEFAULT 0 CHECK(usage_provenance_complete IN (0, 1))");
+  addColumnIfMissing(database, "index_generation", "source_order_complete",
+    "INTEGER NOT NULL DEFAULT 0 CHECK(source_order_complete IN (0, 1))");
+  addColumnIfMissing(database, "index_generation", "quota_provenance_complete",
+    "INTEGER NOT NULL DEFAULT 0 CHECK(quota_provenance_complete IN (0, 1))");
+  addColumnIfMissing(database, "index_generation", "tool_facts", "INTEGER");
+  addColumnIfMissing(database, "index_generation", "tool_fact_fingerprint", "TEXT");
+  addColumnIfMissing(database, "index_generation", "tool_provenance_complete",
+    "INTEGER NOT NULL DEFAULT 0 CHECK(tool_provenance_complete IN (0, 1))");
+}
+
+function ensureToolDiagnosticCodes(database) {
+  const sql = database.prepare(
+    "SELECT sql FROM sqlite_master WHERE type = 'table' AND name = 'source_diagnostic'",
+  ).get()?.sql;
+  if (typeof sql !== "string"
+      || (sql.includes("toolRecordsSkipped")
+        && sql.includes("toolSourceHistoryUnavailable"))) return;
+  // SQLite cannot widen a CHECK constraint in place. Rebuild this small,
+  // content-free count table inside the caller's migration transaction so a
+  // v7 index either retains every diagnostic row under the v8 vocabulary or
+  // remains wholly v7 after rollback.
+  database.exec(`
+    ALTER TABLE source_diagnostic RENAME TO source_diagnostic_v7;
+    CREATE TABLE source_diagnostic(
+      generation_id INTEGER NOT NULL REFERENCES index_generation ON DELETE CASCADE,
+      source_local BLOB NOT NULL CHECK(length(source_local) = 32),
+      code TEXT NOT NULL CHECK(code IN (
+        'relevantLines', 'malformedLines', 'malformedTimestamps',
+        'partialLines', 'salvagedRecords', 'turnContexts', 'tokenCounts',
+        'forkReplayEventsSkipped', 'unattributedForkReplayEventsSkipped',
+        'cumulativeCounterRegressions', 'tierEvents', 'modelSeededFromLineage',
+        'tierSeededFromLineage', 'modelMissing', 'oversizedLines',
+        'contradictedLeadingSnapshotsSkipped', 'toolRecords', 'toolEvents',
+        'toolRecordsSkipped', 'toolSourceHistoryUnavailable')),
+      count INTEGER NOT NULL CHECK(count >= 0),
+      PRIMARY KEY(generation_id, source_local, code)) STRICT, WITHOUT ROWID;
+    INSERT INTO source_diagnostic(generation_id, source_local, code, count)
+      SELECT generation_id, source_local, code, count
+      FROM source_diagnostic_v7;
+    DROP TABLE source_diagnostic_v7;
+  `);
+}
+
+function validateDatabase(database, {
+  readOnly = false,
+  deferSecondaryIndexes = false,
+} = {}) {
   const applicationId = Number(
     database.prepare("PRAGMA application_id").get().application_id,
   );
@@ -532,66 +837,304 @@ function validateDatabase(database, { readOnly = false } = {}) {
   const schema = database.prepare(
     "SELECT value FROM meta WHERE key = 'schema_version'",
   ).get();
-  // Read-only connections accept any migratable version: readers never touch
-  // the widened tables, and rejecting a version-1 file here would force a
-  // rebuild that cannot recover rows whose rollout files have rotated away.
-  const acceptable = readOnly
-    ? MIGRATABLE_USER_VERSIONS.has(userVersion)
-    : userVersion === INDEX_USER_VERSION;
-  if (applicationId !== INDEX_APPLICATION_ID
-      || !acceptable
-      || schema?.value !== LOCAL_UNIFIED_INDEX_SCHEMA_VERSION) {
+  // Read-only connections may inspect a pre-v4 file, but it is explicitly a
+  // legacy partial source. Writable opens must migrate it before use.
+  const legacy = MIGRATABLE_USER_VERSIONS.has(userVersion)
+    && userVersion < INDEX_USER_VERSION
+    && schema?.value === LEGACY_LOCAL_UNIFIED_INDEX_SCHEMA_VERSION;
+  const current = userVersion === INDEX_USER_VERSION
+    && schema?.value === LOCAL_UNIFIED_INDEX_SCHEMA_VERSION;
+  const acceptable = readOnly ? (legacy || current) : current;
+  if (applicationId !== INDEX_APPLICATION_ID || !acceptable) {
     throw fixedError("local_unified_index_schema_invalid");
   }
+  if (current && !deferSecondaryIndexes) assertSecondaryIndexes(database);
+  return { userVersion, schemaVersion: schema?.value ?? null, legacy };
 }
 
-function migrateDatabase(database) {
+function migrateDatabase(database, { deferSecondaryIndexes = false } = {}) {
   const userVersion = Number(
     database.prepare("PRAGMA user_version").get().user_version,
   );
-  if (userVersion === INDEX_USER_VERSION) return;
   if (!MIGRATABLE_USER_VERSIONS.has(userVersion)) {
     throw fixedError("local_unified_index_schema_invalid");
   }
-  // Every migration is additive: create widened tables, add nullable columns,
-  // and stamp the new version. Existing rows are untouched by construction.
-  database.exec(SCHEMA);
-  const usageColumns = new Set(
-    database.prepare("PRAGMA table_info(usage_event)").all()
-      .map((column) => column.name),
-  );
-  if (!usageColumns.has("source_id")) {
-    database.exec(`
-      ALTER TABLE usage_event
-      ADD COLUMN source_id INTEGER REFERENCES source_dimension;
-    `);
+  // Every migration is additive and transactional: existing rows are left
+  // untouched, while old rows receive NULL generation/provenance by
+  // construction. A subsequent ingest sees the incomplete attestation and
+  // performs the staged rebuild before those rows can become authoritative.
+  database.exec("BEGIN IMMEDIATE");
+  try {
+    // Create every missing table first, then widen pre-existing tables before
+    // creating indexes that refer to the new columns.
+    database.exec(SCHEMA);
+    addColumnIfMissing(database, "usage_event", "source_id",
+      "INTEGER REFERENCES source_dimension");
+    addColumnIfMissing(database, "usage_event", "generation_id",
+      "INTEGER REFERENCES index_generation");
+    addColumnIfMissing(database, "usage_event", "source_local",
+      "BLOB CHECK(source_local IS NULL OR length(source_local) = 32)");
+    addColumnIfMissing(database, "usage_event", "source_offset",
+      "INTEGER CHECK(source_offset IS NULL OR source_offset >= 0)");
+    addColumnIfMissing(database, "usage_event", "source_ordinal",
+      "INTEGER CHECK(source_ordinal IS NULL OR source_ordinal >= 0)");
+    addColumnIfMissing(database, "usage_event", "tier_observed_at_ms", "INTEGER");
+    addColumnIfMissing(database, "source_cursor", "source_ordinal",
+      "INTEGER CHECK(source_ordinal IS NULL OR source_ordinal >= 0)");
+    ensureToolDiagnosticCodes(database);
+    if (!deferSecondaryIndexes) database.exec(SECONDARY_INDEX_SCHEMA);
+    ensureGenerationAttestationColumns(database);
+    database.prepare(
+      "INSERT INTO meta(key, value) VALUES (?, ?) "
+        + "ON CONFLICT(key) DO UPDATE SET value = excluded.value",
+    ).run("schema_version", LOCAL_UNIFIED_INDEX_SCHEMA_VERSION);
+    database.exec(`PRAGMA user_version=${INDEX_USER_VERSION}`);
+    database.exec("COMMIT");
+  } catch (error) {
+    try {
+      database.exec("ROLLBACK");
+    } catch {
+      // Preserve the original migration failure.
+    }
+    throw error;
   }
-  if (!usageColumns.has("source_offset")) {
-    database.exec(`
-      ALTER TABLE usage_event ADD COLUMN source_offset INTEGER;
-    `);
-  }
-  database.exec(`PRAGMA user_version=${INDEX_USER_VERSION};`);
 }
 
 export function openLocalUnifiedIndex(indexFile, {
   readOnly = false,
   create = false,
   staging = false,
+  deferSecondaryIndexes = false,
 } = {}) {
+  if (deferSecondaryIndexes && (readOnly || !create || !staging)) {
+    throw fixedError("local_unified_index_deferred_indexes_invalid");
+  }
+  if (deferSecondaryIndexes) {
+    try {
+      lstatSync(resolve(indexFile));
+      throw fixedError("local_unified_index_deferred_indexes_requires_new_stage");
+    } catch (error) {
+      if (error?.code === "ENOENT") {
+        // The stage is genuinely new. DatabaseSync creates it below.
+      } else if (error?.code?.startsWith("local_unified_index_")) {
+        throw error;
+      } else {
+        throw fixedError("local_unified_index_unavailable");
+      }
+    }
+  }
   let database;
   try {
     database = new DatabaseSync(indexFile, { readOnly, timeout: 5_000 });
     configureDatabase(database, { readOnly, staging });
-    if (create) initializeSchema(database);
-    if (!readOnly) migrateDatabase(database);
-    validateDatabase(database, { readOnly });
+    if (create) initializeSchema(database, { deferSecondaryIndexes });
+    if (!readOnly) migrateDatabase(database, { deferSecondaryIndexes });
+    validateDatabase(database, { readOnly, deferSecondaryIndexes });
     return database;
   } catch (error) {
     if (database?.isOpen) database.close();
     if (error?.code?.startsWith("local_unified_index_")) throw error;
     throw fixedError("local_unified_index_unavailable");
   }
+}
+
+/**
+ * Mark abandoned writer generations before starting a new publication. A
+ * reader treats in_progress as partial, so this is recovery bookkeeping, not
+ * an attempt to make an interrupted pass appear complete.
+ */
+export function recoverUnifiedIndexGenerations(database) {
+  database.exec("BEGIN IMMEDIATE");
+  try {
+    const result = database.prepare(`
+      UPDATE index_generation
+      SET status = 'partial', block_reason = 'crash_recovered',
+          completed_at_ms = COALESCE(completed_at_ms, ?)
+      WHERE status = 'in_progress'`).run(Date.now());
+    database.exec("COMMIT");
+    return Number(result.changes ?? 0);
+  } catch (error) {
+    try {
+      database.exec("ROLLBACK");
+    } catch {
+      // Preserve original failure.
+    }
+    throw error;
+  }
+}
+
+/** Begin a durable generation before any source facts are changed. */
+export function beginUnifiedIndexGeneration(database, {
+  parserVersion = LOCAL_UNIFIED_INDEX_PARSER_VERSION,
+  contractVersion,
+  receivedAtMs = Date.now(),
+  discoveredSourceCount = null,
+  discoveredSourceBytes = null,
+} = {}) {
+  if (typeof contractVersion !== "string" || contractVersion.length < 1) {
+    throw new TypeError("contractVersion must be a non-empty string");
+  }
+  database.exec("BEGIN IMMEDIATE");
+  try {
+    database.prepare(`
+      INSERT INTO parser_version(parser_version, contract_version)
+      VALUES (?, ?) ON CONFLICT DO NOTHING`).run(parserVersion, contractVersion);
+    const parserVersionId = Number(database.prepare(`
+      SELECT id FROM parser_version
+      WHERE parser_version = ? AND contract_version = ?
+    `).get(parserVersion, contractVersion).id);
+    const ingestRunId = Number(database.prepare(`
+      INSERT INTO ingest_run(received_at_ms, parser_version_id)
+      VALUES (?, ?)
+    `).run(receivedAtMs, parserVersionId).lastInsertRowid);
+    const generationId = Number(database.prepare(`
+      INSERT INTO index_generation(
+        started_at_ms, parser_version_id, contract_version, status,
+        discovered_source_count, discovered_source_bytes)
+      VALUES (?, ?, ?, 'in_progress', ?, ?)
+    `).run(
+      receivedAtMs,
+      parserVersionId,
+      contractVersion,
+      discoveredSourceCount,
+      discoveredSourceBytes,
+    ).lastInsertRowid);
+    database.exec("COMMIT");
+    return { generationId, parserVersionId, ingestRunId };
+  } catch (error) {
+    try {
+      database.exec("ROLLBACK");
+    } catch {
+      // Preserve original failure.
+    }
+    throw error;
+  }
+}
+
+/** A bounded publication descriptor safe to hand to a downstream reader. */
+export function readUnifiedIndexGenerationDescriptor(database, generationId = null) {
+  const meta = Object.fromEntries(database.prepare(
+    "SELECT key, value FROM meta",
+  ).all().map((row) => [row.key, row.value]));
+  const id = generationId === null
+    ? Number(meta.current_generation_id)
+    : Number(generationId);
+  if (!Number.isSafeInteger(id) || id < 1) return null;
+  const row = database.prepare(`
+    SELECT id, started_at_ms, completed_at_ms, parser_version_id,
+           contract_version, status, block_reason,
+           discovered_source_count, discovered_source_bytes,
+           indexed_source_count, indexed_source_bytes, usage_events,
+           quota_occurrences, covered_start_ms, covered_end_ms,
+           discovery_complete, diagnostics_complete,
+           usage_provenance_complete, source_order_complete,
+           quota_provenance_complete, tool_facts, tool_fact_fingerprint,
+           tool_provenance_complete
+    FROM index_generation WHERE id = ?
+  `).get(id);
+  if (row === undefined) return null;
+  const parser = database.prepare(
+    "SELECT parser_version FROM parser_version WHERE id = ?",
+  ).get(row.parser_version_id)?.parser_version ?? null;
+  const material = [
+    row.id, row.started_at_ms, row.completed_at_ms, row.parser_version_id,
+    row.contract_version, row.status, row.block_reason,
+    row.discovered_source_count, row.discovered_source_bytes,
+    row.indexed_source_count, row.indexed_source_bytes, row.usage_events,
+    row.quota_occurrences, row.covered_start_ms, row.covered_end_ms,
+    row.discovery_complete, row.diagnostics_complete,
+    row.usage_provenance_complete, row.source_order_complete,
+    row.quota_provenance_complete, row.tool_facts, row.tool_fact_fingerprint,
+    row.tool_provenance_complete,
+  ].map((value) => value === null || value === undefined ? "" : String(value));
+  const first = row.covered_start_ms === null ? null : Number(row.covered_start_ms);
+  const last = row.covered_end_ms === null ? null : Number(row.covered_end_ms);
+  return {
+    id,
+    fingerprint: `generation-v2-${createHash("sha256")
+      .update(material.join("\u001f"), "utf8").digest("hex")}`,
+    status: row.status,
+    blockReason: row.block_reason ?? null,
+    schemaVersion: meta.schema_version ?? null,
+    parserVersion: parser,
+    contractVersion: row.contract_version,
+    startedAtMs: Number(row.started_at_ms),
+    completedAtMs: row.completed_at_ms === null ? null : Number(row.completed_at_ms),
+    discoveredSourceCount: row.discovered_source_count === null
+      ? null : Number(row.discovered_source_count),
+    discoveredSourceBytes: row.discovered_source_bytes === null
+      ? null : Number(row.discovered_source_bytes),
+    indexedSourceCount: row.indexed_source_count === null
+      ? null : Number(row.indexed_source_count),
+    indexedSourceBytes: row.indexed_source_bytes === null
+      ? null : Number(row.indexed_source_bytes),
+    usageEvents: row.usage_events === null ? null : Number(row.usage_events),
+    quotaOccurrences: row.quota_occurrences === null
+      ? null : Number(row.quota_occurrences),
+    coveredStartMs: first,
+    coveredEndMs: last,
+    discoveryComplete: Number(row.discovery_complete) === 1,
+    diagnosticsComplete: Number(row.diagnostics_complete) === 1,
+    usageProvenanceComplete: Number(row.usage_provenance_complete) === 1,
+    sourceOrderComplete: Number(row.source_order_complete) === 1,
+    quotaProvenanceComplete: Number(row.quota_provenance_complete) === 1,
+    toolFacts: row.tool_facts === null ? null : Number(row.tool_facts),
+    toolFactFingerprint: row.tool_fact_fingerprint ?? null,
+    toolProvenanceComplete: Number(row.tool_provenance_complete) === 1,
+  };
+}
+
+/**
+ * Return a deterministic digest over one generation's typed tool facts. The
+ * digest is content-free: it commits only to local HMACs, offsets, ordinals,
+ * timestamps and fixed classifications. Readers use it to detect a fact row
+ * edited or appended after publication without retaining any raw tool data.
+ */
+export function createUnifiedIndexToolFactFingerprintAccumulator() {
+  const hash = createHash("sha256");
+  let settled = false;
+  return {
+    add(row) {
+      if (settled) throw new TypeError("tool fact fingerprint is settled");
+      hash.update([
+        Buffer.from(row.event_key).toString("hex"),
+        Buffer.from(row.source_local).toString("hex"),
+        row.source_offset,
+        row.source_ordinal,
+        Buffer.from(row.session_local).toString("hex"),
+        row.observed_at_ms,
+        row.tool_ordinal,
+        row.tool_class,
+        row.source_kind,
+      ].map((value) => String(value)).join("\u001f"), "utf8");
+      hash.update("\n", "utf8");
+    },
+    digest() {
+      if (settled) throw new TypeError("tool fact fingerprint is settled");
+      settled = true;
+      return `tool-facts-v1-${hash.digest("hex")}`;
+    },
+  };
+}
+
+export function readUnifiedIndexToolFactFingerprint(database, generationId) {
+  if (!Number.isSafeInteger(Number(generationId)) || Number(generationId) < 1) {
+    return null;
+  }
+  const present = database.prepare(
+    "SELECT 1 AS present FROM sqlite_master WHERE type = 'table' AND name = 'tool_class_fact'",
+  ).get();
+  if (present === undefined) return null;
+  const fingerprint = createUnifiedIndexToolFactFingerprintAccumulator();
+  for (const row of database.prepare(`
+    SELECT event_key, source_local, source_offset, source_ordinal,
+           session_local, observed_at_ms, tool_ordinal, tool_class, source_kind
+    FROM tool_class_fact
+    WHERE generation_id = ?
+    ORDER BY event_key`).iterate(Number(generationId))) {
+    fingerprint.add(row);
+  }
+  return fingerprint.digest();
 }
 
 async function syncFile(path) {
@@ -611,9 +1154,11 @@ async function syncDirectoryPath(path) {
   try {
     handle = await open(path, constants.O_RDONLY);
     await handle.sync();
-  } catch {
-    // Directory fsync is a best-effort durability step on platforms that
-    // refuse to open a directory read-only. The rename itself is still atomic.
+  } catch (error) {
+    if (error?.code === "local_unified_index_directory_sync_failed") {
+      throw error;
+    }
+    throw fixedError("local_unified_index_directory_sync_failed");
   } finally {
     await handle?.close();
   }
@@ -635,6 +1180,9 @@ export function createUnifiedIndexWriter(database, {
   receivedAtMs = Date.now(),
   parserVersion = LOCAL_UNIFIED_INDEX_PARSER_VERSION,
   contractVersion,
+  generationId = null,
+  parserVersionId = null,
+  ingestRunId: suppliedIngestRunId = null,
 } = {}) {
   if (!Number.isSafeInteger(commitRows) || commitRows < 1) {
     throw new TypeError("commitRows must be a positive safe integer");
@@ -712,17 +1260,50 @@ export function createUnifiedIndexWriter(database, {
     selectQuota: database.prepare(`
       SELECT id FROM quota_observation
       WHERE observed_at_ms = ? AND limit_id = ? AND slot = ?`),
+    quotaOccurrence: database.prepare(`
+      INSERT INTO quota_occurrence(
+        generation_id, source_local, source_offset, source_ordinal, surface_id,
+        canonical_observation_id, observed_at_ms, provider, plan_type,
+        limit_id, slot, slot_order, used_percent, resets_at_ms,
+        duration_mins, admission)
+      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+      ON CONFLICT(source_local, source_offset, slot_order) DO UPDATE SET
+        generation_id = excluded.generation_id,
+        source_ordinal = excluded.source_ordinal,
+        surface_id = excluded.surface_id,
+        canonical_observation_id = excluded.canonical_observation_id,
+        observed_at_ms = excluded.observed_at_ms,
+        provider = excluded.provider,
+        plan_type = excluded.plan_type,
+        limit_id = excluded.limit_id,
+        slot = excluded.slot,
+        used_percent = excluded.used_percent,
+        resets_at_ms = excluded.resets_at_ms,
+        duration_mins = excluded.duration_mins,
+        admission = excluded.admission`),
+    selectSettledQuota: database.prepare(`
+      SELECT provider, plan_type AS planType, limit_id AS limitId,
+             slot, used_percent AS usedPercent,
+             resets_at_ms AS resetsAt, duration_mins AS windowDurationMins
+      FROM quota_occurrence
+      WHERE source_local = ? AND admission = 'admitted'
+      GROUP BY provider, plan_type, limit_id, slot, used_percent,
+               resets_at_ms, duration_mins`),
     usage: database.prepare(`
       INSERT INTO usage_event(
-        event_key, observed_at_ms, ingest_run_id, parser_version_id,
-        source_id, source_offset, session_local, account_scope_id,
-        model_id, tier_id, surface_id,
-        quota_observation_id, reasoning_effort, outcome,
+        event_key, observed_at_ms, generation_id, ingest_run_id,
+        parser_version_id, source_id, source_offset,
+        session_local, account_scope_id, model_id, tier_id, surface_id,
+        quota_observation_id, source_local, source_ordinal,
+        tier_observed_at_ms, reasoning_effort, outcome,
         tokens_in_uncached, tokens_in_cache_read, tokens_in_cache_write,
         tokens_in_cache_write_5m, tokens_in_cache_write_1h,
         tokens_out_text, tokens_out_reasoning, tokens_out_combined,
         total_input_context)
-      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+      VALUES (
+        ?, ?, ?, ?, ?, ?, ?, ?, ?, ?,
+        ?, ?, ?, ?, ?, ?, ?, ?, ?, ?,
+        ?, ?, ?, ?, ?, ?, ?)
       ON CONFLICT(event_key) DO NOTHING`),
     boundary: database.prepare(`
       INSERT INTO usage_event_boundary(
@@ -735,15 +1316,33 @@ export function createUnifiedIndexWriter(database, {
       VALUES (?, ?, ?)
       ON CONFLICT(session_local, tool_class)
       DO UPDATE SET count = count + excluded.count`),
+    toolFact: database.prepare(`
+      INSERT INTO tool_class_fact(
+        event_key, generation_id, source_local, source_offset, source_ordinal,
+        session_local, observed_at_ms, tool_ordinal, tool_class, source_kind)
+      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+      ON CONFLICT(event_key) DO NOTHING`),
+    deleteToolFactsForSource: database.prepare(
+      "DELETE FROM tool_class_fact WHERE source_local = ?",
+    ),
+    rebindToolFactsForSource: database.prepare(`
+      UPDATE tool_class_fact SET generation_id = ? WHERE source_local = ?`),
+    clearToolClasses: database.prepare("DELETE FROM tool_class_count"),
+    rebuildToolClasses: database.prepare(`
+      INSERT INTO tool_class_count(session_local, tool_class, count)
+      SELECT session_local, tool_class, COUNT(*)
+      FROM tool_class_fact
+      GROUP BY session_local, tool_class`),
     sourceCursor: database.prepare(`
       INSERT INTO source_cursor(
-        source_local, session_local, scanned_bytes, size_bytes, mtime_ms,
+        source_local, source_ordinal, session_local, scanned_bytes, size_bytes, mtime_ms,
         snapshots_persisted, turn_context_seen, carry_model, carry_effort,
         carry_tier_raw, carry_tier_observed_at_ms, carry_total_input,
         carry_total_cached, carry_total_cache_write, carry_total_output,
         carry_total_reasoning, carry_total_total, ingest_run_id)
-      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
       ON CONFLICT(source_local) DO UPDATE SET
+        source_ordinal = excluded.source_ordinal,
         session_local = excluded.session_local,
         scanned_bytes = excluded.scanned_bytes,
         size_bytes = excluded.size_bytes,
@@ -779,6 +1378,48 @@ export function createUnifiedIndexWriter(database, {
     sessionIdentity: database.prepare(`
       INSERT INTO session_identity(session_local, session_uuid)
       VALUES (?, ?) ON CONFLICT DO NOTHING`),
+    generationSource: database.prepare(`
+      INSERT INTO generation_source(
+        generation_id, source_local, source_ordinal, session_local, surface_id,
+        status, discovered_size_bytes, scanned_bytes, mtime_ms,
+        diagnostics_complete)
+      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+      ON CONFLICT(generation_id, source_local) DO UPDATE SET
+        source_ordinal = excluded.source_ordinal,
+        session_local = excluded.session_local,
+        surface_id = excluded.surface_id,
+        status = excluded.status,
+        discovered_size_bytes = excluded.discovered_size_bytes,
+        scanned_bytes = excluded.scanned_bytes,
+        mtime_ms = excluded.mtime_ms,
+        diagnostics_complete = excluded.diagnostics_complete`),
+    sourceDiagnostic: database.prepare(`
+      INSERT INTO source_diagnostic(generation_id, source_local, code, count)
+      VALUES (?, ?, ?, ?)
+      ON CONFLICT(generation_id, source_local, code)
+      DO UPDATE SET count = excluded.count`),
+    copySourceDiagnostics: database.prepare(`
+      INSERT INTO source_diagnostic(generation_id, source_local, code, count)
+      SELECT ?, source_local, code, count
+      FROM source_diagnostic
+      WHERE generation_id = ? AND source_local = ?
+      ON CONFLICT(generation_id, source_local, code)
+      DO UPDATE SET count = excluded.count`),
+    selectGenerationSource: database.prepare(`
+      SELECT diagnostics_complete, scanned_bytes, status
+      FROM generation_source
+      WHERE generation_id = ? AND source_local = ?`),
+    generation: database.prepare(`
+      UPDATE index_generation SET
+        completed_at_ms = ?, status = ?, block_reason = ?,
+        indexed_source_count = ?, indexed_source_bytes = ?,
+        usage_events = ?, quota_occurrences = ?,
+        covered_start_ms = ?, covered_end_ms = ?,
+        discovery_complete = ?, diagnostics_complete = ?,
+        usage_provenance_complete = ?, source_order_complete = ?,
+        quota_provenance_complete = ?, tool_facts = ?,
+        tool_fact_fingerprint = ?, tool_provenance_complete = ?
+      WHERE id = ?`),
     meta: database.prepare(`
       INSERT INTO meta(key, value) VALUES (?, ?)
       ON CONFLICT(key) DO UPDATE SET value = excluded.value`),
@@ -801,6 +1442,7 @@ export function createUnifiedIndexWriter(database, {
   let usageRows = 0;
   let boundaryRows = 0;
   let toolRows = 0;
+  let quotaOccurrenceRows = 0;
   let batches = 0;
 
   function begin() {
@@ -832,16 +1474,20 @@ export function createUnifiedIndexWriter(database, {
     return id;
   }
 
-  const defaultParserVersionId = (() => {
-    begin();
-    return internParserVersion(parserVersion);
-  })();
-  const ingestRunId = (() => {
-    begin();
-    return Number(
-      statements.ingestRun.run(receivedAtMs, defaultParserVersionId).lastInsertRowid,
-    );
-  })();
+  const defaultParserVersionId = parserVersionId === null
+    ? (() => {
+      begin();
+      return internParserVersion(parserVersion);
+    })()
+    : Number(parserVersionId);
+  const ingestRunId = suppliedIngestRunId === null
+    ? (() => {
+      begin();
+      return Number(
+        statements.ingestRun.run(receivedAtMs, defaultParserVersionId).lastInsertRowid,
+      );
+    })()
+    : Number(suppliedIngestRunId);
 
   function internModel(modelId, recognition) {
     const cached = modelIds.get(modelId);
@@ -854,7 +1500,7 @@ export function createUnifiedIndexWriter(database, {
   }
 
   function internTier(tier) {
-    const key = `${tier.apiServiceTier} ${tier.billingSurface} ${tier.codexSpeedMode} ${tier.tierSource} ${tier.providerTierRaw ?? ""} ${tier.providerTierRaw === null ? "n" : "s"}`;
+    const key = `${tier.apiServiceTier}\0${tier.billingSurface}\0${tier.codexSpeedMode}\0${tier.tierSource}\0${tier.providerTierRaw ?? ""}\0${tier.providerTierRaw === null ? "n" : "s"}`;
     const cached = tierIds.get(key);
     if (cached !== undefined) return cached;
     begin();
@@ -877,7 +1523,7 @@ export function createUnifiedIndexWriter(database, {
   }
 
   function internSurface(surface) {
-    const key = `${surface.agentScope} ${surface.surface} ${surface.threadSource} ${surface.lineageDisposition}`;
+    const key = `${surface.agentScope}\0${surface.surface}\0${surface.threadSource}\0${surface.lineageDisposition}`;
     const cached = surfaceIds.get(key);
     if (cached !== undefined) return cached;
     begin();
@@ -899,7 +1545,7 @@ export function createUnifiedIndexWriter(database, {
 
   function internAccountScope(scope) {
     const scopeBlob = scope.scopeLocal ?? null;
-    const key = `${scope.status} ${scope.reason ?? ""} ${scope.reason === null ? "n" : "s"} ${scope.planType ?? ""} ${scope.planType === null ? "n" : "s"} ${scopeBlob === null ? "" : Buffer.from(scopeBlob).toString("base64")}`;
+    const key = `${scope.status}\0${scope.reason ?? ""}\0${scope.reason === null ? "n" : "s"}\0${scope.planType ?? ""}\0${scope.planType === null ? "n" : "s"}\0${scopeBlob === null ? "" : Buffer.from(scopeBlob).toString("base64")}`;
     const cached = accountScopeIds.get(key);
     if (cached !== undefined) return cached;
     begin();
@@ -936,9 +1582,9 @@ export function createUnifiedIndexWriter(database, {
     // Caching on the uniqueness key alone would let the first arrival suppress
     // a genuinely different reading for the same millisecond, reintroducing the
     // arrival-order dependence the upsert above exists to remove.
-    const key = `${observation.observedAtMs} ${observation.limitId} ${observation.slot}`
-      + ` ${observation.planType ?? ""} ${observation.usedPercent ?? ""}`
-      + ` ${observation.resetsAtMs ?? ""} ${observation.durationMins ?? ""}`;
+    const key = `${observation.observedAtMs}\0${observation.limitId}\0${observation.slot}`
+      + `\0${observation.planType ?? ""}\0${observation.usedPercent ?? ""}`
+      + `\0${observation.resetsAtMs ?? ""}\0${observation.durationMins ?? ""}`;
     const cached = quotaIds.get(key);
     if (cached !== undefined) return cached;
     begin();
@@ -968,8 +1614,10 @@ export function createUnifiedIndexWriter(database, {
     get usageRows() { return usageRows; },
     get boundaryRows() { return boundaryRows; },
     get toolRows() { return toolRows; },
+    get quotaOccurrenceRows() { return quotaOccurrenceRows; },
     get batches() { return batches; },
     ingestRunId,
+    generationId,
 
     internModel,
     internTier,
@@ -979,11 +1627,50 @@ export function createUnifiedIndexWriter(database, {
     internQuota,
     internParserVersion,
 
+    loadSettledQuotaWindows(sourceLocalKey) {
+      begin();
+      return statements.selectSettledQuota.all(sourceLocalKey).map((row) => ({
+        provider: row.provider,
+        planType: row.planType,
+        limitId: row.limitId,
+        slot: row.slot,
+        usedPercent: Number(row.usedPercent),
+        resetsAt: row.resetsAt === null ? null : Number(row.resetsAt),
+        windowDurationMins: Number(row.windowDurationMins),
+      }));
+    },
+
+    writeQuotaOccurrence(occurrence) {
+      begin();
+      const result = statements.quotaOccurrence.run(
+        occurrence.generationId ?? generationId,
+        occurrence.sourceLocal,
+        occurrence.sourceOffset,
+        occurrence.sourceOrdinal,
+        occurrence.surfaceId,
+        occurrence.canonicalObservationId,
+        occurrence.observedAtMs,
+        occurrence.provider,
+        occurrence.planType ?? null,
+        occurrence.limitId,
+        occurrence.slot,
+        occurrence.slotOrder,
+        occurrence.usedPercent,
+        occurrence.resetsAtMs ?? null,
+        occurrence.durationMins,
+        occurrence.admission,
+      );
+      quotaOccurrenceRows += Number(result.changes ?? 0);
+      step();
+      return Number(result.changes ?? 0);
+    },
+
     writeUsageEvent(event) {
       begin();
       const changes = statements.usage.run(
         event.eventKey,
         event.observedAtMs,
+        event.generationId ?? generationId,
         ingestRunId,
         event.partial
           ? internParserVersion(LOCAL_UNIFIED_INDEX_PARTIAL_PARSER_VERSION)
@@ -996,6 +1683,9 @@ export function createUnifiedIndexWriter(database, {
         event.tierId,
         event.surfaceId,
         event.quotaObservationId ?? null,
+        event.sourceLocal ?? null,
+        event.sourceOrdinal ?? null,
+        event.tierObservedAtMs ?? null,
         event.reasoningEffort,
         event.outcome,
         event.tokensInUncached ?? null,
@@ -1039,10 +1729,61 @@ export function createUnifiedIndexWriter(database, {
       step();
     },
 
+    writeToolClassFact(fact) {
+      if (generationId === null && fact.generationId === undefined) {
+        throw fixedError("local_unified_index_generation_required");
+      }
+      begin();
+      const result = statements.toolFact.run(
+        fact.eventKey,
+        fact.generationId ?? generationId,
+        fact.sourceLocal,
+        fact.sourceOffset,
+        fact.sourceOrdinal,
+        fact.sessionLocal,
+        fact.observedAtMs,
+        fact.toolOrdinal,
+        fact.toolClass,
+        fact.sourceKind,
+      );
+      const inserted = Number(result.changes ?? 0);
+      if (inserted > 0) {
+        // Keep the pre-cutover aggregate populated for rollback/compatibility
+        // consumers, but only after the source-scoped fact's UNIQUE key says
+        // this observation is new. A crash/re-scan therefore cannot inflate
+        // the compatibility count.
+        statements.toolClass.run(fact.sessionLocal, fact.toolClass, 1);
+        toolRows += 1;
+      }
+      step();
+      return inserted;
+    },
+
+    deleteToolFactsForSource(sourceLocalKey) {
+      begin();
+      const result = statements.deleteToolFactsForSource.run(sourceLocalKey);
+      step();
+      return Number(result.changes ?? 0);
+    },
+
+    rebindToolFactsForSource(sourceLocalKey, targetGenerationId = generationId) {
+      if (targetGenerationId === null || targetGenerationId === undefined) {
+        throw fixedError("local_unified_index_generation_required");
+      }
+      begin();
+      const result = statements.rebindToolFactsForSource.run(
+        targetGenerationId,
+        sourceLocalKey,
+      );
+      step();
+      return Number(result.changes ?? 0);
+    },
+
     writeSourceCursor(cursor) {
       begin();
       statements.sourceCursor.run(
         cursor.sourceLocal,
+        cursor.sourceOrdinal ?? null,
         cursor.sessionLocal ?? null,
         cursor.scannedBytes,
         cursor.sizeBytes,
@@ -1077,6 +1818,75 @@ export function createUnifiedIndexWriter(database, {
       step();
     },
 
+    writeGenerationSource(source) {
+      if (generationId === null && source.generationId === undefined) {
+        throw fixedError("local_unified_index_generation_required");
+      }
+      begin();
+      statements.generationSource.run(
+        source.generationId ?? generationId,
+        source.sourceLocal,
+        source.sourceOrdinal,
+        source.sessionLocal ?? null,
+        source.surfaceId,
+        source.status,
+        source.discoveredSizeBytes,
+        source.scannedBytes,
+        source.mtimeMs,
+        source.diagnosticsComplete ? 1 : 0,
+      );
+      step();
+    },
+
+    writeSourceDiagnostics(sourceLocalKey, diagnostics, {
+      generationId: sourceGenerationId = generationId,
+    } = {}) {
+      if (sourceGenerationId === null) {
+        throw fixedError("local_unified_index_generation_required");
+      }
+      begin();
+      for (const [code, value] of Object.entries(diagnostics ?? {})) {
+        if (!Number.isSafeInteger(Number(value)) || Number(value) < 0) continue;
+        if (!DIAGNOSTIC_CODES.has(code)) continue;
+        statements.sourceDiagnostic.run(
+          sourceGenerationId,
+          sourceLocalKey,
+          code,
+          Number(value),
+        );
+      }
+      step();
+    },
+
+    copySourceDiagnostics(sourceLocalKey, fromGenerationId, {
+      toGenerationId = generationId,
+    } = {}) {
+      if (toGenerationId === null || fromGenerationId === null) return false;
+      begin();
+      const result = statements.copySourceDiagnostics.run(
+        toGenerationId,
+        fromGenerationId,
+        sourceLocalKey,
+      );
+      step();
+      return Number(result.changes ?? 0) > 0;
+    },
+
+    previousGenerationSource(sourceLocalKey, previousGenerationId) {
+      if (previousGenerationId === null || previousGenerationId === undefined) {
+        return null;
+      }
+      const row = statements.selectGenerationSource.get(
+        previousGenerationId,
+        sourceLocalKey,
+      );
+      return row === undefined ? null : {
+        diagnosticsComplete: Number(row.diagnostics_complete) === 1,
+        scannedBytes: Number(row.scanned_bytes),
+        status: row.status,
+      };
+    },
+
     addLineageSnapshot(sessionLocalKey, snapshotLocalKey) {
       begin();
       statements.lineageSnapshot.run(sessionLocalKey, snapshotLocalKey);
@@ -1108,6 +1918,216 @@ export function createUnifiedIndexWriter(database, {
       step();
     },
 
+    finalizeGeneration({
+      status = "complete",
+      blockReason = null,
+      discoveredSourceCount = null,
+      discoveredSourceBytes = null,
+      indexedSourceCount = null,
+      indexedSourceBytes = null,
+      coveredStartMs = null,
+      coveredEndMs = null,
+      discoveryComplete = status === "complete",
+      diagnosticsComplete = status === "complete",
+      completedAtMs = Date.now(),
+    } = {}) {
+      if (generationId === null) return;
+      if (!["complete", "partial", "failed"].includes(status)) {
+        throw new TypeError("invalid generation status");
+      }
+      begin();
+      // `tool_class_count` remains a rollback/transport compatibility table.
+      // Re-derive it from the source-scoped facts before every publication so
+      // rescanning one source cannot erase or double-count a same-session
+      // sibling's aggregate.
+      statements.clearToolClasses.run();
+      statements.rebuildToolClasses.run();
+      // A generation publishes the complete clone, not only rows inserted by
+      // this pass. Include retained and legacy rows in the durable totals and
+      // covered interval.
+      const counts = database.prepare(`
+        SELECT
+          (SELECT COUNT(*) FROM usage_event) AS usage_events,
+          (SELECT COUNT(*) FROM quota_occurrence) AS quota_occurrences,
+          (SELECT MIN(observed_at_ms) FROM usage_event) AS usage_first_ms,
+          (SELECT MAX(observed_at_ms) FROM usage_event) AS usage_last_ms,
+          (SELECT MIN(observed_at_ms) FROM quota_occurrence) AS quota_first_ms,
+          (SELECT MAX(observed_at_ms) FROM quota_occurrence) AS quota_last_ms
+      `).get();
+      const starts = [counts?.usage_first_ms, counts?.quota_first_ms]
+        .filter((value) => value !== null && value !== undefined)
+        .map(Number);
+      const ends = [counts?.usage_last_ms, counts?.quota_last_ms]
+        .filter((value) => value !== null && value !== undefined)
+        .map(Number);
+      const sourceCompleteness = database.prepare(`
+        SELECT COUNT(*) AS total,
+               SUM(CASE WHEN diagnostics_complete <> 1
+                          OR status IN ('pending', 'failed')
+                        THEN 1 ELSE 0 END) AS incomplete
+        FROM generation_source
+        WHERE generation_id = ?
+      `).get(generationId);
+      const actualDiagnosticsComplete = diagnosticsComplete
+        && Number(sourceCompleteness?.incomplete ?? 0) === 0;
+      const usageProvenanceComplete = Number(database.prepare(`
+        SELECT COUNT(*) AS count FROM usage_event
+        WHERE source_local IS NULL OR source_offset IS NULL
+          OR source_ordinal IS NULL
+      `).get()?.count ?? 0) === 0;
+      const sourceOrderMissing = Number(database.prepare(`
+        SELECT (
+          (SELECT COUNT(*) FROM generation_source
+           WHERE generation_id = ? AND source_ordinal IS NULL)
+          +
+          (SELECT COUNT(*) FROM (
+             SELECT source_ordinal FROM generation_source
+             WHERE generation_id = ?
+             GROUP BY source_ordinal HAVING COUNT(*) > 1
+           ))
+          +
+          (SELECT COUNT(*) FROM usage_event
+           WHERE source_local IS NOT NULL AND source_ordinal IS NULL)
+          +
+          (SELECT COUNT(*) FROM quota_occurrence
+           WHERE source_local IS NOT NULL AND source_ordinal IS NULL)
+          +
+          (SELECT COUNT(*) FROM source_cursor sc
+           WHERE NOT EXISTS (
+             SELECT 1 FROM generation_source gs
+             WHERE gs.generation_id = ?
+               AND gs.source_local = sc.source_local))
+          +
+          (SELECT COUNT(*) FROM usage_event u
+           WHERE u.source_local IS NOT NULL AND NOT EXISTS (
+             SELECT 1 FROM generation_source gs
+             WHERE gs.generation_id = ?
+               AND gs.source_local = u.source_local
+               AND gs.source_ordinal = u.source_ordinal))
+          +
+          (SELECT COUNT(*) FROM quota_occurrence q
+           WHERE NOT EXISTS (
+             SELECT 1 FROM generation_source gs
+               WHERE gs.generation_id = ?
+                 AND gs.source_local = q.source_local
+                 AND gs.source_ordinal = q.source_ordinal))
+          +
+          -- A source cursor is the durable owner of the source ordinal. A
+          -- generation that merely has a non-NULL ordinal on its source row
+          -- is not attested if the cursor is missing, NULL, or disagrees.
+          (SELECT COUNT(*) FROM generation_source gs
+           LEFT JOIN source_cursor sc ON sc.source_local = gs.source_local
+           WHERE gs.generation_id = ?
+             AND (sc.source_local IS NULL OR sc.source_ordinal IS NULL
+               OR sc.source_ordinal != gs.source_ordinal))
+        ) AS count
+      `).get(
+        generationId,
+        generationId,
+        generationId,
+        generationId,
+        generationId,
+        generationId,
+      )?.count ?? 0);
+      const quotaProvenanceMissing = Number(database.prepare(`
+        SELECT (
+          (SELECT COUNT(*) FROM quota_occurrence
+           WHERE source_local IS NULL OR source_offset IS NULL
+             OR source_ordinal IS NULL OR slot_order IS NULL
+             OR surface_id IS NULL OR admission IS NULL)
+          +
+          (SELECT COUNT(*) FROM quota_observation q
+           WHERE NOT EXISTS (
+             SELECT 1 FROM quota_occurrence o
+             WHERE o.canonical_observation_id = q.id))
+        ) AS count
+      `).get()?.count ?? 0);
+      const toolFacts = Number(database.prepare(`
+        SELECT COUNT(*) AS count FROM tool_class_fact
+        WHERE generation_id = ?
+      `).get(generationId)?.count ?? 0);
+      const toolProvenanceMissing = Number(database.prepare(`
+        SELECT (
+          (SELECT COUNT(*) FROM tool_class_fact f
+           WHERE f.generation_id = ?
+             AND (f.source_local IS NULL OR f.source_offset IS NULL
+               OR f.source_ordinal IS NULL OR f.session_local IS NULL
+               OR f.tool_class IS NULL OR f.source_kind IS NULL
+               OR NOT EXISTS (
+                 SELECT 1 FROM generation_source gs
+                 WHERE gs.generation_id = ?
+                   AND gs.source_local = f.source_local
+                   AND gs.source_ordinal = f.source_ordinal)))
+          +
+          (SELECT COUNT(*) FROM source_diagnostic
+           WHERE generation_id = ?
+             AND code IN ('toolRecordsSkipped', 'toolSourceHistoryUnavailable')
+             AND count > 0)
+        ) AS count
+      `).get(generationId, generationId, generationId)?.count ?? 0);
+      const toolProvenanceComplete = toolProvenanceMissing === 0;
+      const toolFactFingerprint = readUnifiedIndexToolFactFingerprint(
+        database,
+        generationId,
+      );
+      const sourceOrderComplete = sourceOrderMissing === 0;
+      const quotaProvenanceComplete = quotaProvenanceMissing === 0;
+      let publishedStatus = status;
+      let publishedReason = blockReason;
+      if (publishedStatus === "complete" && !usageProvenanceComplete) {
+        publishedStatus = "partial";
+        publishedReason = "legacy_nullable_rows";
+      } else if (publishedStatus === "complete" && !sourceOrderComplete) {
+        publishedStatus = "partial";
+        publishedReason = "source_order_incomplete";
+      } else if (publishedStatus === "complete" && !quotaProvenanceComplete) {
+        publishedStatus = "partial";
+        publishedReason = "quota_occurrences_incomplete";
+      } else if (publishedStatus === "complete" && !actualDiagnosticsComplete) {
+        publishedStatus = "partial";
+        publishedReason = "source_diagnostics_incomplete";
+      } else if (publishedStatus === "complete" && !toolProvenanceComplete) {
+        publishedStatus = "partial";
+        publishedReason = "tool_provenance_incomplete";
+      }
+      statements.generation.run(
+        completedAtMs,
+        publishedStatus,
+        publishedReason,
+        indexedSourceCount ?? discoveredSourceCount,
+        indexedSourceBytes ?? discoveredSourceBytes,
+        Number(counts?.usage_events ?? 0),
+        Number(counts?.quota_occurrences ?? 0),
+        starts.length === 0 ? coveredStartMs : Math.min(...starts),
+        ends.length === 0 ? coveredEndMs : Math.max(...ends),
+        discoveryComplete ? 1 : 0,
+        actualDiagnosticsComplete ? 1 : 0,
+        usageProvenanceComplete ? 1 : 0,
+        sourceOrderComplete ? 1 : 0,
+        quotaProvenanceComplete ? 1 : 0,
+        toolFacts,
+        toolFactFingerprint,
+        toolProvenanceComplete ? 1 : 0,
+        generationId,
+      );
+      if (publishedStatus === "complete" || publishedStatus === "partial") {
+        statements.meta.run("current_generation_id", generationId);
+        statements.meta.run("status", publishedStatus);
+      }
+      commit();
+    },
+
+    failGeneration(blockReason = "exception") {
+      if (generationId === null) return;
+      begin();
+      statements.generation.run(
+        Date.now(), "failed", blockReason,
+        null, null, null, null, null, null, 0, 0, 0, 0, 0,
+        null, null, 0, generationId,
+      );
+      commit();
+    },
+
     flush() {
       commit();
     },
@@ -1129,7 +2149,13 @@ export function createUnifiedIndexWriter(database, {
         await chmod(fsyncPath, 0o600);
         await syncFile(fsyncPath);
       }
-      return { usageRows, boundaryRows, toolRows, batches };
+      return {
+        usageRows,
+        boundaryRows,
+        toolRows,
+        quotaOccurrenceRows,
+        batches,
+      };
     },
   };
 }
@@ -1142,9 +2168,21 @@ export function createUnifiedIndexWriter(database, {
 export async function publishStagedUnifiedIndex(stageFile, indexFile) {
   await chmod(stageFile, 0o600);
   await syncFile(stageFile);
+  await assertSafeLocalUnifiedIndexTarget(indexFile, { allowMissing: true });
   await rename(stageFile, indexFile);
-  await syncDirectoryPath(dirname(resolve(indexFile)));
-  await syncFile(indexFile);
+  try {
+    await syncDirectoryPath(dirname(resolve(indexFile)));
+    await syncFile(indexFile);
+  } catch {
+    // The rename has already happened. Report that exact bounded state so the
+    // caller retains its last generation-bound cache and retries inspection;
+    // never pretend the old file is still live or attempt a destructive undo.
+    const error = fixedError(
+      "local_unified_index_publication_durability_uncertain",
+    );
+    error.published = true;
+    throw error;
+  }
 }
 
 export async function removeIfPresent(path) {
@@ -1205,7 +2243,11 @@ export async function inspectLocalUnifiedIndex({
         database.prepare("SELECT COUNT(*) AS c FROM quota_observation").get()?.c ?? 0,
       ),
       toolClassRows: Number(
-        database.prepare("SELECT COUNT(*) AS c FROM tool_class_count").get()?.c ?? 0,
+        database.prepare(`SELECT COUNT(*) AS c FROM ${
+          database.prepare(
+            "SELECT 1 AS present FROM sqlite_master WHERE type = 'table' AND name = 'tool_class_fact'",
+          ).get() === undefined ? "tool_class_count" : "tool_class_fact"
+        }`).get()?.c ?? 0,
       ),
       sessions: Number(usage?.sessions ?? 0),
       models,

--- a/src/passive-collector.js
+++ b/src/passive-collector.js
@@ -1400,6 +1400,12 @@ export async function runCollectorOnce({
   refreshStale = true,
   backfill = false,
   backfillSinceAt = null,
+  // Unified-index authority does not need the legacy rollout ledger. This
+  // opt-in path keeps the checkpoint and quota snapshot semantics, but skips
+  // rollout discovery/ingestion entirely so an inherited recent backfill can
+  // never keep growing collector state. It is intentionally false by
+  // default; legacy callers retain the existing collection behavior.
+  skipRolloutIngestion = false,
   signal = null,
   onProgress = null,
   maximumBufferedLineBytes = MAX_BUFFERED_ROLLOUT_LINE_BYTES,
@@ -1424,6 +1430,9 @@ export async function runCollectorOnce({
   if (backfillSinceAt !== null) {
     canonicalInstant(backfillSinceAt, "backfillSinceAt");
     if (!backfill) throw new TypeError("backfillSinceAt requires backfill");
+  }
+  if (typeof skipRolloutIngestion !== "boolean") {
+    throw new TypeError("skipRolloutIngestion must be boolean");
   }
   if (typeof stateFile !== "string" || stateFile.length < 1) {
     throw new TypeError("stateFile must be a non-empty string");
@@ -1466,6 +1475,87 @@ export async function runCollectorOnce({
       backfillSinceAt: requestedBackfillStart,
       nowIso,
     });
+
+    if (skipRolloutIngestion) {
+      // The unified index owns usage facts. Keep the existing bounded
+      // indexing descriptor available to the quick headline, then perform
+      // only the independent provider quota refresh below. No raw rollout
+      // files are discovered or read, and no legacy collector records are
+      // appended.
+      await emitIndexingProgress(onProgress, indexing);
+      const lastObservedMs = checkpoint.lastQuotaObservedAt
+        ? Date.parse(checkpoint.lastQuotaObservedAt)
+        : Number.NEGATIVE_INFINITY;
+      const shouldRefresh = !signal?.aborted
+        && refreshStale
+        && clock() - lastObservedMs > staleAfterMs;
+      let refresh = { attempted: false, recordWritten: false, errorCode: null };
+      if (shouldRefresh) {
+        refresh.attempted = true;
+        try {
+          client = appServerFactory();
+          abortClient = () => client?.close();
+          signal?.addEventListener("abort", abortClient, { once: true });
+          await client.start();
+          if (signal?.aborted) throw new Error("collector_aborted");
+          const capturedAt = new Date(clock()).toISOString();
+          const payload = await readSanitizedAppServerSnapshot(
+            client,
+            capturedAt,
+            loadAccountObservationSecret,
+          );
+          if (signal?.aborted) throw new Error("collector_aborted");
+          const record = await appendAppRecord({
+            payload,
+            source: "app_server_read",
+            checkpoint,
+            clock,
+            commitRecord: commitRecords,
+          });
+          refresh.recordWritten = record !== null;
+          if (record !== null) {
+            const notificationEvidence = notificationEvidenceFromAppServerRecord(record);
+            if (notificationEvidence !== null) {
+              refresh.notificationEvidence = notificationEvidence;
+            }
+          }
+        } catch (error) {
+          const restored = await readLocalCollectorCheckpoint({ stateFile });
+          if (!restored) throw new Error("Collector app-record recovery completed without a durable checkpoint");
+          for (const key of Object.keys(checkpoint)) delete checkpoint[key];
+          Object.assign(checkpoint, restored);
+          if (!signal?.aborted) refresh.errorCode = recordAppServerError(checkpoint, error);
+        } finally {
+          signal?.removeEventListener("abort", abortClient);
+          abortClient = null;
+          client?.close();
+        }
+      }
+      checkpoint.savedAt = new Date(clock()).toISOString();
+      await saveCheckpoint();
+      await emitIndexingProgress(onProgress, checkpoint.indexing);
+      const skippedResult = {
+        mode: "run_once",
+        status: signal?.aborted ? "bounded_pause" : "complete",
+        pauseReason: signal?.aborted ? "collector_aborted" : null,
+        resourceLimit: null,
+        rolloutRecordsWritten: 0,
+        recordBatchesWritten: 0,
+        maximumBufferedRecords: 0,
+        filesDiscovered: 0,
+        filesSelected: 0,
+        filesProcessed: 0,
+        refresh,
+        indexing: cloneIndexing(checkpoint.indexing),
+        diagnostics: publicDiagnostics(checkpoint.diagnostics),
+      };
+      if (pooled !== null) {
+        sessionSettled = true;
+        await pooled.close();
+      }
+      return resultStateProperties(skippedResult, { stateFile });
+    }
+
     const indexingRun = indexing.mode === "recent_7d"
       && !["recent_7d_complete", "recent_7d_partial"].includes(indexing.status);
     const priorIndexedRecords = indexing.status === "bounded_pause"

--- a/src/replay-safe-accounting-cache.js
+++ b/src/replay-safe-accounting-cache.js
@@ -2,12 +2,17 @@ import { lstat } from "node:fs/promises";
 import { homedir } from "node:os";
 import { dirname, join, resolve } from "node:path";
 import { scanCodexLogEvents } from "./codex-log-scan.js";
-import { openLocalUnifiedIndex } from "./local-unified-index.js";
+import {
+  defaultLocalUnifiedIndexPath,
+  openLocalUnifiedIndex,
+  readUnifiedIndexGenerationDescriptor,
+} from "./local-unified-index.js";
 import { declaredSpeedModeAt } from "./codex-speed-baseline.js";
 import {
   createIndexedCodexLogScan,
   defaultLocalAnalysisIndexSecretPath,
 } from "./local-analysis-index.js";
+import { createLocalUnifiedAccountingSource } from "./local-unified-accounting-source.js";
 import {
   CODEX_TRANSITION_DERIVATION_CEILINGS,
   deriveCodexTransitionSeriesCooperatively,
@@ -88,13 +93,48 @@ import { fastQuotaMultiplier } from "./application/index.js";
 // fitted unresolved-as-Standard and unresolved-as-Fast weekly capacities.
 // Allowance-facing readers can therefore couple every weighted numerator to a
 // denominator derived under the same scenario without replaying raw events.
+// v0.10 (2026-08-17): production refreshes select the unified typed index by
+// default, record the source/generation/context contract, and attach a
+// separate full-history period. A v0.9 cache cannot prove which scanner or
+// generation produced its totals, so it is withheld and rebuilt.
 export const REPLAY_SAFE_ACCOUNTING_SCHEMA_VERSION =
-  "local-replay-safe-accounting-v0.9";
+  "local-replay-safe-accounting-v0.10";
 const ALLOWANCE_CAPACITY_SCHEMA_VERSION =
   "codex-primary-allowance-capacity-v0.1";
 const ALLOWANCE_SCENARIO_CANDIDATES = Object.freeze({
   unresolved_as_standard: "speed_lower",
   unresolved_as_fast: "speed_upper",
+});
+
+export const REPLAY_SAFE_ACCOUNTING_SOURCE_MODES = Object.freeze([
+  "unified",
+  "legacy",
+]);
+
+export const REPLAY_SAFE_ACCOUNTING_CONTEXT_BEHAVIORS = Object.freeze([
+  "legacy_zero",
+  "source_native",
+]);
+
+const DEFAULT_ACCOUNTING_CONTEXT_BEHAVIOR = "legacy_zero";
+const SOURCE_DESCRIPTOR_VERSION = "local-accounting-source-descriptor-v1";
+const GENERATION_TOKEN = /^[A-Za-z0-9._:-]{1,256}$/u;
+const ACCOUNTING_SOURCE_ERROR_CODES = Object.freeze({
+  local_unified_index_missing: "accounting_unified_index_missing",
+  local_unified_index_unavailable: "accounting_unified_index_unavailable",
+  local_unified_index_file_invalid: "accounting_unified_index_unavailable",
+  local_unified_index_file_changed: "accounting_unified_generation_changed",
+  local_unified_index_schema_invalid: "accounting_unified_index_incompatible",
+  local_unified_index_compatibility_invalid: "accounting_unified_index_incompatible",
+  local_unified_index_meta_invalid: "accounting_unified_index_invalid",
+  local_unified_index_row_invalid: "accounting_unified_index_invalid",
+  local_unified_index_accounting_coverage_incomplete:
+    "accounting_unified_coverage_incomplete",
+  local_unified_index_generation_mismatch:
+    "accounting_unified_generation_mismatch",
+  local_unified_index_read_aborted: "accounting_refresh_aborted",
+  local_unified_index_callback_failed: "accounting_unified_callback_failed",
+  local_unified_index_read_failed: "accounting_unified_read_failed",
 });
 
 const HISTORICAL_PRICE_EPOCH_BASIS =
@@ -161,6 +201,25 @@ const ACCOUNTING_BUDGET_MISS_CODES = new Set([
   "accounting_transition_memory_budget_exceeded",
   "accounting_scan_rss_limit_exceeded",
 ]);
+const ACCOUNTING_READER_PASSTHROUGH_CODES = new Set([
+  ...Object.values(ACCOUNTING_SOURCE_ERROR_CODES),
+  "accounting_refresh_aborted",
+  "accounting_scan_source_bytes_limit_exceeded",
+  "accounting_scan_rss_limit_exceeded",
+  "accounting_transition_rss_measurement_invalid",
+  "accounting_transition_rss_limit_exceeded",
+  "accounting_transition_memory_budget_exceeded",
+  "accounting_transition_usage_limit_exceeded",
+  "accounting_transition_snapshot_limit_exceeded",
+  "accounting_transition_input_limit_exceeded",
+  "accounting_transition_derivation_limit_exceeded",
+  "accounting_archive_rss_measurement_invalid",
+  "accounting_archive_rss_limit_exceeded",
+  "accounting_unified_coverage_unavailable",
+  "accounting_unified_generation_unavailable",
+  "accounting_unified_generation_required",
+  "accounting_unified_history_unavailable",
+]);
 const ACCOUNTING_RSS_CHECK_INTERVAL = 2_048;
 // This scanner runs inside the same process that immediately expands the
 // full-history calibration corpus. Four extraction workers preserve useful
@@ -203,10 +262,386 @@ const LINEAGE = new Set(["standalone", "forked", "parent_linked", "unknown"]);
 const QUOTA_PLANS = new Set(TELEMETRY_PLAN_TYPES);
 const QUOTA_SLOTS = new Set(["primary", "secondary"]);
 
-function fixedError(code) {
+function fixedError(code, name = "Error") {
   const error = new Error(code);
+  error.name = name;
   error.code = code;
   return error;
+}
+
+function normalizeAccountingSourceMode(value, { defaultValue = "legacy" } = {}) {
+  const selected = value ?? defaultValue;
+  if (!REPLAY_SAFE_ACCOUNTING_SOURCE_MODES.includes(selected)) {
+    throw new TypeError("sourceMode must be unified or legacy");
+  }
+  return selected;
+}
+
+function normalizeContextBehavior(value, {
+  defaultValue = DEFAULT_ACCOUNTING_CONTEXT_BEHAVIOR,
+} = {}) {
+  const selected = value ?? defaultValue;
+  if (!REPLAY_SAFE_ACCOUNTING_CONTEXT_BEHAVIORS.includes(selected)) {
+    throw new TypeError("contextBehavior is invalid");
+  }
+  return selected;
+}
+
+function generationToken(value) {
+  if (value === null || value === undefined) return null;
+  if (typeof value === "string") {
+    return GENERATION_TOKEN.test(value) ? value : null;
+  }
+  if (typeof value === "number" && Number.isSafeInteger(value)) {
+    return String(value);
+  }
+  if (!value || typeof value !== "object" || Array.isArray(value)) return null;
+  for (const key of ["generation", "generationId", "id", "fingerprint"]) {
+    if (Object.hasOwn(value, key)) {
+      const token = generationToken(value[key]);
+      if (token !== null) return token;
+    }
+  }
+  return null;
+}
+
+// SQLite stores the published generation id in the TEXT-valued meta table.
+// Keep generation fingerprints byte-for-byte exact, but accept the
+// integer-like decimal spelling SQLite can produce for an id (for example,
+// `"1.0"`) and compare it using the same canonical token as the reader's
+// numeric generation descriptor.
+function generationIdMetaToken(value) {
+  if (typeof value === "number") {
+    return Number.isSafeInteger(value) && value >= 0
+      ? String(value)
+      : null;
+  }
+  if (typeof value !== "string" || !/^\d+(?:\.0+)?$/u.test(value)) {
+    return null;
+  }
+  const numeric = Number(value);
+  return Number.isSafeInteger(numeric) && numeric >= 0
+    ? String(numeric)
+    : null;
+}
+
+function expectedGenerationIdToken(value) {
+  return generationIdMetaToken(value) ?? generationToken(value);
+}
+
+function scannerGeneration(scanned) {
+  return generationToken(
+    scanned?.generation
+      ?? scanned?.generationId
+      ?? scanned?.coverage?.generation
+      ?? scanned?.coverage?.generationId
+      ?? scanned?.coverage?.generationFingerprint
+      ?? scanned?.coverage?.fingerprint,
+  );
+}
+
+function scannerGenerationTokens(scanned) {
+  const values = [
+    scanned?.generation,
+    scanned?.generationId,
+    scanned?.generationFingerprint,
+    scanned?.coverage?.generation,
+    scanned?.coverage?.generationId,
+    scanned?.coverage?.generationFingerprint,
+    scanned?.coverage?.fingerprint,
+  ];
+  return [...new Set(values.map(generationToken).filter((value) => value !== null))];
+}
+
+function expectedGenerationParts(value) {
+  if (value === null || value === undefined) return null;
+  if (typeof value !== "object" || Array.isArray(value)) {
+    const token = generationToken(value);
+    return token === null
+      ? null
+      : { opaque: token, id: null, fingerprint: null };
+  }
+  const collect = (keys, tokenForValue = generationToken) => {
+    const present = keys.filter((key) => Object.hasOwn(value, key));
+    const tokens = present.map((key) => tokenForValue(value[key]));
+    if (tokens.some((token) => token === null)) return null;
+    const unique = [...new Set(tokens)];
+    return unique.length <= 1 ? unique[0] ?? null : null;
+  };
+  const id = collect([
+    "generation",
+    "generationId",
+    "currentGenerationId",
+    "id",
+  ], expectedGenerationIdToken);
+  const fingerprint = collect([
+    "fingerprint",
+    "generationFingerprint",
+    "currentGenerationFingerprint",
+  ]);
+  const hasId = [
+    "generation",
+    "generationId",
+    "currentGenerationId",
+    "id",
+  ].some((key) => Object.hasOwn(value, key));
+  const hasFingerprint = [
+    "fingerprint",
+    "generationFingerprint",
+    "currentGenerationFingerprint",
+  ].some((key) => Object.hasOwn(value, key));
+  if ((hasId && id === null) || (hasFingerprint && fingerprint === null)
+      || (!hasId && !hasFingerprint)) return null;
+  return { opaque: null, id, fingerprint };
+}
+
+function expectedGenerationTokens(value) {
+  const parts = expectedGenerationParts(value);
+  return parts === null
+    ? []
+    : [...new Set([
+      parts.opaque,
+      parts.id,
+      parts.fingerprint,
+    ].filter((token) => token !== null))];
+}
+
+function generationMatchesExpected(value, observedTokens) {
+  const parts = expectedGenerationParts(value);
+  if (parts === null) return false;
+  const observed = new Set(observedTokens);
+  if (parts.opaque !== null) return observed.has(parts.opaque);
+  return (parts.id === null || observed.has(parts.id))
+    && (parts.fingerprint === null || observed.has(parts.fingerprint));
+}
+
+function coverageWindow(coverage) {
+  const coveredAt = coverage?.coveredAt ?? coverage?.coverage ?? null;
+  const startAt = canonicalInstant(coveredAt?.startAt);
+  const endAt = canonicalInstant(coveredAt?.endAt);
+  if (startAt === null || endAt === null || Date.parse(startAt) > Date.parse(endAt)) {
+    return null;
+  }
+  return { startAt, endAt };
+}
+
+function boundedDescriptorText(value) {
+  return typeof value === "string" && GENERATION_TOKEN.test(value)
+    ? value
+    : null;
+}
+
+function boundedDescriptorCount(value) {
+  return Number.isSafeInteger(value) && value >= 0 ? value : null;
+}
+
+function descriptorCapability(value, key) {
+  return typeof value?.[key] === "boolean" ? value[key] : null;
+}
+
+function sourceDescriptor({
+  mode,
+  contextBehavior,
+  scanned,
+  coverage,
+  generation,
+  generationMatched = false,
+}) {
+  const coveredAt = mode === "unified" ? coverageWindow(coverage) : null;
+  return {
+    schemaVersion: SOURCE_DESCRIPTOR_VERSION,
+    mode,
+    contextBehavior,
+    readerVersion: boundedDescriptorText(scanned?.readerVersion),
+    schemaVersionUsed: boundedDescriptorText(scanned?.schemaVersion),
+    parserVersion: boundedDescriptorText(scanned?.parserVersion),
+    contractVersion: boundedDescriptorText(scanned?.contractVersion),
+    generation,
+    generationFingerprint: boundedDescriptorText(
+      scanned?.generationFingerprint
+        ?? coverage?.generationFingerprint
+        ?? coverage?.fingerprint,
+    ),
+    coverageStatus: mode === "unified"
+      ? boundedDescriptorText(coverage?.status)
+      : null,
+    coverage: mode === "unified"
+      ? {
+        status: boundedDescriptorText(coverage?.status),
+        generatedAt: canonicalInstant(coverage?.generatedAt) ?? null,
+        coveredAt,
+        sourceCount: boundedDescriptorCount(coverage?.sourceCount),
+        sourceBytes: boundedDescriptorCount(coverage?.sourceBytes),
+        usageEvents: boundedDescriptorCount(coverage?.usageEvents),
+        quotaObservations: boundedDescriptorCount(coverage?.quotaObservations),
+        quotaOccurrences: boundedDescriptorCount(coverage?.quotaOccurrences),
+        admittedQuotaOccurrences: boundedDescriptorCount(
+          coverage?.admittedQuotaOccurrences,
+        ),
+        generationProof: coverage?.generationProof === true,
+      }
+      : null,
+    diagnosticsAvailable: mode === "unified"
+      ? (typeof scanned?.diagnosticsAvailable === "boolean"
+        ? scanned.diagnosticsAvailable
+        : null)
+      : null,
+    generationMatched,
+    fallbackCount: 0,
+    capabilities: mode === "unified"
+      ? {
+        readsRawSources: descriptorCapability(
+          scanned?.capabilities,
+          "readsRawSources",
+        ),
+        deterministicCanonicalOrder: descriptorCapability(
+          scanned?.capabilities,
+          "deterministicCanonicalOrder",
+        ),
+        sourceOrderingProvenance: descriptorCapability(
+          scanned?.capabilities,
+          "sourceOrderingProvenance",
+        ),
+        sourceOffsetProvenance: descriptorCapability(
+          scanned?.capabilities,
+          "sourceOffsetProvenance",
+        ),
+        sourceScopedQuotaOccurrences: descriptorCapability(
+          scanned?.capabilities,
+          "sourceScopedQuotaOccurrences",
+        ),
+        durableDiagnostics: descriptorCapability(
+          scanned?.capabilities,
+          "durableDiagnostics",
+        ),
+        crashSafeGenerationPublication: descriptorCapability(
+          scanned?.capabilities,
+          "crashSafeGenerationPublication",
+        ),
+      }
+      : null,
+  };
+}
+
+function normalizeUnifiedCoverage(scanned, expectedGeneration) {
+  const coverage = scanned?.coverage;
+  if (!coverage || typeof coverage !== "object" || Array.isArray(coverage)) {
+    throw fixedError("accounting_unified_coverage_unavailable");
+  }
+  if (coverage.status !== "complete" || coverage.generationProof !== true) {
+    throw fixedError("accounting_unified_coverage_incomplete");
+  }
+  const capabilities = scanned?.capabilities;
+  if (scanned?.diagnosticsAvailable !== true
+      || !capabilities
+      || capabilities.readsRawSources !== false
+      || capabilities.deterministicCanonicalOrder !== true
+      || capabilities.sourceOrderingProvenance !== true
+      || capabilities.sourceOffsetProvenance !== true
+      || capabilities.sourceScopedQuotaOccurrences !== true
+      || capabilities.durableDiagnostics !== true
+      || capabilities.crashSafeGenerationPublication !== true) {
+    throw fixedError("accounting_unified_coverage_incomplete");
+  }
+  const coveredAt = coverageWindow(coverage);
+  if (coveredAt === null) {
+    throw fixedError("accounting_unified_coverage_unavailable");
+  }
+  const generation = scannerGeneration(scanned);
+  if (generation === null) {
+    throw fixedError("accounting_unified_generation_unavailable");
+  }
+  const generationFingerprint = generationToken(
+    scanned?.generationFingerprint
+      ?? coverage?.generationFingerprint
+      ?? coverage?.fingerprint,
+  );
+  if (generationFingerprint === null) {
+    throw fixedError("accounting_unified_generation_unavailable");
+  }
+  const expected = expectedGenerationTokens(expectedGeneration);
+  if (expectedGeneration !== null && expected.length === 0) {
+    throw new TypeError("expectedGeneration is invalid");
+  }
+  const observed = scannerGenerationTokens(scanned);
+  if (expected.length > 0
+      && !generationMatchesExpected(expectedGeneration, observed)) {
+    throw fixedError("accounting_unified_generation_mismatch");
+  }
+  return {
+    coverage,
+    coveredAt,
+    generation,
+    generationFingerprint,
+  };
+}
+
+function mapUnifiedReaderError(error) {
+  const code = error?.code;
+  if (typeof code === "string" && !code.startsWith("local_unified_index_")) {
+    if (ACCOUNTING_READER_PASSTHROUGH_CODES.has(code)) {
+      return fixedError(
+        code,
+        error?.name === "AbortError" ? "AbortError" : "Error",
+      );
+    }
+    return fixedError("accounting_unified_read_failed");
+  }
+  const mappedCode = ACCOUNTING_SOURCE_ERROR_CODES[code]
+    ?? "accounting_unified_read_failed";
+  const mapped = fixedError(
+    mappedCode,
+    error?.name === "AbortError"
+      || (typeof code === "string" && code.endsWith("_aborted"))
+      ? "AbortError"
+      : "Error",
+  );
+  return mapped;
+}
+
+function historyUnavailable(
+  errorCode,
+  coverage = null,
+  generation = null,
+  generationFingerprint = null,
+) {
+  const coveredAt = coverage?.coveredAt ?? coverage;
+  return {
+    status: "unavailable",
+    errorCode,
+    coverage: {
+      status: "unavailable",
+      generatedAt: null,
+      coveredAt: coveredAt?.startAt && coveredAt?.endAt
+        ? {
+          startAt: coveredAt.startAt,
+          endAt: coveredAt.endAt,
+        }
+        : { startAt: null, endAt: null },
+      generation,
+      generationFingerprint,
+    },
+    generation,
+    generationFingerprint,
+    period: null,
+  };
+}
+
+function historyProjection(value, coverage, generation, generationFingerprint) {
+  return {
+    status: "available",
+    errorCode: null,
+    coverage: {
+      status: "complete",
+      generatedAt: value.generatedAt,
+      coveredAt: value.coveredAt,
+      generation,
+      generationFingerprint,
+    },
+    generation,
+    generationFingerprint,
+    period: value.period,
+  };
 }
 
 // True for the RSS/byte memory-budget misses that the refresh wrapper treats
@@ -1363,6 +1798,26 @@ function roundedMoney(value) {
   return Number(value.toFixed(6));
 }
 
+// The period's numeric total is a display projection of the exact decimal
+// ledger, not an independently accumulated binary-float sum. Round the
+// decimal string at six places with decimal half-up semantics before converting
+// it to the bounded numeric projection. This keeps a large aggregation stable
+// at the exact half boundary (and avoids Number#toFixed's representation
+// dependent result for values such as 0.0000005).
+function roundedExactMoney(value) {
+  if (typeof value !== "string" || !/^\d+(?:\.\d+)?$/u.test(value)) {
+    return Number.NaN;
+  }
+  const [whole, fraction = ""] = value.split(".");
+  const retainedFraction = fraction.padEnd(6, "0").slice(0, 6);
+  let scaled = BigInt(`${whole}${retainedFraction}`);
+  if ((fraction[6] ?? "0") >= "5") scaled += 1n;
+  const integerPart = scaled / 1_000_000n;
+  const fractionalPart = String(scaled % 1_000_000n).padStart(6, "0");
+  const numeric = Number(`${integerPart}.${fractionalPart}`);
+  return Number.isFinite(numeric) ? numeric : Number.NaN;
+}
+
 function finalizeDimension(dimension) {
   return Object.fromEntries(Object.entries(dimension).map(([key, row]) => [
     key,
@@ -1398,7 +1853,9 @@ function finalizePeriod(period) {
     + period.pricingCoverage.partiallyPricedEvents;
   const finalized = {
     ...period,
-    apiPriceEquivalentUsd: roundedMoney(period.apiPriceEquivalentUsd),
+    apiPriceEquivalentUsd: roundedExactMoney(
+      period.apiPriceEquivalentUsdExact,
+    ),
     priceCardIds: [...period.priceCardIds].sort(),
     priceCardBreakdown: Object.values(period.priceCardBreakdown).sort(
       (left, right) => left.priceCardId.localeCompare(right.priceCardId),
@@ -2019,6 +2476,26 @@ async function probeUnifiedCalibrationCorpus(indexFile) {
   }
 }
 
+function sameIndexFileIdentity(before, after) {
+  const canCompareIdentity = [
+    before?.dev,
+    before?.ino,
+    after?.dev,
+    after?.ino,
+  ].every((value) => value !== undefined && value !== null);
+  return !canCompareIdentity
+    || (before.dev === after.dev && before.ino === after.ino);
+}
+
+function publishedUnifiedGenerationTokens(database) {
+  const descriptor = readUnifiedIndexGenerationDescriptor(database);
+  if (descriptor === null) return [];
+  return [
+    generationIdMetaToken(descriptor.id),
+    generationToken(descriptor.fingerprint),
+  ].filter((token) => token !== null);
+}
+
 /**
  * The full-history weekly-calibration corpus, read from the unified local
  * index in the same compact pre-priced encoding the windowed scan retains.
@@ -2049,6 +2526,7 @@ async function readUnifiedIndexCalibrationCorpus({
   declaredSpeedBaselines,
   signal,
   checkRuntimeMemory,
+  expectedGeneration = null,
 }) {
   let metadata;
   try {
@@ -2064,6 +2542,15 @@ async function readUnifiedIndexCalibrationCorpus({
     return null;
   }
   try {
+    if (expectedGeneration !== null
+        && expectedGeneration !== undefined) {
+      const expected = expectedGenerationTokens(expectedGeneration);
+      const observed = publishedUnifiedGenerationTokens(database);
+      if (expected.length === 0
+          || !generationMatchesExpected(expectedGeneration, observed)) {
+        throw fixedError("accounting_unified_generation_mismatch");
+      }
+    }
     const usageGraceMs = endMs + 5 * 60_000;
     const usageCount = Number(database.prepare(
       "SELECT COUNT(*) AS c FROM usage_event WHERE observed_at_ms <= ?",
@@ -2295,6 +2782,24 @@ async function readUnifiedIndexCalibrationCorpus({
     const coveredStartMs = firstSnapshotMs === null
       ? firstUsageMs
       : Math.min(firstUsageMs, firstSnapshotMs);
+    if (expectedGeneration !== null
+        && expectedGeneration !== undefined) {
+      const expected = expectedGenerationTokens(expectedGeneration);
+      const observed = publishedUnifiedGenerationTokens(database);
+      if (expected.length === 0
+          || !generationMatchesExpected(expectedGeneration, observed)) {
+        throw fixedError("accounting_unified_generation_mismatch");
+      }
+    }
+    let finalMetadata;
+    try {
+      finalMetadata = await lstat(indexFile);
+    } catch {
+      throw fixedError("accounting_unified_generation_changed");
+    }
+    if (!sameIndexFileIdentity(metadata, finalMetadata)) {
+      throw fixedError("accounting_unified_generation_changed");
+    }
     return {
       rawUsageEvents,
       weeklyRateLimitSnapshots,
@@ -2319,7 +2824,13 @@ export async function buildReplaySafeAccountingCache({
   codexHome = join(homedir(), ".codex"),
   now = () => Date.now(),
   windowDays = DEFAULT_WINDOW_DAYS,
-  scan = scanCodexLogEvents,
+  // Direct builders historically accepted an injected raw scanner. Keep that
+  // characterization seam usable, while refreshReplaySafeAccountingCache
+  // selects the unified reader explicitly for production.
+  scan = null,
+  sourceMode = null,
+  expectedGeneration = null,
+  contextBehavior = DEFAULT_ACCOUNTING_CONTEXT_BEHAVIOR,
   signal = null,
   // Timestamped Codex `service_tier` readings. Each covers only the interval
   // it was actually observed over, so a reading can never reach back before it
@@ -2334,6 +2845,32 @@ export async function buildReplaySafeAccountingCache({
   rss = () => process.memoryUsage().rss,
   maximumRssBytes = MAX_ACCOUNTING_RSS_BYTES,
 } = {}) {
+  if (scan === null && (sourceMode === null || sourceMode === undefined)) {
+    throw fixedError("accounting_source_required");
+  }
+  const selectedSourceMode = normalizeAccountingSourceMode(sourceMode);
+  const selectedContextBehavior = normalizeContextBehavior(contextBehavior);
+  if (selectedSourceMode === "unified"
+      && (expectedGeneration === null || expectedGeneration === undefined)) {
+    throw fixedError("accounting_unified_generation_required");
+  }
+  if (expectedGeneration !== null
+      && expectedGeneration !== undefined
+      && expectedGenerationTokens(expectedGeneration).length === 0) {
+    throw new TypeError("expectedGeneration is invalid");
+  }
+  const selectedUnifiedIndexFile = unifiedIndexFile
+    ?? (selectedSourceMode === "unified"
+      ? defaultLocalUnifiedIndexPath()
+      : null);
+  const effectiveScan = scan ?? (selectedSourceMode === "unified"
+    ? createLocalUnifiedAccountingSource({
+      indexFile: selectedUnifiedIndexFile,
+      requireComplete: true,
+      expectedGeneration,
+      contextBehavior: selectedContextBehavior,
+    })
+    : scanCodexLogEvents);
   const endMs = now();
   if (!Number.isFinite(endMs)
       || !Number.isSafeInteger(windowDays)
@@ -2341,7 +2878,7 @@ export async function buildReplaySafeAccountingCache({
       || windowDays > MAXIMUM_WINDOW_DAYS
       || (unifiedIndexFile !== null
         && (typeof unifiedIndexFile !== "string" || unifiedIndexFile.length < 1))
-      || typeof scan !== "function"
+      || typeof effectiveScan !== "function"
       || !validAbortSignal(signal)
       || typeof rss !== "function"
       || !Number.isSafeInteger(maximumRssBytes)
@@ -2403,8 +2940,8 @@ export async function buildReplaySafeAccountingCache({
   // keeping the two working sets sequential rather than resident together. A
   // missing or unusable index degrades to the windowed corpus here; it never
   // fails the build.
-  const useUnifiedCalibration = unifiedIndexFile !== null
-    && await probeUnifiedCalibrationCorpus(unifiedIndexFile);
+  const useUnifiedCalibration = selectedUnifiedIndexFile !== null
+    && await probeUnifiedCalibrationCorpus(selectedUnifiedIndexFile);
   const retainWindowedCalibrationInputs = !useUnifiedCalibration;
   throwIfAborted(signal);
   const startMs = endMs - windowDays * 24 * 60 * 60 * 1_000;
@@ -2469,8 +3006,9 @@ export async function buildReplaySafeAccountingCache({
     }
   };
   let scanned;
+  let unifiedCoverage = null;
   try {
-    scanned = await scan({
+    scanned = await effectiveScan({
       startAt: new Date(startMs).toISOString(),
       endAt: new Date(endMs).toISOString(),
       codexHome,
@@ -2557,22 +3095,103 @@ export async function buildReplaySafeAccountingCache({
         }
       },
     });
+    if (selectedSourceMode === "unified") {
+      unifiedCoverage = normalizeUnifiedCoverage(scanned, expectedGeneration);
+    }
   } catch (error) {
     const bounded = accountingScanResourceError(error);
     if (bounded !== null) throw bounded;
+    if (selectedSourceMode === "unified") {
+      if (error?.name === "AbortError"
+          || error?.code === "accounting_refresh_aborted") {
+        const aborted = fixedError("accounting_refresh_aborted", "AbortError");
+        throw aborted;
+      }
+      throw mapUnifiedReaderError(error) ?? error;
+    }
     throw error;
   }
   throwIfAborted(signal);
   checkRuntimeMemory();
+  let history = historyUnavailable(
+    selectedSourceMode === "unified"
+      ? "accounting_unified_history_unavailable"
+      : "accounting_history_unavailable",
+    unifiedCoverage?.coveredAt ?? null,
+    unifiedCoverage?.generation ?? null,
+    unifiedCoverage?.generationFingerprint ?? null,
+  );
+  if (selectedSourceMode === "unified" && unifiedCoverage !== null) {
+    let historyScanned = null;
+    const historyScan = async (scanOptions) => {
+      historyScanned = await effectiveScan(scanOptions);
+      return historyScanned;
+    };
+    try {
+      const historyValue = await buildReplaySafeAccountingPeriod({
+        id: "history",
+        label: "Indexed history",
+        startAt: unifiedCoverage.coveredAt.startAt,
+        endAt: unifiedCoverage.coveredAt.endAt,
+        scan: historyScan,
+        signal,
+        declaredSpeedBaselines: baselines,
+        rss,
+        maximumRssBytes: effectiveMaximumRssBytes,
+      });
+      const historyCoverage = normalizeUnifiedCoverage(
+        historyScanned,
+        expectedGeneration,
+      );
+      if (historyCoverage.generation !== unifiedCoverage.generation
+          || historyCoverage.generationFingerprint
+            !== unifiedCoverage.generationFingerprint
+          || historyCoverage.coveredAt.startAt
+            !== unifiedCoverage.coveredAt.startAt
+          || historyCoverage.coveredAt.endAt
+            !== unifiedCoverage.coveredAt.endAt) {
+        throw fixedError("accounting_unified_generation_mismatch");
+      }
+      history = historyProjection(
+        historyValue,
+        historyCoverage,
+        historyCoverage.generation,
+        historyCoverage.generationFingerprint,
+      );
+    } catch (error) {
+      if (error?.name === "AbortError"
+          || error?.code === "accounting_refresh_aborted") {
+        throw fixedError("accounting_refresh_aborted", "AbortError");
+      }
+      const mapped = mapUnifiedReaderError(error) ?? error;
+      if (mapped?.code === "accounting_unified_generation_mismatch"
+          || mapped?.name === "AbortError"
+          || isAccountingBudgetMiss(mapped)
+          || mapped?.code === "accounting_archive_rss_limit_exceeded"
+          || (typeof mapped?.code === "string"
+            && !mapped.code.startsWith("accounting_unified_"))) {
+        throw mapped;
+      }
+      history = historyUnavailable(
+        mapped?.code ?? "accounting_unified_history_unavailable",
+        unifiedCoverage.coveredAt,
+        unifiedCoverage.generation,
+        unifiedCoverage.generationFingerprint,
+      );
+    }
+  }
   let unifiedCalibration = null;
   if (useUnifiedCalibration) {
     unifiedCalibration = await readUnifiedIndexCalibrationCorpus({
-      indexFile: unifiedIndexFile,
+      indexFile: selectedUnifiedIndexFile,
       endMs,
       limits,
       declaredSpeedBaselines: baselines,
       signal,
       checkRuntimeMemory,
+      ...(selectedSourceMode === "unified"
+        ? { expectedGeneration: unifiedCoverage?.generation ?? null }
+        : {}),
     });
     // The probe accepted this index, so the scan retained no windowed
     // fallback corpus. If the full read then fails, the only honest outputs
@@ -2734,6 +3353,17 @@ export async function buildReplaySafeAccountingCache({
     priceEpochBasis: HISTORICAL_PRICE_EPOCH_BASIS,
     priceRegistryVersion: APP_PRICE_REGISTRY_MANIFEST.version,
     priceRegistryObservedAt: APP_PRICE_REGISTRY_MANIFEST.observedAt,
+    sourceDescriptor: sourceDescriptor({
+      mode: selectedSourceMode,
+      contextBehavior: selectedContextBehavior,
+      scanned,
+      coverage: unifiedCoverage?.coverage ?? null,
+      generation: unifiedCoverage?.generation ?? null,
+      generationMatched: selectedSourceMode === "unified"
+        && expectedGeneration !== null
+        && expectedGeneration !== undefined,
+    }),
+    history,
     periods: [...periods.values()].map(finalizePeriod),
     timeline: finalizeTimeline(timeline),
     sparkUsageTimeline: finalizeTimeline(sparkTimeline),
@@ -2777,6 +3407,10 @@ export async function refreshReplaySafeAccountingCache({
   indexFile = null,
   indexSecretFile = null,
   scan = null,
+  sourceMode = null,
+  unifiedIndexFile = null,
+  expectedGeneration = null,
+  contextBehavior = null,
   indexWorkerCount,
   indexChunkBytes,
   // Optional, layer-local hook fired when a rebuild misses its memory budget
@@ -2797,6 +3431,24 @@ export async function refreshReplaySafeAccountingCache({
     throw new TypeError("onAccountingRebuildDeferred must be a function or null");
   }
   const selectedStateFile = stateFile ?? defaultReplaySafeAccountingCachePath();
+  const selectedSourceMode = normalizeAccountingSourceMode(
+    sourceMode,
+    { defaultValue: scan === null ? "unified" : "legacy" },
+  );
+  const selectedContextBehavior = normalizeContextBehavior(
+    contextBehavior,
+  );
+  if (expectedGeneration !== null
+      && expectedGeneration !== undefined
+      && expectedGenerationTokens(expectedGeneration).length === 0) {
+    throw new TypeError("expectedGeneration is invalid");
+  }
+  if (selectedSourceMode === "unified"
+      && (expectedGeneration === null || expectedGeneration === undefined)) {
+    throw fixedError("accounting_unified_generation_required");
+  }
+  const selectedUnifiedIndexFile = unifiedIndexFile
+    ?? resolve(dirname(selectedStateFile), "local-unified-index-v1.sqlite");
   const selectedIndexFile = indexFile ?? resolve(
     dirname(selectedStateFile),
     "local-analysis-index-v2.sqlite",
@@ -2804,20 +3456,29 @@ export async function refreshReplaySafeAccountingCache({
   const selectedIndexSecretFile = indexSecretFile
     ?? defaultLocalAnalysisIndexSecretPath(selectedIndexFile);
   if (typeof selectedStateFile !== "string" || selectedStateFile.length < 1
+      || typeof selectedUnifiedIndexFile !== "string"
+      || selectedUnifiedIndexFile.length < 1
       || typeof selectedIndexFile !== "string" || selectedIndexFile.length < 1) {
     throw new TypeError("Replay-safe SQLite state paths are invalid");
   }
   if (scan !== null && typeof scan !== "function") {
     throw new TypeError("scan must be a function or null");
   }
-  const effectiveScan = scan ?? createIndexedCodexLogScan({
-    indexFile: selectedIndexFile,
-    secretFile: selectedIndexSecretFile,
-    workerCount: indexWorkerCount ?? DEFAULT_ACCOUNTING_INDEX_WORKERS,
-    ...(indexChunkBytes === undefined
-      ? {}
-      : { chunkBytes: indexChunkBytes }),
-  });
+  const effectiveScan = scan ?? (selectedSourceMode === "unified"
+    ? createLocalUnifiedAccountingSource({
+      indexFile: selectedUnifiedIndexFile,
+      requireComplete: true,
+      expectedGeneration,
+      contextBehavior: selectedContextBehavior,
+    })
+    : createIndexedCodexLogScan({
+      indexFile: selectedIndexFile,
+      secretFile: selectedIndexSecretFile,
+      workerCount: indexWorkerCount ?? DEFAULT_ACCOUNTING_INDEX_WORKERS,
+      ...(indexChunkBytes === undefined
+        ? {}
+        : { chunkBytes: indexChunkBytes }),
+    }));
   // Converge legacy state before spending a potentially substantial raw-log
   // scan. A live old JSON collector or an unverified parity mismatch must
   // fail before we derive a cache that cannot be committed safely.
@@ -2827,6 +3488,12 @@ export async function refreshReplaySafeAccountingCache({
     cache = await buildReplaySafeAccountingCache({
       ...options,
       scan: effectiveScan,
+      sourceMode: selectedSourceMode,
+      contextBehavior: selectedContextBehavior,
+      expectedGeneration,
+      unifiedIndexFile: selectedSourceMode === "unified"
+        ? selectedUnifiedIndexFile
+        : unifiedIndexFile,
     });
   } catch (error) {
     if (!isAccountingBudgetMiss(error)) throw error;
@@ -2869,6 +3536,10 @@ export async function refreshReplaySafeAccountingCache({
     }
     return deferred;
   }
+  // Validate the complete derived artifact before publication. The write is
+  // atomic, but atomicity alone would preserve a newly-created invalid cache;
+  // fail closed here so a bad build leaves the prior valid state untouched.
+  assertReplaySafeAccountingCache(cache);
   if (Buffer.byteLength(stableJson(cache)) > MAX_CACHE_BYTES) {
     throw fixedError("cache_invalid_size");
   }
@@ -3084,9 +3755,194 @@ function validPriceCardProvenance(row) {
     return false;
   }
   const exactNumber = Number(row.apiPriceEquivalentUsdExact);
+  const expectedRounded = roundedExactMoney(row.apiPriceEquivalentUsdExact);
   return Number.isFinite(exactNumber)
-    && Number(row.apiPriceEquivalentUsd.toFixed(6))
-      === Number(exactNumber.toFixed(6));
+    && Number.isFinite(expectedRounded)
+    && row.apiPriceEquivalentUsd === expectedRounded;
+}
+
+function validSourceDescriptor(value) {
+  const expectedKeys = [
+    "contextBehavior",
+    "contractVersion",
+    "coverageStatus",
+    "coverage",
+    "diagnosticsAvailable",
+    "fallbackCount",
+    "generation",
+    "generationFingerprint",
+    "generationMatched",
+    "mode",
+    "parserVersion",
+    "readerVersion",
+    "schemaVersion",
+    "schemaVersionUsed",
+    "capabilities",
+  ].sort().join("\0");
+  if (!value || typeof value !== "object" || Array.isArray(value)
+      || Object.keys(value).sort().join("\0") !== expectedKeys
+      || value.schemaVersion !== SOURCE_DESCRIPTOR_VERSION
+      || !REPLAY_SAFE_ACCOUNTING_SOURCE_MODES.includes(value.mode)
+      || !REPLAY_SAFE_ACCOUNTING_CONTEXT_BEHAVIORS.includes(
+        value.contextBehavior,
+      )) return false;
+  const optionalText = [
+    "contractVersion",
+    "parserVersion",
+    "readerVersion",
+    "schemaVersionUsed",
+  ];
+  if (!optionalText.every((key) => (
+    value[key] === null || boundedDescriptorText(value[key]) !== null
+  ))) return false;
+  if (!Number.isSafeInteger(value.fallbackCount)
+      || value.fallbackCount < 0
+      || typeof value.generationMatched !== "boolean") {
+    return false;
+  }
+  if (value.mode === "unified") {
+    if (value.fallbackCount !== 0
+        || value.generationMatched !== true
+        || generationToken(value.generationFingerprint) === null) {
+      return false;
+    }
+    const coverage = value.coverage;
+    const coverageKeys = [
+      "admittedQuotaOccurrences",
+      "coveredAt",
+      "generatedAt",
+      "generationProof",
+      "quotaObservations",
+      "quotaOccurrences",
+      "sourceBytes",
+      "sourceCount",
+      "status",
+      "usageEvents",
+    ].sort().join("\0");
+    const capabilityKeys = [
+      "crashSafeGenerationPublication",
+      "deterministicCanonicalOrder",
+      "durableDiagnostics",
+      "readsRawSources",
+      "sourceOffsetProvenance",
+      "sourceOrderingProvenance",
+      "sourceScopedQuotaOccurrences",
+    ].sort().join("\0");
+    const validCoveredAt = coverage?.coveredAt === null
+      || (coverage?.coveredAt
+        && canonicalInstant(coverage.coveredAt.startAt) !== null
+        && canonicalInstant(coverage.coveredAt.endAt) !== null
+        && Date.parse(coverage.coveredAt.startAt)
+          <= Date.parse(coverage.coveredAt.endAt));
+    const validCount = (candidate) => (
+      candidate === null
+      || (Number.isSafeInteger(candidate) && candidate >= 0)
+    );
+    const capabilities = value.capabilities;
+    if (value.generationFingerprint !== null
+        && boundedDescriptorText(value.generationFingerprint) === null) {
+      return false;
+    }
+    return value.coverageStatus === "complete"
+      && value.diagnosticsAvailable === true
+      && value.generationMatched === true
+      && coverage
+      && typeof coverage === "object"
+      && !Array.isArray(coverage)
+      && Object.keys(coverage).sort().join("\0") === coverageKeys
+      && coverage.status === "complete"
+      && (coverage.generatedAt === null
+        || canonicalInstant(coverage.generatedAt) !== null)
+      && validCoveredAt
+      && [
+        coverage.sourceCount,
+        coverage.sourceBytes,
+        coverage.usageEvents,
+        coverage.quotaObservations,
+        coverage.quotaOccurrences,
+        coverage.admittedQuotaOccurrences,
+      ].every(validCount)
+      && coverage.generationProof === true
+      && capabilities
+      && typeof capabilities === "object"
+      && !Array.isArray(capabilities)
+      && Object.keys(capabilities).sort().join("\0") === capabilityKeys
+      && capabilities.readsRawSources === false
+      && capabilities.deterministicCanonicalOrder === true
+      && capabilities.sourceOrderingProvenance === true
+      && capabilities.sourceOffsetProvenance === true
+      && capabilities.sourceScopedQuotaOccurrences === true
+      && capabilities.durableDiagnostics === true
+      && capabilities.crashSafeGenerationPublication === true
+      && generationToken(value.generation) !== null;
+  }
+  return value.coverageStatus === null
+    && value.generation === null
+    && value.generationFingerprint === null
+    && value.coverage === null
+    && value.diagnosticsAvailable === null
+    && value.generationMatched === false
+    && value.capabilities === null;
+}
+
+function validHistoryPeriod(value) {
+  return value
+    && typeof value === "object"
+    && !Array.isArray(value)
+    && value.id === "history"
+    && typeof value.label === "string"
+    && value.label.length > 0
+    && value.label.length <= 96
+    && Number.isSafeInteger(value.events)
+    && value.events >= 0
+    && Number.isSafeInteger(value.totalTokens)
+    && value.totalTokens >= 0
+    && typeof value.apiPriceEquivalentUsd === "number"
+    && Number.isFinite(value.apiPriceEquivalentUsd)
+    && value.apiPriceEquivalentUsd >= 0
+    && validPriceCardProvenance(value);
+}
+
+function validHistory(value) {
+  if (!value || typeof value !== "object" || Array.isArray(value)
+      || !["available", "unavailable"].includes(value.status)
+      || (value.errorCode !== null
+        && (typeof value.errorCode !== "string"
+          || !/^[a-z][a-z0-9_.-]{0,95}$/u.test(value.errorCode)))
+      || !value.coverage
+      || typeof value.coverage !== "object"
+      || Array.isArray(value.coverage)
+      || !["complete", "unavailable"].includes(value.coverage.status)
+      || (value.generation !== null
+        && generationToken(value.generation) === null)
+      || (value.generationFingerprint !== null
+        && generationToken(value.generationFingerprint) === null)
+      || value.coverage.generation !== value.generation
+      || value.coverage.generationFingerprint
+        !== value.generationFingerprint) return false;
+  const coveredAt = value.coverage.coveredAt;
+  if (!coveredAt || typeof coveredAt !== "object" || Array.isArray(coveredAt)) {
+    return false;
+  }
+  const validCoveredAt = value.coverage.status === "unavailable"
+    ? ((coveredAt.startAt === null && coveredAt.endAt === null)
+      || (canonicalInstant(coveredAt.startAt) !== null
+        && canonicalInstant(coveredAt.endAt) !== null
+        && Date.parse(coveredAt.startAt) <= Date.parse(coveredAt.endAt)))
+    : canonicalInstant(coveredAt.startAt) !== null
+      && canonicalInstant(coveredAt.endAt) !== null
+      && Date.parse(coveredAt.startAt) <= Date.parse(coveredAt.endAt)
+      && canonicalInstant(value.coverage.generatedAt) !== null;
+  if (!validCoveredAt) return false;
+  if (value.status === "available") {
+    return value.errorCode === null
+      && value.coverage.status === "complete"
+      && value.generation !== null
+      && validHistoryPeriod(value.period);
+  }
+  return value.errorCode !== null
+    && value.period === null
+    && value.coverage.status === "unavailable";
 }
 
 function speedWeightingTotals(value) {
@@ -3284,6 +4140,11 @@ function validCache(value) {
       // survive a registry correction just because its JSON shape is valid.
       || value.priceRegistryVersion !== APP_PRICE_REGISTRY_MANIFEST.version
       || value.priceRegistryObservedAt !== APP_PRICE_REGISTRY_MANIFEST.observedAt
+      || !validSourceDescriptor(value.sourceDescriptor)
+      || !validHistory(value.history)
+      || value.history.generation !== value.sourceDescriptor.generation
+      || value.history.generationFingerprint
+        !== value.sourceDescriptor.generationFingerprint
       || !Array.isArray(value.periods)
       || !Array.isArray(value.timeline)
       || !validQuotaTimeline(value.quotaTimeline, value.coveredAt)
@@ -3364,6 +4225,9 @@ export async function readReplaySafeAccountingCache({
   cacheFile = undefined,
   now = null,
   maximumAgeMs = null,
+  sourceMode = null,
+  expectedGeneration = null,
+  contextBehavior = null,
 } = {}) {
   if (cacheFile !== undefined) {
     throw new TypeError("cacheFile was retired; use stateFile");
@@ -3378,6 +4242,21 @@ export async function readReplaySafeAccountingCache({
   if (maximumAgeMs !== null
       && (!Number.isSafeInteger(maximumAgeMs) || maximumAgeMs < 0)) {
     throw new TypeError("maximumAgeMs must be a non-negative safe integer or null");
+  }
+  if (sourceMode !== null && sourceMode !== undefined) {
+    normalizeAccountingSourceMode(sourceMode);
+  }
+  if (sourceMode === "unified"
+      && (expectedGeneration === null || expectedGeneration === undefined)) {
+    throw fixedError("accounting_unified_generation_required");
+  }
+  if (contextBehavior !== null && contextBehavior !== undefined) {
+    normalizeContextBehavior(contextBehavior);
+  }
+  if (expectedGeneration !== null
+      && expectedGeneration !== undefined
+      && expectedGenerationTokens(expectedGeneration).length === 0) {
+    throw new TypeError("expectedGeneration is invalid");
   }
   let unavailableErrorCode = null;
   let parsed = null;
@@ -3417,6 +4296,41 @@ export async function readReplaySafeAccountingCache({
       errorCode: unavailableErrorCode ?? "cache_unavailable",
       cache: null,
     };
+  }
+  const descriptor = parsed.sourceDescriptor;
+  if (sourceMode !== null
+      && sourceMode !== undefined
+      && descriptor.mode !== sourceMode) {
+    return {
+      status: "unavailable",
+      errorCode: "cache_source_mode_mismatch",
+      cache: null,
+    };
+  }
+  if (contextBehavior !== null
+      && contextBehavior !== undefined
+      && descriptor.contextBehavior !== contextBehavior) {
+    return {
+      status: "unavailable",
+      errorCode: "cache_context_behavior_mismatch",
+      cache: null,
+    };
+  }
+  if (expectedGeneration !== null && expectedGeneration !== undefined) {
+    const expectedTokens = expectedGenerationTokens(expectedGeneration);
+    const storedGenerations = [
+      generationToken(descriptor.generation),
+      generationToken(descriptor.generationFingerprint),
+    ].filter((value) => value !== null);
+    if (storedGenerations.length === 0
+        || expectedTokens.length === 0
+        || !generationMatchesExpected(expectedGeneration, storedGenerations)) {
+      return {
+        status: "unavailable",
+        errorCode: "cache_generation_mismatch",
+        cache: null,
+      };
+    }
   }
   if (now !== null) {
     const nowMs = now();

--- a/test/benchmark-local-analysis-pipeline.test.mjs
+++ b/test/benchmark-local-analysis-pipeline.test.mjs
@@ -1,0 +1,117 @@
+import assert from "node:assert/strict";
+import { spawn } from "node:child_process";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import test from "node:test";
+
+import {
+  createSyntheticLocalIndexRetirementCorpus,
+} from "../scripts/benchmark-local-index-retirement.mjs";
+
+const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const SCRIPT = join(ROOT, "scripts", "benchmark-local-analysis-pipeline.mjs");
+
+function runLegacyBenchmark({
+  codexHome,
+  stateDirectory,
+  startAt = "2025-08-02T00:00:00.000Z",
+  endAt = "2026-08-02T00:00:00.000Z",
+  workers = 1,
+}) {
+  return new Promise((resolveResult, reject) => {
+    const child = spawn(process.execPath, [
+      SCRIPT,
+      "--codex-home",
+      codexHome,
+      "--state",
+      stateDirectory,
+      "--start-at",
+      startAt,
+      "--end-at",
+      endAt,
+      "--workers",
+      String(workers),
+    ], {
+      cwd: ROOT,
+      env: { ...process.env },
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    let stdout = "";
+    let stderr = "";
+    child.stdout.setEncoding("utf8");
+    child.stderr.setEncoding("utf8");
+    child.stdout.on("data", (chunk) => { stdout += chunk; });
+    child.stderr.on("data", (chunk) => { stderr += chunk; });
+    child.on("error", reject);
+    child.on("close", (code, signal) => {
+      resolveResult({ code, signal, stdout, stderr });
+    });
+  });
+}
+
+test("retained legacy benchmark emits JSON after the accounting refresh", async () => {
+  const root = await mkdtemp(join(tmpdir(), "legacy-analysis-pipeline-cli-"));
+  const fixtureDirectory = join(root, "fixture");
+  const stateDirectory = join(root, "state");
+  try {
+    const corpus = await createSyntheticLocalIndexRetirementCorpus(
+      fixtureDirectory,
+    );
+    const result = await runLegacyBenchmark({
+      codexHome: corpus.codexHome,
+      stateDirectory,
+    });
+
+    assert.equal(result.signal, null);
+    assert.equal(result.code, 0, result.stderr || result.stdout);
+    assert.equal(result.stderr, "");
+    const receipt = JSON.parse(result.stdout);
+    assert.equal(receipt.schemaVersion, "local-analysis-performance-receipt-v2");
+    assert.deepEqual(receipt.accountingWindow, {
+      startAt: "2025-08-02T00:00:00.000Z",
+      endAt: "2026-08-02T00:00:00.000Z",
+      durationDays: 365,
+    });
+    assert.deepEqual(receipt.coveredAt, {
+      startAt: receipt.accountingWindow.startAt,
+      endAt: receipt.accountingWindow.endAt,
+    });
+    assert.equal(receipt.accounting.sourceMode, "legacy");
+    assert.equal(receipt.accounting.events, 4);
+    assert.equal(receipt.accounting.totalTokens, 800);
+    assert.equal(receipt.sourceCount, 2);
+    assert.equal(receipt.privacy.sourcePathsStored, false);
+    assert.equal(receipt.privacy.rawJsonStored, false);
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("standalone legacy benchmark rejects noncanonical or unsupported windows", async () => {
+  const root = await mkdtemp(join(tmpdir(), "legacy-analysis-pipeline-window-"));
+  const fixtureDirectory = join(root, "fixture");
+  try {
+    const corpus = await createSyntheticLocalIndexRetirementCorpus(
+      fixtureDirectory,
+    );
+    const noncanonical = await runLegacyBenchmark({
+      codexHome: corpus.codexHome,
+      stateDirectory: join(root, "noncanonical-state"),
+      startAt: "2025-08-02T00:00:00Z",
+    });
+    assert.notEqual(noncanonical.code, 0);
+    assert.match(noncanonical.stderr, /canonical ISO instants/u);
+
+    const unsupported = await runLegacyBenchmark({
+      codexHome: corpus.codexHome,
+      stateDirectory: join(root, "unsupported-state"),
+      startAt: "2026-07-01T00:00:00.000Z",
+    });
+    assert.notEqual(unsupported.code, 0);
+    assert.match(unsupported.stderr, /between 365 and 3653 days/u);
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});

--- a/test/export-tibotattle.test.js
+++ b/test/export-tibotattle.test.js
@@ -38,6 +38,18 @@ test("client exporter creates a history-free, verified allow-list artifact", asy
     assert.equal(verified.files.some((path) => path.startsWith("apps/web/public/admin")), false);
     assert.equal(verified.files.length, created.fileCount);
 
+    // The unified reader is part of the shipped local client. Keep the old
+    // index/archive modules in the reviewed runtime inventory while rollback
+    // remains supported; this test makes both halves of that boundary explicit.
+    for (const path of [
+      "src/local-unified-accounting-source.js",
+      "src/local-analysis-index.js",
+      "src/local-archive-accounting-index.js",
+      "src/replay-safe-accounting-cache.js",
+    ]) {
+      assert.equal(verified.files.includes(path), true, `export must include ${path}`);
+    }
+
     const workspace = await readFile(join(output, "pnpm-workspace.yaml"), "utf8");
     assert.match(workspace, /^  fast-uri: 3\.1\.5$/m);
 

--- a/test/local-accounting-parity-receipt.test.js
+++ b/test/local-accounting-parity-receipt.test.js
@@ -1,0 +1,446 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  LOCAL_ACCOUNTING_PARITY_RECEIPT_SCOPE,
+  LOCAL_ACCOUNTING_PARITY_RECEIPT_SCOPE_VERSION,
+  LOCAL_ACCOUNTING_PARITY_RECEIPT_VERSION,
+  compareLocalAccountingSemanticReceipts,
+  createLocalAccountingSemanticReceipt,
+} from "../src/local-accounting-parity-receipt.js";
+
+const START_AT = "2026-08-01T00:00:00.000Z";
+const END_AT = "2026-08-02T00:00:00.000Z";
+const BYTE_KEY = new TextEncoder().encode(
+  "local-accounting-parity-test-key-v1",
+);
+const OTHER_BYTE_KEY = new TextEncoder().encode(
+  "local-accounting-parity-other-key-v1",
+);
+
+const COMPONENT_KEYS = [
+  "input_uncached_tokens",
+  "input_cache_read_tokens",
+  "input_cache_write_tokens",
+  "output_text_tokens",
+  "output_reasoning_tokens",
+  "output_combined_tokens",
+];
+
+function usage({
+  timestamp = "2026-08-01T12:00:00.000Z",
+  model = "gpt-5.6-sol",
+  input = 10,
+  components = null,
+  totalInputContextTokens = 1_000,
+  omitTotalInputContext = false,
+  speed = "standard",
+  apiServiceTier = "unknown",
+  surface = "extension_or_ide",
+  agentScope = "root",
+  lineage = "standalone",
+} = {}) {
+  return {
+    timestamp,
+    // These fields are deliberately not part of the semantic projection.
+    timestampMs: Date.parse(timestamp),
+    sequence: 99,
+    sourceRolloutOrdinal: 123,
+    sourceRecordOrdinal: 456,
+    model,
+    ...(omitTotalInputContext ? {} : { totalInputContextTokens }),
+    components: components ?? Object.fromEntries(COMPONENT_KEYS.map((key) => [
+      key,
+      key === "input_uncached_tokens" ? input : 0,
+    ])),
+    tierSemantics: { codexSpeedMode: speed, apiServiceTier },
+    surfaceClassification: {
+      surface,
+      agentScope,
+      lineageDisposition: lineage,
+    },
+  };
+}
+
+function quota({
+  timestamp = "2026-08-01T13:00:00.000Z",
+  usedPercent = 21.25,
+  provider = "openai_codex",
+  planType = "pro",
+  limitId = "codex",
+  slot = "primary",
+  durationMinutes = 10_080,
+  resetsAt = Math.floor(Date.parse(END_AT) / 1_000),
+} = {}) {
+  return {
+    timestamp,
+    timestampMs: Date.parse(timestamp),
+    sequence: 100,
+    sourceRolloutOrdinal: 789,
+    sourceRecordOrdinal: 987,
+    window: {
+      provider,
+      planType,
+      limitId,
+      slot,
+      usedPercent,
+      windowDurationMins: durationMinutes,
+      resetsAt,
+    },
+    // Quota classification is not consumed by replay-safe accounting.
+    surfaceClassification: { surface: "/private/canary/surface" },
+  };
+}
+
+function scannerFor(rows, { reverse = false, asynchronous = false } = {}) {
+  return async ({ startAt, endAt, signal, onUsage, onRateLimitSnapshot }) => {
+    assert.equal(startAt, START_AT);
+    assert.equal(endAt, END_AT);
+    assert.ok(signal === null || typeof signal === "object");
+    const sequence = reverse ? [...rows].reverse() : rows;
+    for (const row of sequence) {
+      if (row.kind === "usage") {
+        if (asynchronous) await Promise.resolve();
+        await onUsage(row.value);
+      } else {
+        if (asynchronous) await Promise.resolve();
+        await onRateLimitSnapshot(row.value);
+      }
+    }
+    // Scanner diagnostics are intentionally discarded by the receipt.
+    return {
+      diagnostics: {
+        path: "/private/canary/path",
+        content: "PRIVATE_PARITY_CANARY",
+        error: "PRIVATE_PARITY_ERROR",
+      },
+    };
+  };
+}
+
+function rows() {
+  return [
+    {
+      kind: "usage",
+      value: usage({ input: 10, speed: "standard" }),
+    },
+    {
+      kind: "usage",
+      value: usage({
+        timestamp: "2026-08-01T14:00:00.000Z",
+        model: "gpt-5.6-terra",
+        input: 20,
+        speed: "fast",
+        apiServiceTier: "priority",
+        surface: "cli_exec",
+        agentScope: "subagent",
+        lineage: "forked",
+      }),
+    },
+    {
+      kind: "quota",
+      value: quota({ usedPercent: 21.25 }),
+    },
+    {
+      kind: "quota",
+      value: quota({
+        timestamp: "2026-08-01T14:00:00.000Z",
+        usedPercent: 23.5,
+        slot: "secondary",
+      }),
+    },
+  ];
+}
+
+async function receipt(source, options = {}) {
+  return createLocalAccountingSemanticReceipt({
+    scan: source,
+    startAt: START_AT,
+    endAt: END_AT,
+    byteKey: BYTE_KEY,
+    ...options,
+  });
+}
+
+test("receipt is pinned, content-free, and excludes source identifiers", async () => {
+  const value = await receipt(scannerFor(rows()));
+  assert.equal(value.version, LOCAL_ACCOUNTING_PARITY_RECEIPT_VERSION);
+  assert.equal(value.scope, LOCAL_ACCOUNTING_PARITY_RECEIPT_SCOPE);
+  assert.equal(value.scopeVersion, LOCAL_ACCOUNTING_PARITY_RECEIPT_SCOPE_VERSION);
+  assert.deepEqual(value.window, { startAt: START_AT, endAt: END_AT });
+  assert.equal(value.usage.count, 2);
+  assert.equal(value.usage.totalTokens, 30);
+  assert.equal(value.quota.count, 2);
+  assert.equal(Object.hasOwn(value, "diagnostics"), false);
+  assert.equal(Object.hasOwn(value.usage, "rows"), false);
+  assert.equal(Object.hasOwn(value.quota, "rows"), false);
+  const serialized = JSON.stringify(value);
+  for (const canary of [
+    "PRIVATE_PARITY_CANARY",
+    "PRIVATE_PARITY_ERROR",
+    "/private/canary/path",
+    "/private/canary/surface",
+  ]) assert.equal(serialized.includes(canary), false);
+});
+
+test("order changes do not change a keyed multiset receipt", async () => {
+  const first = await receipt(scannerFor(rows()));
+  const reversed = await receipt(scannerFor(rows(), {
+    reverse: true,
+    asynchronous: true,
+  }));
+  assert.deepEqual(reversed, first);
+  assert.deepEqual(compareLocalAccountingSemanticReceipts(first, reversed), {
+    equal: true,
+    mismatchCategories: [],
+  });
+});
+
+test("duplicate rows are multiplicity-sensitive", async () => {
+  const originalRows = rows();
+  const first = await receipt(scannerFor(originalRows));
+  const duplicated = await receipt(scannerFor([
+    ...originalRows,
+    originalRows[0],
+  ]));
+  const comparison = compareLocalAccountingSemanticReceipts(first, duplicated);
+  assert.equal(comparison.equal, false);
+  assert.ok(comparison.mismatchCategories.includes("usage_count"));
+  assert.ok(comparison.mismatchCategories.includes("usage_tokens"));
+  assert.ok(comparison.mismatchCategories.includes("usage_digest"));
+  assert.ok(comparison.mismatchCategories.includes("usage_dimensions"));
+});
+
+test("zero-token usage callbacks are suppressed before receipt aggregation", async () => {
+  const baseline = await receipt(scannerFor(rows()));
+  const withZero = await receipt(scannerFor([
+    { kind: "usage", value: usage({ input: 0 }) },
+    ...rows(),
+  ]));
+  assert.deepEqual(
+    compareLocalAccountingSemanticReceipts(baseline, withZero),
+    { equal: true, mismatchCategories: [] },
+  );
+  assert.equal(withZero.usage.count, baseline.usage.count);
+  assert.equal(withZero.usage.totalTokens, baseline.usage.totalTokens);
+});
+
+test("absent context tokens remain distinct from an explicit zero", async () => {
+  const absent = await receipt(scannerFor([{
+    kind: "usage",
+    value: usage({ omitTotalInputContext: true }),
+  }]));
+  const explicitZero = await receipt(scannerFor([{
+    kind: "usage",
+    value: usage({ totalInputContextTokens: 0 }),
+  }]));
+  assert.equal(absent.usage.totalInputContextTokens, 0);
+  assert.equal(explicitZero.usage.totalInputContextTokens, 0);
+  assert.equal(absent.usage.missingTotalInputContextCount, 1);
+  assert.equal(explicitZero.usage.missingTotalInputContextCount, 0);
+  const comparison = compareLocalAccountingSemanticReceipts(
+    absent,
+    explicitZero,
+  );
+  assert.equal(comparison.equal, false);
+  assert.ok(comparison.mismatchCategories.includes("usage_tokens"));
+  assert.ok(comparison.mismatchCategories.includes("usage_digest"));
+});
+
+test("callbacks outside the pinned window do not enter the receipt", async () => {
+  const baseline = await receipt(scannerFor(rows()));
+  const outside = await receipt(scannerFor([
+    {
+      kind: "usage",
+      value: usage({
+        timestamp: "2026-07-31T23:59:59.999Z",
+        input: 999,
+      }),
+    },
+    {
+      kind: "quota",
+      value: quota({
+        timestamp: "2026-08-02T00:00:00.001Z",
+        usedPercent: 99,
+      }),
+    },
+    ...rows(),
+  ]));
+  assert.deepEqual(
+    compareLocalAccountingSemanticReceipts(baseline, outside),
+    { equal: true, mismatchCategories: [] },
+  );
+});
+
+test("a different receipt key changes the keyed digests", async () => {
+  const first = await receipt(scannerFor(rows()));
+  const second = await receipt(scannerFor(rows()), { byteKey: OTHER_BYTE_KEY });
+  const comparison = compareLocalAccountingSemanticReceipts(first, second);
+  assert.equal(comparison.equal, false);
+  assert.ok(comparison.mismatchCategories.includes("usage_digest"));
+  assert.ok(comparison.mismatchCategories.includes("usage_dimensions"));
+  assert.ok(comparison.mismatchCategories.includes("quota_digest"));
+  assert.ok(comparison.mismatchCategories.includes("quota_dimensions"));
+});
+
+test("omitted combined-output components are zero, matching the legacy reader", async () => {
+  const omitted = usage({ input: 7 });
+  delete omitted.components.output_combined_tokens;
+  const explicitZero = usage({ input: 7 });
+  const omittedReceipt = await receipt(scannerFor([{
+    kind: "usage",
+    value: omitted,
+  }]));
+  const explicitReceipt = await receipt(scannerFor([{
+    kind: "usage",
+    value: explicitZero,
+  }]));
+  assert.equal(omittedReceipt.usage.totalTokens, 7);
+  assert.deepEqual(
+    compareLocalAccountingSemanticReceipts(omittedReceipt, explicitReceipt),
+    { equal: true, mismatchCategories: [] },
+  );
+});
+
+test("separated output takes precedence over the overlapping combined alias", async () => {
+  const withAlias = usage({
+    input: 1,
+    components: {
+      input_uncached_tokens: 1,
+      input_cache_read_tokens: 0,
+      input_cache_write_tokens: 0,
+      output_text_tokens: 4,
+      output_reasoning_tokens: 6,
+      output_combined_tokens: 999,
+    },
+  });
+  const separatedOnly = structuredClone(withAlias);
+  separatedOnly.components.output_combined_tokens = 0;
+  const withAliasReceipt = await receipt(scannerFor([{
+    kind: "usage",
+    value: withAlias,
+  }]));
+  const separatedOnlyReceipt = await receipt(scannerFor([{
+    kind: "usage",
+    value: separatedOnly,
+  }]));
+  assert.equal(withAliasReceipt.usage.totalTokens, 11);
+  assert.deepEqual(
+    compareLocalAccountingSemanticReceipts(
+      withAliasReceipt,
+      separatedOnlyReceipt,
+    ),
+    { equal: true, mismatchCategories: [] },
+  );
+});
+
+test("semantic usage and quota changes have fixed mismatch categories", async () => {
+  const changedRows = rows();
+  changedRows[1] = {
+    ...changedRows[1],
+    value: usage({
+      timestamp: "2026-08-01T14:00:00.000Z",
+      model: "gpt-5.6-terra",
+      input: 20,
+      speed: "standard",
+      apiServiceTier: "priority",
+      surface: "cli_exec",
+      agentScope: "subagent",
+      lineage: "forked",
+    }),
+  };
+  changedRows[3] = {
+    ...changedRows[3],
+    value: quota({
+      timestamp: "2026-08-01T14:00:00.000Z",
+      usedPercent: 24.5,
+      slot: "secondary",
+    }),
+  };
+  const comparison = compareLocalAccountingSemanticReceipts(
+    await receipt(scannerFor(rows())),
+    await receipt(scannerFor(changedRows)),
+  );
+  assert.equal(comparison.equal, false);
+  assert.deepEqual(comparison.mismatchCategories, [
+    "usage_digest",
+    "usage_dimensions",
+    "quota_digest",
+    "quota_dimensions",
+  ]);
+});
+
+test("receipt schema changes are reported as a fixed category", async () => {
+  const first = await receipt(scannerFor(rows()));
+  const changed = { ...first, version: "local-accounting-semantic-receipt-v2" };
+  assert.deepEqual(compareLocalAccountingSemanticReceipts(first, changed), {
+    equal: false,
+    mismatchCategories: ["receipt_schema"],
+  });
+});
+
+test("malformed callback values fail with fixed errors and no scanner text", async () => {
+  await assert.rejects(
+    receipt(scannerFor([{
+      kind: "usage",
+      value: usage({
+        components: "PRIVATE_PARITY_CANARY",
+      }),
+    }])),
+    (error) => (
+      error.code === "accounting_parity_usage_callback_invalid"
+      && error.message === "accounting_parity_usage_callback_invalid"
+      && !error.message.includes("PRIVATE_PARITY_CANARY")
+    ),
+  );
+  await assert.rejects(
+    receipt(scannerFor([{
+      kind: "quota",
+      value: quota({ usedPercent: Number.NaN }),
+    }])),
+    (error) => (
+      error.code === "accounting_parity_quota_callback_invalid"
+      && error.message === "accounting_parity_quota_callback_invalid"
+    ),
+  );
+  await assert.rejects(
+    receipt(async () => {
+      throw new Error("PRIVATE_PARITY_CANARY /private/canary/path");
+    }),
+    (error) => (
+      error.code === "accounting_parity_scan_failed"
+      && error.message === "accounting_parity_scan_failed"
+      && !error.message.includes("PRIVATE_PARITY_CANARY")
+      && !error.message.includes("/private/canary/path")
+    ),
+  );
+});
+
+test("pinned windows, byte keys, and aborts are validated", async () => {
+  await assert.rejects(
+    createLocalAccountingSemanticReceipt({
+      scan: scannerFor(rows()),
+      startAt: "2026-08-01T00:00:00Z",
+      endAt: END_AT,
+      byteKey: BYTE_KEY,
+    }),
+    (error) => error.code === "accounting_parity_window_invalid",
+  );
+  await assert.rejects(
+    receipt(scannerFor(rows()), { byteKey: new Uint8Array(31) }),
+    (error) => error.code === "accounting_parity_byte_key_invalid",
+  );
+  await assert.rejects(
+    receipt(scannerFor(rows()), { byteKey: new Uint8Array(257) }),
+    (error) => error.code === "accounting_parity_byte_key_invalid",
+  );
+  const controller = new AbortController();
+  controller.abort();
+  await assert.rejects(
+    receipt(scannerFor(rows()), { signal: controller.signal }),
+    (error) => (
+      error.name === "AbortError"
+      && error.code === "accounting_parity_aborted"
+    ),
+  );
+});

--- a/test/local-analysis-index.test.js
+++ b/test/local-analysis-index.test.js
@@ -254,6 +254,33 @@ test("does not launch an empty worker for one source with many chunks", async ()
   assert.equal(workerLaunches, 1);
 });
 
+test("preserves bounded accounting callback stops for cache-level handling", async () => {
+  const { root, codexHome } = await fixture();
+  const indexFile = join(root, "local-analysis-index-callback-stop.sqlite");
+  const secretFile = join(root, "local-analysis-index-callback-stop-secret");
+  let callbackCount = 0;
+  const callbackStop = new Error("accounting_transition_rss_limit_exceeded");
+  callbackStop.code = "accounting_transition_rss_limit_exceeded";
+
+  await assert.rejects(
+    refreshLocalAnalysisIndex({
+      indexFile,
+      secretFile,
+      codexHome,
+      startAt: START_AT,
+      endAt: END_AT,
+      workerCount: 1,
+      chunkBytes: CHUNK_BYTES,
+      onUsage() {
+        callbackCount += 1;
+        throw callbackStop;
+      },
+    }),
+    { code: "accounting_transition_rss_limit_exceeded" },
+  );
+  assert.equal(callbackCount > 0, true);
+});
+
 test("preserves source-affine shard mapping and chunk order", async () => {
   const { root, codexHome } = await chunkedFixture({
     includeSecondSource: true,
@@ -808,6 +835,7 @@ test("the canonical SQLite accounting state never falls back to an index project
   const nowMs = Date.parse(END_AT);
   const written = await refreshReplaySafeAccountingCache({
     stateFile,
+    sourceMode: "legacy",
     indexFile,
     indexSecretFile,
     codexHome,

--- a/test/local-collector-state.test.js
+++ b/test/local-collector-state.test.js
@@ -3,6 +3,7 @@ import assert from "node:assert/strict";
 import { spawn } from "node:child_process";
 import { createHash } from "node:crypto";
 import { once } from "node:events";
+import { DatabaseSync } from "node:sqlite";
 import { mkdir, mkdtemp, readFile, rm, stat, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -15,8 +16,11 @@ import {
   migrateLegacyLocalCollectorState,
   planLocalCollectorStateRetention,
   prepareLocalCollectorState,
+  LOCAL_COLLECTOR_LEGACY_REFRESH_USE_MAX,
+  readLocalCollectorLegacyRefreshUse,
   readLocalCollectorRolloutStalenessSummary,
   readLocalCollectorState,
+  recordLocalCollectorLegacyRefreshAttempt,
 } from "../src/local-collector-state.js";
 import { stableJson } from "../src/storage.js";
 
@@ -92,6 +96,99 @@ test("SQLite commits collector records and checkpoints atomically", async () => 
     if (process.platform !== "win32") {
       assert.equal((await stat(value.stateFile)).mode & 0o777, 0o600);
     }
+  } finally {
+    await rm(value.root, { recursive: true, force: true });
+  }
+});
+
+test("legacy refresh-use receipt increments durably in one fixed meta row", async () => {
+  const value = await fixture();
+  try {
+    const first = await recordLocalCollectorLegacyRefreshAttempt({
+      stateFile: value.stateFile,
+      clock: () => Date.parse("2026-08-03T00:00:00.000Z"),
+    });
+    assert.deepEqual(first, {
+      schemaVersion: "local-collector-legacy-refresh-use-v1",
+      sourceMode: "legacy",
+      attempts: 1,
+      saturated: false,
+      lastAttemptedAt: "2026-08-03T00:00:00.000Z",
+    });
+    const second = await recordLocalCollectorLegacyRefreshAttempt({
+      stateFile: value.stateFile,
+      clock: () => Date.parse("2026-08-03T00:01:00.000Z"),
+    });
+    assert.equal(second.attempts, 2);
+    assert.equal(
+      (await readLocalCollectorLegacyRefreshUse({ stateFile: value.stateFile }))
+        .receipt.lastAttemptedAt,
+      "2026-08-03T00:01:00.000Z",
+    );
+    const state = await readLocalCollectorState({
+      stateFile: value.stateFile,
+      includeRecords: false,
+    });
+    assert.deepEqual(state.legacyRefreshUse, second);
+    const database = new DatabaseSync(value.stateFile, { readOnly: true });
+    const rowCount = Number(database.prepare(
+      "SELECT COUNT(*) AS count FROM meta WHERE key = 'legacy_refresh_use'",
+    ).get().count);
+    database.close();
+    assert.equal(rowCount, 1);
+  } finally {
+    await rm(value.root, { recursive: true, force: true });
+  }
+});
+
+test("legacy refresh-use receipt saturates without growing rows and rejects corrupt shape", async () => {
+  const value = await fixture();
+  try {
+    await recordLocalCollectorLegacyRefreshAttempt({
+      stateFile: value.stateFile,
+      clock: () => Date.parse("2026-08-03T00:00:00.000Z"),
+    });
+    let database = new DatabaseSync(value.stateFile, { readOnly: false });
+    database.prepare(
+      "UPDATE meta SET value_json = ? WHERE key = 'legacy_refresh_use'",
+    ).run(JSON.stringify({
+      schemaVersion: "local-collector-legacy-refresh-use-v1",
+      sourceMode: "legacy",
+      attempts: LOCAL_COLLECTOR_LEGACY_REFRESH_USE_MAX - 1,
+      saturated: false,
+      lastAttemptedAt: "2026-08-03T00:00:00.000Z",
+    }));
+    database.close();
+
+    const saturated = await recordLocalCollectorLegacyRefreshAttempt({
+      stateFile: value.stateFile,
+      clock: () => Date.parse("2026-08-03T00:02:00.000Z"),
+    });
+    assert.equal(saturated.attempts, LOCAL_COLLECTOR_LEGACY_REFRESH_USE_MAX);
+    assert.equal(saturated.saturated, true);
+    const stillSaturated = await recordLocalCollectorLegacyRefreshAttempt({
+      stateFile: value.stateFile,
+      clock: () => Date.parse("2026-08-03T00:03:00.000Z"),
+    });
+    assert.equal(stillSaturated.attempts, LOCAL_COLLECTOR_LEGACY_REFRESH_USE_MAX);
+    assert.equal(stillSaturated.lastAttemptedAt, "2026-08-03T00:03:00.000Z");
+
+    database = new DatabaseSync(value.stateFile, { readOnly: true });
+    const rowCount = Number(database.prepare(
+      "SELECT COUNT(*) AS count FROM meta WHERE key = 'legacy_refresh_use'",
+    ).get().count);
+    database.close();
+    assert.equal(rowCount, 1);
+
+    database = new DatabaseSync(value.stateFile, { readOnly: false });
+    database.prepare(
+      "UPDATE meta SET value_json = ? WHERE key = 'legacy_refresh_use'",
+    ).run(JSON.stringify({ attempts: "not-a-count" }));
+    database.close();
+    await assert.rejects(
+      () => readLocalCollectorLegacyRefreshUse({ stateFile: value.stateFile }),
+      { code: "local_collector_state_corrupt" },
+    );
   } finally {
     await rm(value.root, { recursive: true, force: true });
   }

--- a/test/local-companion-data.test.js
+++ b/test/local-companion-data.test.js
@@ -1,5 +1,6 @@
 import test from "node:test";
 import assert from "node:assert/strict";
+import { renameSync } from "node:fs";
 import {
   mkdir,
   mkdtemp,
@@ -25,6 +26,13 @@ import {
   writeLocalCollectorAccountingCache,
 } from "../src/local-collector-state.js";
 import { emptySpeedWeightingCrossing } from "@app-usagemonitor/accounting";
+import {
+  openLocalUnifiedIndex,
+  readUnifiedIndexGenerationDescriptor,
+} from "../src/local-unified-index.js";
+import {
+  readLocalUnifiedCompanionProjection,
+} from "../src/local-unified-companion-source.js";
 
 const ARTIFACT_FILES = {
   gradient: "2026-07-24-simple-quota-gradient-artifact.json",
@@ -1728,6 +1736,24 @@ test("the unified index removes the 31-day ceiling and keeps fork replay out of 
       count("2026-07-25T11:30:00.000Z", usageTotals(100, 10), usageTotals(100, 10)),
       count("2026-07-25T11:30:01.000Z", usageTotals(300, 30), usageTotals(200, 20)),
       turn("2026-07-25T11:30:02.000Z"),
+      ...Array.from({ length: 4 }, (_, index) => line({
+        timestamp: `2026-07-25T11:30:02.${String(index + 1).padStart(3, "0")}Z`,
+        type: "response_item",
+        payload: {
+          type: "function_call",
+          name: "thread_spawn",
+          call_id: `private-subagent-call-${index}`,
+        },
+      })),
+      ...Array.from({ length: 2 }, (_, index) => line({
+        timestamp: `2026-07-25T11:30:02.${String(index + 5).padStart(3, "0")}Z`,
+        type: "response_item",
+        payload: {
+          type: "custom_tool_call",
+          name: "private-tool-class",
+          call_id: `private-other-call-${index}`,
+        },
+      })),
       count("2026-07-25T11:30:03.000Z", usageTotals(400, 50), usageTotals(100, 20)),
     ].join("\n")}\n`);
     const { rebuildLocalUnifiedIndex } = await import("../src/local-unified-index-build.js");
@@ -1739,6 +1765,53 @@ test("the unified index removes the 31-day ceiling and keeps fork replay out of 
     });
     assert.equal(built.usageEvents, 3);
     assert.equal(built.forkReplayEventsSkipped, 2);
+    assert.equal(built.toolEvents, 6);
+
+    // A readable SQLite publication whose ingest status is partial remains
+    // useful coverage metadata, but it is not an accounting authority.
+    const partialIndexFile = join(
+      root,
+      ".usage-monitor",
+      "local-unified-index-v1.sqlite",
+    );
+    const partialDatabase = openLocalUnifiedIndex(partialIndexFile, {
+      readOnly: false,
+    });
+    partialDatabase.prepare(
+      "UPDATE meta SET value = ? WHERE key = 'status'",
+    ).run("partial");
+    partialDatabase.close();
+    const partialSnapshot = await buildLocalCompanionSnapshot({
+      root,
+      accountingSourceMode: "unified",
+      unifiedIndexFile: partialIndexFile,
+      allowDevelopmentArtifactFallback: false,
+      now: () => Date.parse("2026-07-25T12:00:00.000Z"),
+    });
+    assert.equal(partialSnapshot.overview.timeline.history.status, "partial");
+    assert.equal(
+      partialSnapshot.overview.timeline.history.reason,
+      "unified_index_partial",
+    );
+    assert.equal(partialSnapshot.overview.timeline.source, "insufficient_evidence");
+    assert.equal(
+      partialSnapshot.overview.accounting.accountingSource,
+      "insufficient_evidence",
+    );
+    assert.equal(
+      partialSnapshot.overview.usage.find((period) => period.id === "all").events,
+      0,
+    );
+    assert.ok(partialSnapshot.overview.warnings.some((warning) => (
+      warning.includes("readable but only partially covered")
+    )));
+    const restoredDatabase = openLocalUnifiedIndex(partialIndexFile, {
+      readOnly: false,
+    });
+    restoredDatabase.prepare(
+      "UPDATE meta SET value = ? WHERE key = 'status'",
+    ).run("complete");
+    restoredDatabase.close();
 
     const snapshot = await buildLocalCompanionSnapshot({
       root,
@@ -1819,6 +1892,9 @@ test("the unified index removes the 31-day ceiling and keeps fork replay out of 
         ?.status,
       "partial",
     );
+    // Legacy rollback mode continues to read the collector ledger; it must
+    // not silently adopt typed unified-index tool counts.
+    assert.equal(snapshot.overview.tools.total, 0);
     assert.ok(!snapshot.overview.warnings.some((warning) => (
       warning.includes("live collector projection")
     )));
@@ -1829,6 +1905,194 @@ test("the unified index removes the 31-day ceiling and keeps fork replay out of 
     const serialized = JSON.stringify(snapshot);
     assert.ok(!serialized.includes("session-deep-parent"));
     assert.ok(!serialized.includes("/Users/private"));
+
+    // Cutover mode reads its long history from the generation-bound cache,
+    // never from the rollback archive. A deliberately invalid archive
+    // sentinel proves the old reader is not even consulted.
+    const stateDirectory = join(root, ".usage-monitor");
+    const collectorStateFile = join(
+      stateDirectory,
+      "local-collector-state-v1.sqlite",
+    );
+    const unifiedIndexFile = join(
+      stateDirectory,
+      "local-unified-index-v1.sqlite",
+    );
+    const archiveIndexFile = join(
+      stateDirectory,
+      "local-archive-accounting-index-v1.sqlite",
+    );
+    await writeFile(archiveIndexFile, "rollback-sentinel", { mode: 0o600 });
+    const archiveBefore = await stat(archiveIndexFile);
+    await refreshReplaySafeAccountingCache({
+      stateFile: collectorStateFile,
+      sourceMode: "unified",
+      unifiedIndexFile,
+      expectedGeneration: built.generation,
+      contextBehavior: "legacy_zero",
+      codexHome: root,
+      now: () => Date.parse("2026-07-25T12:00:00.000Z"),
+    });
+    const unifiedSnapshot = await buildLocalCompanionSnapshot({
+      root,
+      accountingSourceMode: "unified",
+      archiveIndexFile,
+      unifiedIndexFile,
+      allowDevelopmentArtifactFallback: false,
+      now: () => Date.parse("2026-07-25T12:00:00.000Z"),
+    });
+    const archiveAfter = await stat(archiveIndexFile);
+    assert.equal(archiveAfter.size, archiveBefore.size);
+    assert.equal(archiveAfter.mtimeMs, archiveBefore.mtimeMs);
+    const history = unifiedSnapshot.overview.accounting.periods
+      .find((period) => period.periodId === "history");
+    assert.equal(history.events, 3);
+    assert.equal(history.totalTokens, 110 + 220 + 120);
+    assert.equal(
+      unifiedSnapshot.overview.accounting.historyPeriodStatus,
+      "available",
+    );
+    assert.equal(
+      unifiedSnapshot.overview.accounting.historyCoverage.status,
+      "complete",
+    );
+    assert.equal(
+      unifiedSnapshot.overview.accounting.historyCoverage.sourceMode,
+      "unified",
+    );
+    assert.equal(unifiedSnapshot.overview.accounting.sourceMode, "unified");
+    assert.equal(
+      unifiedSnapshot.overview.accounting.compatibilityBehavior,
+      "legacy_zero",
+    );
+    assert.equal(
+      unifiedSnapshot.overview.accounting.generationMatched,
+      true,
+    );
+    assert.equal(
+      unifiedSnapshot.overview.accounting.diagnosticsAvailable,
+      true,
+    );
+    assert.equal(
+      unifiedSnapshot.overview.accounting.sourceCapabilities
+        .crashSafeGenerationPublication,
+      true,
+    );
+    assert.equal(unifiedSnapshot.overview.tools.total, 6);
+    assert.equal(unifiedSnapshot.overview.tools.counts.subagent, 4);
+    assert.equal(unifiedSnapshot.overview.tools.counts.other, 2);
+    assert.equal(unifiedSnapshot.overview.evidenceStatus, "available");
+    assert.equal(unifiedSnapshot.overview.freshness.status, "live");
+    assert.equal(
+      unifiedSnapshot.overview.freshness.latestObservedAt,
+      "2026-07-25T11:30:03.000Z",
+    );
+    assert.deepEqual(unifiedSnapshot.overview.collector.exportableCoveredAt, {
+      startAt: "2026-06-01T12:00:01.000Z",
+      endAt: "2026-07-25T11:30:03.000Z",
+    });
+
+    const toolPartialDatabase = openLocalUnifiedIndex(unifiedIndexFile, {
+      readOnly: false,
+    });
+    toolPartialDatabase.prepare(`
+      UPDATE index_generation
+      SET status = 'partial', block_reason = 'tool_provenance_incomplete',
+          tool_provenance_complete = 0
+      WHERE id = (SELECT CAST(value AS INTEGER) FROM meta
+                  WHERE key = 'current_generation_id')
+    `).run();
+    toolPartialDatabase.prepare(
+      "UPDATE meta SET value = 'partial' WHERE key = 'status'",
+    ).run();
+    const toolPartialGeneration = readUnifiedIndexGenerationDescriptor(
+      toolPartialDatabase,
+    );
+    toolPartialDatabase.close();
+    await refreshReplaySafeAccountingCache({
+      stateFile: collectorStateFile,
+      sourceMode: "unified",
+      unifiedIndexFile,
+      expectedGeneration: toolPartialGeneration,
+      contextBehavior: "legacy_zero",
+      codexHome: root,
+      now: () => Date.parse("2026-07-25T12:00:00.000Z"),
+    });
+    const toolPartialSnapshot = await buildLocalCompanionSnapshot({
+      root,
+      accountingSourceMode: "unified",
+      archiveIndexFile,
+      unifiedIndexFile,
+      allowDevelopmentArtifactFallback: false,
+      now: () => Date.parse("2026-07-25T12:00:00.000Z"),
+    });
+    assert.equal(
+      toolPartialSnapshot.overview.usage.find((period) => period.id === "all")
+        .events,
+      3,
+    );
+    assert.equal(toolPartialSnapshot.overview.tools.total, 0);
+    assert.ok(toolPartialSnapshot.overview.warnings.some((warning) => (
+      warning.includes("typed tool history is partial")
+    )));
+    const restoreToolDatabase = openLocalUnifiedIndex(unifiedIndexFile, {
+      readOnly: false,
+    });
+    restoreToolDatabase.prepare(`
+      UPDATE index_generation
+      SET status = 'complete', block_reason = NULL,
+          tool_provenance_complete = 1
+      WHERE id = (SELECT CAST(value AS INTEGER) FROM meta
+                  WHERE key = 'current_generation_id')
+    `).run();
+    restoreToolDatabase.prepare(
+      "UPDATE meta SET value = 'complete' WHERE key = 'status'",
+    ).run();
+    restoreToolDatabase.close();
+
+    // A copy-on-write publisher replacing the path mid-read must not let the
+    // old opened inode masquerade as the current publication.
+    const movedIndexFile = `${unifiedIndexFile}.reader-race`;
+    let moved = false;
+    const raceBaselines = [];
+    raceBaselines[Symbol.iterator] = function* triggerReplacement() {
+      if (!moved) {
+        moved = true;
+        renameSync(unifiedIndexFile, movedIndexFile);
+      }
+    };
+    let raced;
+    try {
+      raced = await readLocalUnifiedCompanionProjection({
+        indexFile: unifiedIndexFile,
+        declaredSpeedBaselines: raceBaselines,
+        nowMs: Date.parse("2026-07-25T12:00:00.000Z"),
+      });
+    } finally {
+      if (moved) renameSync(movedIndexFile, unifiedIndexFile);
+    }
+    assert.equal(raced.status, "unavailable");
+    assert.equal(raced.errorCode, "local_unified_index_file_changed");
+
+    // The descriptor commits to the exact fixed-class fact set. Any in-place
+    // edit after publication is withheld rather than silently displayed.
+    const tamperedDatabase = openLocalUnifiedIndex(unifiedIndexFile, {
+      readOnly: false,
+    });
+    tamperedDatabase.prepare(`
+      UPDATE tool_class_fact SET tool_class = 'web_search'
+      WHERE event_key = (SELECT event_key FROM tool_class_fact LIMIT 1)
+    `).run();
+    tamperedDatabase.close();
+    const tampered = await readLocalUnifiedCompanionProjection({
+      indexFile: unifiedIndexFile,
+      nowMs: Date.parse("2026-07-25T12:00:00.000Z"),
+    });
+    assert.equal(tampered.status, "unavailable");
+    assert.equal(
+      tampered.errorCode,
+      "local_unified_index_tool_attestation_mismatch",
+    );
   } finally {
     await rm(root, { recursive: true });
   }
@@ -1862,6 +2126,55 @@ test("a missing unified index keeps the bounded window and says so in the payloa
     )));
     const broadest = snapshot.overview.usage.find((period) => period.id === "all");
     assert.equal(broadest.label, "Cached 31-day collector window");
+  } finally {
+    await rm(root, { recursive: true });
+  }
+});
+
+test("unified mode with no valid generation withholds the provisional collector projection", async () => {
+  const root = await fixtureRoot();
+  try {
+    const usage = JSON.stringify({
+      schemaVersion: "0.3",
+      kind: "codex_rollout_usage_snapshot",
+      observedAt: "2026-07-25T11:00:00.000Z",
+      model: "gpt-5.6-sol",
+      components: { input_uncached_tokens: 100 },
+    });
+    const tool = JSON.stringify({
+      kind: "codex_tool_class_event",
+      observedAt: "2026-07-25T11:01:00.000Z",
+      toolClass: "subagent",
+    });
+    await writeFile(
+      join(root, ".usage-monitor", "collector-events.jsonl"),
+      `${usage}\n${tool}\n`,
+      { mode: 0o600 },
+    );
+    const snapshot = await buildLocalCompanionSnapshot({
+      root,
+      accountingSourceMode: "unified",
+      now: () => Date.parse("2026-07-25T12:00:00.000Z"),
+    });
+    assert.equal(snapshot.overview.timeline.source, "insufficient_evidence");
+    assert.deepEqual(snapshot.overview.timeline.usage, []);
+    assert.equal(
+      snapshot.overview.accounting.accountingSource,
+      "insufficient_evidence",
+    );
+    assert.equal(snapshot.overview.pricing.totalCostUsd, 0);
+    assert.equal(snapshot.overview.pricing.eventCount, 0);
+    assert.equal(snapshot.overview.tools.total, 0);
+    assert.deepEqual(snapshot.overview.collector.exportableCoveredAt, {
+      startAt: null,
+      endAt: null,
+    });
+    assert.ok(snapshot.overview.warnings.some((warning) => (
+      warning.includes("Usage totals and timelines remain unavailable")
+    )));
+    assert.ok(!snapshot.overview.warnings.some((warning) => (
+      warning.includes("live collector projection")
+    )));
   } finally {
     await rm(root, { recursive: true });
   }

--- a/test/local-companion-refresh.test.js
+++ b/test/local-companion-refresh.test.js
@@ -18,6 +18,9 @@ import {
   localCompanionStatePaths,
 } from "../src/local-installation-diagnostics.js";
 import {
+  readLocalCollectorLegacyRefreshUse,
+} from "../src/local-collector-state.js";
+import {
   REPLAY_SAFE_ACCOUNTING_SCHEMA_VERSION,
 } from "../src/replay-safe-accounting-cache.js";
 
@@ -70,6 +73,23 @@ const REUSABLE_ACCOUNTING_CACHE = Object.freeze({
   diagnostics: Object.freeze({
     forkReplayEventsExcluded: 29,
   }),
+});
+
+const PUBLIC_LEGACY_ACCOUNTING_AUTHORITY = Object.freeze({
+  sourceMode: "legacy",
+  readerVersion: null,
+  compatibilityBehavior: null,
+  coverageStatus: null,
+  generation: null,
+  generationFingerprint: null,
+  generationMatched: false,
+  fallbackCount: 0,
+  diagnosticsAvailable: false,
+});
+
+const INTERNAL_LEGACY_ACCOUNTING_AUTHORITY = Object.freeze({
+  ...PUBLIC_LEGACY_ACCOUNTING_AUTHORITY,
+  capabilities: null,
 });
 
 const FRESH_NOTIFICATION_EVIDENCE = Object.freeze({
@@ -338,6 +358,9 @@ test("local refresh routes collector, credential lock, and accounting writes ben
     const runner = createLocalCollectorRefreshRunner({
       codexHome: join(stateRoot, "read-only-codex-source"),
       stateFile: paths.collectorStateFile,
+      legacyAnalysisIndexFile: paths.legacyAnalysisIndexFile,
+      legacyAnalysisIndexSecretFile:
+        paths.legacyAnalysisIndexSecretFile,
       accountObservationOperationLockFile:
         paths.accountObservationLockFile,
       selectAccountObservationSecret: (options) => {
@@ -356,8 +379,17 @@ test("local refresh routes collector, credential lock, and accounting writes ben
           },
         };
       },
-      refreshAccounting: async ({ stateFile }) => {
+      refreshAccounting: async ({
+        stateFile,
+        indexFile,
+        indexSecretFile,
+      }) => {
         assert.equal(stateFile, paths.collectorStateFile);
+        assert.equal(indexFile, paths.legacyAnalysisIndexFile);
+        assert.equal(
+          indexSecretFile,
+          paths.legacyAnalysisIndexSecretFile,
+        );
         return {
           generatedAt: "2026-07-23T12:00:00.000Z",
           periods: [],
@@ -438,6 +470,716 @@ test("local refresh starts a bounded archive index only after the foreground res
     status: "scanning",
   });
   assert.equal(JSON.stringify(result).includes("/private/"), false);
+});
+
+test("unified accounting mode never advances the legacy archive and passes explicit authority", async () => {
+  const order = [];
+  let accountingOptions = null;
+  const runner = createLocalCollectorRefreshRunner({
+    accountingSourceMode: "unified",
+    codexHome: "/private/codex-home",
+    unifiedIndexFile: "/private/local-unified-index-v1.sqlite",
+    selectAccountObservationSecret: () => ({
+      loadAccountObservationSecret: null,
+    }),
+    runCollector: async () => ({
+      rolloutRecordsWritten: 1,
+      filesDiscovered: 1,
+      refresh: {
+        attempted: false,
+        recordWritten: false,
+        errorCode: null,
+      },
+      indexing: COMPLETE_INDEX,
+    }),
+    refreshUnifiedIndex: async () => {
+      order.push("unified");
+      return {
+        status: "ingested",
+        generation: {
+          id: 7,
+          fingerprint: "a".repeat(64),
+          status: "complete",
+          discoveryComplete: true,
+          diagnosticsComplete: true,
+          usageProvenanceComplete: true,
+          sourceOrderComplete: true,
+          quotaProvenanceComplete: true,
+          toolProvenanceComplete: true,
+        },
+      };
+    },
+    refreshAccounting: async (options) => {
+      order.push("accounting");
+      accountingOptions = options;
+      return {
+        generatedAt: "2026-07-23T12:00:00.000Z",
+        periods: [{ id: "7d", events: 1 }],
+        diagnostics: {},
+        sourceDescriptor: { fallbackCount: 0 },
+      };
+    },
+    refreshArchiveIndex: async () => {
+      throw new Error("legacy archive must stay dormant in unified mode");
+    },
+  });
+
+  const result = await runner();
+  assert.deepEqual(order, ["unified", "accounting"]);
+  assert.equal(accountingOptions.sourceMode, "unified");
+  assert.equal(accountingOptions.contextBehavior, "legacy_zero");
+  assert.equal(
+    accountingOptions.unifiedIndexFile,
+    "/private/local-unified-index-v1.sqlite",
+  );
+  assert.equal(result.archiveIndex, undefined);
+  assert.equal(result.accounting.sourceMode, "unified");
+});
+
+test("tool-only partial coverage does not block complete usage accounting", async () => {
+  let accountingCalls = 0;
+  const generation = {
+    id: 8,
+    fingerprint: "t".repeat(64),
+    status: "partial",
+    blockReason: "tool_provenance_incomplete",
+    discoveryComplete: true,
+    diagnosticsComplete: true,
+    usageProvenanceComplete: true,
+    sourceOrderComplete: true,
+    quotaProvenanceComplete: true,
+    toolProvenanceComplete: false,
+  };
+  const runner = createLocalCollectorRefreshRunner({
+    accountingSourceMode: "unified",
+    unifiedIndexFile: "/private/local-unified-index-v1.sqlite",
+    selectAccountObservationSecret: () => ({
+      loadAccountObservationSecret: null,
+    }),
+    runCollector: async () => ({
+      rolloutRecordsWritten: 1,
+      filesDiscovered: 1,
+      refresh: { attempted: false, recordWritten: false, errorCode: null },
+      indexing: COMPLETE_INDEX,
+    }),
+    refreshUnifiedIndex: async () => ({ status: "ingested", generation }),
+    refreshAccounting: async (options) => {
+      accountingCalls += 1;
+      assert.equal(options.expectedGeneration.status, "partial");
+      assert.equal(
+        options.expectedGeneration.blockReason,
+        "tool_provenance_incomplete",
+      );
+      return {
+        generatedAt: "2026-07-23T12:00:00.000Z",
+        periods: [{ id: "7d", events: 1 }],
+        diagnostics: {},
+        sourceDescriptor: { fallbackCount: 0 },
+      };
+    },
+  });
+
+  const result = await runner();
+  assert.equal(accountingCalls, 1);
+  assert.equal(result.accounting.sourceMode, "unified");
+  assert.equal(result.accounting.refreshStatus, "rebuilt");
+  assert.equal(result.unifiedIndex.generation.toolProvenanceComplete, false);
+});
+
+test("explicit legacy rollback leaves the unified index untouched", async () => {
+  let unifiedCalls = 0;
+  let archiveCalls = 0;
+  const runner = createLocalCollectorRefreshRunner({
+    accountingSourceMode: "legacy",
+    selectAccountObservationSecret: () => ({
+      loadAccountObservationSecret: null,
+    }),
+    runCollector: async () => ({
+      rolloutRecordsWritten: 0,
+      filesDiscovered: 1,
+      refresh: { attempted: false, recordWritten: false, errorCode: null },
+      indexing: COMPLETE_INDEX,
+    }),
+    refreshUnifiedIndex: async () => {
+      unifiedCalls += 1;
+      throw new Error("legacy rollback must not advance the unified index");
+    },
+    refreshArchiveIndex: async () => {
+      archiveCalls += 1;
+      return PARTIAL_ARCHIVE_INDEX;
+    },
+  });
+
+  const result = await runner();
+  assert.equal(unifiedCalls, 0);
+  assert.equal(archiveCalls, 1);
+  assert.equal(Object.hasOwn(result, "unifiedIndex"), false);
+  assert.deepEqual(result.archiveIndex, PARTIAL_ARCHIVE_INDEX);
+});
+
+test("unified authority keeps quota-only collection prospective and softens a collector-only pause", async () => {
+  const collectorOptions = [];
+  const expectedGeneration = {
+    id: 12,
+    fingerprint: "p".repeat(64),
+    status: "complete",
+    discoveryComplete: true,
+    diagnosticsComplete: true,
+    usageProvenanceComplete: true,
+    sourceOrderComplete: true,
+    quotaProvenanceComplete: true,
+    toolProvenanceComplete: true,
+  };
+  const runner = createLocalCollectorRefreshRunner({
+    accountingSourceMode: "unified",
+    unifiedIndexFile: "/private/local-unified-index-v1.sqlite",
+    selectAccountObservationSecret: () => ({
+      loadAccountObservationSecret: null,
+    }),
+    runCollector: async (options) => {
+      collectorOptions.push(options);
+      return {
+        rolloutRecordsWritten: 0,
+        filesDiscovered: 9,
+        resourceLimit: {
+          code: "collector_resource_source_bytes_limit_exceeded",
+          dimension: "source_bytes",
+          limit: 128 * 1024 * 1024,
+          observed: 128 * 1024 * 1024 + 1,
+        },
+        refresh: {
+          attempted: false,
+          recordWritten: false,
+          errorCode: null,
+        },
+        indexing: PAUSED_INDEX,
+      };
+    },
+    refreshUnifiedIndex: async () => ({
+      status: "ingested",
+      generation: expectedGeneration,
+    }),
+    refreshAccounting: async () => ({
+      generatedAt: "2026-07-23T12:00:00.000Z",
+      periods: [{ id: "7d", events: 3 }],
+      diagnostics: {},
+      sourceDescriptor: { fallbackCount: 0 },
+    }),
+  });
+
+  const result = await runner();
+  assert.equal(collectorOptions.length, 1);
+  assert.equal(collectorOptions[0].backfill, false);
+  assert.equal(collectorOptions[0].skipRolloutIngestion, true);
+  assert.equal(Object.hasOwn(collectorOptions[0], "backfillSinceAt"), false);
+  assert.equal(result.indexing.status, "bounded_pause");
+  assert.equal(result.accounting.sourceMode, "unified");
+  assert.equal(result.accounting.refreshStatus, "rebuilt");
+});
+
+test("unified mode fails closed when the authoritative generation is missing or incomplete", async (t) => {
+  const cases = [
+    {
+      name: "failed ingest",
+      unifiedIndex: {
+        status: "failed",
+        errorCode: "local_unified_index_file_changed",
+      },
+      expectedUnifiedIndex: {
+        status: "failed",
+        errorCode: "local_unified_index_refresh_failed",
+      },
+      expectedAccountingError: "accounting_unified_source_unavailable",
+      expectedCoverage: "unavailable",
+      expectedGeneration: null,
+      expectedFingerprint: null,
+    },
+    {
+      name: "missing generation",
+      unifiedIndex: { status: "ingested" },
+      expectedUnifiedIndex: {
+        status: "failed",
+        errorCode: "local_unified_index_generation_invalid",
+      },
+      expectedAccountingError: "accounting_unified_source_unavailable",
+      expectedCoverage: "unavailable",
+      expectedGeneration: null,
+      expectedFingerprint: null,
+    },
+    {
+      name: "partial generation",
+      unifiedIndex: {
+        status: "ingested",
+        generation: {
+          id: 7,
+          fingerprint: "b".repeat(64),
+          status: "partial",
+          discoveryComplete: false,
+          diagnosticsComplete: true,
+          usageProvenanceComplete: true,
+          sourceOrderComplete: true,
+          quotaProvenanceComplete: true,
+          toolProvenanceComplete: true,
+        },
+      },
+      expectedUnifiedIndex: {
+        status: "ingested",
+        generation: {
+          id: 7,
+          fingerprint: "b".repeat(64),
+          status: "partial",
+          blockReason: null,
+          schemaVersion: null,
+          parserVersion: null,
+          contractVersion: null,
+          coveredAt: { startAt: null, endAt: null },
+          sourceCount: 0,
+          sourceBytes: 0,
+          discoveredSourceCount: 0,
+          discoveredSourceBytes: 0,
+          indexedSourceCount: 0,
+          indexedSourceBytes: 0,
+          usageEvents: 0,
+          quotaOccurrences: 0,
+          toolFacts: 0,
+          toolFactFingerprint: null,
+          discoveryComplete: false,
+          diagnosticsComplete: true,
+          usageProvenanceComplete: true,
+          sourceOrderComplete: true,
+          quotaProvenanceComplete: true,
+          toolProvenanceComplete: true,
+        },
+        unchanged: false,
+        sources: 0,
+        sourcesSkipped: 0,
+        sourcesTouched: 0,
+        sourcesResumed: 0,
+        sourcesRescanned: 0,
+        sourcesScanned: 0,
+        bytesScanned: 0,
+        forkReplayEventsSkipped: 0,
+        unattributedForkReplayEventsSkipped: 0,
+        insertedUsageEvents: 0,
+        totalUsageEvents: 0,
+        wallMs: 0,
+      },
+      expectedAccountingError: "accounting_unified_coverage_incomplete",
+      expectedCoverage: "partial",
+      expectedGeneration: 7,
+      expectedFingerprint: "b".repeat(64),
+    },
+  ];
+
+  for (const fixture of cases) {
+    await t.test(fixture.name, async () => {
+      let accountingCalls = 0;
+      let cacheReads = 0;
+      let archiveCalls = 0;
+      const runner = createLocalCollectorRefreshRunner({
+        accountingSourceMode: "unified",
+        codexHome: "/private/codex-home",
+        unifiedIndexFile: "/private/local-unified-index-v1.sqlite",
+        readAccountingCache: async () => {
+          cacheReads += 1;
+          throw new Error("unified mode must not read a cache without authority");
+        },
+        selectAccountObservationSecret: () => ({
+          loadAccountObservationSecret: null,
+        }),
+        runCollector: async () => ({
+          rolloutRecordsWritten: 1,
+          filesDiscovered: 1,
+          refresh: {
+            attempted: false,
+            recordWritten: false,
+            errorCode: null,
+          },
+          indexing: COMPLETE_INDEX,
+        }),
+        refreshUnifiedIndex: async () => fixture.unifiedIndex,
+        refreshAccounting: async () => {
+          accountingCalls += 1;
+          throw new Error("unified accounting must not run without authority");
+        },
+        refreshArchiveIndex: async () => {
+          archiveCalls += 1;
+          throw new Error("legacy archive must stay dormant in unified mode");
+        },
+      });
+
+      const result = await runner();
+      assert.deepEqual(result.unifiedIndex, fixture.expectedUnifiedIndex);
+      assert.deepEqual(result.accounting, {
+        status: "unavailable",
+        sourceMode: "unified",
+        errorCode: fixture.expectedAccountingError,
+        compatibilityBehavior: "legacy_zero",
+        coverageStatus: fixture.expectedCoverage,
+        generation: fixture.expectedGeneration,
+        generationFingerprint: fixture.expectedFingerprint,
+        generationMatched: false,
+        fallbackCount: 0,
+        diagnosticsAvailable: false,
+      });
+      assert.equal(accountingCalls, 0);
+      assert.equal(cacheReads, 0);
+      assert.equal(archiveCalls, 0);
+      assert.equal(result.archiveIndex, undefined);
+      assert.equal(JSON.stringify(result).includes("/private/"), false);
+    });
+  }
+});
+
+test("unified accounting reader errors stay unavailable without legacy fallback", async () => {
+  let accountingCalls = 0;
+  let archiveCalls = 0;
+  const expectedGeneration = {
+    id: 8,
+    fingerprint: "c".repeat(64),
+    status: "complete",
+    discoveryComplete: true,
+    diagnosticsComplete: true,
+    usageProvenanceComplete: true,
+    sourceOrderComplete: true,
+    quotaProvenanceComplete: true,
+    toolProvenanceComplete: true,
+  };
+  const runner = createLocalCollectorRefreshRunner({
+    accountingSourceMode: "unified",
+    codexHome: "/private/codex-home",
+    unifiedIndexFile: "/private/local-unified-index-v1.sqlite",
+    selectAccountObservationSecret: () => ({
+      loadAccountObservationSecret: null,
+    }),
+    runCollector: async () => ({
+      rolloutRecordsWritten: 1,
+      filesDiscovered: 1,
+      refresh: {
+        attempted: false,
+        recordWritten: false,
+        errorCode: null,
+      },
+      indexing: COMPLETE_INDEX,
+    }),
+    refreshUnifiedIndex: async () => ({
+      status: "ingested",
+      generation: expectedGeneration,
+    }),
+    refreshAccounting: async (options) => {
+      accountingCalls += 1;
+      assert.equal(options.sourceMode, "unified");
+      assert.equal(options.contextBehavior, "legacy_zero");
+      assert.equal(options.expectedGeneration.id, expectedGeneration.id);
+      assert.equal(
+        options.expectedGeneration.fingerprint,
+        expectedGeneration.fingerprint,
+      );
+      assert.equal(options.expectedGeneration.status, expectedGeneration.status);
+      const error = new Error("private reader path must not escape");
+      error.code = "accounting_unified_generation_changed";
+      throw error;
+    },
+    refreshArchiveIndex: async () => {
+      archiveCalls += 1;
+      throw new Error("legacy archive must stay dormant in unified mode");
+    },
+  });
+
+  const result = await runner();
+  assert.deepEqual(result.accounting, {
+    status: "unavailable",
+    sourceMode: "unified",
+    errorCode: "accounting_unified_generation_changed",
+    compatibilityBehavior: "legacy_zero",
+    coverageStatus: "complete",
+    generation: 8,
+    generationFingerprint: "c".repeat(64),
+    generationMatched: false,
+    fallbackCount: 0,
+    diagnosticsAvailable: false,
+  });
+  assert.equal(accountingCalls, 1);
+  assert.equal(archiveCalls, 0);
+  assert.equal(result.archiveIndex, undefined);
+  assert.equal(JSON.stringify(result).includes("private reader path"), false);
+});
+
+test("unified accounting resource limits reach the bounded refresh failure", async () => {
+  const expectedGeneration = {
+    id: 9,
+    fingerprint: "d".repeat(64),
+    status: "complete",
+    discoveryComplete: true,
+    diagnosticsComplete: true,
+    usageProvenanceComplete: true,
+    sourceOrderComplete: true,
+    quotaProvenanceComplete: true,
+    toolProvenanceComplete: true,
+  };
+  const runner = createLocalCollectorRefreshRunner({
+    accountingSourceMode: "unified",
+    unifiedIndexFile: "/private/local-unified-index-v1.sqlite",
+    selectAccountObservationSecret: () => ({
+      loadAccountObservationSecret: null,
+    }),
+    runCollector: async () => ({
+      rolloutRecordsWritten: 1,
+      filesDiscovered: 1,
+      refresh: { attempted: false, recordWritten: false, errorCode: null },
+      indexing: COMPLETE_INDEX,
+    }),
+    refreshUnifiedIndex: async () => ({
+      status: "ingested",
+      generation: expectedGeneration,
+    }),
+    refreshAccounting: async () => {
+      const error = new Error("private accounting budget detail");
+      error.code = "accounting_transition_usage_limit_exceeded";
+      throw error;
+    },
+  });
+
+  await assert.rejects(
+    runner(),
+    (error) => error?.code === "accounting_transition_usage_limit_exceeded"
+      && error?.refreshStep === "accounting",
+  );
+
+  const controller = new LocalCompanionRefreshController({
+    runner,
+    dataStore: { async reload() {} },
+    clock: () => Date.parse("2026-07-23T12:00:00.000Z"),
+  });
+  assert.equal(controller.start(), true);
+  for (let attempt = 0; attempt < 100; attempt += 1) {
+    if (controller.getStatus().status === "failed") break;
+    await new Promise((resolve) => setImmediate(resolve));
+  }
+  const status = controller.getStatus();
+  assert.equal(status.status, "failed");
+  assert.equal(status.errorCode, "refresh_resource_limited");
+  assert.equal(status.failedStep, "accounting");
+  assert.equal(status.failureCode, "accounting_transition_usage_limit_exceeded");
+  assert.equal(JSON.stringify(status).includes("private accounting budget detail"), false);
+});
+
+test("unified accounting measurement-invalid failures remain terminal", async () => {
+  const measurementCodes = [
+    "accounting_transition_rss_measurement_invalid",
+    "accounting_archive_rss_measurement_invalid",
+  ];
+  for (const code of measurementCodes) {
+    const expectedGeneration = {
+      id: 11,
+      fingerprint: "m".repeat(64),
+      status: "complete",
+      discoveryComplete: true,
+      diagnosticsComplete: true,
+      usageProvenanceComplete: true,
+      sourceOrderComplete: true,
+      quotaProvenanceComplete: true,
+      toolProvenanceComplete: true,
+    };
+    const runner = createLocalCollectorRefreshRunner({
+      accountingSourceMode: "unified",
+      unifiedIndexFile: "/private/local-unified-index-v1.sqlite",
+      selectAccountObservationSecret: () => ({
+        loadAccountObservationSecret: null,
+      }),
+      runCollector: async () => ({
+        rolloutRecordsWritten: 1,
+        filesDiscovered: 1,
+        refresh: { attempted: false, recordWritten: false, errorCode: null },
+        indexing: COMPLETE_INDEX,
+      }),
+      refreshUnifiedIndex: async () => ({
+        status: "ingested",
+        generation: expectedGeneration,
+      }),
+      refreshAccounting: async () => {
+        const error = new Error("private RSS measurement detail");
+        error.code = code;
+        throw error;
+      },
+    });
+
+    await assert.rejects(
+      runner(),
+      (error) => error?.code === code && error?.refreshStep === "accounting",
+    );
+
+    const controller = new LocalCompanionRefreshController({
+      runner,
+      dataStore: { async reload() {} },
+      clock: () => Date.parse("2026-07-23T12:00:00.000Z"),
+    });
+    assert.equal(controller.start(), true);
+    for (let attempt = 0; attempt < 100; attempt += 1) {
+      if (controller.getStatus().status === "failed") break;
+      await new Promise((resolve) => setImmediate(resolve));
+    }
+    const status = controller.getStatus();
+    assert.equal(status.status, "failed");
+    assert.equal(status.errorCode, "refresh_failed");
+    assert.equal(status.failedStep, "accounting");
+    assert.equal(status.failureCode, code);
+    assert.equal(JSON.stringify(status).includes("private RSS measurement detail"), false);
+  }
+});
+
+test("public unified accounting errors use the fixed unavailable-code allowlist", async () => {
+  const controller = new LocalCompanionRefreshController({
+    runner: async () => ({
+      accounting: {
+        status: "unavailable",
+        sourceMode: "unified",
+        errorCode: "accounting_private_callback",
+      },
+    }),
+    dataStore: { async reload() {} },
+    clock: () => Date.parse("2026-07-23T12:00:00.000Z"),
+  });
+
+  assert.equal(controller.start(), true);
+  for (let attempt = 0; attempt < 100; attempt += 1) {
+    if (controller.getStatus().status === "succeeded") break;
+    await new Promise((resolve) => setImmediate(resolve));
+  }
+  const status = controller.getStatus();
+  assert.equal(status.status, "succeeded");
+  assert.equal(
+    status.result.accounting.errorCode,
+    "accounting_unified_source_unavailable",
+  );
+  assert.equal(JSON.stringify(status).includes("accounting_private_callback"), false);
+});
+
+test("unified accounting rejects a cache whose fallback attestation is nonzero", async () => {
+  const runner = createLocalCollectorRefreshRunner({
+    accountingSourceMode: "unified",
+    unifiedIndexFile: "/private/local-unified-index-v1.sqlite",
+    selectAccountObservationSecret: () => ({
+      loadAccountObservationSecret: null,
+    }),
+    runCollector: async () => ({
+      rolloutRecordsWritten: 1,
+      filesDiscovered: 1,
+      refresh: { attempted: false, recordWritten: false, errorCode: null },
+      indexing: COMPLETE_INDEX,
+    }),
+    refreshUnifiedIndex: async () => ({
+      status: "ingested",
+      generation: {
+        id: 10,
+        fingerprint: "e".repeat(64),
+        status: "complete",
+        discoveryComplete: true,
+        diagnosticsComplete: true,
+        usageProvenanceComplete: true,
+        sourceOrderComplete: true,
+        quotaProvenanceComplete: true,
+        toolProvenanceComplete: true,
+      },
+    }),
+    refreshAccounting: async () => ({
+      generatedAt: "2026-07-23T12:00:00.000Z",
+      periods: [{ id: "7d", events: 4 }],
+      sourceDescriptor: { fallbackCount: 1 },
+    }),
+  });
+
+  const result = await runner();
+  assert.equal(result.accounting.status, "unavailable");
+  assert.equal(result.accounting.errorCode, "accounting_unified_source_unavailable");
+  assert.equal(result.accounting.fallbackCount, 0);
+});
+
+test("legacy refresh receipt records failed attempts and unified mode does not increment it", async () => {
+  const root = await mkdtemp(join(tmpdir(), "local-refresh-legacy-receipt-"));
+  const stateFile = join(root, "local-collector-state-v1.sqlite");
+  try {
+    const failingRunner = createLocalCollectorRefreshRunner({
+      accountingSourceMode: "legacy",
+      stateFile,
+      selectAccountObservationSecret: () => ({
+        loadAccountObservationSecret: null,
+      }),
+      runCollector: async () => {
+        const error = new Error("private legacy failure");
+        error.code = "legacy_collector_failure";
+        throw error;
+      },
+    });
+    await assert.rejects(
+      failingRunner(),
+      (error) => error?.code === "legacy_collector_failure",
+    );
+    let receipt = await readLocalCollectorLegacyRefreshUse({ stateFile });
+    assert.equal(receipt.status, "available");
+    assert.equal(receipt.receipt.attempts, 1);
+
+    const succeedingRunner = createLocalCollectorRefreshRunner({
+      accountingSourceMode: "legacy",
+      stateFile,
+      selectAccountObservationSecret: () => ({
+        loadAccountObservationSecret: null,
+      }),
+      runCollector: async () => ({
+        rolloutRecordsWritten: 0,
+        filesDiscovered: 0,
+        refresh: { attempted: false, recordWritten: false, errorCode: null },
+        indexing: COMPLETE_INDEX,
+      }),
+    });
+    const controller = new LocalCompanionRefreshController({
+      runner: succeedingRunner,
+      dataStore: { async reload() {} },
+      clock: () => Date.parse("2026-08-03T00:01:00.000Z"),
+    });
+    assert.equal(controller.start(), true);
+    for (let attempt = 0; attempt < 1_000; attempt += 1) {
+      if (controller.getStatus().status === "succeeded") break;
+      await new Promise((resolve) => setTimeout(resolve, 1));
+    }
+    assert.equal(controller.getStatus().status, "succeeded");
+    assert.equal(controller.getStatus().result.legacyRefreshUse.attempts, 2);
+
+    const unifiedRunner = createLocalCollectorRefreshRunner({
+      accountingSourceMode: "unified",
+      stateFile,
+      unifiedIndexFile: join(root, "local-unified-index-v1.sqlite"),
+      selectAccountObservationSecret: () => ({
+        loadAccountObservationSecret: null,
+      }),
+      runCollector: async () => ({
+        rolloutRecordsWritten: 0,
+        filesDiscovered: 0,
+        refresh: { attempted: false, recordWritten: false, errorCode: null },
+        indexing: COMPLETE_INDEX,
+      }),
+      refreshUnifiedIndex: async () => ({
+        status: "ingested",
+        generation: {
+          id: 1,
+          fingerprint: "f".repeat(64),
+          status: "complete",
+          discoveryComplete: true,
+          diagnosticsComplete: true,
+          usageProvenanceComplete: true,
+          sourceOrderComplete: true,
+          quotaProvenanceComplete: true,
+          toolProvenanceComplete: true,
+        },
+      }),
+    });
+    const unifiedResult = await unifiedRunner();
+    assert.equal(Object.hasOwn(unifiedResult, "legacyRefreshUse"), false);
+    receipt = await readLocalCollectorLegacyRefreshUse({ stateFile });
+    assert.equal(receipt.receipt.attempts, 2);
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
 });
 
 test("archive coverage advances while a recent foreground pass remains bounded", async () => {
@@ -567,12 +1309,14 @@ test("zero-write local refresh reuses a current valid accounting cache without a
   assert.deepEqual(readOptions, {
     stateFile: "/private/local-collector-state.sqlite",
     now: clock,
+    sourceMode: "legacy",
     maximumAgeMs: 30 * 60 * 1_000,
   });
   assert.equal(rebuilds, 0);
   assert.deepEqual(REUSABLE_ACCOUNTING_CACHE, before);
   assert.deepEqual(result.accounting, {
     status: "replay_safe",
+    ...INTERNAL_LEGACY_ACCOUNTING_AUTHORITY,
     refreshStatus: "reused",
     generatedAt: "2026-07-23T10:00:00.000Z",
     events: 17,
@@ -657,6 +1401,7 @@ test("zero-write local refresh rebuilds when the cache cannot be safely reused",
       assert.equal(rebuilds, 1);
       assert.deepEqual(result.accounting, {
         status: "replay_safe",
+        ...INTERNAL_LEGACY_ACCOUNTING_AUTHORITY,
         refreshStatus: "rebuilt",
         generatedAt: "2026-07-23T12:00:00.000Z",
         events: 23,
@@ -749,6 +1494,7 @@ test("a memory-budget rebuild miss serves the retained cache, reports deferred, 
   assert.equal(rebuildAttempts, 1);
   assert.deepEqual(first.accounting, {
     status: "replay_safe",
+    ...INTERNAL_LEGACY_ACCOUNTING_AUTHORITY,
     refreshStatus: "deferred",
     generatedAt: "2026-07-23T10:00:00.000Z",
     events: 17,
@@ -1010,6 +1756,7 @@ test("local refresh forwards its AbortSignal into replay-safe accounting", async
   assert.equal(accountingOptions.signal, controller.signal);
   assert.deepEqual(result.accounting, {
     status: "replay_safe",
+    ...INTERNAL_LEGACY_ACCOUNTING_AUTHORITY,
     refreshStatus: "rebuilt",
     generatedAt: "2026-07-23T12:00:00.000Z",
     events: 17,
@@ -1024,6 +1771,7 @@ test("local refresh forwards its AbortSignal into replay-safe accounting", async
 test("the unified index advances before accounting reads it for calibration", async () => {
   const order = [];
   const runner = createLocalCollectorRefreshRunner({
+    accountingSourceMode: "unified",
     unifiedIndexFile: "/private/local-unified-index-v1.sqlite",
     unifiedIndexSecretFile: "/private/local-unified-index-device-salt-v1",
     selectAccountObservationSecret: () => ({
@@ -1039,6 +1787,17 @@ test("the unified index advances before accounting reads it for calibration", as
       order.push(["unified_index", options.indexFile, options.secretFile]);
       return {
         status: "ingested",
+        generation: {
+          id: 1,
+          fingerprint: "b".repeat(64),
+          status: "complete",
+          discoveryComplete: true,
+          diagnosticsComplete: true,
+          usageProvenanceComplete: true,
+          sourceOrderComplete: true,
+          quotaProvenanceComplete: true,
+          toolProvenanceComplete: true,
+        },
         sources: 1,
         sourcesTouched: 1,
         insertedUsageEvents: 1,
@@ -1053,6 +1812,7 @@ test("the unified index advances before accounting reads it for calibration", as
         generatedAt: "2026-07-23T12:00:00.000Z",
         periods: [],
         diagnostics: {},
+        sourceDescriptor: { fallbackCount: 0 },
       };
     },
   });
@@ -1805,6 +2565,35 @@ test("refresh controller publishes bounded progress and reloads after success", 
           events: 17,
           forkReplayEventsExcluded: 29,
         },
+        // The runner has already projected this descriptor once before the
+        // controller applies the final HTTP-safe projection.
+        unifiedIndex: {
+          status: "ingested",
+          unchanged: true,
+          generation: {
+            id: 8,
+            fingerprint: `generation-v2-${"a".repeat(64)}`,
+            status: "complete",
+            blockReason: null,
+            schemaVersion: "local-unified-index-v2",
+            parserVersion: "unified-rollout-typed-v4",
+            contractVersion: "telemetry-contribution-v0.1",
+            coveredAt: {
+              startAt: "2026-06-01T00:00:00.000Z",
+              endAt: "2026-07-23T12:00:00.000Z",
+            },
+            sourceCount: 4_566,
+            sourceBytes: 118_712_104_546,
+            usageEvents: 560_047,
+            quotaOccurrences: 778_963,
+            discoveryComplete: true,
+            diagnosticsComplete: true,
+            usageProvenanceComplete: true,
+            sourceOrderComplete: true,
+            quotaProvenanceComplete: true,
+            toolProvenanceComplete: true,
+          },
+        },
         indexing: COMPLETE_INDEX,
       };
     },
@@ -1832,12 +2621,59 @@ test("refresh controller publishes bounded progress and reloads after success", 
   assert.deepEqual(status.result.indexing, COMPLETE_INDEX);
   assert.deepEqual(status.result.accounting, {
     status: "replay_safe",
+    ...PUBLIC_LEGACY_ACCOUNTING_AUTHORITY,
     refreshStatus: "reused",
     generatedAt: "2026-07-23T11:45:00.000Z",
     events: 17,
     forkReplayEventsExcluded: 29,
   });
+  assert.deepEqual(status.result.unifiedIndex.generation.coveredAt, {
+    startAt: "2026-06-01T00:00:00.000Z",
+    endAt: "2026-07-23T12:00:00.000Z",
+  });
+  assert.equal(status.result.unifiedIndex.generation.sourceCount, 4_566);
+  assert.equal(
+    status.result.unifiedIndex.generation.sourceBytes,
+    118_712_104_546,
+  );
   assert.equal(reloads, 1);
+});
+
+test("refresh controller exposes only allowlisted unified-index failure codes", async () => {
+  for (const fixture of [
+    {
+      input: "local_unified_index_file_changed",
+      expected: "local_unified_index_file_changed",
+    },
+    {
+      input: "local_unified_index_private_path_detail",
+      expected: "local_unified_index_refresh_failed",
+    },
+    {
+      input: "Failed reading /Users/private/unified.sqlite",
+      expected: "local_unified_index_refresh_failed",
+    },
+  ]) {
+    const controller = new LocalCompanionRefreshController({
+      runner: async () => ({
+        unifiedIndex: {
+          status: "failed",
+          errorCode: fixture.input,
+        },
+      }),
+      dataStore: { reload: async () => {} },
+    });
+
+    assert.equal(controller.start(), true);
+    for (let attempt = 0; attempt < 100; attempt += 1) {
+      if (controller.getStatus().status === "succeeded") break;
+      await new Promise((resolve) => setImmediate(resolve));
+    }
+    const status = controller.getStatus();
+    assert.equal(status.status, "succeeded");
+    assert.equal(status.result.unifiedIndex.errorCode, fixture.expected);
+    assert.equal(JSON.stringify(status).includes("/Users/private"), false);
+  }
 });
 
 test("refresh controller projects a fixed safety-limit state while retaining the quick result", async () => {

--- a/test/local-index-retirement-qualification.test.js
+++ b/test/local-index-retirement-qualification.test.js
@@ -1,0 +1,173 @@
+import assert from "node:assert/strict";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+
+import {
+  LOCAL_INDEX_RETIREMENT_BENCHMARK_LIMITS,
+  createSyntheticLocalIndexRetirementCorpus,
+  runLocalIndexRetirementQualification,
+} from "../scripts/benchmark-local-index-retirement.mjs";
+
+test("synthetic unified index retirement path qualifies without legacy state", async () => {
+  const stateDirectory = await mkdtemp(
+    join(tmpdir(), "local-index-retirement-qualification-"),
+  );
+  try {
+    const receipt = await runLocalIndexRetirementQualification({
+      stateDirectory,
+    });
+
+    assert.equal(receipt.synthetic, true);
+    assert.deepEqual(receipt.accountingWindow, {
+      startAt: "2025-08-02T00:00:00.000Z",
+      endAt: "2026-08-02T00:00:00.000Z",
+      durationDays: 365,
+    });
+    assert.equal(receipt.accounting.sourceMode, "unified");
+    assert.equal(receipt.accounting.contextBehavior, "legacy_zero");
+    assert.equal(receipt.accounting.weeklyCalibrationSource, "unified_index");
+    assert.equal(receipt.accounting.relaunchedStatus, "available");
+    assert.equal(receipt.companion.timelineSource, "unified_local_index");
+    assert.equal(receipt.companion.historyStatus, "complete");
+    assert.equal(receipt.noChange.unchanged, true);
+    assert.equal(receipt.noChange.bytesScanned, 0);
+    assert.equal(receipt.noChange.sizeUnchanged, true);
+    assert.equal(receipt.noChange.mtimeUnchanged, true);
+    assert.equal(receipt.append.sourcesResumed, 1);
+    assert.equal(receipt.append.bytesScanned, receipt.appendedBytes);
+    assert.ok(receipt.append.insertedUsageEvents >= 1);
+    assert.equal(receipt.legacyPathsAbsent, true);
+    assert.deepEqual(receipt.legacyState, {
+      analysisSentinelsSeeded: false,
+      analysisSentinelsPresentAfter: false,
+      analysisSentinelsUnchanged: true,
+      archiveFilesAbsentAfter: true,
+    });
+    assert.ok(receipt.sourceCount >= 2);
+    assert.ok(receipt.usageEvents >= 5);
+    assert.ok(receipt.sourceBytes > 0);
+    assert.equal(receipt.finalSourceBytes, receipt.sourceBytes + receipt.appendedBytes);
+    assert.ok(receipt.appendedBytes > 0);
+    assert.notEqual(receipt.generations.cold.fingerprint, receipt.generations.append.fingerprint);
+    assert.equal(receipt.runCount, 1);
+    assert.equal(receipt.statistics.runCount, 1);
+    assert.equal(
+      receipt.statistics.timings.coldRebuild.median,
+      receipt.timings.coldRebuild,
+    );
+    assert.ok(receipt.counts.usageCallbacks >= receipt.counts.usageEvents);
+    assert.ok(receipt.counts.quotaCallbacks >= 0);
+    assert.equal(
+      receipt.counts.indexedFacts,
+      receipt.counts.usageFacts + receipt.counts.quotaFacts,
+    );
+
+    for (const elapsedMs of Object.values(receipt.timings)) {
+      assert.ok(Number.isFinite(elapsedMs));
+      assert.ok(elapsedMs <= LOCAL_INDEX_RETIREMENT_BENCHMARK_LIMITS.maxPhaseMs);
+    }
+    assert.ok(receipt.timings.totalMs <= LOCAL_INDEX_RETIREMENT_BENCHMARK_LIMITS.maxTotalMs);
+    assert.ok(receipt.rssDeltaBytes <= LOCAL_INDEX_RETIREMENT_BENCHMARK_LIMITS.maxRssDeltaBytes);
+    assert.ok(receipt.diskBytes <= LOCAL_INDEX_RETIREMENT_BENCHMARK_LIMITS.maxDiskBytes);
+    assert.ok(receipt.sourceBytes <= LOCAL_INDEX_RETIREMENT_BENCHMARK_LIMITS.maxSourceBytes);
+
+    // The benchmark receipt is safe to persist or attach to a release record:
+    // it reports bounded counters and fingerprints only, never fixture paths,
+    // source filenames, or raw JSONL/event content.
+    const serializedReceipt = JSON.stringify(receipt);
+    assert.doesNotMatch(
+      serializedReceipt,
+      /synthetic-codex-home|rollout-|synthetic-qualification|token_count|\.jsonl|\.sqlite/u,
+    );
+    assert.equal(Object.hasOwn(receipt, "stateDirectory"), false);
+    assert.equal(Object.hasOwn(receipt, "paths"), false);
+    assert.equal(receipt.legacyComparison, null);
+  } finally {
+    await rm(stateDirectory, { recursive: true, force: true });
+  }
+});
+
+test("unified refresh preserves existing legacy analysis sentinels byte-for-byte", async () => {
+  const stateDirectory = await mkdtemp(
+    join(tmpdir(), "local-index-retirement-legacy-sentinels-"),
+  );
+  try {
+    const receipt = await runLocalIndexRetirementQualification({
+      stateDirectory,
+      seedLegacySentinels: true,
+    });
+    assert.equal(receipt.legacyPathsAbsent, false);
+    assert.deepEqual(receipt.legacyState, {
+      analysisSentinelsSeeded: true,
+      analysisSentinelsPresentAfter: true,
+      analysisSentinelsUnchanged: true,
+      archiveFilesAbsentAfter: true,
+    });
+  } finally {
+    await rm(stateDirectory, { recursive: true, force: true });
+  }
+});
+
+test("explicit real-corpus mode supports repeated statistics and explicit legacy comparison", async () => {
+  const corpusDirectory = await mkdtemp(
+    join(tmpdir(), "local-index-retirement-real-corpus-fixture-"),
+  );
+  const stateDirectory = await mkdtemp(
+    join(tmpdir(), "local-index-retirement-real-corpus-state-"),
+  );
+  try {
+    const corpus = await createSyntheticLocalIndexRetirementCorpus(corpusDirectory);
+    const receipt = await runLocalIndexRetirementQualification({
+      codexHome: corpus.codexHome,
+      stateDirectory,
+      runs: 2,
+      startAt: "2024-08-02T00:00:00.000Z",
+      endAt: "2026-08-02T00:00:00.000Z",
+      workerCount: 2,
+      compareLegacy: true,
+    });
+    assert.equal(receipt.synthetic, false);
+    assert.equal(receipt.runCount, 2);
+    assert.equal(receipt.statistics.runCount, 2);
+    assert.ok(receipt.statistics.timings.coldRebuild.median >= 0);
+    assert.ok(receipt.statistics.timings.coldRebuild.p95 >= receipt.statistics.timings.coldRebuild.median);
+    assert.ok(receipt.statistics.counts.sourceBytes.median > 0);
+    assert.equal(receipt.runs.every((run) => run.synthetic === false), true);
+    assert.equal(receipt.runs.every((run) => run.append.status === "not_run"), true);
+    assert.equal(receipt.legacyComparison.mode, "legacy");
+    assert.equal(receipt.legacyComparison.selection, "explicit");
+    assert.deepEqual(receipt.accountingWindow, {
+      startAt: "2024-08-02T00:00:00.000Z",
+      endAt: "2026-08-02T00:00:00.000Z",
+      durationDays: 730,
+    });
+    assert.equal(receipt.workerCount, 2);
+    assert.equal(
+      receipt.legacyComparison.runs.every((run) => run.workerCount === 2),
+      true,
+    );
+    assert.deepEqual(
+      receipt.legacyComparison.accountingWindow,
+      receipt.accountingWindow,
+    );
+    assert.equal(receipt.legacyComparison.runCount, 2);
+    assert.match(
+      receipt.legacyComparison.invocation.legacyCommandTemplate,
+      /benchmark-local-analysis-pipeline\.mjs .*--start-at <ISO> .*--workers <WORKERS>/u,
+    );
+    assert.equal(
+      receipt.legacyComparison.runs.every((run) => run.mode === "legacy"),
+      true,
+    );
+    const serializedReceipt = JSON.stringify(receipt);
+    assert.doesNotMatch(
+      serializedReceipt,
+      /local-index-retirement-real-corpus|synthetic-codex-home|\.jsonl|\.sqlite/u,
+    );
+  } finally {
+    await rm(stateDirectory, { recursive: true, force: true });
+    await rm(corpusDirectory, { recursive: true, force: true });
+  }
+});

--- a/test/local-index-retirement-shadow-parity.test.js
+++ b/test/local-index-retirement-shadow-parity.test.js
@@ -121,9 +121,13 @@ function accountingProjection(cache) {
   };
 }
 
-async function fileReceipt(indexFile, unified = false) {
+async function fileReceipt(
+  indexFile,
+  unified = false,
+  contextBehavior = "source_native",
+) {
   const scan = unified
-    ? createLocalUnifiedAccountingSource({ indexFile })
+    ? createLocalUnifiedAccountingSource({ indexFile, contextBehavior })
     : createLocalAnalysisIndexReadScan({ indexFile, requireComplete: true });
   return createLocalAccountingSemanticReceipt({
     scan,
@@ -187,28 +191,61 @@ test("published legacy and unified indexes classify context-presence mismatch th
       startAt: START_AT,
       endAt: END_AT,
     });
-    assert.equal(unifiedReadResult.coverage.status, "partial");
-    assert.equal(
-      unifiedReadResult.coverage.blockReason,
-      "accounting_contract_incomplete",
-    );
-    assert.equal(unifiedReadResult.diagnosticCoverage, "unavailable");
-    assert.deepEqual(unifiedReadResult.diagnostics, {});
+    assert.equal(unifiedReadResult.coverage.status, "complete");
+    assert.equal(unifiedReadResult.coverage.blockReason, null);
+    assert.equal(unifiedReadResult.diagnosticCoverage, "complete");
+    assert.deepEqual(unifiedReadResult.diagnostics, {
+      contradictedLeadingSnapshotsSkipped: 0,
+      cumulativeCounterRegressions: 0,
+      forkReplayEventsSkipped: 0,
+      malformedLines: 0,
+      malformedTimestamps: 0,
+      modelMissing: 0,
+      modelSeededFromLineage: 0,
+      oversizedLines: 0,
+      partialLines: 0,
+      relevantLines: 3,
+      salvagedRecords: 0,
+      tierEvents: 0,
+      tierSeededFromLineage: 0,
+      tokenCounts: 2,
+      toolEvents: 0,
+      toolRecords: 0,
+      toolRecordsSkipped: 0,
+      turnContexts: 1,
+      unattributedForkReplayEventsSkipped: 0,
+    });
     assert.deepEqual(unifiedReadResult.capabilities, {
       readsRawSources: false,
       deterministicCanonicalOrder: true,
-      sourceOrderingProvenance: false,
-      sourceOffsetProvenance: false,
-      sourceScopedQuotaOccurrences: false,
-      durableDiagnostics: false,
-      crashSafeGenerationPublication: false,
+      sourceOrderingProvenance: true,
+      sourceOffsetProvenance: true,
+      sourceScopedQuotaOccurrences: true,
+      durableDiagnostics: true,
+      crashSafeGenerationPublication: true,
     });
 
     const legacyReceipt = await fileReceipt(legacyIndexFile);
-    const unifiedReceipt = await fileReceipt(unifiedIndexFile, true);
+    const unifiedReceipt = await fileReceipt(
+      unifiedIndexFile,
+      true,
+      "source_native",
+    );
+    const unifiedLegacyZeroReceipt = await fileReceipt(
+      unifiedIndexFile,
+      true,
+      "legacy_zero",
+    );
     assert.equal(legacyReceipt.version, LOCAL_ACCOUNTING_PARITY_RECEIPT_VERSION);
     assert.equal(unifiedReceipt.version, LOCAL_ACCOUNTING_PARITY_RECEIPT_VERSION);
     assertContextPresenceMismatch(legacyReceipt, unifiedReceipt);
+    assert.deepEqual(
+      compareLocalAccountingSemanticReceipts(
+        legacyReceipt,
+        unifiedLegacyZeroReceipt,
+      ),
+      { equal: true, mismatchCategories: [] },
+    );
 
     const legacyCache = await buildReplaySafeAccountingCache({
       codexHome,
@@ -294,14 +331,40 @@ test("published readers stay usable after raw fixture sources disappear", async 
       stat(unifiedIndexFile),
     ]);
     const expectedLegacy = await fileReceipt(legacyIndexFile);
-    const expectedUnified = await fileReceipt(unifiedIndexFile, true);
+    const expectedUnified = await fileReceipt(
+      unifiedIndexFile,
+      true,
+      "source_native",
+    );
+    const expectedUnifiedLegacyZero = await fileReceipt(
+      unifiedIndexFile,
+      true,
+      "legacy_zero",
+    );
     await rm(codexHome, { recursive: true, force: true });
 
     const actualLegacy = await fileReceipt(legacyIndexFile);
-    const actualUnified = await fileReceipt(unifiedIndexFile, true);
+    const actualUnified = await fileReceipt(
+      unifiedIndexFile,
+      true,
+      "source_native",
+    );
+    const actualUnifiedLegacyZero = await fileReceipt(
+      unifiedIndexFile,
+      true,
+      "legacy_zero",
+    );
     assert.deepEqual(actualLegacy, expectedLegacy);
     assert.deepEqual(actualUnified, expectedUnified);
+    assert.deepEqual(actualUnifiedLegacyZero, expectedUnifiedLegacyZero);
     assertContextPresenceMismatch(actualLegacy, actualUnified);
+    assert.deepEqual(
+      compareLocalAccountingSemanticReceipts(
+        actualLegacy,
+        actualUnifiedLegacyZero,
+      ),
+      { equal: true, mismatchCategories: [] },
+    );
 
     const after = await Promise.all([
       stat(legacyIndexFile),

--- a/test/local-index-retirement-shadow-parity.test.js
+++ b/test/local-index-retirement-shadow-parity.test.js
@@ -1,0 +1,317 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import {
+  mkdir,
+  mkdtemp,
+  rm,
+  stat,
+  writeFile,
+} from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import {
+  LOCAL_ACCOUNTING_PARITY_RECEIPT_VERSION,
+  compareLocalAccountingSemanticReceipts,
+  createLocalAccountingSemanticReceipt,
+} from "../src/local-accounting-parity-receipt.js";
+import {
+  createLocalAnalysisIndexReadScan,
+  refreshLocalAnalysisIndex,
+} from "../src/local-analysis-index.js";
+import { buildReplaySafeAccountingCache } from "../src/replay-safe-accounting-cache.js";
+import { rebuildLocalUnifiedIndex } from "../src/local-unified-index-build.js";
+import { createLocalUnifiedAccountingSource } from "../src/local-unified-accounting-source.js";
+
+const START_AT = "2026-08-01T00:00:00.000Z";
+const END_AT = "2026-08-02T00:00:00.000Z";
+const CONTRACT_VERSION = "local-index-retirement-shadow-parity-v1";
+const PARITY_KEY = Buffer.from(
+  "local-index-retirement-shadow-parity-key-v1",
+);
+
+function usage(input, output = 0) {
+  return {
+    input_tokens: input,
+    cached_input_tokens: 0,
+    cache_write_input_tokens: 0,
+    output_tokens: output,
+    reasoning_output_tokens: 0,
+    total_tokens: input + output,
+  };
+}
+
+function tokenCount(timestamp, total, last, usedPercent) {
+  return JSON.stringify({
+    timestamp,
+    type: "event_msg",
+    payload: {
+      type: "token_count",
+      info: {
+        total_token_usage: total,
+        last_token_usage: last,
+      },
+      rate_limits: {
+        limit_id: "codex",
+        plan_type: "pro",
+        primary: {
+          used_percent: usedPercent,
+          window_minutes: 10_080,
+          resets_at: Math.floor(Date.parse("2026-08-08T00:00:00.000Z") / 1_000),
+        },
+      },
+    },
+  });
+}
+
+async function createCorpus() {
+  const root = await mkdtemp(join(tmpdir(), "local-index-retirement-shadow-"));
+  const codexHome = join(root, "codex-home");
+  const sessions = join(codexHome, "sessions", "2026", "08", "01");
+  const state = join(root, "state");
+  await mkdir(sessions, { recursive: true });
+  await mkdir(state, { recursive: true });
+  await writeFile(
+    join(sessions, "rollout-2026-08-01T12-00-00-shadow.jsonl"),
+    `${[
+      JSON.stringify({
+        timestamp: "2026-08-01T12:00:00.000Z",
+        type: "session_meta",
+        payload: {
+          id: "SHADOW_PARITY_SESSION",
+          session_id: "SHADOW_PARITY_SESSION",
+          thread_source: "user",
+          originator: "codex_cli_rs",
+          cwd: "/private/shadow-parity-project",
+        },
+      }),
+      JSON.stringify({
+        timestamp: "2026-08-01T12:00:00.010Z",
+        type: "turn_context",
+        payload: { model: "gpt-5.6-sol", effort: "medium" },
+      }),
+      tokenCount(
+        "2026-08-01T12:01:00.000Z",
+        usage(100, 20),
+        usage(100, 20),
+        10,
+      ),
+      tokenCount(
+        "2026-08-01T12:02:00.000Z",
+        usage(180, 35),
+        usage(80, 15),
+        12,
+      ),
+    ].join("\n")}\n`,
+    { mode: 0o600 },
+  );
+  return { root, codexHome, state };
+}
+
+function accountingProjection(cache) {
+  return {
+    periods: cache.periods,
+    timeline: cache.timeline,
+    sparkUsageTimeline: cache.sparkUsageTimeline,
+    quotaTimeline: cache.quotaTimeline,
+    sparkQuotaTimeline: cache.sparkQuotaTimeline,
+    weekly: cache.weekly,
+    weeklyCalibration: cache.weeklyCalibration,
+    weeklyCalibrationInput: cache.weeklyCalibrationInput,
+  };
+}
+
+async function fileReceipt(indexFile, unified = false) {
+  const scan = unified
+    ? createLocalUnifiedAccountingSource({ indexFile })
+    : createLocalAnalysisIndexReadScan({ indexFile, requireComplete: true });
+  return createLocalAccountingSemanticReceipt({
+    scan,
+    startAt: START_AT,
+    endAt: END_AT,
+    byteKey: PARITY_KEY,
+  });
+}
+
+function assertContextPresenceMismatch(legacyReceipt, unifiedReceipt) {
+  assert.equal(legacyReceipt.usage.missingTotalInputContextCount, 0);
+  assert.equal(legacyReceipt.usage.count, unifiedReceipt.usage.count);
+  assert.equal(
+    unifiedReceipt.usage.missingTotalInputContextCount,
+    unifiedReceipt.usage.count,
+  );
+  // This is a known cutover blocker: the legacy reader materializes a missing
+  // context value as explicit zero, while unified preserves SQL NULL as an
+  // omitted callback field. Keep the mismatch classified; do not canonicalize
+  // it away in the test or production reader.
+  assert.deepEqual(
+    compareLocalAccountingSemanticReceipts(legacyReceipt, unifiedReceipt),
+    {
+      equal: false,
+      mismatchCategories: [
+        "usage_tokens",
+        "usage_digest",
+        "usage_dimensions",
+      ],
+    },
+  );
+}
+
+test("published legacy and unified indexes classify context-presence mismatch that blocks cutover", async () => {
+  const { root, codexHome, state } = await createCorpus();
+  const legacyIndexFile = join(state, "local-analysis-index-v2.sqlite");
+  const legacySecretFile = join(state, "local-analysis-index-secret-v2");
+  const unifiedIndexFile = join(state, "local-unified-index-v1.sqlite");
+  const unifiedSecretFile = join(state, "local-unified-index-device-salt-v1");
+  try {
+    await refreshLocalAnalysisIndex({
+      indexFile: legacyIndexFile,
+      secretFile: legacySecretFile,
+      codexHome,
+      startAt: START_AT,
+      endAt: END_AT,
+      workerCount: 1,
+      chunkBytes: 4 * 1024 * 1024,
+    });
+    await rebuildLocalUnifiedIndex({
+      codexHome,
+      indexFile: unifiedIndexFile,
+      secretFile: unifiedSecretFile,
+      contractVersion: CONTRACT_VERSION,
+    });
+
+    const unifiedReader = createLocalUnifiedAccountingSource({
+      indexFile: unifiedIndexFile,
+    });
+    const unifiedReadResult = await unifiedReader({
+      startAt: START_AT,
+      endAt: END_AT,
+    });
+    assert.equal(unifiedReadResult.coverage.status, "partial");
+    assert.equal(
+      unifiedReadResult.coverage.blockReason,
+      "accounting_contract_incomplete",
+    );
+    assert.equal(unifiedReadResult.diagnosticCoverage, "unavailable");
+    assert.deepEqual(unifiedReadResult.diagnostics, {});
+    assert.deepEqual(unifiedReadResult.capabilities, {
+      readsRawSources: false,
+      deterministicCanonicalOrder: true,
+      sourceOrderingProvenance: false,
+      sourceOffsetProvenance: false,
+      sourceScopedQuotaOccurrences: false,
+      durableDiagnostics: false,
+      crashSafeGenerationPublication: false,
+    });
+
+    const legacyReceipt = await fileReceipt(legacyIndexFile);
+    const unifiedReceipt = await fileReceipt(unifiedIndexFile, true);
+    assert.equal(legacyReceipt.version, LOCAL_ACCOUNTING_PARITY_RECEIPT_VERSION);
+    assert.equal(unifiedReceipt.version, LOCAL_ACCOUNTING_PARITY_RECEIPT_VERSION);
+    assertContextPresenceMismatch(legacyReceipt, unifiedReceipt);
+
+    const legacyCache = await buildReplaySafeAccountingCache({
+      codexHome,
+      scan: createLocalAnalysisIndexReadScan({
+        indexFile: legacyIndexFile,
+        requireComplete: true,
+      }),
+      now: () => Date.parse(END_AT),
+      windowDays: 365,
+    });
+    const unifiedCache = await buildReplaySafeAccountingCache({
+      codexHome,
+      scan: createLocalUnifiedAccountingSource({ indexFile: unifiedIndexFile }),
+      now: () => Date.parse(END_AT),
+      windowDays: 365,
+    });
+    assert.deepEqual(
+      accountingProjection(legacyCache),
+      accountingProjection(unifiedCache),
+    );
+
+    // Exercise the opt-in full-history calibration reader without changing
+    // production authority: legacyCache above remains the authoritative
+    // shadow result.
+    const unifiedHistoryCache = await buildReplaySafeAccountingCache({
+      codexHome,
+      scan: unifiedReader,
+      unifiedIndexFile,
+      now: () => Date.parse(END_AT),
+      windowDays: 365,
+    });
+    assert.equal(
+      unifiedHistoryCache.weeklyCalibrationInput.source,
+      "unified_index",
+    );
+    const legacyHistoryCache = await buildReplaySafeAccountingCache({
+      codexHome,
+      scan: createLocalAnalysisIndexReadScan({
+        indexFile: legacyIndexFile,
+        requireComplete: true,
+      }),
+      unifiedIndexFile,
+      now: () => Date.parse(END_AT),
+      windowDays: 365,
+    });
+    assert.deepEqual(
+      accountingProjection(legacyHistoryCache),
+      accountingProjection(unifiedHistoryCache),
+    );
+
+    // The legacy result remains the authoritative shadow result. This test only
+    // reads the published generations and never writes either database.
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("published readers stay usable after raw fixture sources disappear", async () => {
+  const { root, codexHome, state } = await createCorpus();
+  const legacyIndexFile = join(state, "local-analysis-index-v2.sqlite");
+  const legacySecretFile = join(state, "local-analysis-index-secret-v2");
+  const unifiedIndexFile = join(state, "local-unified-index-v1.sqlite");
+  const unifiedSecretFile = join(state, "local-unified-index-device-salt-v1");
+  try {
+    await refreshLocalAnalysisIndex({
+      indexFile: legacyIndexFile,
+      secretFile: legacySecretFile,
+      codexHome,
+      startAt: START_AT,
+      endAt: END_AT,
+      workerCount: 1,
+      chunkBytes: 4 * 1024 * 1024,
+    });
+    await rebuildLocalUnifiedIndex({
+      codexHome,
+      indexFile: unifiedIndexFile,
+      secretFile: unifiedSecretFile,
+      contractVersion: CONTRACT_VERSION,
+    });
+
+    const before = await Promise.all([
+      stat(legacyIndexFile),
+      stat(unifiedIndexFile),
+    ]);
+    const expectedLegacy = await fileReceipt(legacyIndexFile);
+    const expectedUnified = await fileReceipt(unifiedIndexFile, true);
+    await rm(codexHome, { recursive: true, force: true });
+
+    const actualLegacy = await fileReceipt(legacyIndexFile);
+    const actualUnified = await fileReceipt(unifiedIndexFile, true);
+    assert.deepEqual(actualLegacy, expectedLegacy);
+    assert.deepEqual(actualUnified, expectedUnified);
+    assertContextPresenceMismatch(actualLegacy, actualUnified);
+
+    const after = await Promise.all([
+      stat(legacyIndexFile),
+      stat(unifiedIndexFile),
+    ]);
+    for (const [beforeStat, afterStat] of before.map((value, index) => [value, after[index]])) {
+      assert.equal(afterStat.size, beforeStat.size);
+      assert.equal(afterStat.mtimeMs, beforeStat.mtimeMs);
+    }
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});

--- a/test/local-installation-diagnostics.test.js
+++ b/test/local-installation-diagnostics.test.js
@@ -18,6 +18,7 @@ import {
   assertLocalStatePath,
   defaultLocalCompanionStateRoot,
   inspectLocalOnboarding,
+  localCompanionStatePaths,
   prepareLocalInstallationRoots,
   projectLocalOnboarding,
 } from "../src/local-installation-diagnostics.js";
@@ -71,6 +72,28 @@ test("installation roots separate immutable resources from owner-only state", as
   } finally {
     await rm(files.root, { recursive: true });
   }
+});
+
+test("legacy accounting rollback paths stay explicit and state-scoped", () => {
+  const stateRoot = join(tmpdir(), "local-installation-explicit-state");
+  const paths = localCompanionStatePaths(stateRoot);
+
+  assert.equal(
+    paths.legacyAnalysisIndexFile,
+    join(stateRoot, "local-analysis-index-v2.sqlite"),
+  );
+  assert.equal(
+    paths.legacyAnalysisIndexSecretFile,
+    join(stateRoot, "local-analysis-index-secret-v2"),
+  );
+  assert.equal(
+    paths.archiveAccountingIndexFile,
+    join(stateRoot, "local-archive-accounting-index-v1.sqlite"),
+  );
+  assert.equal(
+    paths.archiveAccountingIndexSecretFile,
+    join(stateRoot, "local-archive-accounting-index-v1-secret"),
+  );
 });
 
 test("installation roots reject relative, overlapping, symlink, and open state directories", async () => {

--- a/test/local-unified-accounting-source.test.js
+++ b/test/local-unified-accounting-source.test.js
@@ -1,0 +1,486 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import {
+  chmod,
+  mkdtemp,
+  readFile,
+  rm,
+  stat,
+  writeFile,
+} from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import {
+  LOCAL_UNIFIED_ACCOUNTING_SOURCE_VERSION,
+  createLocalUnifiedAccountingSource,
+} from "../src/local-unified-accounting-source.js";
+import {
+  createUnifiedIndexWriter,
+  openLocalUnifiedIndex,
+} from "../src/local-unified-index.js";
+
+const START_AT = "2026-08-01T00:00:00.000Z";
+const END_AT = "2026-08-02T00:00:00.000Z";
+const OBSERVED_MS = Date.parse("2026-08-01T12:00:00.000Z");
+const RESET_MS = Date.parse("2026-08-08T00:00:00.000Z");
+
+async function createIndex({ status = "complete", empty = false } = {}) {
+  const root = await mkdtemp(join(tmpdir(), "unified-accounting-source-"));
+  const indexFile = join(root, "unified.sqlite");
+  const database = openLocalUnifiedIndex(indexFile, { create: true });
+  const writer = createUnifiedIndexWriter(database, {
+    contractVersion: "usage-event-v0.2",
+    receivedAtMs: OBSERVED_MS,
+  });
+  writer.writeMeta("contract_version", "usage-event-v0.2");
+  writer.writeMeta("status", status);
+  writer.writeMeta("generated_at", "2026-08-01T13:00:00.000Z");
+  writer.writeMeta("source_count", empty ? 0 : 1);
+  writer.writeMeta("source_bytes", empty ? 0 : 4096);
+  if (!empty) {
+    const accountScopeId = writer.internAccountScope({
+      status: "unavailable",
+      reason: "missing_account",
+      planType: null,
+      scopeLocal: null,
+    });
+    const modelId = writer.internModel("gpt-5.6-sol", "recognized");
+    const tierId = writer.internTier({
+      apiServiceTier: "unknown",
+      billingSurface: "chatgpt_subscription",
+      codexSpeedMode: "fast",
+      tierSource: "rollout_thread_settings",
+      providerTierRaw: "priority",
+    });
+    const surfaceId = writer.internSurface({
+      agentScope: "root",
+      surface: "cli_exec",
+      threadSource: "user",
+      lineageDisposition: "standalone",
+    });
+    const quotaObservationId = writer.internQuota({
+      observedAtMs: OBSERVED_MS + 1_000,
+      limitId: "codex",
+      slot: "primary",
+      planType: null,
+      usedPercent: 12.5,
+      resetsAtMs: RESET_MS,
+      durationMins: 10_080,
+    });
+    const writeUsage = (eventKeyByte, inputTokens) => writer.writeUsageEvent({
+      eventKey: Buffer.alloc(32, eventKeyByte),
+      observedAtMs: OBSERVED_MS,
+      sessionLocal: Buffer.alloc(32, 7),
+      accountScopeId,
+      modelId,
+      tierId,
+      surfaceId,
+      quotaObservationId,
+      reasoningEffort: 4,
+      outcome: 5,
+      tokensInUncached: inputTokens,
+      tokensInCacheRead: 0,
+      tokensInCacheWrite: 0,
+      tokensInCacheWrite5m: null,
+      tokensInCacheWrite1h: null,
+      tokensOutText: 2,
+      tokensOutReasoning: 1,
+      tokensOutCombined: null,
+      totalInputContext: null,
+      partial: false,
+    });
+    // Insert in reverse key order; the read contract must still be stable.
+    writeUsage(2, 20);
+    writeUsage(1, 10);
+    // Quota-only token records exist in the current schema. They must not
+    // become zero-token accounting usage callbacks.
+    writer.writeUsageEvent({
+      eventKey: Buffer.alloc(32, 3),
+      observedAtMs: OBSERVED_MS + 1_000,
+      sessionLocal: Buffer.alloc(32, 7),
+      accountScopeId,
+      modelId,
+      tierId,
+      surfaceId,
+      quotaObservationId,
+      reasoningEffort: 4,
+      outcome: 5,
+      tokensInUncached: null,
+      tokensInCacheRead: null,
+      tokensInCacheWrite: null,
+      tokensInCacheWrite5m: null,
+      tokensInCacheWrite1h: null,
+      tokensOutText: null,
+      tokensOutReasoning: null,
+      tokensOutCombined: null,
+      totalInputContext: null,
+      partial: false,
+    });
+  }
+  writer.writeMeta("usage_events", writer.usageRows);
+  await writer.close({ fsyncPath: indexFile });
+  return { root, indexFile };
+}
+
+async function scan(indexFile, options = {}) {
+  const usage = [];
+  const quota = [];
+  const source = createLocalUnifiedAccountingSource({ indexFile, ...options });
+  const result = await source({
+    startAt: START_AT,
+    endAt: END_AT,
+    onUsage: async (row) => {
+      await Promise.resolve();
+      usage.push(row);
+    },
+    onRateLimitSnapshot: async (row) => {
+      await Promise.resolve();
+      quota.push(row);
+    },
+  });
+  return { result, usage, quota };
+}
+
+test("the current unified index maps deterministically without mutating SQLite", async () => {
+  const { root, indexFile } = await createIndex();
+  try {
+    const before = await stat(indexFile);
+    const { result, usage, quota } = await scan(indexFile);
+    const after = await stat(indexFile);
+    assert.equal(after.size, before.size);
+    assert.equal(after.mtimeMs, before.mtimeMs);
+    assert.equal(result.readerVersion, LOCAL_UNIFIED_ACCOUNTING_SOURCE_VERSION);
+    assert.equal(result.schemaVersion, "local-unified-index-v1");
+    assert.equal(result.parserVersion, "unified-rollout-typed-v3");
+    assert.equal(result.contractVersion, "usage-event-v0.2");
+    assert.deepEqual(result.compatibility.contractVersions, ["usage-event-v0.2"]);
+    assert.equal(result.coverage.status, "partial");
+    assert.equal(result.coverage.indexStatus, "complete");
+    assert.equal(result.coverage.blockReason, "accounting_contract_incomplete");
+    assert.deepEqual(result.capabilities, {
+      readsRawSources: false,
+      deterministicCanonicalOrder: true,
+      sourceOrderingProvenance: false,
+      sourceOffsetProvenance: false,
+      sourceScopedQuotaOccurrences: false,
+      durableDiagnostics: false,
+      crashSafeGenerationPublication: false,
+    });
+    assert.equal(result.diagnosticsAvailable, false);
+    assert.deepEqual(usage.map((row) => row.components.input_uncached_tokens), [10, 20]);
+    assert.deepEqual(usage.map((row) => row.sequence), [0, 1]);
+    assert.equal(Object.hasOwn(usage[0], "totalInputContextTokens"), false);
+    assert.equal(usage[0].model, "gpt-5.6-sol");
+    assert.deepEqual(usage[0].tierSemantics, {
+      billingSurface: "chatgpt_subscription",
+      codexSpeedMode: "fast",
+      apiServiceTier: "unknown",
+      tierSource: "rollout_thread_settings",
+      tierObservedAt: null,
+    });
+    assert.deepEqual(usage[0].surfaceClassification, {
+      surface: "cli_exec",
+      threadSource: "user",
+      agentScope: "root",
+      lineageDisposition: "standalone",
+    });
+    assert.equal(quota.length, 1);
+    assert.equal(quota[0].sequence, 2);
+    assert.deepEqual(quota[0].window, {
+      provider: "openai_codex",
+      planType: "unknown",
+      limitId: "codex",
+      slot: "primary",
+      usedPercent: 12.5,
+      windowDurationMins: 10_080,
+      resetsAt: RESET_MS / 1_000,
+    });
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("strict metadata validation rejects missing or stale required fields", async () => {
+  const { root, indexFile } = await createIndex();
+  try {
+    const database = openLocalUnifiedIndex(indexFile);
+    database.prepare("DELETE FROM meta WHERE key = ?").run("contract_version");
+    database.close();
+    await assert.rejects(
+      createLocalUnifiedAccountingSource({ indexFile })({
+        startAt: START_AT,
+        endAt: END_AT,
+      }),
+      (error) => error.code === "local_unified_index_meta_invalid",
+    );
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+
+  const stale = await createIndex();
+  try {
+    const database = openLocalUnifiedIndex(stale.indexFile);
+    database.prepare(
+      "UPDATE meta SET value = ? WHERE key = ?",
+    ).run("1", "usage_events");
+    database.close();
+    await assert.rejects(
+      createLocalUnifiedAccountingSource({ indexFile: stale.indexFile })({
+        startAt: START_AT,
+        endAt: END_AT,
+      }),
+      (error) => error.code === "local_unified_index_meta_invalid",
+    );
+  } finally {
+    await rm(stale.root, { recursive: true, force: true });
+  }
+});
+
+test("mixed parser rows are reported without pretending to have one parser", async () => {
+  const { root, indexFile } = await createIndex();
+  try {
+    const database = openLocalUnifiedIndex(indexFile);
+    database.prepare(
+      "INSERT INTO parser_version(parser_version, contract_version) VALUES (?, ?)",
+    ).run("unified-rollout-typed-v2", "usage-event-v0.2");
+    database.close();
+    const result = await createLocalUnifiedAccountingSource({ indexFile })({
+      startAt: START_AT,
+      endAt: END_AT,
+    });
+    assert.equal(result.parserVersion, null);
+    assert.equal(result.compatibility.status, "mixed_parser_versions");
+    assert.deepEqual(result.compatibility.parserVersions, [
+      "unified-rollout-typed-v2",
+      "unified-rollout-typed-v3",
+    ]);
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("callback errors stay fixed and content-free, and sequence counts callbacks only", async () => {
+  const { root, indexFile } = await createIndex();
+  try {
+    const callbackError = Object.assign(
+      new Error("PRIVATE_CALLBACK_CANARY"),
+      { code: "accounting_private_callback" },
+    );
+    await assert.rejects(
+      createLocalUnifiedAccountingSource({ indexFile })({
+        startAt: START_AT,
+        endAt: END_AT,
+        onUsage: () => {
+          throw callbackError;
+        },
+      }),
+      (error) => error.code === "local_unified_index_callback_failed"
+        && !error.message.includes("PRIVATE_CALLBACK_CANARY"),
+    );
+
+    const quota = [];
+    await createLocalUnifiedAccountingSource({ indexFile })({
+      startAt: START_AT,
+      endAt: END_AT,
+      onRateLimitSnapshot: (row) => quota.push(row),
+    });
+    assert.equal(quota[0].sequence, 0);
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("orphaned dimensions and null quota percentages fail closed", async () => {
+  const orphan = await createIndex();
+  try {
+    const database = openLocalUnifiedIndex(orphan.indexFile);
+    database.exec("PRAGMA foreign_keys = OFF");
+    database.prepare("UPDATE usage_event SET model_id = 999").run();
+    database.close();
+    await assert.rejects(
+      createLocalUnifiedAccountingSource({ indexFile: orphan.indexFile })({
+        startAt: START_AT,
+        endAt: END_AT,
+      }),
+      (error) => error.code === "local_unified_index_row_invalid",
+    );
+  } finally {
+    await rm(orphan.root, { recursive: true, force: true });
+  }
+
+  const nullQuota = await createIndex();
+  try {
+    const database = openLocalUnifiedIndex(nullQuota.indexFile);
+    database.prepare("UPDATE quota_observation SET used_percent = NULL").run();
+    database.close();
+    await assert.rejects(
+      createLocalUnifiedAccountingSource({ indexFile: nullQuota.indexFile })({
+        startAt: START_AT,
+        endAt: END_AT,
+      }),
+      (error) => error.code === "local_unified_index_row_invalid",
+    );
+  } finally {
+    await rm(nullQuota.root, { recursive: true, force: true });
+  }
+});
+
+test("tampered short event keys fail the fixed row boundary", async () => {
+  const { root, indexFile } = await createIndex();
+  try {
+    const database = openLocalUnifiedIndex(indexFile);
+    database.prepare(`
+      UPDATE usage_event
+      SET event_key = ?
+      WHERE rowid = (SELECT MIN(rowid) FROM usage_event)
+    `).run(Buffer.alloc(1, 9));
+    database.close();
+    await assert.rejects(
+      createLocalUnifiedAccountingSource({ indexFile })({
+        startAt: START_AT,
+        endAt: END_AT,
+      }),
+      (error) => error.code === "local_unified_index_row_invalid",
+    );
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("complete index status cannot overstate current accounting coverage", async () => {
+  const { root, indexFile } = await createIndex();
+  try {
+    const source = createLocalUnifiedAccountingSource({
+      indexFile,
+      requireComplete: true,
+    });
+    await assert.rejects(
+      source({ startAt: START_AT, endAt: END_AT }),
+      (error) => error.code
+        === "local_unified_index_accounting_coverage_incomplete",
+    );
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("empty and source-partial indexes remain honest readable characterizations", async () => {
+  for (const fixture of [
+    { status: "complete", empty: true, expectedReason: "accounting_contract_incomplete" },
+    { status: "partial", empty: false, expectedReason: "unified_index_incomplete" },
+  ]) {
+    const { root, indexFile } = await createIndex(fixture);
+    try {
+      const { result, usage } = await scan(indexFile);
+      assert.equal(result.coverage.status, "partial");
+      assert.equal(result.coverage.indexStatus, fixture.status);
+      assert.equal(result.coverage.blockReason, fixture.expectedReason);
+      if (fixture.empty) assert.deepEqual(usage, []);
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  }
+});
+
+test("missing, insecure, and incompatible files fail with fixed errors", async () => {
+  const root = await mkdtemp(join(tmpdir(), "unified-accounting-source-bad-"));
+  try {
+    const missing = createLocalUnifiedAccountingSource({
+      indexFile: join(root, "missing.sqlite"),
+    });
+    await assert.rejects(
+      missing({ startAt: START_AT, endAt: END_AT }),
+      (error) => error.code === "local_unified_index_missing",
+    );
+    const incompatibleFile = join(root, "incompatible.sqlite");
+    await writeFile(incompatibleFile, "PRIVATE_UNIFIED_SOURCE_CANARY", { mode: 0o600 });
+    const incompatible = createLocalUnifiedAccountingSource({
+      indexFile: incompatibleFile,
+    });
+    await assert.rejects(
+      incompatible({ startAt: START_AT, endAt: END_AT }),
+      (error) => (
+        error.code === "local_unified_index_schema_invalid"
+        || error.code === "local_unified_index_unavailable"
+      ) && !error.message.includes("PRIVATE_UNIFIED_SOURCE_CANARY"),
+    );
+    await chmod(incompatibleFile, 0o644);
+    await assert.rejects(
+      incompatible({ startAt: START_AT, endAt: END_AT }),
+      (error) => error.code === "local_unified_index_file_invalid",
+    );
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("requests and aborts fail before publishing partial callback output", async () => {
+  const { root, indexFile } = await createIndex();
+  try {
+    const source = createLocalUnifiedAccountingSource({ indexFile });
+    await assert.rejects(
+      source({ startAt: "2026-08-01T00:00:00Z", endAt: END_AT }),
+      (error) => error.code === "local_unified_index_read_request_invalid",
+    );
+    const preAborted = new AbortController();
+    preAborted.abort();
+    await assert.rejects(
+      source({
+        startAt: START_AT,
+        endAt: END_AT,
+        signal: preAborted.signal,
+      }),
+      (error) => error.name === "AbortError"
+        && error.code === "local_unified_index_read_aborted",
+    );
+    const midAbort = new AbortController();
+    const seen = [];
+    await assert.rejects(
+      source({
+        startAt: START_AT,
+        endAt: END_AT,
+        signal: midAbort.signal,
+        onUsage: (row) => {
+          seen.push(row);
+          midAbort.abort();
+        },
+      }),
+      (error) => error.name === "AbortError"
+        && error.code === "local_unified_index_read_aborted",
+    );
+    assert.equal(seen.length, 1);
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("malformed stored scalars fail content-free and the module has no raw-log boundary", async () => {
+  const { root, indexFile } = await createIndex();
+  const privateCanary = "/private/rollout/PRIVATE_UNIFIED_SOURCE_CANARY.jsonl";
+  try {
+    const database = openLocalUnifiedIndex(indexFile);
+    database.prepare("UPDATE model SET model_id = ?").run(privateCanary);
+    database.close();
+    await assert.rejects(
+      createLocalUnifiedAccountingSource({ indexFile })({
+        startAt: START_AT,
+        endAt: END_AT,
+      }),
+      (error) => error.code === "local_unified_index_row_invalid"
+        && !error.message.includes(privateCanary),
+    );
+    const source = await readFile(
+      new URL("../src/local-unified-accounting-source.js", import.meta.url),
+      "utf8",
+    );
+    for (const forbidden of [
+      "codex-log-scan",
+      "discoverCodexRolloutInfos",
+      "rollout-line-reader",
+      "local-analysis-index",
+    ]) assert.equal(source.includes(forbidden), false);
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});

--- a/test/local-unified-accounting-source.test.js
+++ b/test/local-unified-accounting-source.test.js
@@ -4,6 +4,7 @@ import {
   chmod,
   mkdtemp,
   readFile,
+  rename,
   rm,
   stat,
   writeFile,
@@ -16,7 +17,9 @@ import {
   createLocalUnifiedAccountingSource,
 } from "../src/local-unified-accounting-source.js";
 import {
+  beginUnifiedIndexGeneration,
   createUnifiedIndexWriter,
+  LOCAL_UNIFIED_INDEX_PARSER_VERSION,
   openLocalUnifiedIndex,
 } from "../src/local-unified-index.js";
 
@@ -29,9 +32,19 @@ async function createIndex({ status = "complete", empty = false } = {}) {
   const root = await mkdtemp(join(tmpdir(), "unified-accounting-source-"));
   const indexFile = join(root, "unified.sqlite");
   const database = openLocalUnifiedIndex(indexFile, { create: true });
+  const generation = beginUnifiedIndexGeneration(database, {
+    contractVersion: "usage-event-v0.2",
+    receivedAtMs: OBSERVED_MS,
+    discoveredSourceCount: empty ? 0 : 1,
+    discoveredSourceBytes: empty ? 0 : 4096,
+  });
+  const sourceLocal = Buffer.alloc(32, 4);
   const writer = createUnifiedIndexWriter(database, {
     contractVersion: "usage-event-v0.2",
     receivedAtMs: OBSERVED_MS,
+    generationId: generation.generationId,
+    parserVersionId: generation.parserVersionId,
+    ingestRunId: generation.ingestRunId,
   });
   writer.writeMeta("contract_version", "usage-event-v0.2");
   writer.writeMeta("status", status);
@@ -68,9 +81,14 @@ async function createIndex({ status = "complete", empty = false } = {}) {
       resetsAtMs: RESET_MS,
       durationMins: 10_080,
     });
-    const writeUsage = (eventKeyByte, inputTokens) => writer.writeUsageEvent({
+    const writeUsage = (eventKeyByte, inputTokens, sourceOffset) => writer.writeUsageEvent({
       eventKey: Buffer.alloc(32, eventKeyByte),
       observedAtMs: OBSERVED_MS,
+      generationId: generation.generationId,
+      sourceLocal,
+      sourceOffset,
+      sourceOrdinal: 0,
+      tierObservedAtMs: OBSERVED_MS - 1_000,
       sessionLocal: Buffer.alloc(32, 7),
       accountScopeId,
       modelId,
@@ -91,13 +109,18 @@ async function createIndex({ status = "complete", empty = false } = {}) {
       partial: false,
     });
     // Insert in reverse key order; the read contract must still be stable.
-    writeUsage(2, 20);
-    writeUsage(1, 10);
+    writeUsage(2, 20, 2);
+    writeUsage(1, 10, 1);
     // Quota-only token records exist in the current schema. They must not
     // become zero-token accounting usage callbacks.
     writer.writeUsageEvent({
       eventKey: Buffer.alloc(32, 3),
       observedAtMs: OBSERVED_MS + 1_000,
+      generationId: generation.generationId,
+      sourceLocal,
+      sourceOffset: 3,
+      sourceOrdinal: 0,
+      tierObservedAtMs: OBSERVED_MS - 1_000,
       sessionLocal: Buffer.alloc(32, 7),
       accountScopeId,
       modelId,
@@ -117,8 +140,67 @@ async function createIndex({ status = "complete", empty = false } = {}) {
       totalInputContext: null,
       partial: false,
     });
+    writer.writeQuotaOccurrence({
+      generationId: generation.generationId,
+      sourceLocal,
+      sourceOffset: 3,
+      sourceOrdinal: 0,
+      surfaceId,
+      canonicalObservationId: quotaObservationId,
+      observedAtMs: OBSERVED_MS + 1_000,
+      provider: "openai_codex",
+      planType: null,
+      limitId: "codex",
+      slot: "primary",
+      slotOrder: 0,
+      usedPercent: 12.5,
+      resetsAtMs: RESET_MS,
+      durationMins: 10_080,
+      admission: "admitted",
+    });
+    writer.writeSourceCursor({
+      sourceLocal,
+      sourceOrdinal: 0,
+      sessionLocal: Buffer.alloc(32, 7),
+      scannedBytes: 4096,
+      sizeBytes: 4096,
+      mtimeMs: OBSERVED_MS,
+      snapshotsPersisted: true,
+      turnContextSeen: true,
+      carryModel: "gpt-5.6-sol",
+      carryEffort: "high",
+      carryTierRaw: "priority",
+      carryTierObservedAtMs: OBSERVED_MS - 1_000,
+      carryTotals: null,
+    });
+    writer.writeGenerationSource({
+      generationId: generation.generationId,
+      sourceLocal,
+      sourceOrdinal: 0,
+      sessionLocal: Buffer.alloc(32, 7),
+      surfaceId,
+      status: "complete",
+      discoveredSizeBytes: 4096,
+      scannedBytes: 4096,
+      mtimeMs: OBSERVED_MS,
+      diagnosticsComplete: true,
+    });
+    writer.writeSourceDiagnostics(sourceLocal, {}, {
+      generationId: generation.generationId,
+    });
   }
-  writer.writeMeta("usage_events", writer.usageRows);
+  writer.writeMeta("contract_version", "usage-event-v0.2");
+  writer.writeMeta("status", status);
+  writer.finalizeGeneration({
+    status,
+    blockReason: status === "complete" ? null : "unified_index_incomplete",
+    discoveredSourceCount: empty ? 0 : 1,
+    discoveredSourceBytes: empty ? 0 : 4096,
+    indexedSourceCount: empty ? 0 : 1,
+    indexedSourceBytes: empty ? 0 : 4096,
+    discoveryComplete: status === "complete",
+    diagnosticsComplete: status === "complete",
+  });
   await writer.close({ fsyncPath: indexFile });
   return { root, indexFile };
 }
@@ -151,23 +233,33 @@ test("the current unified index maps deterministically without mutating SQLite",
     assert.equal(after.size, before.size);
     assert.equal(after.mtimeMs, before.mtimeMs);
     assert.equal(result.readerVersion, LOCAL_UNIFIED_ACCOUNTING_SOURCE_VERSION);
-    assert.equal(result.schemaVersion, "local-unified-index-v1");
-    assert.equal(result.parserVersion, "unified-rollout-typed-v3");
+    assert.equal(result.schemaVersion, "local-unified-index-v2");
+    assert.equal(result.parserVersion, LOCAL_UNIFIED_INDEX_PARSER_VERSION);
     assert.equal(result.contractVersion, "usage-event-v0.2");
     assert.deepEqual(result.compatibility.contractVersions, ["usage-event-v0.2"]);
-    assert.equal(result.coverage.status, "partial");
+    assert.equal(result.coverage.status, "complete");
     assert.equal(result.coverage.indexStatus, "complete");
-    assert.equal(result.coverage.blockReason, "accounting_contract_incomplete");
+    assert.equal(result.coverage.blockReason, null);
+    assert.equal(result.coverage.usageProvenanceAttested, true);
+    assert.equal(result.coverage.sourceOrderAttested, true);
+    assert.equal(result.coverage.quotaProvenanceAttested, true);
+    assert.equal(result.coverage.toolProvenanceAttested, true);
+    assert.equal(result.coverage.toolFactsComplete, true);
+    assert.equal(result.coverage.toolFacts, 0);
+    assert.match(
+      result.coverage.toolFactFingerprint,
+      /^tool-facts-v1-[a-f0-9]{64}$/u,
+    );
     assert.deepEqual(result.capabilities, {
       readsRawSources: false,
       deterministicCanonicalOrder: true,
-      sourceOrderingProvenance: false,
-      sourceOffsetProvenance: false,
-      sourceScopedQuotaOccurrences: false,
-      durableDiagnostics: false,
-      crashSafeGenerationPublication: false,
+      sourceOrderingProvenance: true,
+      sourceOffsetProvenance: true,
+      sourceScopedQuotaOccurrences: true,
+      durableDiagnostics: true,
+      crashSafeGenerationPublication: true,
     });
-    assert.equal(result.diagnosticsAvailable, false);
+    assert.equal(result.diagnosticsAvailable, true);
     assert.deepEqual(usage.map((row) => row.components.input_uncached_tokens), [10, 20]);
     assert.deepEqual(usage.map((row) => row.sequence), [0, 1]);
     assert.equal(Object.hasOwn(usage[0], "totalInputContextTokens"), false);
@@ -177,7 +269,7 @@ test("the current unified index maps deterministically without mutating SQLite",
       codexSpeedMode: "fast",
       apiServiceTier: "unknown",
       tierSource: "rollout_thread_settings",
-      tierObservedAt: null,
+      tierObservedAt: "2026-08-01T11:59:59.000Z",
     });
     assert.deepEqual(usage[0].surfaceClassification, {
       surface: "cli_exec",
@@ -196,6 +288,96 @@ test("the current unified index maps deterministically without mutating SQLite",
       windowDurationMins: 10_080,
       resetsAt: RESET_MS / 1_000,
     });
+    assert.equal(quota[0].surfaceClassification.surface, "cli_exec");
+    assert.equal(quota[0].sourceRecordOrdinal, 3);
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("context behavior is explicit and expected generations are bound", async () => {
+  const { root, indexFile } = await createIndex();
+  try {
+    const native = await scan(indexFile, { contextBehavior: "source_native" });
+    assert.equal(Object.hasOwn(native.usage[0], "totalInputContextTokens"), false);
+    const legacy = await scan(indexFile, { contextBehavior: "legacy_zero" });
+    assert.equal(legacy.usage[0].totalInputContextTokens, 0);
+    assert.equal(native.result.coverage.generationId > 0, true);
+    assert.equal(
+      native.result.coverage.generationFingerprint.startsWith("generation-v2-"),
+      true,
+    );
+    const bound = await scan(indexFile, {
+      expectedGeneration: {
+        id: native.result.coverage.generationId,
+        fingerprint: native.result.coverage.generationFingerprint,
+      },
+    });
+    assert.equal(bound.result.coverage.generationId, native.result.coverage.generationId);
+    await assert.rejects(
+      createLocalUnifiedAccountingSource({
+        indexFile,
+        expectedGeneration: native.result.coverage.generationId + 1,
+      })({ startAt: START_AT, endAt: END_AT }),
+      (error) => error.code === "local_unified_index_generation_mismatch",
+    );
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("generation fingerprints are canonical and metadata overrides must agree", async () => {
+  const { root, indexFile } = await createIndex();
+  try {
+    const baseline = await scan(indexFile);
+    const canonical = baseline.result.coverage.generationFingerprint;
+    const database = openLocalUnifiedIndex(indexFile);
+    database.prepare(`
+      INSERT INTO meta(key, value) VALUES (?, ?)
+      ON CONFLICT(key) DO UPDATE SET value = excluded.value
+    `).run("current_generation_fingerprint", canonical);
+    database.close();
+    const accepted = await scan(indexFile);
+    assert.equal(accepted.result.coverage.generationFingerprint, canonical);
+
+    const wrong = `generation-v2-${"0".repeat(64)}`;
+    const tampered = openLocalUnifiedIndex(indexFile);
+    tampered.prepare(`
+      UPDATE meta SET value = ? WHERE key = 'current_generation_fingerprint'
+    `).run(wrong);
+    tampered.close();
+    await assert.rejects(
+      scan(indexFile),
+      (error) => error.code === "local_unified_index_generation_invalid",
+    );
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("legacy nullable provenance is partial even when generation status is complete", async () => {
+  const { root, indexFile } = await createIndex();
+  try {
+    const database = openLocalUnifiedIndex(indexFile);
+    database.prepare(
+      "UPDATE usage_event SET source_offset = NULL WHERE source_offset = 1",
+    ).run();
+    database.close();
+    const result = await createLocalUnifiedAccountingSource({ indexFile })({
+      startAt: START_AT,
+      endAt: END_AT,
+    });
+    assert.equal(result.coverage.status, "partial");
+    assert.equal(result.coverage.blockReason, "legacy_nullable_rows");
+    assert.equal(result.capabilities.sourceOffsetProvenance, false);
+    await assert.rejects(
+      createLocalUnifiedAccountingSource({
+        indexFile,
+        requireComplete: true,
+      })({ startAt: START_AT, endAt: END_AT }),
+      (error) => error.code
+        === "local_unified_index_accounting_coverage_incomplete",
+    );
   } finally {
     await rm(root, { recursive: true, force: true });
   }
@@ -222,15 +404,22 @@ test("strict metadata validation rejects missing or stale required fields", asyn
   try {
     const database = openLocalUnifiedIndex(stale.indexFile);
     database.prepare(
-      "UPDATE meta SET value = ? WHERE key = ?",
-    ).run("1", "usage_events");
+      `UPDATE index_generation
+       SET usage_events = usage_events + 1
+       WHERE id = (SELECT value FROM meta WHERE key = 'current_generation_id')`,
+    ).run();
     database.close();
     await assert.rejects(
-      createLocalUnifiedAccountingSource({ indexFile: stale.indexFile })({
+      createLocalUnifiedAccountingSource({
+        indexFile: stale.indexFile,
+        requireComplete: true,
+        verifyPublishedGeneration: true,
+      })({
         startAt: START_AT,
         endAt: END_AT,
       }),
-      (error) => error.code === "local_unified_index_meta_invalid",
+      (error) => error.code
+        === "local_unified_index_accounting_coverage_incomplete",
     );
   } finally {
     await rm(stale.root, { recursive: true, force: true });
@@ -244,6 +433,14 @@ test("mixed parser rows are reported without pretending to have one parser", asy
     database.prepare(
       "INSERT INTO parser_version(parser_version, contract_version) VALUES (?, ?)",
     ).run("unified-rollout-typed-v2", "usage-event-v0.2");
+    const parserVersionId = database.prepare(
+      `SELECT id FROM parser_version
+       WHERE parser_version = 'unified-rollout-typed-v2'`,
+    ).get().id;
+    database.prepare(
+      `UPDATE usage_event SET parser_version_id = ?
+       WHERE rowid = (SELECT MIN(rowid) FROM usage_event)`,
+    ).run(parserVersionId);
     database.close();
     const result = await createLocalUnifiedAccountingSource({ indexFile })({
       startAt: START_AT,
@@ -253,7 +450,7 @@ test("mixed parser rows are reported without pretending to have one parser", asy
     assert.equal(result.compatibility.status, "mixed_parser_versions");
     assert.deepEqual(result.compatibility.parserVersions, [
       "unified-rollout-typed-v2",
-      "unified-rollout-typed-v3",
+      LOCAL_UNIFIED_INDEX_PARSER_VERSION,
     ]);
   } finally {
     await rm(root, { recursive: true, force: true });
@@ -279,6 +476,60 @@ test("callback errors stay fixed and content-free, and sequence counts callbacks
         && !error.message.includes("PRIVATE_CALLBACK_CANARY"),
     );
 
+    for (const abortError of [
+      Object.assign(new Error("PRIVATE_ABORT_CANARY"), { name: "AbortError" }),
+      Object.assign(new Error("PRIVATE_ABORT_CODE_CANARY"), { code: "ABORT_ERR" }),
+    ]) {
+      await assert.rejects(
+        createLocalUnifiedAccountingSource({ indexFile })({
+          startAt: START_AT,
+          endAt: END_AT,
+          onUsage: () => {
+            throw abortError;
+          },
+        }),
+        (error) => error.name === "AbortError"
+          && error.code === "local_unified_index_read_aborted"
+          && !error.message.includes("PRIVATE_ABORT"),
+      );
+    }
+
+    const resourceError = Object.assign(
+      new Error("PRIVATE_RESOURCE_CANARY"),
+      { code: "accounting_scan_rss_limit_exceeded" },
+    );
+    await assert.rejects(
+      createLocalUnifiedAccountingSource({ indexFile })({
+        startAt: START_AT,
+        endAt: END_AT,
+        onUsage: () => {
+          throw resourceError;
+        },
+      }),
+      (error) => error.code === "accounting_scan_rss_limit_exceeded"
+        && !error.message.includes("PRIVATE_RESOURCE_CANARY"),
+    );
+
+    for (const code of [
+      "accounting_refresh_aborted",
+      "accounting_transition_rss_measurement_invalid",
+      "accounting_archive_rss_measurement_invalid",
+    ]) {
+      await assert.rejects(
+        createLocalUnifiedAccountingSource({ indexFile })({
+          startAt: START_AT,
+          endAt: END_AT,
+          onUsage: () => {
+            throw Object.assign(new Error("PRIVATE_FIXED_CODE_CANARY"), {
+              code,
+            });
+          },
+        }),
+        (error) => error.code === code
+          && !error.message.includes("PRIVATE_FIXED_CODE_CANARY"),
+      );
+    }
+
     const quota = [];
     await createLocalUnifiedAccountingSource({ indexFile })({
       startAt: START_AT,
@@ -295,8 +546,7 @@ test("orphaned dimensions and null quota percentages fail closed", async () => {
   const orphan = await createIndex();
   try {
     const database = openLocalUnifiedIndex(orphan.indexFile);
-    database.exec("PRAGMA foreign_keys = OFF");
-    database.prepare("UPDATE usage_event SET model_id = 999").run();
+    database.prepare("UPDATE model SET model_id = ?").run("invalid model");
     database.close();
     await assert.rejects(
       createLocalUnifiedAccountingSource({ indexFile: orphan.indexFile })({
@@ -312,7 +562,7 @@ test("orphaned dimensions and null quota percentages fail closed", async () => {
   const nullQuota = await createIndex();
   try {
     const database = openLocalUnifiedIndex(nullQuota.indexFile);
-    database.prepare("UPDATE quota_observation SET used_percent = NULL").run();
+    database.prepare("UPDATE quota_occurrence SET resets_at_ms = NULL").run();
     database.close();
     await assert.rejects(
       createLocalUnifiedAccountingSource({ indexFile: nullQuota.indexFile })({
@@ -351,6 +601,9 @@ test("tampered short event keys fail the fixed row boundary", async () => {
 test("complete index status cannot overstate current accounting coverage", async () => {
   const { root, indexFile } = await createIndex();
   try {
+    const database = openLocalUnifiedIndex(indexFile);
+    database.prepare("UPDATE usage_event SET source_local = NULL").run();
+    database.close();
     const source = createLocalUnifiedAccountingSource({
       indexFile,
       requireComplete: true,
@@ -365,15 +618,84 @@ test("complete index status cannot overstate current accounting coverage", async
   }
 });
 
+test("full integrity rejects duplicate source ordinals and orphan quota observations", async () => {
+  const duplicate = await createIndex();
+  try {
+    const database = openLocalUnifiedIndex(duplicate.indexFile);
+    const generationId = Number(database.prepare(
+      "SELECT value FROM meta WHERE key = 'current_generation_id'",
+    ).get().value);
+    const surfaceId = database.prepare(
+      "SELECT surface_id FROM generation_source LIMIT 1",
+    ).get().surface_id;
+    database.prepare(`
+      INSERT INTO generation_source(
+        generation_id, source_local, source_ordinal, session_local, surface_id,
+        status, discovered_size_bytes, scanned_bytes, mtime_ms,
+        diagnostics_complete
+      ) VALUES (?, ?, ?, ?, ?, 'complete', ?, ?, ?, 1)
+    `).run(
+      generationId,
+      Buffer.alloc(32, 8),
+      0,
+      Buffer.alloc(32, 9),
+      surfaceId,
+      4096,
+      4096,
+      OBSERVED_MS,
+    );
+    database.prepare(`
+      UPDATE index_generation
+      SET indexed_source_count = 2, indexed_source_bytes = 8192
+      WHERE id = ?
+    `).run(generationId);
+    database.close();
+
+    const result = await scan(duplicate.indexFile, {
+      verifyPublishedGeneration: true,
+    });
+    assert.equal(result.result.coverage.generationProof, false);
+    assert.equal(result.result.coverage.provenanceComplete, false);
+    assert.equal(result.result.capabilities.deterministicCanonicalOrder, false);
+  } finally {
+    await rm(duplicate.root, { recursive: true, force: true });
+  }
+
+  const orphan = await createIndex();
+  try {
+    const database = openLocalUnifiedIndex(orphan.indexFile);
+    const generationId = Number(database.prepare(
+      "SELECT value FROM meta WHERE key = 'current_generation_id'",
+    ).get().value);
+    database.prepare("DELETE FROM quota_occurrence").run();
+    database.prepare(`
+      UPDATE index_generation SET quota_occurrences = 0 WHERE id = ?
+    `).run(generationId);
+    database.close();
+
+    const result = await scan(orphan.indexFile, {
+      verifyPublishedGeneration: true,
+    });
+    assert.equal(result.result.coverage.generationProof, false);
+    assert.equal(result.result.coverage.quotaOccurrencesComplete, false);
+    assert.equal(result.result.capabilities.sourceScopedQuotaOccurrences, false);
+  } finally {
+    await rm(orphan.root, { recursive: true, force: true });
+  }
+});
+
 test("empty and source-partial indexes remain honest readable characterizations", async () => {
   for (const fixture of [
-    { status: "complete", empty: true, expectedReason: "accounting_contract_incomplete" },
+    { status: "complete", empty: true, expectedReason: null },
     { status: "partial", empty: false, expectedReason: "unified_index_incomplete" },
   ]) {
     const { root, indexFile } = await createIndex(fixture);
     try {
       const { result, usage } = await scan(indexFile);
-      assert.equal(result.coverage.status, "partial");
+      assert.equal(
+        result.coverage.status,
+        fixture.status === "complete" ? "complete" : "partial",
+      );
       assert.equal(result.coverage.indexStatus, fixture.status);
       assert.equal(result.coverage.blockReason, fixture.expectedReason);
       if (fixture.empty) assert.deepEqual(usage, []);
@@ -452,6 +774,31 @@ test("requests and aborts fail before publishing partial callback output", async
     assert.equal(seen.length, 1);
   } finally {
     await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("published path identity is revalidated after callbacks", async () => {
+  const original = await createIndex();
+  const replacement = await createIndex();
+  try {
+    let swapped = false;
+    await assert.rejects(
+      createLocalUnifiedAccountingSource({ indexFile: original.indexFile })({
+        startAt: START_AT,
+        endAt: END_AT,
+        onUsage: async () => {
+          if (swapped) return;
+          swapped = true;
+          await rename(original.indexFile, `${original.indexFile}.old`);
+          await rename(replacement.indexFile, original.indexFile);
+        },
+      }),
+      (error) => error.code === "local_unified_index_file_changed",
+    );
+    assert.equal(swapped, true);
+  } finally {
+    await rm(original.root, { recursive: true, force: true });
+    await rm(replacement.root, { recursive: true, force: true });
   }
 });
 

--- a/test/local-unified-index.test.js
+++ b/test/local-unified-index.test.js
@@ -1,10 +1,24 @@
 import assert from "node:assert/strict";
-import { appendFile, mkdir, mkdtemp, rm, stat, writeFile } from "node:fs/promises";
+import {
+  appendFile,
+  lstat,
+  mkdir,
+  mkdtemp,
+  readFile,
+  readdir,
+  rm,
+  stat,
+  symlink,
+  utimes,
+  writeFile,
+} from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import test from "node:test";
 
 import { readCacheImpacts } from "../src/cache-switch-impact.js";
+import { readLocalUnifiedCompanionProjection } from "../src/local-unified-companion-source.js";
+import { createLocalUnifiedAccountingSource } from "../src/local-unified-accounting-source.js";
 
 import {
   balanceComponents,
@@ -22,6 +36,9 @@ import {
   ingestLocalUnifiedIndexIncrement,
 } from "../src/local-unified-index-ingest.js";
 import {
+  createLocalUnifiedIndexSecondaryIndexes,
+  createUnifiedIndexWriter,
+  beginUnifiedIndexGeneration,
   inspectLocalUnifiedIndex,
   LOCAL_UNIFIED_INDEX_PARSER_VERSION,
   localDigest,
@@ -29,6 +46,7 @@ import {
   OUTCOMES,
   outcomeOrdinal,
   readUnifiedIndexAggregate,
+  readUnifiedIndexGenerationDescriptor,
   REASONING_EFFORTS,
   reasoningEffortOrdinal,
   sessionLocal,
@@ -78,6 +96,14 @@ function threadSettings(timestamp, serviceTier) {
       type: "thread_settings_applied",
       thread_settings: { service_tier: serviceTier, reasoning_effort: "medium" },
     },
+  });
+}
+
+function toolCall(timestamp, payload) {
+  return JSON.stringify({
+    timestamp,
+    type: "response_item",
+    payload,
   });
 }
 
@@ -155,6 +181,64 @@ async function build(root, extra = {}) {
     contractVersion: CONTRACT,
     ...extra,
   });
+}
+
+const SECONDARY_INDEX_NAMES = [
+  "usage_event_observed",
+  "usage_event_session",
+  "usage_event_boundary_session",
+  "usage_event_replay_order",
+  "quota_occurrence_canonical",
+  "quota_occurrence_replay_order",
+  "tool_class_fact_generation",
+  "tool_class_fact_source",
+];
+
+function secondaryIndexNames(database) {
+  const placeholders = SECONDARY_INDEX_NAMES.map(() => "?").join(", ");
+  return database.prepare(
+    `SELECT name FROM sqlite_master
+     WHERE type = 'index' AND name IN (${placeholders}) ORDER BY name`,
+  ).all(...SECONDARY_INDEX_NAMES).map((row) => row.name);
+}
+
+function logicalProjection(database) {
+  return {
+    usage: database.prepare(`
+      SELECT hex(u.event_key) AS event_key, u.observed_at_ms,
+             m.model_id, t.billing_surface, t.codex_speed_mode,
+             t.api_service_tier, t.tier_source,
+             s.surface, s.thread_source, s.agent_scope,
+             s.lineage_disposition,
+             u.tokens_in_uncached, u.tokens_in_cache_read,
+             u.tokens_in_cache_write, u.tokens_in_cache_write_5m,
+             u.tokens_in_cache_write_1h, u.tokens_out_text,
+             u.tokens_out_reasoning, u.tokens_out_combined,
+             u.total_input_context, hex(u.source_local) AS source_local,
+             u.source_offset, u.source_ordinal, u.tier_observed_at_ms
+      FROM usage_event u
+      JOIN model m ON m.id = u.model_id
+      JOIN tier_semantics t ON t.id = u.tier_id
+      JOIN surface_class s ON s.id = u.surface_id
+      ORDER BY u.observed_at_ms, u.source_ordinal, u.source_local,
+               u.source_offset, u.event_key`).all(),
+    quotaObservations: database.prepare(`
+      SELECT observed_at_ms, limit_id, slot, plan_type, used_percent,
+             resets_at_ms, duration_mins
+      FROM quota_observation
+      ORDER BY observed_at_ms, limit_id, slot`).all(),
+    quotaOccurrences: database.prepare(`
+      SELECT hex(q.source_local) AS source_local, q.source_offset,
+             q.source_ordinal, q.observed_at_ms, q.provider, q.plan_type,
+             q.limit_id, q.slot, q.slot_order, q.used_percent,
+             q.resets_at_ms, q.duration_mins, q.admission,
+             s.surface, s.thread_source, s.agent_scope,
+             s.lineage_disposition
+      FROM quota_occurrence q
+      JOIN surface_class s ON s.id = q.surface_id
+      ORDER BY q.observed_at_ms, q.source_ordinal, q.source_local,
+               q.source_offset, q.slot_order`).all(),
+  };
 }
 
 test("the enum ordinals match the telemetry contract's fixed member lists", () => {
@@ -321,6 +405,409 @@ test("a rebuild indexes typed usage events and never stores content", async () =
       assert.ok(!dump.includes("/Users/nobody"));
       assert.ok(!dump.includes("session-a"));
       assert.ok(!dump.includes("turn-1"));
+    } finally {
+      database.close();
+    }
+  } finally {
+    await rm(root, { recursive: true });
+  }
+});
+
+test("deferred secondary indexes preserve logical facts and are present before publication", async () => {
+  const { root } = await corpus({
+    "rollout-2026-07-25T00-00-00-deferred.jsonl": [
+      sessionMeta("session-deferred"),
+      turnContext("2026-07-25T00:00:00.000Z", "gpt-5.6-sol"),
+      threadSettings("2026-07-25T00:00:01.000Z", "priority"),
+      tokenCount(
+        "2026-07-25T00:00:02.000Z",
+        usage(100, 10),
+        usage(100, 10),
+        { usedPercent: 12 },
+      ),
+      tokenCount(
+        "2026-07-25T00:00:03.000Z",
+        usage(300, 40),
+        usage(200, 30),
+      ),
+    ],
+  });
+  const indexFile = join(root, "index.sqlite");
+  const readProjection = () => {
+    const database = openLocalUnifiedIndex(indexFile, { readOnly: true });
+    try {
+      return {
+        aggregate: readUnifiedIndexAggregate(database),
+        logical: logicalProjection(database),
+        secondaryIndexes: secondaryIndexNames(database),
+      };
+    } finally {
+      database.close();
+    }
+  };
+  try {
+    await build(root, { deferSecondaryIndexes: false });
+    const online = readProjection();
+    assert.deepEqual(online.secondaryIndexes, [...SECONDARY_INDEX_NAMES].sort());
+
+    const deferred = await build(root, { deferSecondaryIndexes: true });
+    assert.equal(deferred.generation.status, "complete");
+    const rebuilt = readProjection();
+    assert.deepEqual(rebuilt.secondaryIndexes, [...SECONDARY_INDEX_NAMES].sort());
+    assert.deepEqual(rebuilt.aggregate, online.aggregate);
+    assert.deepEqual(rebuilt.logical, online.logical);
+  } finally {
+    await rm(root, { recursive: true });
+  }
+});
+
+test("quota coverage proof is planned through its canonical-occurrence index", async () => {
+  const { root } = await corpus({
+    "rollout-2026-07-25T00-00-00-proof-index.jsonl": [
+      sessionMeta("session-proof-index"),
+      turnContext("2026-07-25T00:00:00.000Z", "gpt-5.6-sol"),
+      tokenCount(
+        "2026-07-25T00:00:01.000Z",
+        usage(100, 10),
+        usage(100, 10),
+        { usedPercent: 12 },
+      ),
+    ],
+  });
+  const indexFile = join(root, "index.sqlite");
+  try {
+    await build(root, { deferSecondaryIndexes: true });
+    const database = openLocalUnifiedIndex(indexFile, { readOnly: true });
+    try {
+      const plan = database.prepare(`
+        EXPLAIN QUERY PLAN
+        SELECT COUNT(*) AS count FROM quota_observation q
+        WHERE NOT EXISTS (
+          SELECT 1 FROM quota_occurrence o
+          WHERE o.canonical_observation_id = q.id)
+      `).all();
+      assert.ok(
+        plan.some((row) => String(row.detail).includes(
+          "quota_occurrence_canonical",
+        )),
+        () => `quota proof plan did not use canonical index: ${JSON.stringify(plan)}`,
+      );
+      assert.equal(
+        Number(database.prepare(`
+          SELECT COUNT(*) AS count FROM quota_observation q
+          WHERE NOT EXISTS (
+            SELECT 1 FROM quota_occurrence o
+            WHERE o.canonical_observation_id = q.id)
+        `).get().count),
+        0,
+      );
+    } finally {
+      database.close();
+    }
+  } finally {
+    await rm(root, { recursive: true });
+  }
+});
+
+test("existing incremental indexes repair the quota proof index while read-only validation rejects its absence", async () => {
+  const { root } = await corpus({
+    "rollout-2026-07-25T00-00-00-proof-migration.jsonl": [
+      sessionMeta("session-proof-migration"),
+      turnContext("2026-07-25T00:00:00.000Z", "gpt-5.6-sol"),
+      tokenCount("2026-07-25T00:00:01.000Z", usage(100, 10), usage(100, 10)),
+    ],
+  });
+  const indexFile = join(root, "index.sqlite");
+  try {
+    await build(root);
+    const writable = openLocalUnifiedIndex(indexFile, { readOnly: false });
+    writable.exec("DROP INDEX quota_occurrence_canonical");
+    writable.close();
+
+    assert.throws(
+      () => openLocalUnifiedIndex(indexFile, { readOnly: true }),
+      (error) => error?.code === "local_unified_index_secondary_indexes_missing",
+    );
+
+    const result = await ingestLocalUnifiedIndexIncrement({
+      codexHome: root,
+      indexFile,
+      secretFile: join(root, "salt"),
+      contractVersion: CONTRACT,
+    });
+    assert.equal(result.status, "ingested");
+    assert.equal(result.insertedUsageEvents, 0);
+    assert.equal(result.totalUsageEvents, 1);
+
+    const repaired = openLocalUnifiedIndex(indexFile, { readOnly: true });
+    try {
+      assert.deepEqual(
+        secondaryIndexNames(repaired),
+        [...SECONDARY_INDEX_NAMES].sort(),
+      );
+    } finally {
+      repaired.close();
+    }
+  } finally {
+    await rm(root, { recursive: true });
+  }
+});
+
+test("deferred secondary-index failure rolls back the stage and cannot target an existing index", async () => {
+  const { root } = await corpus({
+    "rollout-2026-07-25T00-00-00-deferred-failure.jsonl": [
+      sessionMeta("session-deferred-failure"),
+      turnContext("2026-07-25T00:00:00.000Z", "gpt-5.6-sol"),
+      tokenCount("2026-07-25T00:00:01.000Z", usage(100, 10), usage(100, 10)),
+    ],
+  });
+  const indexFile = join(root, "index.sqlite");
+  const stageFile = join(root, "blocked-stage.sqlite");
+  try {
+    await build(root, { deferSecondaryIndexes: false });
+    const before = await stat(indexFile);
+    const beforeProjection = (() => {
+      const database = openLocalUnifiedIndex(indexFile, { readOnly: true });
+      try {
+        return logicalProjection(database);
+      } finally {
+        database.close();
+      }
+    })();
+
+    const staging = openLocalUnifiedIndex(stageFile, {
+      readOnly: false,
+      create: true,
+      staging: true,
+      deferSecondaryIndexes: true,
+    });
+    try {
+      assert.deepEqual(secondaryIndexNames(staging), []);
+      // The first index can be created, but the second is deliberately blocked
+      // by a table with the same name. The helper's transaction must roll the
+      // first one back rather than leaving a partially indexed stage.
+      staging.exec("CREATE TABLE usage_event_session(blocked INTEGER)");
+      assert.throws(
+        () => createLocalUnifiedIndexSecondaryIndexes(staging),
+        (error) => error?.code === "local_unified_index_secondary_indexes_failed",
+      );
+      assert.deepEqual(secondaryIndexNames(staging), []);
+    } finally {
+      staging.close();
+    }
+
+    assert.throws(
+      () => openLocalUnifiedIndex(indexFile, {
+        readOnly: false,
+        create: true,
+        staging: true,
+        deferSecondaryIndexes: true,
+      }),
+      (error) => error?.code
+        === "local_unified_index_deferred_indexes_requires_new_stage",
+    );
+    const after = await stat(indexFile);
+    assert.equal(after.size, before.size);
+    assert.equal(after.mtimeMs, before.mtimeMs);
+    const database = openLocalUnifiedIndex(indexFile, { readOnly: true });
+    try {
+      assert.deepEqual(logicalProjection(database), beforeProjection);
+      assert.deepEqual(secondaryIndexNames(database), [...SECONDARY_INDEX_NAMES].sort());
+    } finally {
+      database.close();
+    }
+  } finally {
+    await rm(root, { recursive: true });
+  }
+});
+
+test("a published generation attests provenance, source order and quota occurrences", async () => {
+  const { root } = await corpus({
+    "rollout-2026-07-25T00-00-00-attested.jsonl": [
+      sessionMeta("session-attested"),
+      turnContext("2026-07-25T00:00:00.000Z", "gpt-5.6-sol"),
+      threadSettings("2026-07-25T00:00:01.000Z", "priority"),
+      tokenCount(
+        "2026-07-25T00:00:02.000Z",
+        usage(100, 10),
+        usage(100, 10),
+        { usedPercent: 12 },
+      ),
+    ],
+  });
+  try {
+    const built = await build(root);
+    assert.equal(built.generation.status, "complete");
+    assert.equal(built.generation.usageProvenanceComplete, true);
+    assert.equal(built.generation.sourceOrderComplete, true);
+    assert.equal(built.generation.quotaProvenanceComplete, true);
+
+    const database = openLocalUnifiedIndex(join(root, "index.sqlite"), { readOnly: true });
+    try {
+      const generation = database.prepare(`
+        SELECT status, usage_events, quota_occurrences,
+               usage_provenance_complete, source_order_complete,
+               quota_provenance_complete
+        FROM index_generation
+        WHERE id = (SELECT CAST(value AS INTEGER)
+                    FROM meta WHERE key = 'current_generation_id')
+      `).get();
+      assert.equal(generation.status, "complete");
+      assert.equal(generation.usage_events, 1);
+      assert.equal(generation.quota_occurrences, 1);
+      assert.equal(generation.usage_provenance_complete, 1);
+      assert.equal(generation.source_order_complete, 1);
+      assert.equal(generation.quota_provenance_complete, 1);
+
+      const usageRow = database.prepare(`
+        SELECT length(source_local) AS source_bytes, source_offset,
+               source_ordinal, tier_observed_at_ms
+        FROM usage_event
+      `).get();
+      assert.equal(usageRow.source_bytes, 32);
+      assert.ok(Number.isSafeInteger(usageRow.source_offset));
+      assert.equal(usageRow.source_ordinal, 0);
+      assert.ok(Number.isSafeInteger(usageRow.tier_observed_at_ms));
+
+      const quota = database.prepare(`
+        SELECT length(source_local) AS source_bytes, source_offset,
+               source_ordinal, slot_order, admission, resets_at_ms
+        FROM quota_occurrence
+      `).get();
+      assert.equal(quota.source_bytes, 32);
+      assert.ok(Number.isSafeInteger(quota.source_offset));
+      assert.equal(quota.source_ordinal, 0);
+      assert.equal(quota.slot_order, 0);
+      assert.equal(quota.admission, "admitted");
+      assert.ok(Number.isSafeInteger(quota.resets_at_ms));
+
+      const source = database.prepare(`
+        SELECT source_ordinal, status, diagnostics_complete
+        FROM generation_source
+      `).get();
+      assert.equal(source.source_ordinal, 0);
+      assert.equal(source.status, "complete");
+      assert.equal(source.diagnostics_complete, 1);
+
+      const descriptor = readUnifiedIndexGenerationDescriptor(database);
+      assert.equal(descriptor.fingerprint, built.generation.fingerprint);
+      assert.equal(descriptor.usageProvenanceComplete, true);
+      assert.equal(descriptor.sourceOrderComplete, true);
+      assert.equal(descriptor.quotaProvenanceComplete, true);
+    } finally {
+      database.close();
+    }
+  } finally {
+    await rm(root, { recursive: true });
+  }
+});
+
+test("generation finalization rejects a cursor with missing source ordinal", async () => {
+  const { root } = await corpus({
+    "rollout-2026-07-25T00-00-00-cursor-order.jsonl": [
+      sessionMeta("session-cursor-order"),
+      turnContext("2026-07-25T00:00:00.000Z", "gpt-5.6-sol"),
+      tokenCount("2026-07-25T00:00:01.000Z", usage(100, 10), usage(100, 10)),
+    ],
+  });
+  const indexFile = join(root, "index.sqlite");
+  try {
+    await build(root);
+    const database = openLocalUnifiedIndex(indexFile, { readOnly: false });
+    const source = database.prepare(`
+      SELECT source_local, source_ordinal, session_local, surface_id,
+             discovered_size_bytes, scanned_bytes, mtime_ms, diagnostics_complete
+      FROM generation_source
+      WHERE generation_id = (SELECT CAST(value AS INTEGER) FROM meta
+                             WHERE key = 'current_generation_id')`).get();
+    database.prepare("UPDATE source_cursor SET source_ordinal = NULL").run();
+    const generation = beginUnifiedIndexGeneration(database, {
+      contractVersion: CONTRACT,
+    });
+    const writer = createUnifiedIndexWriter(database, {
+      contractVersion: CONTRACT,
+      generationId: generation.generationId,
+      parserVersionId: generation.parserVersionId,
+      ingestRunId: generation.ingestRunId,
+    });
+    writer.writeGenerationSource({
+      sourceLocal: Buffer.from(source.source_local),
+      sourceOrdinal: Number(source.source_ordinal),
+      sessionLocal: Buffer.from(source.session_local),
+      surfaceId: Number(source.surface_id),
+      status: "complete",
+      discoveredSizeBytes: Number(source.discovered_size_bytes),
+      scannedBytes: Number(source.scanned_bytes),
+      mtimeMs: Number(source.mtime_ms),
+      diagnosticsComplete: Number(source.diagnostics_complete) === 1,
+    });
+    writer.finalizeGeneration({
+      status: "complete",
+      discoveryComplete: true,
+      diagnosticsComplete: true,
+    });
+    await writer.close({ integrityCheck: true, fsyncPath: null });
+    const published = openLocalUnifiedIndex(indexFile, { readOnly: true });
+    // The staged test generation is not published over the path, but its
+    // descriptor is durable in this connection before close; the source-order
+    // proof itself is asserted by the generation row below.
+    try {
+      const row = published.prepare(`
+        SELECT source_order_complete, status, block_reason
+        FROM index_generation WHERE id = ?`).get(generation.generationId);
+      assert.equal(row.source_order_complete, 0);
+      assert.equal(row.status, "partial");
+      assert.equal(row.block_reason, "source_order_incomplete");
+    } finally {
+      published.close();
+    }
+  } finally {
+    await rm(root, { recursive: true });
+  }
+});
+
+test("held and suppressed quota observations remain represented by a complete generation", async () => {
+  const { root } = await corpus({
+    "rollout-2026-07-25T00-00-00-quota-gate.jsonl": [
+      sessionMeta("session-quota-gate"),
+      turnContext("2026-07-25T00:00:00.000Z", "gpt-5.6-sol"),
+      tokenCount(
+        "2026-07-25T00:00:01.000Z",
+        usage(100, 10),
+        usage(100, 10),
+        { usedPercent: 12 },
+      ),
+      // The quick ten-minute rise is withheld as a contradicted leading
+      // snapshot; the later reading is admitted when the source is flushed.
+      tokenCount(
+        "2026-07-25T00:00:02.000Z",
+        usage(200, 20),
+        usage(100, 10),
+        { usedPercent: 25 },
+      ),
+    ],
+  });
+  try {
+    const built = await build(root);
+    assert.equal(built.generation.status, "complete");
+    assert.equal(built.generation.quotaProvenanceComplete, true);
+    const database = openLocalUnifiedIndex(join(root, "index.sqlite"), { readOnly: true });
+    try {
+      const rows = database.prepare(`
+        SELECT admission, canonical_observation_id
+        FROM quota_occurrence ORDER BY slot_order, id
+      `).all();
+      assert.ok(rows.some((row) => row.admission === "suppressed"));
+      assert.ok(rows.some((row) => row.admission === "admitted"));
+      assert.equal(
+        Number(database.prepare(`
+          SELECT COUNT(*) AS c FROM quota_observation q
+          WHERE NOT EXISTS (
+            SELECT 1 FROM quota_occurrence o
+            WHERE o.canonical_observation_id = q.id)
+        `).get().c),
+        0,
+      );
     } finally {
       database.close();
     }
@@ -1140,6 +1627,44 @@ test("a rebuild refuses an unstated contract version", async () => {
   }
 });
 
+test("a rebuild setup failure removes its unpublished staging database", async () => {
+  const { root } = await corpus({
+    "rollout-2026-07-25T00-00-00-setup.jsonl": [sessionMeta("session-setup")],
+  });
+  try {
+    await assert.rejects(
+      build(root, { commitRows: 0 }),
+      /commitRows must be a positive safe integer/u,
+    );
+    assert.deepEqual(
+      (await readdir(root)).filter((name) => name.includes(".building-")),
+      [],
+    );
+  } finally {
+    await rm(root, { recursive: true });
+  }
+});
+
+test("writers refuse to replace an unsafe published-index target", async () => {
+  const { root } = await corpus({
+    "rollout-2026-07-25T00-00-00-target.jsonl": [sessionMeta("session-target")],
+  });
+  const sentinel = join(root, "sentinel.txt");
+  const indexFile = join(root, "index.sqlite");
+  try {
+    await writeFile(sentinel, "do-not-touch", { mode: 0o600 });
+    await symlink(sentinel, indexFile);
+    await assert.rejects(
+      build(root),
+      (error) => error?.code === "local_unified_index_file_invalid",
+    );
+    assert.equal(await readFile(sentinel, "utf8"), "do-not-touch");
+    assert.equal((await lstat(indexFile)).isSymbolicLink(), true);
+  } finally {
+    await rm(root, { recursive: true });
+  }
+});
+
 // --- Incremental ingest -----------------------------------------------------
 
 test("an incremental pass resumes a cold rebuild's cursors and reads only appended bytes", async () => {
@@ -1320,6 +1845,483 @@ test("a same-parser shrink removes stale usage and boundary rows before rescan",
   }
 });
 
+test("an unchanged incremental pass preserves the live generation and file metadata", async () => {
+  const { root } = await corpus({
+    "rollout-2026-07-25T00-00-00-unchanged.jsonl": [
+      sessionMeta("session-unchanged"),
+      turnContext("2026-07-25T00:00:00.000Z", "gpt-5.6-sol"),
+      tokenCount("2026-07-25T00:00:01.000Z", usage(100, 10), usage(100, 10)),
+    ],
+  });
+  const indexFile = join(root, "index.sqlite");
+  try {
+    const built = await build(root);
+    const before = await stat(indexFile);
+    const result = await ingestLocalUnifiedIndexIncrement({
+      codexHome: root,
+      indexFile,
+      secretFile: join(root, "salt"),
+      contractVersion: CONTRACT,
+    });
+    const after = await stat(indexFile);
+    assert.equal(result.unchanged, true);
+    assert.equal(result.bytesScanned, 0);
+    assert.equal(result.insertedUsageEvents, 0);
+    assert.equal(result.generation.fingerprint, built.generation.fingerprint);
+    assert.equal(after.size, before.size);
+    assert.equal(after.mtimeMs, before.mtimeMs);
+    assert.deepEqual(
+      (await readdir(root)).filter((name) => name.includes(".incremental-")),
+      [],
+    );
+  } finally {
+    await rm(root, { recursive: true });
+  }
+});
+
+test("tool facts are private, generation-bound, incremental and rescan-safe", async () => {
+  const sourceName = "rollout-2026-07-25T00-00-00-tools.jsonl";
+  const privateToolName = "PRIVATE_TOOL_NAME_CANARY";
+  const privateCallId = "PRIVATE_TOOL_CALL_ID_CANARY";
+  const initialLines = [
+    sessionMeta("session-tools"),
+    turnContext("2026-07-25T00:00:00.000Z", "gpt-5.6-sol"),
+    toolCall("2026-07-25T00:00:01.000Z", {
+      type: "function_call",
+      name: "thread_spawn",
+      call_id: privateCallId,
+    }),
+    toolCall("2026-07-25T00:00:02.000Z", {
+      type: "custom_tool_call",
+      name: privateToolName,
+      call_id: `${privateCallId}-other`,
+    }),
+  ];
+  const { root, sessions } = await corpus({ [sourceName]: initialLines });
+  const sourceFile = join(sessions, sourceName);
+  const indexFile = join(root, "index.sqlite");
+  const ingest = () => ingestLocalUnifiedIndexIncrement({
+    codexHome: root,
+    indexFile,
+    secretFile: join(root, "salt"),
+    contractVersion: CONTRACT,
+  });
+  const readFacts = () => {
+    const database = openLocalUnifiedIndex(indexFile, { readOnly: true });
+    try {
+      return {
+        descriptor: readUnifiedIndexGenerationDescriptor(database),
+        facts: database.prepare(`
+          SELECT hex(event_key) AS event_key, tool_class, source_kind,
+                 source_offset, tool_ordinal, generation_id
+          FROM tool_class_fact ORDER BY source_offset, tool_ordinal`).all(),
+        compatibility: database.prepare(`
+          SELECT tool_class, SUM(count) AS count
+          FROM tool_class_count GROUP BY tool_class ORDER BY tool_class`).all()
+          .map((row) => ({
+            tool_class: row.tool_class,
+            count: Number(row.count),
+          })),
+      };
+    } finally {
+      database.close();
+    }
+  };
+  try {
+    const built = await build(root);
+    assert.equal(built.toolEvents, 2);
+    assert.equal(built.generation.toolFacts, 2);
+    assert.equal(built.generation.toolProvenanceComplete, true);
+    assert.match(built.generation.toolFactFingerprint, /^tool-facts-v1-[a-f0-9]{64}$/u);
+    const cold = readFacts();
+    assert.deepEqual(cold.facts.map((row) => row.tool_class), [
+      "subagent",
+      "other",
+    ]);
+    assert.deepEqual(cold.compatibility, [
+      { tool_class: "other", count: 1 },
+      { tool_class: "subagent", count: 1 },
+    ]);
+    const publishedBytes = await readFile(indexFile);
+    assert.equal(publishedBytes.includes(privateToolName), false);
+    assert.equal(publishedBytes.includes(privateCallId), false);
+
+    const before = await stat(indexFile);
+    const unchanged = await ingest();
+    const after = await stat(indexFile);
+    assert.equal(unchanged.unchanged, true);
+    assert.equal(unchanged.bytesScanned, 0);
+    assert.equal(after.size, before.size);
+    assert.equal(after.mtimeMs, before.mtimeMs);
+
+    await appendFile(sourceFile, `${toolCall(
+      "2026-07-25T00:00:03.000Z",
+      { type: "web_search_call", id: `${privateCallId}-server` },
+    )}\n`);
+    const appended = await ingest();
+    assert.equal(appended.sourcesResumed, 1);
+    assert.equal(appended.toolEvents, 1);
+    assert.equal(appended.generation.toolFacts, 3);
+    assert.equal(appended.generation.toolProvenanceComplete, true);
+    const afterAppend = readFacts();
+    assert.deepEqual(afterAppend.facts.slice(0, 2).map((row) => row.event_key),
+      cold.facts.map((row) => row.event_key));
+    assert.deepEqual(afterAppend.facts.map((row) => row.tool_class), [
+      "subagent",
+      "other",
+      "web_search",
+    ]);
+    assert.ok(afterAppend.facts.every((row) => (
+      row.generation_id === appended.generation.id
+    )));
+
+    await writeFile(sourceFile, `${[
+      sessionMeta("session-tools"),
+      turnContext("2026-07-25T00:00:00.000Z", "gpt-5.6-sol"),
+      toolCall("2026-07-25T00:00:04.000Z", {
+        type: "shell_call",
+        id: `${privateCallId}-replacement`,
+      }),
+    ].join("\n")}\n`);
+    const rescanned = await ingest();
+    assert.equal(rescanned.sourcesRescanned, 1);
+    assert.equal(rescanned.generation.toolFacts, 1);
+    const afterRescan = readFacts();
+    assert.deepEqual(afterRescan.facts.map((row) => row.tool_class), [
+      "hosted_shell",
+    ]);
+    assert.deepEqual(afterRescan.compatibility, [
+      { tool_class: "hosted_shell", count: 1 },
+    ]);
+  } finally {
+    await rm(root, { recursive: true });
+  }
+});
+
+test("an oversized typed tool record blocks complete generation publication", async () => {
+  const { root } = await corpus({
+    "rollout-2026-07-25T00-00-00-tool-limit.jsonl": [
+      sessionMeta("session-tool-limit"),
+      turnContext("2026-07-25T00:00:00.000Z", "gpt-5.6-sol"),
+      toolCall("2026-07-25T00:00:01.000Z", {
+        type: "custom_tool_call",
+        name: "exec",
+        input: `PRIVATE_OVERSIZED_TOOL_INPUT_${"x".repeat(4_096)}`,
+      }),
+    ],
+  });
+  try {
+    const built = await build(root, { maximumLineBytes: 512 });
+    assert.equal(built.generation.status, "partial");
+    assert.equal(built.generation.blockReason, "tool_provenance_incomplete");
+    assert.equal(built.generation.toolProvenanceComplete, false);
+    const database = openLocalUnifiedIndex(join(root, "index.sqlite"), {
+      readOnly: true,
+    });
+    try {
+      const skipped = database.prepare(`
+        SELECT count FROM source_diagnostic
+        WHERE generation_id = ? AND code = 'toolRecordsSkipped'
+      `).get(built.generation.id);
+      assert.equal(Number(skipped?.count), 1);
+      assert.equal(Number(database.prepare(
+        "SELECT COUNT(*) AS count FROM tool_class_fact",
+      ).get().count), 0);
+    } finally {
+      database.close();
+    }
+  } finally {
+    await rm(root, { recursive: true });
+  }
+});
+
+test("same-size replacement and truncation replace source usage and quota facts", async () => {
+  const sourceName = "rollout-2026-07-25T00-00-00-replaced.jsonl";
+  const initialLines = [
+    sessionMeta("session-replaced"),
+    turnContext("2026-07-25T00:00:00.000Z", "gpt-5.6-sol"),
+    tokenCount(
+      "2026-07-25T00:00:01.000Z",
+      usage(100, 10),
+      usage(100, 10),
+      { usedPercent: 12 },
+    ),
+  ];
+  const { root, sessions } = await corpus({ [sourceName]: initialLines });
+  const sourceFile = join(sessions, sourceName);
+  const indexFile = join(root, "index.sqlite");
+  try {
+    await build(root);
+    const original = await stat(sourceFile);
+    const replacementLines = [
+      sessionMeta("session-replaced"),
+      turnContext("2026-07-25T00:00:00.000Z", "gpt-5.6-sol"),
+      tokenCount(
+        "2026-07-25T00:00:01.000Z",
+        usage(900, 90),
+        usage(900, 90),
+        { usedPercent: 92 },
+      ),
+    ];
+    await writeFile(sourceFile, `${replacementLines.join("\n")}\n`);
+    assert.equal((await stat(sourceFile)).size, original.size);
+    await utimes(
+      sourceFile,
+      original.atime,
+      new Date(original.mtimeMs + 2_000),
+    );
+
+    const replaced = await ingestLocalUnifiedIndexIncrement({
+      codexHome: root,
+      indexFile,
+      secretFile: join(root, "salt"),
+      contractVersion: CONTRACT,
+    });
+    assert.equal(replaced.sourcesRescanned, 1);
+    assert.equal(replaced.totalUsageEvents, 1);
+    assert.equal(replaced.quotaOccurrenceRowsDeletedForRescan, 1);
+    {
+      const database = openLocalUnifiedIndex(indexFile, { readOnly: true });
+      try {
+        assert.equal(Number(database.prepare(`
+          SELECT SUM(tokens_in_uncached) AS total FROM usage_event`).get().total), 900);
+        assert.equal(Number(database.prepare(`
+          SELECT used_percent FROM quota_observation`).get().used_percent), 92);
+        assert.equal(Number(database.prepare(`
+          SELECT COUNT(*) AS count FROM quota_occurrence`).get().count), 1);
+      } finally {
+        database.close();
+      }
+    }
+
+    await writeFile(sourceFile, `${initialLines.slice(0, 2).join("\n")}\n`);
+    const truncated = await ingestLocalUnifiedIndexIncrement({
+      codexHome: root,
+      indexFile,
+      secretFile: join(root, "salt"),
+      contractVersion: CONTRACT,
+    });
+    assert.equal(truncated.sourcesRescanned, 1);
+    assert.equal(truncated.totalUsageEvents, 0);
+    {
+      const database = openLocalUnifiedIndex(indexFile, { readOnly: true });
+      try {
+        assert.equal(Number(database.prepare(`
+          SELECT COUNT(*) AS count FROM usage_event`).get().count), 0);
+        assert.equal(Number(database.prepare(`
+          SELECT COUNT(*) AS count FROM quota_occurrence`).get().count), 0);
+        assert.equal(Number(database.prepare(`
+          SELECT COUNT(*) AS count FROM quota_observation`).get().count), 0);
+      } finally {
+        database.close();
+      }
+    }
+  } finally {
+    await rm(root, { recursive: true });
+  }
+});
+
+test("a shrunken discovered source set publishes a new generation", async () => {
+  const firstName = "rollout-2026-07-25T00-00-00-source-a.jsonl";
+  const secondName = "rollout-2026-07-25T00-00-00-source-b.jsonl";
+  const { root, sessions } = await corpus({
+    [firstName]: [
+      sessionMeta("session-source-a"),
+      turnContext("2026-07-25T00:00:00.000Z", "gpt-5.6-sol"),
+      tokenCount("2026-07-25T00:00:01.000Z", usage(100, 10), usage(100, 10)),
+    ],
+    [secondName]: [
+      sessionMeta("session-source-b"),
+      turnContext("2026-07-25T00:00:00.000Z", "gpt-5.6-sol"),
+      tokenCount("2026-07-25T00:00:01.000Z", usage(200, 20), usage(200, 20)),
+    ],
+  });
+  const indexFile = join(root, "index.sqlite");
+  try {
+    const built = await build(root);
+    assert.equal(built.generation.discoveredSourceCount, 2);
+    await rm(join(sessions, secondName));
+
+    const result = await ingestLocalUnifiedIndexIncrement({
+      codexHome: root,
+      indexFile,
+      secretFile: join(root, "salt"),
+      contractVersion: CONTRACT,
+    });
+
+    assert.notEqual(result.unchanged, true);
+    assert.ok(result.generation.id > built.generation.id);
+    assert.equal(result.generation.discoveredSourceCount, 1);
+    assert.equal(result.generation.indexedSourceCount, 2);
+    assert.equal(result.generation.status, "complete");
+    assert.equal(result.sources, 1);
+    assert.equal(result.sourcesSkipped, 1);
+    assert.equal(result.bytesScanned, 0);
+    assert.equal(result.totalUsageEvents, 2, "rotated raw sources remain indexed");
+    const database = openLocalUnifiedIndex(indexFile, { readOnly: true });
+    try {
+      assert.equal(Number(database.prepare(`
+        SELECT COUNT(*) AS count FROM generation_source
+        WHERE generation_id = ?`).get(result.generation.id).count), 2);
+    } finally {
+      database.close();
+    }
+    const projection = await readLocalUnifiedCompanionProjection({
+      indexFile,
+      nowMs: Date.parse("2026-07-25T12:00:00.000Z"),
+    });
+    assert.equal(projection.status, "available");
+    assert.equal(projection.discoveredSourceCount, 1);
+    assert.equal(projection.indexedSourceCount, 2);
+    assert.ok(projection.indexedSourceBytes > projection.discoveredSourceBytes);
+  } finally {
+    await rm(root, { recursive: true });
+  }
+});
+
+test("a rotated pre-tool source withholds tools without blocking accounting", async () => {
+  const firstName = "rollout-2026-07-25T00-00-00-current-tools.jsonl";
+  const secondName = "rollout-2026-07-25T00-00-00-rotated-v7.jsonl";
+  const { root, sessions } = await corpus({
+    [firstName]: [
+      sessionMeta("session-current-tools"),
+      turnContext("2026-07-25T00:00:00.000Z", "gpt-5.6-sol"),
+      tokenCount("2026-07-25T00:00:01.000Z", usage(100, 10), usage(100, 10)),
+    ],
+    [secondName]: [
+      sessionMeta("session-rotated-v7"),
+      turnContext("2026-07-25T00:00:00.000Z", "gpt-5.6-sol"),
+      tokenCount("2026-07-25T00:00:02.000Z", usage(200, 20), usage(200, 20)),
+    ],
+  });
+  const indexFile = join(root, "index.sqlite");
+  try {
+    await build(root);
+    const database = openLocalUnifiedIndex(indexFile, { readOnly: false });
+    database.prepare(`
+      INSERT INTO parser_version(parser_version, contract_version)
+      VALUES ('unified-rollout-typed-v7', ?)
+      ON CONFLICT(parser_version, contract_version) DO NOTHING
+    `).run(CONTRACT);
+    const parserVersionId = database.prepare(`
+      SELECT id FROM parser_version
+      WHERE parser_version = 'unified-rollout-typed-v7'
+        AND contract_version = ?
+    `).get(CONTRACT).id;
+    const runId = database.prepare(`
+      INSERT INTO ingest_run(received_at_ms, parser_version_id)
+      VALUES (?, ?)
+    `).run(Date.parse("2026-07-25T00:00:03.000Z"), parserVersionId)
+      .lastInsertRowid;
+    database.prepare(`
+      UPDATE source_cursor SET ingest_run_id = ? WHERE source_ordinal = 1
+    `).run(runId);
+    database.close();
+    await rm(join(sessions, secondName));
+
+    const ingested = await ingestLocalUnifiedIndexIncrement({
+      codexHome: root,
+      indexFile,
+      secretFile: join(root, "salt"),
+      contractVersion: CONTRACT,
+    });
+    assert.equal(ingested.generation.status, "partial");
+    assert.equal(
+      ingested.generation.blockReason,
+      "tool_provenance_incomplete",
+    );
+    assert.equal(ingested.generation.usageProvenanceComplete, true);
+    assert.equal(ingested.generation.sourceOrderComplete, true);
+    assert.equal(ingested.generation.quotaProvenanceComplete, true);
+    assert.equal(ingested.generation.toolProvenanceComplete, false);
+
+    const source = createLocalUnifiedAccountingSource({
+      indexFile,
+      requireComplete: true,
+      expectedGeneration: ingested.generation,
+      contextBehavior: "legacy_zero",
+    });
+    const accounting = await source({
+      startAt: "2026-07-25T00:00:00.000Z",
+      endAt: "2026-07-26T00:00:00.000Z",
+    });
+    assert.equal(accounting.coverage.status, "complete");
+    assert.equal(accounting.coverage.generationProof, true);
+    assert.equal(accounting.coverage.toolFactsComplete, false);
+
+    const projection = await readLocalUnifiedCompanionProjection({
+      indexFile,
+      nowMs: Date.parse("2026-07-25T12:00:00.000Z"),
+    });
+    assert.equal(projection.status, "available");
+    assert.equal(projection.toolCoverageStatus, "partial");
+    assert.equal(projection.tools.total, 0);
+    assert.equal(projection.discoveredSourceCount, 1);
+    assert.equal(projection.indexedSourceCount, 2);
+  } finally {
+    await rm(root, { recursive: true });
+  }
+});
+
+test("an aborted incremental pass discards its staged clone and preserves the live index", async () => {
+  const { root, sessions } = await corpus({
+    "rollout-2026-07-25T00-00-00-abort.jsonl": [
+      sessionMeta("session-abort"),
+      turnContext("2026-07-25T00:00:00.000Z", "gpt-5.6-sol"),
+      tokenCount("2026-07-25T00:00:01.000Z", usage(100, 10), usage(100, 10)),
+    ],
+  });
+  const indexFile = join(root, "index.sqlite");
+  const sourceFile = join(
+    sessions,
+    "rollout-2026-07-25T00-00-00-abort.jsonl",
+  );
+  try {
+    const built = await build(root);
+    const before = await stat(indexFile);
+    await appendFile(
+      sourceFile,
+      `${tokenCountTotalOnly("2026-07-25T00:00:02.000Z", usage(150, 15))}\n`,
+    );
+    const controller = new AbortController();
+    await assert.rejects(
+      () => ingestLocalUnifiedIndexIncrement({
+        codexHome: root,
+        indexFile,
+        secretFile: join(root, "salt"),
+        contractVersion: CONTRACT,
+        signal: controller.signal,
+        onProgress: () => controller.abort(),
+      }),
+      (error) => error?.code === "local_unified_index_aborted",
+    );
+    const after = await stat(indexFile);
+    assert.equal(after.size, before.size);
+    assert.equal(after.mtimeMs, before.mtimeMs);
+    const database = openLocalUnifiedIndex(indexFile, { readOnly: true });
+    try {
+      assert.equal(
+        Number(database.prepare("SELECT COUNT(*) AS c FROM usage_event").get().c),
+        built.usageEvents,
+      );
+      assert.equal(
+        Number(database.prepare(
+          "SELECT value FROM meta WHERE key = 'current_generation_id'",
+        ).get().value),
+        built.generation.id,
+      );
+    } finally {
+      database.close();
+    }
+    assert.deepEqual(
+      (await readdir(root)).filter((name) => name.includes(".incremental-")),
+      [],
+    );
+  } finally {
+    await rm(root, { recursive: true });
+  }
+});
+
 test("a fork created after its parent was indexed still suppresses replay", async () => {
   // The parent is indexed in one pass, alone: nothing references it yet, so
   // no snapshot set was collected for it. The fork appears later and replays
@@ -1415,10 +2417,13 @@ test("a version-1 index is migrated additively, never rebuilt", async () => {
         DROP TABLE lineage_snapshot;
         DROP TABLE session_identity;
         DROP TABLE usage_event_boundary;
+        DROP INDEX usage_event_replay_order;
         UPDATE usage_event SET source_id = NULL, source_offset = NULL;
         ALTER TABLE usage_event DROP COLUMN source_offset;
         ALTER TABLE usage_event DROP COLUMN source_id;
         DROP TABLE source_dimension;
+        INSERT INTO meta(key, value) VALUES ('schema_version', 'local-unified-index-v1')
+          ON CONFLICT(key) DO UPDATE SET value = excluded.value;
         PRAGMA user_version=1;
       `);
       raw.close();
@@ -1435,7 +2440,7 @@ test("a version-1 index is migrated additively, never rebuilt", async () => {
     const writable = openLocalUnifiedIndex(join(root, "index.sqlite"), { readOnly: false });
     assert.equal(
       Number(writable.prepare("PRAGMA user_version").get().user_version),
-      6,
+      8,
     );
     assert.equal(
       Number(writable.prepare("SELECT COUNT(*) AS c FROM usage_event").get().c),
@@ -1453,6 +2458,162 @@ test("a version-1 index is migrated additively, never rebuilt", async () => {
   }
 });
 
+test("v7 diagnostic rows survive the closed-vocabulary v8 migration", async () => {
+  const { root } = await corpus({
+    "rollout-2026-07-25T00-00-00-v7-diagnostics.jsonl": [
+      sessionMeta("session-v7-diagnostics"),
+      turnContext("2026-07-25T00:00:00.000Z", "gpt-5.6-sol"),
+      tokenCount("2026-07-25T00:00:01.000Z", usage(100, 10), usage(100, 10)),
+    ],
+  });
+  const indexFile = join(root, "index.sqlite");
+  try {
+    await build(root);
+    const { DatabaseSync } = await import("node:sqlite");
+    const old = new DatabaseSync(indexFile);
+    const before = Number(old.prepare(
+      "SELECT COUNT(*) AS count FROM source_diagnostic",
+    ).get().count);
+    old.exec(`
+      BEGIN IMMEDIATE;
+      ALTER TABLE source_diagnostic RENAME TO source_diagnostic_v8;
+      CREATE TABLE source_diagnostic(
+        generation_id INTEGER NOT NULL REFERENCES index_generation ON DELETE CASCADE,
+        source_local BLOB NOT NULL CHECK(length(source_local) = 32),
+        code TEXT NOT NULL CHECK(code IN (
+          'relevantLines', 'malformedLines', 'malformedTimestamps',
+          'partialLines', 'salvagedRecords', 'turnContexts', 'tokenCounts',
+          'forkReplayEventsSkipped', 'unattributedForkReplayEventsSkipped',
+          'cumulativeCounterRegressions', 'tierEvents', 'modelSeededFromLineage',
+          'tierSeededFromLineage', 'modelMissing', 'oversizedLines',
+          'contradictedLeadingSnapshotsSkipped')),
+        count INTEGER NOT NULL CHECK(count >= 0),
+        PRIMARY KEY(generation_id, source_local, code)) STRICT, WITHOUT ROWID;
+      INSERT INTO source_diagnostic(generation_id, source_local, code, count)
+        SELECT generation_id, source_local, code, count
+        FROM source_diagnostic_v8
+        WHERE code NOT IN ('toolRecords', 'toolEvents', 'toolRecordsSkipped');
+      DROP TABLE source_diagnostic_v8;
+      PRAGMA user_version=7;
+      COMMIT;
+    `);
+    const retained = Number(old.prepare(
+      "SELECT COUNT(*) AS count FROM source_diagnostic",
+    ).get().count);
+    assert.ok(retained <= before);
+    old.close();
+
+    const migrated = openLocalUnifiedIndex(indexFile, { readOnly: false });
+    try {
+      assert.equal(
+        Number(migrated.prepare("PRAGMA user_version").get().user_version),
+        8,
+      );
+      assert.equal(Number(migrated.prepare(
+        "SELECT COUNT(*) AS count FROM source_diagnostic",
+      ).get().count), retained);
+      const sql = migrated.prepare(`
+        SELECT sql FROM sqlite_master
+        WHERE type = 'table' AND name = 'source_diagnostic'
+      `).get()?.sql;
+      assert.match(sql, /toolRecordsSkipped/u);
+    } finally {
+      migrated.close();
+    }
+  } finally {
+    await rm(root, { recursive: true });
+  }
+});
+
+test("the first ingest after a legacy migration publishes a clean authoritative rebuild", async () => {
+  const { root } = await corpus({
+    "rollout-2026-07-25T00-00-00-migrated.jsonl": [
+      sessionMeta("session-migrated"),
+      turnContext("2026-07-25T00:00:00.000Z", "gpt-5.6-sol"),
+      tokenCount(
+        "2026-07-25T00:00:01.000Z",
+        usage(100, 10),
+        usage(100, 10),
+        { usedPercent: 12 },
+      ),
+    ],
+  });
+  const indexFile = join(root, "index.sqlite");
+  try {
+    await build(root);
+    {
+      const { DatabaseSync } = await import("node:sqlite");
+      const raw = new DatabaseSync(indexFile);
+      raw.exec(`
+        UPDATE usage_event SET source_local = NULL, source_offset = NULL,
+          source_ordinal = NULL;
+        INSERT INTO meta(key, value) VALUES ('schema_version', 'local-unified-index-v1')
+          ON CONFLICT(key) DO UPDATE SET value = excluded.value;
+        PRAGMA user_version=1;
+      `);
+      raw.close();
+    }
+
+    const healed = await ingestLocalUnifiedIndexIncrement({
+      codexHome: root,
+      indexFile,
+      secretFile: join(root, "salt"),
+      contractVersion: CONTRACT,
+    });
+    assert.equal(healed.rebuilt, true);
+    assert.equal(healed.rebuildReason, "legacy_schema");
+    assert.equal(healed.generation.status, "complete");
+    assert.equal(healed.generation.usageProvenanceComplete, true);
+    assert.equal(healed.generation.sourceOrderComplete, true);
+    assert.equal(healed.generation.quotaProvenanceComplete, true);
+    const database = openLocalUnifiedIndex(indexFile, { readOnly: true });
+    try {
+      assert.equal(Number(database.prepare(`
+        SELECT COUNT(*) AS count FROM usage_event
+        WHERE source_local IS NULL OR source_offset IS NULL
+          OR source_ordinal IS NULL`).get().count), 0);
+    } finally {
+      database.close();
+    }
+  } finally {
+    await rm(root, { recursive: true });
+  }
+});
+
+test("an additively widened but unattested generation rebuilds in one refresh", async () => {
+  const { root } = await corpus({
+    "rollout-2026-07-25T00-00-00-unattested.jsonl": [
+      sessionMeta("session-unattested"),
+      turnContext("2026-07-25T00:00:00.000Z", "gpt-5.6-sol"),
+      tokenCount("2026-07-25T00:00:01.000Z", usage(100, 10), usage(100, 10)),
+    ],
+  });
+  const indexFile = join(root, "index.sqlite");
+  try {
+    await build(root);
+    {
+      const database = openLocalUnifiedIndex(indexFile, { readOnly: false });
+      database.prepare(`
+        UPDATE index_generation SET usage_provenance_complete = 0,
+          source_order_complete = 0, quota_provenance_complete = 0
+        WHERE id = (SELECT CAST(value AS INTEGER) FROM meta
+                    WHERE key = 'current_generation_id')`).run();
+      database.close();
+    }
+    const healed = await ingestLocalUnifiedIndexIncrement({
+      codexHome: root,
+      indexFile,
+      secretFile: join(root, "salt"),
+      contractVersion: CONTRACT,
+    });
+    assert.equal(healed.rebuilt, true);
+    assert.equal(healed.rebuildReason, "incomplete_generation");
+    assert.equal(healed.generation.status, "complete");
+  } finally {
+    await rm(root, { recursive: true });
+  }
+});
+
 test("classifySource maps growth, touch, shrink and novelty to the right work", () => {
   const info = { size: 100, mtimeMs: 5 };
   assert.deepEqual(classifySource(info, undefined), { mode: "rescan" });
@@ -1462,7 +2623,7 @@ test("classifySource maps growth, touch, shrink and novelty to the right work", 
   );
   assert.deepEqual(
     classifySource(info, { size_bytes: 100, mtime_ms: 4 }),
-    { mode: "touch" },
+    { mode: "rescan", reason: "same_size_changed" },
   );
   assert.deepEqual(
     classifySource(info, { size_bytes: 60, mtime_ms: 5 }),
@@ -1505,7 +2666,7 @@ test("classifySource forces a whole-file rescan for cursors stamped by an older 
   }
 });
 
-test("a v5 development cursor migrates to v6 and backfills nullable source order", async () => {
+test("a v5 development cursor migrates to v8 with complete source order", async () => {
   const { root } = await corpus({
     "rollout-2026-07-25T00-00-00-aaaa.jsonl": [
       sessionMeta("session-a"),
@@ -1545,6 +2706,9 @@ test("a v5 development cursor migrates to v6 and backfills nullable source order
     assert.equal(healed.sourcesReparsedForParserVersion, 1);
     assert.equal(healed.usageRowsDeletedForReparse, 2);
     assert.equal(healed.boundaryRowsDeletedForReparse, 2);
+    assert.equal(healed.generation.status, "complete");
+    assert.equal(healed.generation.usageProvenanceComplete, true);
+    assert.equal(healed.generation.sourceOrderComplete, true);
     assert.equal(healed.sourcesRescanned, 1);
     assert.equal(healed.insertedUsageEvents, 2);
     assert.equal(healed.insertedBoundaryLinks, 2);
@@ -1553,14 +2717,18 @@ test("a v5 development cursor migrates to v6 and backfills nullable source order
     try {
       assert.equal(
         Number(database.prepare("PRAGMA user_version").get().user_version),
-        6,
+        8,
       );
       assert.equal(
         Number(database.prepare(`
           SELECT COUNT(*) AS c FROM usage_event
-          WHERE source_id IS NULL OR source_offset IS NULL`).get().c),
+          WHERE source_id IS NULL OR source_local IS NULL
+            OR source_offset IS NULL OR source_ordinal IS NULL`).get().c),
         0,
       );
+      assert.equal(Number(database.prepare(
+        "SELECT COUNT(*) AS c FROM usage_event_boundary",
+      ).get().c), 2);
       assert.deepEqual(database.prepare(`
         SELECT DISTINCT parser.parser_version
         FROM usage_event event
@@ -1658,6 +2826,95 @@ test("a parser-version bump re-derives poisoned sources and replaces their rows"
     assert.equal(settled.sourcesSkipped, 1);
     assert.equal(settled.insertedUsageEvents, 0);
     assert.equal(settled.insertedBoundaryLinks, 0);
+  } finally {
+    await rm(root, { recursive: true });
+  }
+});
+
+test("parser healing preserves stored shared-session sibling facts and quota occurrences", async () => {
+  const { root } = await corpus({
+    "rollout-2026-07-25T00-00-00-segment-a.jsonl": [
+      sessionMeta("session-segment-a"),
+      turnContext("2026-07-25T00:00:00.000Z", "gpt-5.6-sol"),
+      tokenCount(
+        "2026-07-25T00:00:01.000Z",
+        usage(100, 10),
+        usage(100, 10),
+        { usedPercent: 12 },
+      ),
+    ],
+    "rollout-2026-07-25T00-00-00-segment-b.jsonl": [
+      sessionMeta("session-segment-b"),
+      turnContext("2026-07-25T00:01:00.000Z", "gpt-5.6-sol"),
+      tokenCount(
+        "2026-07-25T00:01:01.000Z",
+        usage(200, 20),
+        usage(200, 20),
+        { usedPercent: 22 },
+      ),
+    ],
+  });
+  const indexFile = join(root, "index.sqlite");
+  try {
+    await build(root);
+    {
+      const database = openLocalUnifiedIndex(indexFile, { readOnly: false });
+      database.prepare(`
+        INSERT INTO parser_version(parser_version, contract_version)
+        VALUES ('unified-rollout-typed-v1', ?)
+        ON CONFLICT DO NOTHING`).run(CONTRACT);
+      const parserId = Number(database.prepare(`
+        SELECT id FROM parser_version
+        WHERE parser_version = 'unified-rollout-typed-v1'
+          AND contract_version = ?`).get(CONTRACT).id);
+      const ingestRunId = Number(database.prepare(`
+        INSERT INTO ingest_run(received_at_ms, parser_version_id)
+        VALUES (?, ?)`).run(Date.now(), parserId).lastInsertRowid);
+      const sources = database.prepare(`
+        SELECT source_local, session_local FROM source_cursor
+        ORDER BY source_ordinal`).all();
+      const firstSource = sources[0];
+      const secondSource = sources[1];
+      database.prepare(`
+        UPDATE source_cursor SET ingest_run_id = ? WHERE source_local = ?`)
+        .run(ingestRunId, firstSource.source_local);
+      // Model a migrated segmented session: two distinct rollout sources share
+      // one stored session key. The old session-wide parser repair deleted both
+      // sources while rescanning only the stale one.
+      database.prepare(`
+        UPDATE source_cursor SET session_local = ? WHERE source_local = ?`)
+        .run(firstSource.session_local, secondSource.source_local);
+      database.prepare(`
+        UPDATE usage_event SET session_local = ? WHERE source_local = ?`)
+        .run(firstSource.session_local, secondSource.source_local);
+      database.close();
+    }
+
+    const healed = await ingestLocalUnifiedIndexIncrement({
+      codexHome: root,
+      indexFile,
+      secretFile: join(root, "salt"),
+      contractVersion: CONTRACT,
+    });
+    assert.equal(healed.sourcesReparsedForParserVersion, 1);
+    assert.equal(healed.sourcesRescanned, 1);
+    assert.equal(healed.totalUsageEvents, 2);
+    const database = openLocalUnifiedIndex(indexFile, { readOnly: true });
+    try {
+      assert.equal(Number(database.prepare(`
+        SELECT COUNT(*) AS count FROM usage_event`).get().count), 2);
+      assert.equal(Number(database.prepare(`
+        SELECT SUM(tokens_in_uncached) AS total FROM usage_event`).get().total), 300);
+      assert.equal(Number(database.prepare(`
+        SELECT COUNT(*) AS count FROM quota_occurrence`).get().count), 2);
+      assert.equal(Number(database.prepare(`
+        SELECT COUNT(*) AS count FROM quota_observation q
+        WHERE NOT EXISTS (
+          SELECT 1 FROM quota_occurrence o
+          WHERE o.canonical_observation_id = q.id)`).get().count), 0);
+    } finally {
+      database.close();
+    }
   } finally {
     await rm(root, { recursive: true });
   }

--- a/test/passive-collector.test.js
+++ b/test/passive-collector.test.js
@@ -305,6 +305,75 @@ test("run-once restarts from byte checkpoints without duplicate records", async 
   }
 });
 
+test("unified quota-only collection does not resume an inherited rollout backfill", async () => {
+  const fixture = await collectorFixture([
+    tokenRecord("2026-07-23T00:00:01.000Z", usage(10), usage(10), 1),
+    tokenRecord("2026-07-23T00:00:02.000Z", usage(20), usage(10), 2),
+  ]);
+  const clock = () => Date.parse("2026-07-23T00:01:00.000Z");
+  class MinimalClient {
+    async start() {}
+    async readRateLimits() { return appPayload(2); }
+    async readAccount() { return null; }
+    async readAccountUsage() { return { dailyUsageBuckets: [] }; }
+    close() {}
+  }
+  try {
+    const paused = await runCollectorOnce({
+      ...fixture,
+      refreshStale: false,
+      backfill: true,
+      backfillSinceAt: "2026-07-20T00:00:00.000Z",
+      maximumRecentRunBytes: 1,
+      clock,
+    });
+    assert.equal(paused.status, "bounded_pause");
+    const before = await readLocalCollectorState({
+      stateFile: fixture.stateFile,
+      includeRecords: true,
+    });
+
+    // The unified authority must remain usable even if the raw source is not
+    // available to this collector pass. No discovery or rollout read is
+    // needed for the independent provider quota snapshot.
+    await rm(fixture.codexHome, { recursive: true, force: true });
+    const options = {
+      ...fixture,
+      backfill: false,
+      skipRolloutIngestion: true,
+      staleAfterMs: 0,
+      appServerFactory: () => new MinimalClient(),
+      clock,
+    };
+    const first = await runCollectorOnce(options);
+    const second = await runCollectorOnce(options);
+    assert.equal(first.status, "complete");
+    assert.equal(first.indexing.status, "bounded_pause");
+    assert.equal(first.rolloutRecordsWritten, 0);
+    assert.equal(first.filesDiscovered, 0);
+    assert.equal(first.refresh.attempted, true);
+    assert.equal(second.rolloutRecordsWritten, 0);
+    const after = await readLocalCollectorState({
+      stateFile: fixture.stateFile,
+      includeRecords: true,
+    });
+    const rolloutCount = (state) => state.records.filter(
+      (record) => record.kind === "codex_rollout_usage_snapshot",
+    ).length;
+    assert.equal(rolloutCount(after), rolloutCount(before));
+    assert.equal(
+      after.records.filter((record) => record.kind === "codex_rollout_usage_snapshot").length,
+      0,
+    );
+    assert.equal(
+      after.records.filter((record) => record.kind === "codex_quota_snapshot").length,
+      1,
+    );
+  } finally {
+    await rm(fixture.root, { recursive: true, force: true });
+  }
+});
+
 test("fresh recent backfill selects only overlapping archives and reports content-free progress", async () => {
   const fixture = await collectorFixture([
     tokenRecord("2026-07-23T00:00:01.000Z", usage(10), usage(10), 1),

--- a/test/replay-safe-accounting-cache.test.js
+++ b/test/replay-safe-accounting-cache.test.js
@@ -17,6 +17,7 @@ import {
   writeLocalCollectorAccountingCache,
 } from "../src/local-collector-state.js";
 import {
+  beginUnifiedIndexGeneration,
   createUnifiedIndexWriter,
   openLocalUnifiedIndex,
 } from "../src/local-unified-index.js";
@@ -60,6 +61,363 @@ test("production replay-cache APIs reject the retired JSON cacheFile option", as
   await assert.rejects(
     readReplaySafeAccountingCacheImpl({ cacheFile: "/private/retired.json" }),
     /cacheFile was retired; use stateFile/u,
+  );
+});
+
+test("a direct cache build without a scanner or explicit source mode fails closed", async () => {
+  await assert.rejects(
+    buildReplaySafeAccountingCache({ now: () => NOW }),
+    (error) => error?.code === "accounting_source_required",
+  );
+  await assert.rejects(
+    buildReplaySafeAccountingCache({
+      sourceMode: "unified",
+      scan: completeUnifiedScanner([]),
+      now: () => NOW,
+    }),
+    (error) => error?.code === "accounting_unified_generation_required",
+  );
+  await assert.rejects(
+    readReplaySafeAccountingCacheImpl({
+      stateFile: "/private/unbound-unified-cache.sqlite",
+      sourceMode: "unified",
+    }),
+    (error) => error?.code === "accounting_unified_generation_required",
+  );
+});
+
+test("refresh defaults to the unified reader without consulting the legacy index", async () => {
+  const directory = await mkdtemp(join(tmpdir(), "usage-monitor-unified-default-"));
+  const stateFile = join(directory, "local-collector-state-v1.sqlite");
+  const legacyIndexFile = join(directory, "local-analysis-index-v2.sqlite");
+  await assert.rejects(
+    refreshReplaySafeAccountingCacheImpl({
+      stateFile,
+      codexHome: directory,
+      now: () => NOW,
+    }),
+    (error) => error?.code === "accounting_unified_generation_required",
+  );
+  await assert.rejects(
+    stat(legacyIndexFile),
+    (error) => error?.code === "ENOENT",
+  );
+  await assert.rejects(
+    refreshReplaySafeAccountingCacheImpl({
+      stateFile,
+      codexHome: directory,
+      expectedGeneration: "generation-test-1",
+      now: () => NOW,
+    }),
+    (error) => error?.code === "accounting_unified_index_missing",
+  );
+  await assert.rejects(
+    stat(legacyIndexFile),
+    (error) => error?.code === "ENOENT",
+  );
+});
+
+test("explicit legacy refresh keeps the injected characterization scanner on legacy authority", async () => {
+  const directory = await mkdtemp(join(tmpdir(), "usage-monitor-legacy-mode-"));
+  const cache = await refreshReplaySafeAccountingCacheImpl({
+    stateFile: join(directory, "local-collector-state-v1.sqlite"),
+    sourceMode: "legacy",
+    scan: scanner([]),
+    now: () => NOW,
+  });
+  assert.equal(cache.sourceDescriptor.mode, "legacy");
+  assert.equal(cache.sourceDescriptor.contextBehavior, "legacy_zero");
+  assert.equal(cache.history.status, "unavailable");
+});
+
+test("unified builds reject incomplete coverage and generation mismatches", async () => {
+  await assert.rejects(
+    buildReplaySafeAccountingCache({
+      sourceMode: "unified",
+      expectedGeneration: "generation-test-1",
+      scan: completeUnifiedScanner([], { coverageStatus: "partial" }),
+      now: () => NOW,
+    }),
+    (error) => error?.code === "accounting_unified_coverage_incomplete",
+  );
+  await assert.rejects(
+    buildReplaySafeAccountingCache({
+      sourceMode: "unified",
+      expectedGeneration: "generation-test-2",
+      scan: completeUnifiedScanner([]),
+      now: () => NOW,
+    }),
+    (error) => error?.code === "accounting_unified_generation_mismatch",
+  );
+  await assert.rejects(
+    buildReplaySafeAccountingCache({
+      sourceMode: "unified",
+      expectedGeneration: {
+        id: "generation-test-1",
+        fingerprint: "generation-fingerprint-expected",
+      },
+      scan: completeUnifiedScanner([], {
+        generationFingerprint: "generation-fingerprint-observed",
+      }),
+      now: () => NOW,
+    }),
+    (error) => error?.code === "accounting_unified_generation_mismatch",
+  );
+});
+
+test("numeric-like object generation ids normalize without changing fingerprints", async () => {
+  const cache = await buildReplaySafeAccountingCache({
+    sourceMode: "unified",
+    expectedGeneration: {
+      id: "1.0",
+      fingerprint: "generation-fingerprint-test-1",
+    },
+    scan: completeUnifiedScanner([], { generation: 1 }),
+    now: () => NOW,
+  });
+  assert.equal(cache.sourceDescriptor.generation, "1");
+  assert.equal(
+    cache.sourceDescriptor.generationFingerprint,
+    "generation-fingerprint-test-1",
+  );
+
+  await assert.rejects(
+    buildReplaySafeAccountingCache({
+      sourceMode: "unified",
+      expectedGeneration: {
+        id: "1.0",
+        fingerprint: "1.0",
+      },
+      scan: completeUnifiedScanner([], {
+        generation: 1,
+        generationFingerprint: "1",
+      }),
+      now: () => NOW,
+    }),
+    (error) => error?.code === "accounting_unified_generation_mismatch",
+  );
+});
+
+test("unified cache history is attached only after a matching second generation read", async () => {
+  const scan = completeUnifiedScanner([
+    usageEvent({
+      timestamp: "2026-07-27T11:00:00.000Z",
+      components: { input_uncached_tokens: 1_000 },
+    }),
+  ]);
+  const cache = await buildReplaySafeAccountingCache({
+    sourceMode: "unified",
+    expectedGeneration: "generation-test-1",
+    scan,
+    now: () => NOW,
+  });
+  assert.equal(scan.calls, 2);
+  assert.equal(cache.sourceDescriptor.mode, "unified");
+  assert.equal(cache.sourceDescriptor.generation, "generation-test-1");
+  assert.equal(cache.history.status, "available");
+  assert.equal(cache.history.coverage.status, "complete");
+  assert.equal(cache.history.generation, "generation-test-1");
+  assert.equal(
+    cache.history.generationFingerprint,
+    "generation-fingerprint-test-1",
+  );
+  assert.equal(
+    cache.history.coverage.generationFingerprint,
+    "generation-fingerprint-test-1",
+  );
+  assert.equal(cache.history.period.id, "history");
+  assert.equal(cache.history.period.events, 1);
+});
+
+test("cache reads invalidate when the unified generation no longer matches", async () => {
+  const directory = await mkdtemp(join(tmpdir(), "usage-monitor-generation-reuse-"));
+  const stateFile = join(directory, "local-collector-state-v1.sqlite");
+  const scan = completeUnifiedScanner([]);
+  await refreshReplaySafeAccountingCacheImpl({
+    stateFile,
+    sourceMode: "unified",
+    expectedGeneration: "generation-test-1",
+    scan,
+    now: () => NOW,
+  });
+  const available = await readReplaySafeAccountingCacheImpl({
+    stateFile,
+    sourceMode: "unified",
+    expectedGeneration: "generation-test-1",
+    contextBehavior: "legacy_zero",
+  });
+  assert.equal(available.status, "available");
+  assert.deepEqual(available.cache.sourceDescriptor, {
+    schemaVersion: "local-accounting-source-descriptor-v1",
+    mode: "unified",
+    contextBehavior: "legacy_zero",
+    readerVersion: "test-unified-reader-v1",
+    schemaVersionUsed: "test-unified-schema-v1",
+    parserVersion: "test-parser-v1",
+    contractVersion: "test-contract-v1",
+    generation: "generation-test-1",
+    generationFingerprint: "generation-fingerprint-test-1",
+    coverageStatus: "complete",
+    coverage: {
+      status: "complete",
+      generatedAt: "2026-07-27T12:00:00.000Z",
+      coveredAt: {
+        startAt: "2026-07-20T12:00:00.000Z",
+        endAt: "2026-07-27T12:00:00.000Z",
+      },
+      sourceCount: null,
+      sourceBytes: null,
+      usageEvents: null,
+      quotaObservations: null,
+      quotaOccurrences: null,
+      admittedQuotaOccurrences: null,
+      generationProof: true,
+    },
+    diagnosticsAvailable: true,
+    generationMatched: true,
+    fallbackCount: 0,
+    capabilities: {
+      readsRawSources: false,
+      deterministicCanonicalOrder: true,
+      sourceOrderingProvenance: true,
+      sourceOffsetProvenance: true,
+      sourceScopedQuotaOccurrences: true,
+      durableDiagnostics: true,
+      crashSafeGenerationPublication: true,
+    },
+  });
+  const contextInvalidated = await readReplaySafeAccountingCacheImpl({
+    stateFile,
+    sourceMode: "unified",
+    expectedGeneration: "generation-test-1",
+    contextBehavior: "source_native",
+  });
+  assert.deepEqual(contextInvalidated, {
+    status: "unavailable",
+    errorCode: "cache_context_behavior_mismatch",
+    cache: null,
+  });
+  const invalidated = await readReplaySafeAccountingCacheImpl({
+    stateFile,
+    sourceMode: "unified",
+    expectedGeneration: "generation-test-2",
+    contextBehavior: "legacy_zero",
+  });
+  assert.deepEqual(invalidated, {
+    status: "unavailable",
+    errorCode: "cache_generation_mismatch",
+    cache: null,
+  });
+
+  const fingerprintScan = completeUnifiedScanner([], {
+    generationFingerprint: "generation-fingerprint-current",
+  });
+  await refreshReplaySafeAccountingCacheImpl({
+    stateFile,
+    sourceMode: "unified",
+    expectedGeneration: {
+      id: "generation-test-1",
+      fingerprint: "generation-fingerprint-current",
+    },
+    scan: fingerprintScan,
+    now: () => NOW,
+  });
+  const fingerprintInvalidated = await readReplaySafeAccountingCacheImpl({
+    stateFile,
+    sourceMode: "unified",
+    expectedGeneration: {
+      id: "generation-test-1",
+      fingerprint: "generation-fingerprint-stale",
+    },
+    contextBehavior: "legacy_zero",
+  });
+  assert.deepEqual(fingerprintInvalidated, {
+    status: "unavailable",
+    errorCode: "cache_generation_mismatch",
+    cache: null,
+  });
+
+  const tampered = await readTestCache(stateFile);
+  tampered.sourceDescriptor.fallbackCount = 1;
+  await writeTestCache(stateFile, tampered);
+  const fallbackInvalidated = await readReplaySafeAccountingCacheImpl({
+    stateFile,
+    sourceMode: "unified",
+    expectedGeneration: {
+      id: "generation-test-1",
+      fingerprint: "generation-fingerprint-current",
+    },
+  });
+  assert.deepEqual(fallbackInvalidated, {
+    status: "unavailable",
+    errorCode: "cache_invalid",
+    cache: null,
+  });
+  tampered.sourceDescriptor.fallbackCount = 0;
+  tampered.history.generationFingerprint = "generation-fingerprint-tampered";
+  await writeTestCache(stateFile, tampered);
+  const historyInvalidated = await readReplaySafeAccountingCacheImpl({
+    stateFile,
+    sourceMode: "unified",
+    expectedGeneration: {
+      id: "generation-test-1",
+      fingerprint: "generation-fingerprint-current",
+    },
+    contextBehavior: "legacy_zero",
+  });
+  assert.deepEqual(historyInvalidated, {
+    status: "unavailable",
+    errorCode: "cache_invalid",
+    cache: null,
+  });
+});
+
+test("unified reader errors map to closed content-free accounting codes", async () => {
+  await assert.rejects(
+    buildReplaySafeAccountingCache({
+      sourceMode: "unified",
+      expectedGeneration: "generation-test-1",
+      now: () => NOW,
+      scan: async () => {
+        const error = new Error("private path and row contents");
+        error.code = "local_unified_index_row_invalid";
+        throw error;
+      },
+    }),
+    (error) => (
+      error?.code === "accounting_unified_index_invalid"
+      && error?.message === "accounting_unified_index_invalid"
+    ),
+  );
+  await assert.rejects(
+    buildReplaySafeAccountingCache({
+      sourceMode: "unified",
+      expectedGeneration: "generation-test-1",
+      now: () => NOW,
+      scan: async () => {
+        throw new Error("private path and row contents");
+      },
+    }),
+    (error) => (
+      error?.code === "accounting_unified_read_failed"
+      && error?.message === "accounting_unified_read_failed"
+    ),
+  );
+  await assert.rejects(
+    buildReplaySafeAccountingCache({
+      sourceMode: "unified",
+      expectedGeneration: "generation-test-1",
+      now: () => NOW,
+      scan: async () => {
+        const error = new Error("private path and row contents");
+        error.code = "accounting_private_internal_detail";
+        throw error;
+      },
+    }),
+    (error) => (
+      error?.code === "accounting_unified_read_failed"
+      && error?.message === "accounting_unified_read_failed"
+    ),
   );
 });
 
@@ -244,6 +602,56 @@ function scanner(events, diagnostics = {}) {
       },
     };
   };
+}
+
+function completeUnifiedScanner(
+  events = [],
+  {
+    generation = "generation-test-1",
+    generationFingerprint = "generation-fingerprint-test-1",
+    startAt = "2026-07-20T12:00:00.000Z",
+    endAt = "2026-07-27T12:00:00.000Z",
+    coverageStatus = "complete",
+    generationProof = true,
+  } = {},
+) {
+  let calls = 0;
+  const scan = async (options) => {
+    calls += 1;
+    for (const event of events) {
+      await options.onUsage?.(event);
+    }
+    return {
+      readerVersion: "test-unified-reader-v1",
+      schemaVersion: "test-unified-schema-v1",
+      parserVersion: "test-parser-v1",
+      contractVersion: "test-contract-v1",
+      generation,
+      generationFingerprint,
+      coverage: {
+        status: coverageStatus,
+        generationProof,
+        generatedAt: endAt,
+        coveredAt: { startAt, endAt },
+      },
+      diagnosticsAvailable: true,
+      capabilities: {
+        readsRawSources: false,
+        deterministicCanonicalOrder: true,
+        sourceOrderingProvenance: true,
+        sourceOffsetProvenance: true,
+        sourceScopedQuotaOccurrences: true,
+        durableDiagnostics: true,
+        crashSafeGenerationPublication: true,
+      },
+      diagnostics: {},
+    };
+  };
+  Object.defineProperty(scan, "calls", {
+    enumerable: true,
+    get: () => calls,
+  });
+  return scan;
 }
 
 function weeklySnapshot({
@@ -588,6 +996,37 @@ test("replay-safe cache rejects price-card event and exact-cost reconciliation d
     errorCode: "cache_invalid",
     cache: null,
   });
+});
+
+test("exact decimal totals survive a floating-point half-boundary round trip", async () => {
+  const directory = await mkdtemp(join(tmpdir(), "usage-monitor-exact-money-rounding-"));
+  const stateFile = join(directory, "local-collector-state-v1.sqlite");
+  const events = Array.from({ length: 31 }, (_, index) => usageEvent({
+    timestamp: new Date(NOW - 60_000 + index).toISOString(),
+    model: "gpt-5.6-terra",
+    components: { input_uncached_tokens: 1 },
+  }));
+
+  // At $2.50 / million tokens, the exact sum is on a seventh-decimal half
+  // boundary. Repeated binary-float addition lands on the other side of that
+  // boundary on some totals, so the published numeric projection must be
+  // derived from the exact decimal ledger rather than the accumulated float.
+  const cache = await refreshReplaySafeAccountingCache({
+    cacheFile: stateFile,
+    now: () => NOW,
+    scan: scanner(events),
+  });
+  const all = period(cache, "all");
+  assert.equal(all.apiPriceEquivalentUsdExact, "0.0000775");
+  assert.equal(all.apiPriceEquivalentUsd, 0.000078);
+  assert.doesNotThrow(() => assertReplaySafeAccountingCache(cache));
+
+  const stored = await readReplaySafeAccountingCache({
+    cacheFile: stateFile,
+    now: () => NOW,
+  });
+  assert.equal(stored.status, "available");
+  assert.equal(period(stored.cache, "all").apiPriceEquivalentUsd, 0.000078);
 });
 
 test("separated output takes precedence over a duplicate combined alias", async () => {
@@ -1250,8 +1689,16 @@ async function writeUnifiedCalibrationFixture(indexFile, {
   boundaries = 10,
 }) {
   const database = openLocalUnifiedIndex(indexFile, { create: true });
+  const generation = beginUnifiedIndexGeneration(database, {
+    contractVersion: "unified-calibration-test-v1",
+    discoveredSourceCount: 0,
+    discoveredSourceBytes: 0,
+  });
   const writer = createUnifiedIndexWriter(database, {
     contractVersion: "unified-calibration-test-v1",
+    generationId: generation.generationId,
+    parserVersionId: generation.parserVersionId,
+    ingestRunId: generation.ingestRunId,
   });
   const modelId = writer.internModel("gpt-5.6-terra", "recognized");
   const tierId = writer.internTier({
@@ -1305,6 +1752,16 @@ async function writeUnifiedCalibrationFixture(indexFile, {
       });
     }
   }
+  writer.finalizeGeneration({
+    status: "partial",
+    blockReason: "calibration_fixture",
+    discoveredSourceCount: 0,
+    discoveredSourceBytes: 0,
+    indexedSourceCount: 0,
+    indexedSourceBytes: 0,
+    discoveryComplete: false,
+    diagnosticsComplete: false,
+  });
   await writer.close({ integrityCheck: true, fsyncPath: indexFile });
 }
 
@@ -1391,6 +1848,42 @@ test("declared speed baselines resolve unified calibration events before scenari
   } finally {
     await rm(directory, { recursive: true, force: true });
   }
+});
+
+test("unified calibration canonicalizes a decimal SQLite generation id", async () => {
+  const directory = await mkdtemp(join(tmpdir(), "usage-monitor-unified-generation-token-"));
+  const indexFile = join(directory, "local-unified-index-v1.sqlite");
+  await writeUnifiedCalibrationFixture(indexFile, {
+    resets: [Date.parse("2025-05-01T00:00:00.000Z")],
+    boundaries: 4,
+  });
+
+  const database = openLocalUnifiedIndex(indexFile);
+  database.prepare(
+    "INSERT INTO meta(key, value) VALUES (?, ?) "
+      + "ON CONFLICT(key) DO UPDATE SET value = excluded.value",
+  ).run("current_generation_id", "1.0");
+  assert.equal(database.prepare(
+    "SELECT value FROM meta WHERE key = 'current_generation_id'",
+  ).get()?.value, "1.0");
+  database.close();
+
+  const cache = await buildReplaySafeAccountingCache({
+    now: () => Date.parse("2026-08-20T12:00:00.000Z"),
+    sourceMode: "unified",
+    expectedGeneration: 1,
+    unifiedIndexFile: indexFile,
+    scan: completeUnifiedScanner([], {
+      generation: 1,
+      startAt: "2026-07-20T12:00:00.000Z",
+      endAt: "2026-07-27T12:00:00.000Z",
+    }),
+  });
+
+  assert.equal(cache.sourceDescriptor.mode, "unified");
+  assert.equal(cache.sourceDescriptor.generation, "1");
+  assert.equal(cache.weeklyCalibrationInput.source, "unified_index");
+  assert.equal(cache.weeklyCalibrationInput.retainedUsageEvents, 3);
 });
 
 test("a missing or empty unified index degrades honestly to the windowed corpus", async () => {

--- a/test/tool-inventory.test.js
+++ b/test/tool-inventory.test.js
@@ -303,8 +303,8 @@ test("the checked-in inventory classifies every retained tool entry point and np
     true,
     formatToolInventoryReport(result),
   );
-  assert.equal(result.records, 62);
-  assert.equal(result.candidates.length, 64);
+  assert.equal(result.records, 63);
+  assert.equal(result.candidates.length, 65);
   assert.ok(result.aliases >= 25);
 });
 

--- a/tools/tool-inventory.json
+++ b/tools/tool-inventory.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": "tool-inventory-v0.1",
-  "reviewedAt": "2026-08-04",
+  "reviewedAt": "2026-08-17",
   "scope": "Executable and executable-adjacent sources under root scripts/** and tools/**, legacy root report builders and verifiers, and product contribution preparation.",
   "records": [
     {
@@ -15,6 +15,24 @@
       ],
       "decision": "retain_and_relocate_after_inventory",
       "provenance": "docs/receipts/2026-07-29-local-analysis-performance-receipt.md",
+      "provenanceReason": null,
+      "legacyPaths": []
+    },
+    {
+      "classification": "reusable_benchmark",
+      "owner": "local_analysis",
+      "canonicalPath": "scripts/benchmark-local-index-retirement.mjs",
+      "stableAlias": null,
+      "stableAliasReason": "Synthetic cutover qualification is invoked by its focused regression and retirement plan rather than as a supported product command.",
+      "additionalAliases": [],
+      "callers": [
+        "scripts/benchmark-local-analysis-pipeline.mjs",
+        "test/benchmark-local-analysis-pipeline.test.mjs",
+        "test/local-index-retirement-qualification.test.js",
+        "docs/plans/2026-08-17-local-analysis-index-retirement-plan.md"
+      ],
+      "decision": "retain_as_retirement_qualification_gate",
+      "provenance": "docs/plans/2026-08-17-local-analysis-index-retirement-plan.md",
       "provenanceReason": null,
       "legacyPaths": []
     },


### PR DESCRIPTION
## Summary

- make the generation-bound unified local index the default accounting and history authority
- retain the legacy index and archive implementation behind an explicit rollback mode, with no silent fallback
- publish durable generation, provenance, quota, tool, cache-history, and bounded diagnostic contracts
- add parity, qualification, incremental/no-change, rollback, packaging, and product-level coverage

## Source-only boundary

- no package or client version bump
- no generated R7 receipt replacement
- no client build, signing, installation, deployment, or old-state deletion
- package version remains 0.1.12

## Validation

- focused cutover suite: 281/281
- local product suite: 214/214
- macOS product suite: 53/53
- architecture boundaries, tool inventory, package export, documentation links, and diff checks pass
- independent consumer audit found no P0/P1/P2 issues

The permission-correct root suite completed 2,564 tests: 2,542 passed, 17 intentionally skipped, and five failed. Two failures are the existing missing jsonc-parser worker-workspace setup boundary; two are the expected stale exact-source R7 receipts intentionally deferred to the later client-release gate; one unchanged legacy report TOCTOU timing test passed in the preceding full run and an immediate focused 8/8 rerun.

## Rollback

Set USAGE_MONITOR_ACCOUNTING_SOURCE_MODE=legacy. The old readers, writers, state files, and tests remain present for the rollback window.
