### PR TITLE
fix(dashboard): show weekly pace standing instead of always-green forecast

### DIFF
--- a/apps/web/public/app.js
+++ b/apps/web/public/app.js
@@ -6416,18 +6416,187 @@ function ensureWeeklyPaceForecastCard() {
   return card;
 }
 
-function weeklyPaceDirection(percentagePointsPerHour, baseline = null) {
-  const pace = finite(percentagePointsPerHour);
-  const steady = firstFiniteForecastNumber(
-    baseline,
-    // A seven-day allowance paced evenly across its full window is the only
-    // baseline this card can derive without inventing a user schedule.
-    100 / (CODEX_WEEKLY_ALLOWANCE_MINUTES / 60),
+// Over, on and under pace are judged against the pace this window can still
+// sustain - the allowance that is left, spread evenly across the time that is
+// left - and never against a fixed 100%-per-seven-days rate.
+//
+// The fixed rate cannot answer the question a reader is actually asking,
+// because it ignores where in the window they already stand. At 3% left with
+// a day to go, "a steady weekly pace" is more than ten times too fast to
+// survive the reset, yet the card called that "ahead of a steady weekly pace"
+// and stayed green, because colour tracked whether the engine had an ETA
+// rather than whether the reader was about to run dry (community report,
+// 2026-08-18).
+const PACE_ON_TRACK_LOWER_RATIO = .85;
+const PACE_ON_TRACK_UPPER_RATIO = 1.15;
+// At twice the sustainable pace the allowance covers less than half the time
+// that is left, so the window ends with more dry hours than covered ones.
+const PACE_CRITICAL_RATIO = 2;
+// Under an hour of observations an overall rate is whatever the reader
+// happened to be doing in that hour, so the headline falls back to the
+// engine's active-interval pace and the card keeps saying it is early.
+const PACE_AVERAGE_MINIMUM_HOURS = 1;
+const PACE_STATE_LABELS = Object.freeze({
+  over: "Over pace",
+  on: "On pace",
+  under: "Under pace",
+});
+
+/**
+ * The two rates this card carries answer different questions and routinely
+ * disagree by an order of magnitude.
+ *
+ * `pace.percentagePointsPerHour` is the engine's median over adjacent
+ * intervals that actually moved, so it measures the pace *while working* and
+ * discards every idle gap. Extrapolated across a whole window it assumes the
+ * reader never stops, which is why a forecast built on it alone always lands
+ * earlier than what happens - the "it always underestimates the time I have
+ * left" complaint this card drew.
+ *
+ * `movementPp / elapsedHours` is the same window's overall rate with idle
+ * time included. That is the honest headline; the active rate stays on the
+ * card as the without-pausing edge, drawn as a separate mark on the track.
+ */
+function weeklyPaceRates(pace, forecast) {
+  const active = firstFiniteForecastNumber(
+    pace.percentagePointsPerHour,
+    pace.percentPerHour,
+    pace.pacePercentPerHour,
+    forecast.percentagePointsPerHour,
+    forecast.pacePercentPerHour,
+    forecast.pacePpPerHour,
   );
-  if (pace === null || steady === null || steady <= 0) return null;
-  if (pace > steady * 1.1) return "Recent pace is ahead of a steady weekly pace.";
-  if (pace < steady * .9) return "Recent pace is behind a steady weekly pace.";
-  return "Recent pace is close to a steady weekly pace.";
+  const elapsedHours = firstFiniteForecastNumber(pace.elapsedHours);
+  const movementPp = firstFiniteForecastNumber(pace.movementPp);
+  const average = elapsedHours !== null
+    && elapsedHours >= PACE_AVERAGE_MINIMUM_HOURS
+    && movementPp !== null
+    && movementPp > 0
+    ? movementPp / elapsedHours
+    : null;
+  return {
+    active: active !== null && active > 0 ? active : null,
+    average,
+    // The overall rate leads whenever the observed span is long enough to
+    // contain a realistic mix of work and rest.
+    headline: average ?? (active !== null && active > 0 ? active : null),
+  };
+}
+
+/**
+ * Where the reader stands relative to the pace that just reaches the reset.
+ *
+ * `ratio` is the whole classification: 1 means the allowance runs out exactly
+ * at the reset, above 1 means it runs out early, below 1 means some is left
+ * over. Because the sustainable pace is `remaining / hoursToReset`, the ratio
+ * is also `hoursToReset / hoursToExhaustion`, so the track below can be drawn
+ * straight from it without a second, separately-rounded division.
+ */
+function weeklyPaceStanding({ remainingPercent, hoursToReset, pacePpPerHour }) {
+  const remaining = finite(remainingPercent);
+  const hoursLeft = finite(hoursToReset);
+  const pace = finite(pacePpPerHour);
+  if (remaining === null
+      || hoursLeft === null
+      || hoursLeft <= 0
+      || remaining <= 0
+      || pace === null
+      || pace <= 0) return null;
+  const sustainable = remaining / hoursLeft;
+  const ratio = pace / sustainable;
+  if (!Number.isFinite(ratio) || ratio <= 0) return null;
+  const coveredHours = Math.min(hoursLeft, remaining / pace);
+  const state = ratio > PACE_ON_TRACK_UPPER_RATIO
+    ? "over"
+    : ratio < PACE_ON_TRACK_LOWER_RATIO ? "under" : "on";
+  return {
+    ratio,
+    state,
+    critical: state === "over" && ratio >= PACE_CRITICAL_RATIO,
+    sustainable,
+    coveredHours,
+    dryHours: Math.max(0, hoursLeft - coveredHours),
+    // Only meaningful when the pace does not exhaust the window; an over-pace
+    // reading leaves nothing spare by definition.
+    sparePercent: Math.max(0, remaining - pace * hoursLeft),
+  };
+}
+
+function formatPaceRatio(ratio) {
+  const value = finite(ratio);
+  if (value === null) return null;
+  return `${formatDecimal(value, value < 10 ? 1 : 0)}×`;
+}
+
+/**
+ * The window as a single track: how much of the time left to the reset the
+ * remaining allowance actually covers, and how much of it is dry.
+ *
+ * The bar is deliberately a picture of time, not of allowance. "You have 3%
+ * left" tells a reader nothing on its own; "that covers the next 20 minutes
+ * of a day and five hours" is the fact they act on. The state name, the
+ * heading and this track's own label all state the standing in words, so
+ * colour is never the only carrier.
+ */
+function weeklyPaceTrack(standing, hoursToReset, activePace, remainingPercent) {
+  const hoursLeft = finite(hoursToReset);
+  if (!standing || hoursLeft === null || hoursLeft <= 0) return null;
+  const coveredShare = Math.max(0, Math.min(1, standing.coveredHours / hoursLeft));
+  const track = node("div", "weekly-pace-track");
+  const bar = node("div", "weekly-pace-track-bar");
+  const covered = node("div", "weekly-pace-track-covered");
+  covered.style.inlineSize = `${(coveredShare * 100).toFixed(2)}%`;
+  bar.append(covered);
+
+  // The engine's active-interval pace, drawn only where it would run the
+  // allowance out sooner than the headline rate does. It is the edge of the
+  // estimate, not the estimate: it answers "and if I do not stop?".
+  const remaining = finite(remainingPercent);
+  const active = finite(activePace);
+  const flatOutHours = active !== null && active > 0 && remaining !== null
+    ? remaining / active
+    : null;
+  let flatOutLabel = null;
+  if (flatOutHours !== null && flatOutHours < standing.coveredHours * .95) {
+    const flatOutShare = Math.max(0, Math.min(1, flatOutHours / hoursLeft));
+    const mark = node("div", "weekly-pace-track-mark");
+    mark.style.insetInlineStart = `${(flatOutShare * 100).toFixed(2)}%`;
+    bar.append(mark);
+    flatOutLabel = formatForecastDuration(flatOutHours);
+  }
+
+  const resetDuration = formatForecastDuration(hoursLeft);
+  const coveredDuration = formatForecastDuration(standing.coveredHours);
+  const dryDuration = formatForecastDuration(standing.dryHours);
+  bar.setAttribute("role", "img");
+  bar.setAttribute(
+    "aria-label",
+    // Whether a gap exists is arithmetic, not a state name: the on-pace band
+    // straddles the point where the allowance lands exactly on the reset, so
+    // an on-pace card can still end with a short dry stretch.
+    dryDuration
+      ? `Of the ${resetDuration ?? "time"} left before the reset, the remaining allowance covers about ${coveredDuration ?? "none of it"}, leaving about ${dryDuration} with none left.`
+      : `The remaining allowance covers all ${resetDuration ?? "of the time"} left before the reset.`,
+  );
+
+  const scale = node("div", "weekly-pace-track-scale");
+  scale.append(
+    node("span", "", "Now"),
+    node(
+      "span",
+      "weekly-pace-track-scale-end",
+      resetDuration ? `Reset in ${resetDuration}` : "Reset",
+    ),
+  );
+  track.append(bar, scale);
+  if (flatOutLabel) {
+    track.append(node(
+      "p",
+      "weekly-pace-track-note",
+      `The mark is where the allowance ends if the recent active pace continues without a pause: about ${flatOutLabel} from now.`,
+    ));
+  }
+  return track;
 }
 
 function renderWeeklyPaceForecast(data) {
@@ -6470,14 +6639,8 @@ function renderWeeklyPaceForecast(data) {
   if (remaining === null && used !== null) remaining = 100 - used;
   if (remaining !== null && (remaining < 0 || remaining > 100)) remaining = null;
 
-  const percentagePointsPerHour = firstFiniteForecastNumber(
-    pace.percentagePointsPerHour,
-    pace.percentPerHour,
-    pace.pacePercentPerHour,
-    forecast.percentagePointsPerHour,
-    forecast.pacePercentPerHour,
-    forecast.pacePpPerHour,
-  );
+  const rates = weeklyPaceRates(pace, forecast);
+  const percentagePointsPerHour = rates.headline;
   const hoursToReset = firstFiniteForecastNumber(
     (resetAt - now) / 3_600_000,
     forecast.hoursToReset,
@@ -6527,16 +6690,37 @@ function renderWeeklyPaceForecast(data) {
       && percentagePointsPerHour === null
       && !reachesResetFirst) return;
 
+  // The standing is computed from the headline rate, so the card's colour,
+  // its heading and its arithmetic all come from one number. The engine's own
+  // `available` / `will_reach_reset_first` split still gates whether a card
+  // appears at all, but it no longer decides how the card reads: an engine ETA
+  // built on the active-interval pace is exactly the reading that overstated
+  // the burn.
+  const standing = collectingEvidence
+    ? null
+    : weeklyPaceStanding({
+      remainingPercent: remaining,
+      hoursToReset,
+      pacePpPerHour: percentagePointsPerHour,
+    });
+  const paceState = standing?.state
+    ?? (collectingEvidence ? null : reachesResetFirst ? "under" : null);
+  const projectedEtaAt = standing !== null && standing.state === "over"
+    ? now + standing.coveredHours * 3_600_000
+    : null;
+
   const title = node("h3", "weekly-pace-forecast-title");
   const cardId = "weekly-pace-forecast-title";
   title.id = cardId;
   title.textContent = collectingEvidence
     ? "Pace estimate ready after one more refresh"
-    : reachesResetFirst
-      ? "At the recent pace, the weekly allowance should last to reset"
-      : etaAt === null
-        ? "At this pace: weekly allowance exhaustion is approaching"
-        : `At this pace: reaches weekly allowance ${formatReportingTime(etaAt)}`;
+    : paceState === "over"
+      ? projectedEtaAt === null
+        ? "At this pace the weekly allowance runs out before the reset"
+        : `At this pace the weekly allowance runs out ${formatReportingTime(projectedEtaAt)}`
+      : paceState === "on"
+        ? "At this pace the weekly allowance runs close to the reset"
+        : "At this pace the weekly allowance lasts to the reset with room to spare";
   card.setAttribute("aria-labelledby", cardId);
 
   const heading = node("div", "weekly-pace-forecast-heading");
@@ -6546,95 +6730,112 @@ function renderWeeklyPaceForecast(data) {
       "panel-kicker",
       collectingEvidence ? "Collecting forecast evidence" : "Forecast from recent pace",
     ),
-    node(
+  );
+  if (collectingEvidence) {
+    heading.append(node(
       "span",
-      collectingEvidence
-        ? "evidence-chip weekly-pace-forecast-collecting-chip"
-        : earlyEstimate
-          ? "evidence-chip weekly-pace-forecast-early-chip"
-          : "evidence-chip",
-      collectingEvidence ? "One more refresh" : earlyEstimate ? "Early estimate" : "Observed pace",
-    ),
-  );
+      "evidence-chip weekly-pace-forecast-collecting-chip",
+      "One more refresh",
+    ));
+  } else if (paceState) {
+    // The standing is named in words on the chip as well as carried in the
+    // card's colour, so the over/on/under reading survives a monochrome
+    // screen, a colour-vision difference and a screen reader alike.
+    heading.append(node(
+      "span",
+      "evidence-chip weekly-pace-forecast-state-chip",
+      PACE_STATE_LABELS[paceState],
+    ));
+  }
+  if (earlyEstimate) {
+    heading.append(node(
+      "span",
+      "evidence-chip weekly-pace-forecast-early-chip",
+      "Early estimate",
+    ));
+  }
 
-  const direction = weeklyPaceDirection(
-    percentagePointsPerHour,
-    firstFiniteForecastNumber(
-      pace.steadyPercentagePointsPerHour,
-      forecast.steadyPercentagePointsPerHour,
-    ),
-  );
+  const ratioLabel = standing === null ? null : formatPaceRatio(standing.ratio);
+  const dryDuration = standing === null
+    ? null
+    : formatForecastDuration(standing.dryHours);
   const copy = node("p", "weekly-pace-forecast-copy");
   copy.textContent = collectingEvidence
     ? "One clean weekly allowance observation is saved. The next fresh observation for this account and reset will establish its pace."
-    : earlyEstimate
-      ? "This is an early estimate from a small amount of recent evidence; it will settle as more observations arrive."
-      : direction ?? (reachesResetFirst
-        ? "Recent allowance movement is not fast enough to exhaust this window before its reset."
-        : "The estimate uses the latest clean allowance observations.");
+    : standing === null
+      ? "Recent allowance movement is not fast enough to exhaust this window before its reset."
+      : standing.state === "over"
+        ? `Recent use is running about ${ratioLabel} the pace this window can still sustain${dryDuration ? `, which leaves roughly ${dryDuration} with none left before the reset` : ""}.`
+        : standing.state === "on"
+          ? `Recent use is close to the pace this window can still sustain, so the allowance should land near the reset with little to spare.`
+          : `Recent use is running about ${ratioLabel} the pace this window can still sustain, so some of the allowance should still be unused at the reset.`;
+  if (earlyEstimate) {
+    copy.textContent += " This is an early estimate from a small amount of recent evidence; it will settle as more observations arrive.";
+  }
 
   const metrics = node("div", "weekly-pace-forecast-metrics");
-  if (remaining !== null) {
-    metrics.append(
-      node("div", "weekly-pace-forecast-metric", "Allowance left"),
-    );
-    const item = metrics.lastElementChild;
-    item.replaceChildren(
-      node("span", "", "Allowance left"),
-      node("strong", "", formatPercent(remaining)),
-    );
-  }
+  const addMetric = (label, value) => {
+    const item = node("div", "weekly-pace-forecast-metric");
+    item.append(node("span", "", label), node("strong", "", value));
+    metrics.append(item);
+  };
+  if (remaining !== null) addMetric("Allowance left", formatPercent(remaining));
   const resetDuration = formatForecastDuration(hoursToReset);
-  if (resetDuration) {
-    metrics.append(
-      node("div", "weekly-pace-forecast-metric"),
-    );
-    const item = metrics.lastElementChild;
-    item.append(
-      node("span", "", "Reset"),
-      node("strong", "", `in ${resetDuration}`),
-    );
-  }
+  if (resetDuration) addMetric("Reset", `in ${resetDuration}`);
   if (collectingEvidence) {
-    metrics.append(
-      node("div", "weekly-pace-forecast-metric"),
-    );
-    const item = metrics.lastElementChild;
-    item.append(
-      node("span", "", "Evidence"),
-      node("strong", "", "1 saved"),
-    );
+    addMetric("Evidence", "1 saved");
+  } else if (dryDuration) {
+    // A dry stretch and spare allowance are mutually exclusive, and the tile
+    // reports whichever one the reading actually produced rather than pinning
+    // itself to the state name.
+    addMetric("Nothing left for", dryDuration);
+  } else if (standing !== null) {
+    addMetric("Spare at reset", formatPercent(standing.sparePercent));
   } else if (percentagePointsPerHour !== null && percentagePointsPerHour > 0) {
-    metrics.append(
-      node("div", "weekly-pace-forecast-metric"),
-    );
-    const item = metrics.lastElementChild;
-    item.append(
-      node("span", "", "Recent pace"),
-      node("strong", "", `${formatDecimal(percentagePointsPerHour, 1)} pp/hour`),
-    );
+    addMetric("Recent pace", `${formatDecimal(percentagePointsPerHour, 1)} pp/hour`);
   }
 
+  const track = collectingEvidence
+    ? null
+    : weeklyPaceTrack(standing, hoursToReset, rates.active, remaining);
+
+  // The evidence line names both rates. A reader who wondered why the old
+  // card's forecast kept arriving early can see the difference between the
+  // pace with idle time counted and the pace while working, instead of being
+  // handed one number with no way to tell which it was.
   const observationDuration = formatForecastDuration(paceElapsedHours);
+  const rateSentences = [];
+  if (rates.average !== null) {
+    rateSentences.push(`${formatDecimal(rates.average, 1)} pp/hour overall`);
+  }
+  if (rates.active !== null) {
+    rateSentences.push(`${formatDecimal(rates.active, 1)} pp/hour while active`);
+  }
   const evidence = observations !== null && observations >= 1
     ? node(
       "p",
       "weekly-pace-forecast-evidence",
       collectingEvidence
         ? "One fresh allowance observation is saved for this weekly reset."
-        : `Based on ${Math.round(observations)} recent allowance observation${Math.round(observations) === 1 ? "" : "s"}${observationDuration ? ` over ${observationDuration}` : ""}.`,
+        : `Based on ${formatDecimal(Math.round(observations), 0)} recent allowance observation${Math.round(observations) === 1 ? "" : "s"}${observationDuration ? ` over ${observationDuration}` : ""}${rateSentences.length > 0 ? `: ${rateSentences.join(", ")}` : ""}.`,
     )
     : null;
   card.className = [
     "weekly-pace-forecast",
     collectingEvidence
       ? "is-insufficient"
-      : reachesResetFirst
-        ? "is-reset-first"
-        : "is-available",
+      : paceState === "over"
+        ? "is-over-pace"
+        : paceState === "on" ? "is-on-pace" : "is-under-pace",
+    standing?.critical ? "is-critical" : "",
     earlyEstimate ? "is-early-estimate" : "",
+    // Retained so the engine's own split stays inspectable from the DOM even
+    // though it no longer drives presentation.
+    reachesResetFirst ? "is-reset-first" : "",
+    available ? "is-available" : "",
   ].filter(Boolean).join(" ");
   card.append(heading, title, copy, metrics);
+  if (track) card.append(track);
   if (evidence) card.append(evidence);
   card.hidden = false;
 }

--- a/apps/web/public/styles.css
+++ b/apps/web/public/styles.css
@@ -1578,33 +1578,70 @@ tbody tr:last-child td { border-bottom: 0; }
 .weekly-hero span, .weekly-hero small { color: rgba(255,255,255,.7); font-size: .72rem; }
 .weekly-hero > div:first-child strong { margin: .2rem 0; font-family: var(--serif); font-size: clamp(3rem, 6vw, 5rem); font-weight: var(--weight-regular); line-height: 1; }
 .weekly-hero > p { max-width: 55ch; margin: 0; color: rgba(255,255,255,.8); font-size: .86rem; line-height: 1.5; }
+/*
+ * Pace forecast card.
+ *
+ * One accent token drives the whole card - rule, wash, chip and track - and
+ * the state class is the only thing that sets it. Colour used to follow
+ * whether the engine had produced an ETA, which put the card's calmest colour
+ * on its most urgent reading: "you run out before the reset" rendered green.
+ * The ramp now runs green (under pace) -> blue (on pace) -> amber (over) ->
+ * rust (over by more than double), and every step is also named in words on
+ * the chip, so nothing here is carried by colour alone.
+ */
 .weekly-pace-forecast {
+  --pace-accent: var(--green);
+  --pace-accent-text: var(--green-text);
+  --pace-accent-soft: var(--green-soft);
+  --pace-accent-edge: rgba(23, 79, 69, .24);
+  --pace-accent-wash: rgba(223, 236, 230, .8);
   display: grid;
   grid-template-columns: minmax(260px, 1fr) minmax(310px, .95fr);
   gap: 15px 24px;
   align-items: start;
   margin: 0 0 18px;
   padding: 22px 24px;
-  border: 1px solid rgba(38, 107, 91, .26);
-  border-inline-start: 4px solid var(--green);
+  border: 1px solid var(--pace-accent-edge);
+  border-inline-start: 4px solid var(--pace-accent);
   border-radius: var(--radius-md);
-  background: linear-gradient(100deg, rgba(221, 239, 233, .75), rgba(255, 253, 247, .94));
+  background: linear-gradient(100deg, var(--pace-accent-wash), rgba(255, 253, 247, .94));
 }
 .weekly-pace-forecast[hidden] { display: none; }
-.weekly-pace-forecast.is-reset-first {
-  border-inline-start-color: var(--blue);
-  border-color: rgba(49, 95, 132, .24);
-  background: linear-gradient(100deg, rgba(226, 235, 243, .76), rgba(255, 253, 247, .94));
+.weekly-pace-forecast.is-on-pace {
+  --pace-accent: var(--blue);
+  --pace-accent-text: var(--blue);
+  --pace-accent-soft: var(--blue-soft);
+  --pace-accent-edge: rgba(49, 95, 132, .24);
+  --pace-accent-wash: rgba(226, 235, 243, .76);
+}
+.weekly-pace-forecast.is-over-pace {
+  --pace-accent: var(--amber);
+  --pace-accent-text: var(--amber);
+  --pace-accent-soft: var(--amber-soft);
+  --pace-accent-edge: rgba(129, 87, 24, .26);
+  --pace-accent-wash: rgba(244, 234, 215, .8);
+}
+/* Past twice the sustainable pace the window ends with more dry hours than
+   covered ones, which is a different message from "ease off". */
+.weekly-pace-forecast.is-over-pace.is-critical {
+  --pace-accent: var(--rust);
+  --pace-accent-text: var(--rust);
+  --pace-accent-soft: var(--rust-soft);
+  --pace-accent-edge: rgba(151, 64, 42, .26);
+  --pace-accent-wash: rgba(244, 228, 222, .82);
 }
 .weekly-pace-forecast.is-insufficient {
-  border-inline-start-color: var(--blue);
-  border-color: rgba(49, 95, 132, .24);
-  background: linear-gradient(100deg, rgba(226, 235, 243, .76), rgba(255, 253, 247, .94));
+  --pace-accent: var(--blue);
+  --pace-accent-text: var(--blue);
+  --pace-accent-soft: var(--blue-soft);
+  --pace-accent-edge: rgba(49, 95, 132, .24);
+  --pace-accent-wash: rgba(226, 235, 243, .76);
 }
+.weekly-pace-forecast-state-chip,
 .weekly-pace-forecast-collecting-chip {
-  color: var(--blue);
-  border-color: rgba(49, 95, 132, .18);
-  background: var(--blue-soft);
+  color: var(--pace-accent-text);
+  border-color: var(--pace-accent-edge);
+  background: var(--pace-accent-soft);
 }
 .weekly-pace-forecast-early-chip {
   color: var(--amber);
@@ -1636,11 +1673,11 @@ tbody tr:last-child td { border-bottom: 0; }
 }
 .weekly-pace-forecast-metrics {
   display: grid;
-  grid-template-columns: repeat(3, minmax(0, 1fr));
+  grid-template-columns: repeat(auto-fit, minmax(88px, 1fr));
   grid-column: 2;
   grid-row: 2 / span 2;
   gap: 8px;
-  align-self: stretch;
+  align-self: start;
 }
 .weekly-pace-forecast-metric {
   display: flex;
@@ -1667,8 +1704,72 @@ tbody tr:last-child td { border-bottom: 0; }
   font-variant-numeric: tabular-nums;
   overflow-wrap: anywhere;
 }
+/*
+ * The window track. Its width is the time left before the reset, and the
+ * filled part is how much of that time the remaining allowance covers - so an
+ * under-pace card fills the bar and an over-pace card shows the gap it will
+ * spend with nothing left. Drawing time rather than allowance is deliberate:
+ * "3% left" carries no urgency on its own, "that covers 20 minutes of the 29
+ * hours left" carries all of it.
+ */
+.weekly-pace-track {
+  display: flex;
+  flex-direction: column;
+  grid-column: 1 / -1;
+  gap: 6px;
+}
+.weekly-pace-track-bar {
+  position: relative;
+  overflow: hidden;
+  block-size: 12px;
+  border: 1px solid var(--pace-accent-edge);
+  border-radius: var(--radius-pill);
+  /* The dry remainder is hatched as well as pale, so the covered/dry split
+     survives a greyscale print or a colour-vision difference. */
+  background-color: var(--surface-raised);
+  background-image: repeating-linear-gradient(
+    135deg,
+    var(--pace-accent-soft) 0 5px,
+    transparent 5px 10px
+  );
+}
+.weekly-pace-track-covered {
+  position: absolute;
+  inset-block: 0;
+  inset-inline-start: 0;
+  min-inline-size: 2px;
+  border-start-end-radius: 2px;
+  border-end-end-radius: 2px;
+  background: var(--pace-accent);
+}
+/* Where the allowance ends if the recent active bursts continue without a
+   pause. It is the fast edge of the estimate, never the estimate itself. */
+.weekly-pace-track-mark {
+  position: absolute;
+  inset-block: -1px;
+  inline-size: 2px;
+  border-radius: 1px;
+  background: var(--surface-raised);
+  box-shadow: 0 0 0 1px var(--pace-accent);
+}
+.weekly-pace-track-scale {
+  display: flex;
+  justify-content: space-between;
+  gap: 12px;
+  color: var(--muted);
+  font-size: .62rem;
+  letter-spacing: .045em;
+  text-transform: uppercase;
+}
+.weekly-pace-track-scale-end { text-align: end; }
+.weekly-pace-track-note {
+  margin: 0;
+  color: var(--muted);
+  font-size: .67rem;
+  line-height: 1.5;
+}
 .weekly-pace-forecast-evidence {
-  grid-column: 1;
+  grid-column: 1 / -1;
   margin: 0;
   color: var(--muted);
   font-size: .67rem;

--- a/apps/web/test/weekly-pace-forecast.test.mjs
+++ b/apps/web/test/weekly-pace-forecast.test.mjs
@@ -8,6 +8,158 @@ const paceSource = appSource.match(
   /function renderWeeklyPaceForecast[\s\S]*?\n\}\n\nfunction renderWeekly\(data\)/u,
 )?.[0] ?? "";
 
+function sliceDeclaration(name) {
+  const source = appSource.match(
+    new RegExp(`\\nfunction ${name}\\([\\s\\S]*?\\n\\}\\n`, "u"),
+  )?.[0];
+  assert.ok(source, `${name} is declared at the top level of app.js`);
+  return source;
+}
+
+function sliceConstant(name) {
+  const source = appSource.match(new RegExp(`\\nconst ${name} = [^;]+;`, "u"))?.[0];
+  assert.ok(source, `${name} is declared at the top level of app.js`);
+  return source;
+}
+
+// The classification is pure arithmetic over numbers the payload already
+// carries, so it is exercised directly rather than asserted about as text. The
+// slice keeps the test bound to the shipped source: app.js is a boot script
+// with no exports, and a copy of the maths here could drift from it silently.
+const pace = new Function(
+  "finite",
+  "formatDecimal",
+  `
+  ${sliceConstant("PACE_ON_TRACK_LOWER_RATIO")}
+  ${sliceConstant("PACE_ON_TRACK_UPPER_RATIO")}
+  ${sliceConstant("PACE_CRITICAL_RATIO")}
+  ${sliceConstant("PACE_AVERAGE_MINIMUM_HOURS")}
+  ${sliceDeclaration("firstFiniteForecastNumber")}
+  ${sliceDeclaration("weeklyPaceRates")}
+  ${sliceDeclaration("weeklyPaceStanding")}
+  ${sliceDeclaration("formatPaceRatio")}
+  return {
+    weeklyPaceRates,
+    weeklyPaceStanding,
+    formatPaceRatio,
+    PACE_ON_TRACK_LOWER_RATIO,
+    PACE_ON_TRACK_UPPER_RATIO,
+    PACE_CRITICAL_RATIO,
+  };
+`,
+)(
+  (value) => (typeof value === "number" && Number.isFinite(value) ? value : null),
+  (value, digits) => value.toFixed(digits),
+);
+
+test("pace standing is measured against what the window can still sustain", () => {
+  // 50% left with 84 hours to run sustains 0.595pp/hour. The three readings
+  // below sit either side of that rate, not either side of a fixed
+  // 100%-per-seven-days rate, which is the whole point of the change.
+  const under = pace.weeklyPaceStanding({
+    remainingPercent: 50,
+    hoursToReset: 84,
+    pacePpPerHour: .3,
+  });
+  const on = pace.weeklyPaceStanding({
+    remainingPercent: 50,
+    hoursToReset: 84,
+    pacePpPerHour: .6,
+  });
+  const over = pace.weeklyPaceStanding({
+    remainingPercent: 50,
+    hoursToReset: 84,
+    pacePpPerHour: .9,
+  });
+  assert.equal(under.state, "under");
+  assert.equal(on.state, "on");
+  assert.equal(over.state, "over");
+  assert.equal(over.critical, false);
+
+  // The reading that prompted the change: 3% left, a day and five hours to
+  // run, and a pace that empties it inside the hour. The old card called this
+  // "ahead of a steady weekly pace" and rendered green.
+  const emergency = pace.weeklyPaceStanding({
+    remainingPercent: 3,
+    hoursToReset: 29,
+    pacePpPerHour: 11.3,
+  });
+  assert.equal(emergency.state, "over");
+  assert.equal(emergency.critical, true);
+  assert.ok(emergency.coveredHours < .3);
+  assert.ok(emergency.dryHours > 28);
+  assert.equal(emergency.sparePercent, 0);
+});
+
+test("the critical step is exactly the point where dry time exceeds covered time", () => {
+  const atThreshold = pace.weeklyPaceStanding({
+    remainingPercent: 40,
+    hoursToReset: 100,
+    // Twice the sustainable 0.4pp/hour.
+    pacePpPerHour: .8,
+  });
+  assert.equal(atThreshold.ratio, pace.PACE_CRITICAL_RATIO);
+  assert.equal(atThreshold.critical, true);
+  assert.equal(atThreshold.coveredHours, 50);
+  assert.equal(atThreshold.dryHours, 50);
+});
+
+test("an under-pace standing reports the allowance left over at the reset", () => {
+  const standing = pace.weeklyPaceStanding({
+    remainingPercent: 60,
+    hoursToReset: 100,
+    pacePpPerHour: .4,
+  });
+  assert.equal(standing.state, "under");
+  // 0.4pp/hour for 100 hours spends 40 of the 60 points that are left.
+  assert.equal(Math.round(standing.sparePercent), 20);
+  assert.equal(standing.dryHours, 0);
+  assert.equal(standing.coveredHours, 100);
+});
+
+test("pace standing refuses readings it cannot classify", () => {
+  const cases = [
+    { remainingPercent: null, hoursToReset: 84, pacePpPerHour: .6 },
+    { remainingPercent: 50, hoursToReset: null, pacePpPerHour: .6 },
+    { remainingPercent: 50, hoursToReset: 0, pacePpPerHour: .6 },
+    { remainingPercent: 0, hoursToReset: 84, pacePpPerHour: .6 },
+    { remainingPercent: 50, hoursToReset: 84, pacePpPerHour: 0 },
+    { remainingPercent: 50, hoursToReset: 84, pacePpPerHour: null },
+  ];
+  for (const input of cases) {
+    assert.equal(pace.weeklyPaceStanding(input), null, JSON.stringify(input));
+  }
+});
+
+test("the headline rate counts idle time and the active rate stays separate", () => {
+  // The engine's percentagePointsPerHour is a median over intervals that
+  // moved, so it measures the pace while working. Extrapolating it alone is
+  // what made every forecast land earlier than it should.
+  const rates = pace.weeklyPaceRates(
+    { percentagePointsPerHour: 11.3, elapsedHours: 100, movementPp: 97 },
+    {},
+  );
+  assert.equal(rates.active, 11.3);
+  assert.equal(Math.round(rates.average * 100) / 100, .97);
+  assert.equal(rates.headline, rates.average);
+});
+
+test("too short an observation span falls back to the active rate", () => {
+  const rates = pace.weeklyPaceRates(
+    { percentagePointsPerHour: 4, elapsedHours: .5, movementPp: 2 },
+    {},
+  );
+  assert.equal(rates.average, null);
+  assert.equal(rates.headline, 4);
+
+  const noMovement = pace.weeklyPaceRates(
+    { percentagePointsPerHour: 4, elapsedHours: 12, movementPp: 0 },
+    {},
+  );
+  assert.equal(noMovement.average, null);
+  assert.equal(noMovement.headline, 4);
+});
+
 test("weekly pace forecast is an optional, allowance-scoped dashboard surface", () => {
   assert.match(paceSource, /data\?\.weekly\?\.paceForecast/u);
   assert.match(paceSource, /weekly-pace-forecast/u);
@@ -17,8 +169,8 @@ test("weekly pace forecast is an optional, allowance-scoped dashboard surface", 
     paceSource,
     /status === "insufficient_observations"[\s\S]*?observations === 1/u,
   );
-  assert.match(paceSource, /At this pace: reaches weekly allowance/u);
-  assert.match(paceSource, /weekly allowance should last to reset/u);
+  assert.match(paceSource, /At this pace the weekly allowance runs out/u);
+  assert.match(paceSource, /lasts to the reset with room to spare/u);
   assert.match(paceSource, /Pace estimate ready after one more refresh/u);
   assert.match(paceSource, /Early estimate/u);
   assert.match(
@@ -32,11 +184,48 @@ test("weekly pace forecast is an optional, allowance-scoped dashboard surface", 
   assert.doesNotMatch(paceSource, /probability|tokens/iu);
 });
 
-test("weekly pace forecast styles keep the card hidden until data is usable", () => {
+test("the standing drives the card's class and is also stated in words", () => {
+  // Colour alone must never carry the reading: the chip names the state, so a
+  // monochrome screen, a colour-vision difference and a screen reader all get
+  // the same answer the border does.
+  assert.match(paceSource, /is-over-pace/u);
+  assert.match(paceSource, /is-on-pace/u);
+  assert.match(paceSource, /is-under-pace/u);
+  assert.match(paceSource, /is-critical/u);
+  assert.match(paceSource, /weekly-pace-forecast-state-chip/u);
+  assert.match(appSource, /over: "Over pace"/u);
+  assert.match(appSource, /on: "On pace"/u);
+  assert.match(appSource, /under: "Under pace"/u);
+  // The engine's own split is no longer what colours the card, but it stays
+  // readable from the DOM.
+  assert.match(paceSource, /reachesResetFirst \? "is-reset-first" : ""/u);
+});
+
+test("weekly pace forecast styles map each standing to its own accent", () => {
   assert.match(styles, /\.weekly-pace-forecast\[hidden\]\s*\{\s*display:\s*none;/u);
   assert.match(styles, /\.weekly-pace-forecast-metrics/u);
   assert.match(styles, /\.weekly-pace-forecast-metric/u);
   assert.match(styles, /\.weekly-pace-forecast\.is-insufficient/u);
   assert.match(styles, /\.weekly-pace-forecast-early-chip/u);
-  assert.match(styles, /weekly-pace-forecast/u);
+  assert.match(styles, /\.weekly-pace-forecast\.is-on-pace/u);
+  assert.match(styles, /\.weekly-pace-forecast\.is-over-pace/u);
+  assert.match(styles, /\.weekly-pace-forecast\.is-over-pace\.is-critical/u);
+  // Under pace keeps the calm accent; every other standing overrides it.
+  assert.match(
+    styles,
+    /\.weekly-pace-forecast \{[\s\S]*?--pace-accent: var\(--green\);/u,
+  );
+  assert.match(
+    styles,
+    /\.weekly-pace-forecast\.is-over-pace \{[\s\S]*?--pace-accent: var\(--amber\);/u,
+  );
+  assert.match(
+    styles,
+    /\.weekly-pace-forecast\.is-over-pace\.is-critical \{[\s\S]*?--pace-accent: var\(--rust\);/u,
+  );
+  assert.match(styles, /\.weekly-pace-track-bar/u);
+  assert.match(styles, /\.weekly-pace-track-covered/u);
+  assert.match(styles, /\.weekly-pace-track-mark/u);
+  // The dry remainder is hatched, not merely a paler colour.
+  assert.match(styles, /repeating-linear-gradient/u);
 });


### PR DESCRIPTION
## The gap

A community report on the weekly pace card, 2026-08-18:

> it always underestimates the time I have left, or overestimates token burn

and, on the same card:

> the colors are always green, so 'ahead of a steady weekly pace' -> you're going to run out -> its still green, which is now what we'd expect as humans

Both are real, and they share a root: the card presented an engine internal as if it were a prediction about the reader's week.

## Colour tracked the wrong fact

`is-available` meant *the engine produced an ETA* — i.e. **you run out before the reset** — and that was the green state. `is-reset-first` meant *your allowance survives* and that was blue. Exactly inverted from how anyone reads a traffic light.

The direction sentence compared against a fixed 100%-per-seven-days rate, which ignores where in the window the reader already stands. At 3% left with a day to go, a "steady weekly pace" is ten times too fast to survive — so "ahead of a steady weekly pace" was technically true and practically useless.

## What replaced it

Comparison is now against the pace the window **can still sustain** (`remaining ÷ hoursToReset`). The ratio to that rate is the whole classification:

| ratio | standing | accent |
|---|---|---|
| < 0.85 | under pace | green |
| 0.85–1.15 | on pace | blue |
| > 1.15 | over pace | amber |
| ≥ 2 | over pace, critical | rust |

The 2× step is where the window ends with more dry hours than covered ones — algebraically `dryFraction = 1 − 1/ratio`, so the threshold and the drawing come from one number.

The visual is a **window track**: its width is the time to the reset, the fill is how much of that time the remaining allowance covers, the hatched remainder is time with nothing left. It draws time rather than allowance deliberately — "3% left" carries no urgency; "that covers 3 hours of the 29 left" carries all of it.

Every standing is also named in words on a chip ("Over pace"), and the track carries an `aria-label` sentence, so the reading survives a monochrome screen, a colour-vision difference and a screen reader alike.

## The accuracy complaint has the same fix

`pace.percentagePointsPerHour` is a **median over adjacent intervals that moved** — `if (elapsedMs > 0 && movement > 0)` in `quota-pace-forecast.js`. Idle gaps are dropped before the median, so it measures pace *while working*. In the reported corpus that is 11.3 pp/hour against an overall 0.97 pp/hour (1,109 observations, 97pp over 4d 4h). Extrapolating it assumes the reader never stops, which is exactly why the forecast always landed early.

The card now headlines on `movementPp / elapsedHours` (idle included) and keeps the active rate as a marked "if you never pause" edge on the track, with both rates named in the evidence line. **The engine is unchanged** — both quantities were already on the wire. Whether the engine's own `status`/`etaAt` should follow is tracked separately; nothing else reads them today.

## Verification

- All six card states rendered through the shipped `renderWeeklyPaceForecast` against the shipped stylesheet
- No overflow at a 360px stacked width; metric tiles reflow via `auto-fit`
- Chip contrasts: amber 5.32:1, rust 5.51:1, green-text 5.25:1, all ≥ AA
- `apps/web/test/weekly-pace-forecast.test.mjs`: 2 source-regex tests → 9, six of which execute the classification arithmetic
- 291/291 in the UI lane; engine, local-companion, refresh-integration and macOS-runtime pace suites all pass

`test/macos-app-bundle.test.js` has 2 pre-existing failures in a worktree without `node_modules` (workspace resolution); confirmed identical on a stashed baseline.

Since `scripts/build-macos-app.js` bundles `app.js` and `styles.css`, the macOS app picks this up with no separate change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)