### PR TITLE
feat(share-card): explain the outlined short-observation marker

### DIFF
--- a/apps/web/public/app.js
+++ b/apps/web/public/app.js
@@ -1962,6 +1962,13 @@ function shareCardTrend(history) {
     }),
     xTicks: Object.freeze([...(history?.xTicks ?? [])]),
     count: points.length,
+    // How many plotted fits carry the outlined short-observation marker, and
+    // the floor that classified them. The outline is a claim about evidence
+    // quality that the picture cannot explain on its own, so the key beside
+    // the plot and the transcript's sentence both read these instead of
+    // re-deriving a classification the dashboard already made.
+    shortCount: points.filter((point) => !point.wellObserved).length,
+    wellObservedFloorPp: finite(history?.wellObservedFloorPp, 0),
     // The population the count sentence names. The page headline counts the
     // whole corpus while the chart draws the filtered subset; the card used
     // to print only the subset count, which read as a different dataset. The
@@ -2144,6 +2151,11 @@ function buildShareCard(data, {
     // behind a five-hour or provider-reported generic allowance window.
     trend,
     trendLabel: t("share.trend.label"),
+    // The plot's marker key. The dashboard reveals its own only when a short
+    // observation is actually drawn (`#weekly-partial-legend`), and the card
+    // follows: a card whose fits are all well observed carries no key, and
+    // the labels are the chart's own, so the two surfaces say one thing.
+    trendLegend: shareCardTrendLegend(trend),
     // The count sentence mirrors the Allowance hero's phrasing: shown of
     // total, plus the range and span filter the shared model applied. A bare
     // subset count beside the page's corpus count read as two different
@@ -2192,6 +2204,33 @@ function shareCardTrendCountLabel(trend) {
 }
 
 /**
+ * The plot's two markers, named: filled for a well-observed fit, outlined for
+ * a short observation.
+ *
+ * Empty unless a short observation is actually plotted, so the common card
+ * spends no pixels explaining a marker it never draws. The branch mirrors the
+ * dashboard's own series label, so a card and the page it came from describe
+ * the same classification.
+ */
+function shareCardTrendLegend(trend) {
+  if (trend === null || trend.shortCount === 0) return Object.freeze([]);
+  return Object.freeze([
+    Object.freeze({
+      filled: true,
+      label: trend.wellObservedFloorPp > 0
+        ? t("weekly.series.wellObserved", {
+          span: formatDecimal(trend.wellObservedFloorPp, 0),
+        })
+        : t("weekly.series.allSpans"),
+    }),
+    Object.freeze({
+      filled: false,
+      label: t("weekly.series.shortObservation"),
+    }),
+  ]);
+}
+
+/**
  * The same card as a sentence, for a screen reader and for a text-only post.
  */
 function shareCardText(card) {
@@ -2211,6 +2250,7 @@ function shareCardText(card) {
     card.plan,
     figures,
     shareCardTrendText(card),
+    shareCardTrendShortText(card),
     card.caveats.join(" "),
     t("share.text.trailer", { trailer }),
     card.home === "" ? "" : t("share.text.more", { home: card.home }),
@@ -2237,6 +2277,22 @@ function shareCardTrendText(card) {
       label: card.trendLabel,
       low: formatMoney(card.trend.low, 0),
       start: card.trend.firstDateLabel,
+    });
+}
+
+/**
+ * The outlined marker, in words.
+ *
+ * The plot draws a short observation differently from a well-observed fit,
+ * and a difference a reader can see is a claim the transcript owes them.
+ * "" when every plotted fit is well observed, which is also when the image
+ * draws no key.
+ */
+function shareCardTrendShortText(card) {
+  return card.trend === null || card.trend.shortCount === 0
+    ? ""
+    : tPlural("share.text.shortObservation", card.trend.shortCount, {
+      count: formatNumber(card.trend.shortCount),
     });
 }
 
@@ -2496,6 +2552,39 @@ function drawShareCardTrend(context, card, x, y, width, height) {
   context.textAlign = "left";
   context.font = shareCardFont(700, 13);
   context.fillText(yAxisLabel, plotLeft, y + 22);
+
+  // The marker key shares that strip, right-aligned to the plot's right edge:
+  // the panel's top padding is already reserved and the axis label leaves it
+  // free. Each swatch is drawn by the same two calls the points are, at the
+  // same radius, so the key cannot drift from what it explains.
+  if (card.trendLegend.length > 0) {
+    context.save();
+    context.font = shareCardFont(600, 13);
+    const swatch = 9;
+    const gap = 7;
+    const between = 18;
+    const widths = card.trendLegend.map((entry) =>
+      swatch + gap + context.measureText(entry.label).width);
+    let cursor = plotRight - widths.reduce(
+      (total, width) => total + width + between,
+      -between,
+    );
+    card.trendLegend.forEach((entry, index) => {
+      context.fillStyle = entry.filled ? "#315f84" : "#fffef9";
+      context.beginPath();
+      context.arc(cursor + swatch / 2, y + 17, 4.5, 0, Math.PI * 2);
+      context.fill();
+      if (!entry.filled) {
+        context.strokeStyle = "#a9492f";
+        context.lineWidth = 2.4;
+        context.stroke();
+      }
+      context.fillStyle = "#65706b";
+      context.fillText(entry.label, cursor + swatch + gap, y + 22);
+      cursor += widths[index] + between;
+    });
+    context.restore();
+  }
 
   for (const tick of xTicks) {
     // SVG uses `middle`; Canvas uses the equivalent `center` value.
@@ -6159,6 +6248,13 @@ function allowanceHistoryChartModel(data, {
     totalCount: allPoints.length,
     inRangeCount: inRange.length,
     spanFloorPp,
+    // The floor `wellObserved` classified against, which a relaxed range
+    // leaves above `spanFloorPp`: the inclusion filter and the marker split
+    // are two different decisions, and a surface that named the applied floor
+    // beside an outlined point would explain the outline with the wrong
+    // number. It travels with the model so the card can name it without
+    // reading the slider itself.
+    wellObservedFloorPp: activeWeeklyMinimumObservedSpanPp,
     rangeDays: boundedRangeDays,
     anchorAt: latestObservedAt,
   });

--- a/apps/web/public/localization.js
+++ b/apps/web/public/localization.js
@@ -1287,6 +1287,13 @@ export const WEB_PLURAL_MESSAGES = Object.freeze({
     one: ["{count} reset fit", "{count} 个重置拟合", "{count} ajuste de restablecimiento"],
     other: ["{count} reset fits", "{count} 个重置拟合", "{count} ajustes de restablecimiento"],
   }),
+  // The card's outlined marker, in words. A reader of the text transcript
+  // cannot see the plot, so the difference the image draws has to be stated
+  // rather than left to the picture.
+  "share.text.shortObservation": Object.freeze({
+    one: ["{count} of these is a short observation, drawn as an outlined marker.", "其中 {count} 个为短观测，以空心标记绘制。", "{count} de estos es una observación corta, dibujada como un marcador sin relleno."],
+    other: ["{count} of these are short observations, drawn as outlined markers.", "其中 {count} 个为短观测，以空心标记绘制。", "{count} de estos son observaciones cortas, dibujadas como marcadores sin relleno."],
+  }),
   // The community allowance caveat: the participant count backing every point
   // is visible copy, so "from 1 contributing account" reads plainly.
   "community.allowance.accountCount": Object.freeze({

--- a/apps/web/test/lib.test.mjs
+++ b/apps/web/test/lib.test.mjs
@@ -89,9 +89,11 @@ import {
   finite,
   formatChartTimestamp,
   formatLocal,
+  formatNumber,
   formatReportingTime,
   formatTimeZoneLabel,
   formatUtcCalendarDay,
+  numberFormatter,
   REPORTING_TIME_ZONE,
   reportingCalendarParts,
   selectAvailableAccountingPeriod,
@@ -7671,6 +7673,11 @@ test("a posted results card can carry only fixed copy and formatted figures", as
       "card.trendEmptyDetail",
       "card.trendLabel.toLocaleUpperCase(localization.locale())",
       "card.versionLabel",
+      // The plot's marker key, composed in `buildShareCard` from the chart's
+      // own series labels and frozen onto `card.trendLegend` (2026-08-19):
+      // the outlined short-observation marker is a claim about evidence the
+      // picture could not otherwise explain.
+      "entry.label",
       "formatMoney(value, axisDigits)",
       "line",
       "plan",
@@ -7956,6 +7963,158 @@ test("a posted results card can carry only fixed copy and formatted figures", as
     /renderWeeklyTable\(values\);\s*\n[\s\S]{0,640}?renderShareCard\(data, \{ history \}\);\s*\n\}/u,
   );
   assert.doesNotMatch(appSource, /renderShareCard\(dashboard\);/u);
+});
+
+/**
+ * The plotted-history helpers in isolation, with the same two formatters and
+ * the real catalogue behind them, so the strings asserted here are the ones a
+ * reader gets.
+ */
+async function loadShareCardTrendHelpers() {
+  const appSource = await readFile(new URL("../public/app.js", import.meta.url), "utf8");
+  const section = shareCardSource(appSource);
+  const helper = (name) => {
+    const match = section.match(
+      new RegExp(`function ${name}\\([\\s\\S]*?\\n\\}`, "u"),
+    );
+    assert.ok(match, `${name} is available`);
+    return match[0];
+  };
+  const names = [
+    "shareCardTrend",
+    "shareCardTrendLegend",
+    "shareCardTrendShortText",
+  ];
+  return Function(
+    "finite",
+    "t",
+    "tPlural",
+    "formatDecimal",
+    "formatNumber",
+    `${names.map(helper).join("\n")}\nreturn { ${names.join(", ")} };`,
+  )(
+    finite,
+    (key, values) => translate(key, values),
+    (key, count, values) => translatePlural(key, count, values),
+    (value, digits = 0) => numberFormatter({
+      maximumFractionDigits: digits,
+      minimumFractionDigits: digits,
+    }).format(value),
+    formatNumber,
+  );
+}
+
+function shareCardTrendHistory(shortSpans) {
+  return {
+    points: shortSpans.map((short, index) => ({
+      at: Date.parse(`2026-08-1${index + 2}T00:00:00.000Z`),
+      dateLabel: `Aug 1${index + 2}, 2026`,
+      value: 1_900 + index,
+      low: 1_800,
+      high: 2_000,
+      historicalMedian: 1_874,
+      acrossResetLow: 1_541,
+      acrossResetHigh: 2_432,
+      wellObserved: !short,
+    })),
+    axis: { low: 1_000, high: 3_000, ticks: [1_000, 2_000, 3_000] },
+    xTicks: [],
+    totalCount: 31,
+    spanFloorPp: 0,
+    wellObservedFloorPp: 50,
+    rangeDays: 7,
+  };
+}
+
+test("a posted card explains its outlined marker, or draws none", async () => {
+  const {
+    shareCardTrend,
+    shareCardTrendLegend,
+    shareCardTrendShortText,
+  } = await loadShareCardTrendHelpers();
+
+  // A short observation only reaches the plot because a range of seven days
+  // or less relaxes the inclusion floor to zero. The classification floor it
+  // failed is a different number, and it is the one the key must name.
+  const mixed = shareCardTrend(shareCardTrendHistory([true, false, false]));
+  assert.equal(mixed.count, 3);
+  assert.equal(mixed.shortCount, 1);
+  assert.equal(mixed.spanFloorPp, 0);
+  assert.equal(mixed.wellObservedFloorPp, 50);
+
+  const legend = shareCardTrendLegend(mixed);
+  assert.deepEqual(legend.map((entry) => entry.filled), [true, false]);
+  assert.equal(legend[0].label, translate("weekly.series.wellObserved", { span: "50" }));
+  assert.match(legend[0].label, /50/u);
+  assert.equal(legend[1].label, translate("weekly.series.shortObservation"));
+  assert.ok(Object.isFrozen(legend) && legend.every((entry) => Object.isFrozen(entry)));
+
+  // The text transcript is the only card a screen reader or a text-only post
+  // gets, so the difference the picture draws is stated there too.
+  const sentence = shareCardTrendShortText({ trend: mixed });
+  assert.match(sentence, /1 of these is a short observation/u);
+  assert.match(sentence, /outlined marker/u);
+  assert.equal(
+    shareCardTrendShortText({ trend: { ...mixed, shortCount: 2 } }),
+    translatePlural("share.text.shortObservation", 2, { count: "2" }),
+  );
+
+  // The common card draws no key and claims nothing: every plotted fit
+  // carries the filled marker, so there is no difference to explain.
+  const clean = shareCardTrend(shareCardTrendHistory([false, false]));
+  assert.equal(clean.shortCount, 0);
+  assert.deepEqual(shareCardTrendLegend(clean), []);
+  assert.equal(shareCardTrendShortText({ trend: clean }), "");
+  assert.deepEqual(shareCardTrendLegend(null), []);
+  assert.equal(shareCardTrendShortText({ trend: null }), "");
+
+  // A slider left at zero classifies nothing as short, but a fit with no
+  // recorded span is still never promoted, so the key names the honest
+  // all-spans series rather than a "0+ pp" threshold nobody set.
+  const unfloored = shareCardTrend({
+    ...shareCardTrendHistory([true, false]),
+    wellObservedFloorPp: 0,
+  });
+  assert.equal(
+    shareCardTrendLegend(unfloored)[0].label,
+    translate("weekly.series.allSpans"),
+  );
+
+  // Every locale carries both forms, and both count the fits they describe.
+  const entry = WEB_PLURAL_MESSAGES["share.text.shortObservation"];
+  assert.ok(entry, "the short-observation sentence is catalogued");
+  for (const form of ["one", "other"]) {
+    assert.equal(entry[form].length, SUPPORTED_LOCALES.length);
+    for (const message of entry[form]) assert.ok(message.includes("{count}"));
+  }
+});
+
+test("the posted card's marker key is drawn by the same calls as its points", async () => {
+  const appSource = await readFile(new URL("../public/app.js", import.meta.url), "utf8");
+  const section = shareCardSource(appSource);
+
+  // One palette, two draw sites: a key painted from its own colours could
+  // drift from the markers it explains without any test noticing.
+  assert.match(section, /context\.fillStyle = point\.wellObserved \? "#315f84" : "#fffef9";/u);
+  assert.match(section, /context\.fillStyle = entry\.filled \? "#315f84" : "#fffef9";/u);
+  assert.equal(section.match(/#a9492f/gu).length, 2);
+  assert.equal(section.match(/context\.arc\([^\n]*4\.5, 0, Math\.PI \* 2\);/gu).length, 2);
+
+  // The key is drawn only when the model composed one, and it restores the
+  // canvas state the axis labels below it inherit.
+  assert.match(
+    section,
+    /if \(card\.trendLegend\.length > 0\) \{\s*\n\s*context\.save\(\);[\s\S]*?context\.restore\(\);\s*\n\s*\}/u,
+  );
+  assert.match(section, /trendLegend: shareCardTrendLegend\(trend\),/u);
+  // The transcript line joins the composed card text, where an empty string
+  // is dropped by the existing filter.
+  assert.match(section, /figures,\s*\n\s*shareCardTrendText\(card\),\s*\n\s*shareCardTrendShortText\(card\),/u);
+
+  // The classification floor travels with the shared history model rather
+  // than being read from the slider at paint time.
+  assert.match(appSource, /wellObservedFloorPp: activeWeeklyMinimumObservedSpanPp,/u);
+  assert.match(section, /wellObservedFloorPp: finite\(history\?\.wellObservedFloorPp, 0\),/u);
 });
 
 test("the posted allowance graph uses the exact history model from the dashboard", async () => {


### PR DESCRIPTION
## What

The posted results card plots a short-observation fit as a hollow, rust-outlined marker, but neither the image nor its text transcript said what that meant. The dashboard reveals a `Short observation` legend entry for exactly this case; the card drew the same distinction and left the reader to guess.

This was an internal inconsistency, not just a gap: the comment above `shareCardTrendText` states that the picture may not say anything the text beside it does not, and the rust ring was a claim the transcript never made.

## Changes

- `allowanceHistoryChartModel` carries `wellObservedFloorPp` — the floor `wellObserved` classified against, which a range of seven days or less leaves above the applied `spanFloorPp`. Inclusion and classification are two different decisions, and a key naming the applied floor would explain the outline with the wrong threshold.
- `shareCardTrend` carries `shortCount`; `shareCardTrendLegend` composes a two-entry key from the dashboard's own series strings, or an empty array when nothing is outlined.
- `drawShareCardTrend` paints the key right-aligned in the panel's reserved top strip, using the same fill/stroke calls and the same 4.5px radius as the plotted markers, inside a `save`/`restore` so the axis labels below it inherit unchanged canvas state.
- `shareCardText` gains a matching sentence via one new plural key in en/zh-Hans/es. It is its own line rather than a clause on the caption, which `share.text.trendPopulated` interpolates mid-sentence.

The key and the sentence both appear only when a short observation is actually plotted, mirroring `#weekly-partial-legend` on the dashboard. Point selection, the caption, and the axis are untouched.

## Verification

- 286/286 `apps/web` tests, plus the root localization, test-lane, and architecture-boundary suites.
- New coverage in `lib.test.mjs`: the helpers exercised in isolation across the mixed, all-well-observed, null, and zero-floor cases; three-locale catalogue parity; and source pins that the key shares one palette and radius with the markers.
- Beyond the source pins, the real `drawShareCardTrend` was run against a recording canvas: key right edge lands exactly on `plotRight`, starts clear of the y-axis label, and the x-tick font is byte-identical with and without the key.

Two pre-existing failures in `test/macos-app-bundle.test.js` (`@app-usagemonitor/accounting workspace dependency resolved unexpectedly`) are unrelated — confirmed identical with these changes stashed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)