### PR TITLE
fix(trends): make calibration exclusion bands visible and correctly keyed

### DIFF
--- a/apps/web/public/app.js
+++ b/apps/web/public/app.js
@@ -3384,16 +3384,32 @@ function timelineStatusIntervals(points, viewport) {
     .map((point) => ({ point, at: pointTimestampMs(point) }))
     .filter(({ at }) => Number.isFinite(at))
     .sort((left, right) => left.at - right.at);
-  return rows.flatMap(({ point, at: current }, index) => {
-    if (!point.status || point.status === "matched" || point.status === "inactive") return [];
+  // A run of consecutive windows excluded by ONE mechanism is one region, and
+  // merging it is a correctness fix rather than a tidy-up. Emitted per window,
+  // each rect is floored to a full viewBox unit by the renderer; at 30d the
+  // spacing between windows is well under a unit, so neighbours in a run
+  // overlapped and composited their alpha on top of each other. The wash then
+  // darkened with point DENSITY instead of duration — dense runs read as solid
+  // blocks while isolated windows stayed invisible, which is precisely the
+  // "I never see them" the exclusion legend was failing to explain.
+  const merged = [];
+  rows.forEach(({ point, at: current }, index) => {
+    if (!TIMELINE_STATUS_BAND_CLASSES[point.status]) return;
     const previous = index === 0 ? viewport.startMs : rows[index - 1].at;
     const next = index === rows.length - 1 ? viewport.endMs : rows[index + 1].at;
-    return [{
-      status: point.status,
-      startMs: Math.max(viewport.startMs, (previous + current) / 2),
-      endMs: Math.min(viewport.endMs, (current + next) / 2),
-    }];
+    const startMs = Math.max(viewport.startMs, (previous + current) / 2);
+    const endMs = Math.min(viewport.endMs, (current + next) / 2);
+    const last = merged[merged.length - 1];
+    // Adjacent windows meet exactly at their shared midpoint, so touching is
+    // the test for contiguity. A matched window in between pushes the next
+    // start past the previous end and correctly breaks the run.
+    if (last && last.status === point.status && startMs <= last.endMs) {
+      last.endMs = Math.max(last.endMs, endMs);
+      return;
+    }
+    merged.push({ status: point.status, startMs, endMs });
   });
+  return merged;
 }
 
 // The weekly track is identified by (limitId, duration) alone. The provider's
@@ -3589,7 +3605,17 @@ function liveTimelinePoints(
     // Pool saturated: the window STARTS at the ceiling, so the display
     // cannot move no matter what the workload costs. Both series suspend —
     // a zero observed against a live expected here is not a measurement.
-    const poolSaturated = sameReset
+    //
+    // Gated on `bracketed`, NOT on `sameReset`. Exhausting a pool spawns a
+    // fresh pool carrying a new `resets_at`, so a window that starts pegged
+    // almost always ends on a different boundary; requiring `sameReset` here
+    // made saturation unobservable in exactly the case it exists to describe,
+    // and every such window was booked as a plain track change instead. This
+    // also restores parity with the local pipeline, which has always read
+    // saturation off the start edge alone (`src/simple-quota-gradient.js`).
+    // `observed` already required `sameReset`, so no window changes from
+    // measured to suspended — only the label it is suspended under.
+    const poolSaturated = Boolean(bracketed)
       && before.usedPercent >= POOL_SATURATION_CEILING_PP;
     const observed = !poolSaturated
         && sameReset
@@ -5446,6 +5472,37 @@ function chartSeriesCaption(label, value) {
   return t("chart.seriesValue", { label, value });
 }
 
+/**
+ * Which evidence states shade the plot, and under which hue.
+ *
+ * This is an explicit table with NO fallback, and both properties matter. The
+ * renderer used to end its status test in `: "ambiguous"`, so three unrelated
+ * states — `quota_weighting_unavailable`, `unpriced_local_activity` and
+ * `unexplained_without_local_activity` — all drew in the violet the legend
+ * captions "Movement needs context". Violet therefore meant four different
+ * things and mapped back to nothing.
+ *
+ * Worse, the last two carry BOTH series and are counted as matched windows, so
+ * the chart was shading spans the caption underneath it calls excluded. A
+ * status absent from this table is not shaded at all: shading is reserved for
+ * the mechanisms that actually suspend a measurement, which is exactly the set
+ * `TIMELINE_EXCLUSION_MESSAGE_KEYS` enumerates and the legend keys.
+ */
+const TIMELINE_STATUS_BAND_CLASSES = Object.freeze({
+  missing_quota_bracket: "missing",
+  reset_or_track_change: "reset",
+  quota_weighting_unavailable: "weighting",
+  backward_or_ambiguous: "ambiguous",
+  pool_saturated: "saturated",
+});
+
+// A band narrower than this cannot be seen, so every region also draws a
+// full-strength tick along the top edge of the plot at no less than this
+// width. The wash keeps the true extent and never widens; the tick is an
+// explicit presence marker, which is why the two are allowed to disagree.
+const STATUS_TICK_MINIMUM_WIDTH = 3;
+const STATUS_TICK_HEIGHT = 4;
+
 function lineChart({
   points,
   series,
@@ -5913,28 +5970,54 @@ function lineChart({
   for (const interval of statusIntervals) {
     if (!Number.isFinite(interval.startMs) || !Number.isFinite(interval.endMs)
         || interval.endMs <= interval.startMs) continue;
+    const band = TIMELINE_STATUS_BAND_CLASSES[interval.status];
+    // No entry means no legend swatch, so nothing is drawn. Silently shading
+    // an unkeyed status is what made the violet band unreadable.
+    if (!band) continue;
+    const plotWidth = width - margin.left - margin.right;
     const start = margin.left + (interval.startMs - domainStartMs)
-      / (safeDomainEndMs - domainStartMs) * (width - margin.left - margin.right);
+      / (safeDomainEndMs - domainStartMs) * plotWidth;
     const end = margin.left + (interval.endMs - domainStartMs)
-      / (safeDomainEndMs - domainStartMs) * (width - margin.left - margin.right);
-    const rect = document.createElementNS(svg.namespaceURI, "rect");
-    rect.setAttribute("x", String(Math.max(margin.left, start)));
-    rect.setAttribute("y", String(margin.top));
-    rect.setAttribute("width", String(Math.max(1, Math.min(width - margin.right, end) - Math.max(margin.left, start))));
-    rect.setAttribute("height", String(height - margin.top - margin.bottom));
-    rect.setAttribute("class", `chart-status-${
-      interval.status === "reset_or_track_change" ? "reset"
-        : interval.status === "missing_quota_bracket" ? "missing"
-          : interval.status === "pool_saturated" ? "saturated"
-            : "ambiguous"
-    }`);
-    const intervalTitle = document.createElementNS(svg.namespaceURI, "title");
-    setRawText(
-      intervalTitle,
-      chartText({ key: timelineStatusKey(interval.status) }, "status interval"),
+      / (safeDomainEndMs - domainStartMs) * plotWidth;
+    const left = Math.max(margin.left, start);
+    const bandWidth = Math.max(1, Math.min(width - margin.right, end) - left);
+    const label = chartText(
+      { key: timelineStatusKey(interval.status) },
+      "status interval",
     );
-    rect.append(intervalTitle);
-    svg.append(rect);
+    const shade = (element) => {
+      const elementTitle = document.createElementNS(svg.namespaceURI, "title");
+      setRawText(elementTitle, label);
+      element.append(elementTitle);
+      svg.append(element);
+    };
+
+    const rect = document.createElementNS(svg.namespaceURI, "rect");
+    rect.setAttribute("x", String(left));
+    rect.setAttribute("y", String(margin.top));
+    rect.setAttribute("width", String(bandWidth));
+    rect.setAttribute("height", String(height - margin.top - margin.bottom));
+    rect.setAttribute("class", `chart-status-${band}`);
+    shade(rect);
+
+    // The wash carries EXTENT and is never widened, so it cannot overstate how
+    // long a mechanism was in force. This tick carries IDENTITY: a fixed
+    // minimum width at legend-swatch strength, so a single excluded window —
+    // four in the owner's 30d view, each under half a unit wide — reads as a
+    // marker in its own hue instead of resolving to nothing. Drawn before the
+    // series, so a line crossing the top of the plot still wins.
+    const tickWidth = Math.max(STATUS_TICK_MINIMUM_WIDTH, bandWidth);
+    const tickLeft = Math.min(
+      width - margin.right - tickWidth,
+      Math.max(margin.left, left + bandWidth / 2 - tickWidth / 2),
+    );
+    const tick = document.createElementNS(svg.namespaceURI, "rect");
+    tick.setAttribute("x", String(tickLeft));
+    tick.setAttribute("y", String(margin.top));
+    tick.setAttribute("width", String(tickWidth));
+    tick.setAttribute("height", String(STATUS_TICK_HEIGHT));
+    tick.setAttribute("class", `chart-status-tick chart-status-${band}`);
+    shade(tick);
   }
 
   for (const item of chartSeries) {

--- a/apps/web/public/index.html
+++ b/apps/web/public/index.html
@@ -562,6 +562,7 @@
             <span class="legend-group-sep" aria-hidden="true"></span>
             <span><i class="legend-dot area chart-status-missing"></i>Missing quota bracket</span>
             <span><i class="legend-dot area chart-status-reset"></i>Window boundary or track change</span>
+            <span><i class="legend-dot area chart-status-weighting"></i>Quota weighting unavailable</span>
             <span><i class="legend-dot area chart-status-ambiguous"></i>Movement needs context</span>
             <span><i class="legend-dot area chart-status-saturated"></i>Allowance exhausted</span>
           </div>

--- a/apps/web/public/localization.js
+++ b/apps/web/public/localization.js
@@ -1454,6 +1454,10 @@ export const LEGACY_TEXT_CATALOG = Object.freeze({
   "Local usage over time": ["本地使用情况随时间变化", "Uso local a lo largo del tiempo"],
   "Observed allowance remaining": ["观测到的剩余额度", "Cuota restante observada"],
   "Window boundary or track change": ["窗口边界或额度轨道变化", "Límite de ventana o cambio de seguimiento"],
+  // Same wording as `chart.status.quotaWeightingUnavailable` above, reused
+  // verbatim: the legend swatch and the band's own tooltip name one mechanism,
+  // so they must not drift into two different phrasings per locale.
+  "Quota weighting unavailable": ["额度加权不可用", "Ponderación por cuota no disponible"],
   "Movement needs context": ["变化需要上下文", "El movimiento necesita contexto"],
   "Allowance exhausted": ["额度已用尽", "Asignación agotada"],
   "Per-model rates": ["各模型费率", "Tasas por modelo"],

--- a/apps/web/public/styles.css
+++ b/apps/web/public/styles.css
@@ -1432,30 +1432,63 @@ h2 {
 .legend-dot.allowance { color: var(--green); }
 .compact-legend { justify-content: flex-end; margin-top: var(--space-2); }
 .chart-area-confidence { fill: rgba(49, 95, 132, .14); }
-/* Four exclusion bands, four distinct hues, so a shaded region on the chart
-   maps to exactly one legend entry. "Missing bracket" and "movement needs
-   context" both drew in the same grey and were indistinguishable; the latter
-   is violet now. Each legend swatch carries its band's hue at a higher alpha
-   so a 12px square reads where the faint plot-width wash would not. */
-.chart-status-missing { fill: rgba(101, 112, 107, .08); }
-.chart-status-reset { fill: rgba(49, 95, 132, .08); }
-.chart-status-ambiguous { fill: rgba(124, 92, 173, .1); }
+/* Five exclusion bands, five distinct hues, so a shaded region on the chart
+   maps to exactly one legend entry.
+
+   The hues were already distinct on paper; the alpha destroyed them. At .08
+   over the card's cream every band composited to within two to five RGB units
+   of every other, which is below the threshold at which a hue is a hue — the
+   whole key read as one grey. The washes sit at .16-.22 now, far enough apart
+   to be told apart, and the neutral was pulled off its green cast so it cannot
+   be confused with the teal.
+
+   Alpha is graded by how much of the plot a mechanism typically covers, not by
+   importance: "missing bracket" arrives in long collection gaps and is the
+   lightest, while "movement needs context" is usually a single window and is
+   the strongest. Each band also draws a top-edge tick at identity strength —
+   see `.chart-status-tick` below, which is what actually makes a lone window
+   visible. The legend swatch carries the tick's exact colour, so the key shows
+   the mark the reader is hunting for rather than the wash behind it. */
+.chart-status-missing { fill: rgba(99, 99, 104, .16); }
+.chart-status-reset { fill: rgba(31, 111, 168, .18); }
+/* "Quota weighting unavailable": a priced-cost gap, so the window carries no
+   expected value to difference against. It is a counted exclusion mechanism
+   with its own message, but it had no hue and no legend entry, and so fell
+   through the renderer's old default into the violet that captions
+   "movement needs context". */
+.chart-status-weighting { fill: rgba(20, 120, 104, .18); }
+.chart-status-ambiguous { fill: rgba(124, 92, 173, .22); }
 /* "Allowance exhausted": the pool is pegged at 100%, so no residual is
    measurable across the span. Warmer than the neutral exclusions so a
    deliberate suspension never reads as a data gap. */
-.chart-status-saturated { fill: rgba(176, 101, 43, .1); }
-.legend-dot.chart-status-missing { background: rgba(101, 112, 107, .54); }
-.legend-dot.chart-status-reset { background: rgba(49, 95, 132, .54); }
-.legend-dot.chart-status-ambiguous { background: rgba(124, 92, 173, .54); }
-.legend-dot.chart-status-saturated { background: rgba(176, 101, 43, .54); }
-/* Two line series (a short stroke swatch) and four shaded-window categories
+.chart-status-saturated { fill: rgba(176, 101, 43, .2); }
+
+/* Identity marker. A band is only as wide as the span it excludes, and at a
+   month's zoom a single excluded window is a fraction of a viewBox unit — no
+   alpha makes that readable, so widening the wash was never the fix (it would
+   claim an exclusion lasted longer than it did). The renderer pairs every band
+   with a fixed-minimum tick along the top edge instead, and these are its
+   colours: the same hue at roughly four times the wash, where the difference
+   between blue, teal and violet is unmistakable. */
+.chart-status-tick.chart-status-missing { fill: rgba(99, 99, 104, .58); }
+.chart-status-tick.chart-status-reset { fill: rgba(31, 111, 168, .62); }
+.chart-status-tick.chart-status-weighting { fill: rgba(20, 120, 104, .62); }
+.chart-status-tick.chart-status-ambiguous { fill: rgba(124, 92, 173, .66); }
+.chart-status-tick.chart-status-saturated { fill: rgba(176, 101, 43, .64); }
+
+.legend-dot.chart-status-missing { background: rgba(99, 99, 104, .58); }
+.legend-dot.chart-status-reset { background: rgba(31, 111, 168, .62); }
+.legend-dot.chart-status-weighting { background: rgba(20, 120, 104, .62); }
+.legend-dot.chart-status-ambiguous { background: rgba(124, 92, 173, .66); }
+.legend-dot.chart-status-saturated { background: rgba(176, 101, 43, .64); }
+/* Two line series (a short stroke swatch) and five shaded-window categories
    share one key. The area swatches are filled squares — the shape the bands
    take on the chart — and a hairline separator sets the two groups apart, so
    a reader tells a line from a band at a glance without a per-locale sublabel. */
 .legend-dot.area { width: 12px; height: 12px; border-radius: 3px; }
 .legend-group-sep { width: 1px; height: 15px; align-self: center; background: var(--line); }
 /* The calibration legend is a full-width horizontal row beneath the chart
-   heading. A slightly tighter column gap keeps all seven entries on one line
+   heading. A slightly tighter column gap keeps the entries on one or two lines
    on a full-width English card; longer labels and narrower cards wrap it, but
    never back into the three-high stack it made inside the control column. */
 .calibration-legend { width: 100%; margin-top: var(--space-4); justify-content: flex-start; column-gap: 14px; }

--- a/apps/web/public/ui-format.js
+++ b/apps/web/public/ui-format.js
@@ -301,11 +301,20 @@ export function classifyTimelineEvidence({
     ? null
     : observedValue - expectedValue;
   // A pegged pool is its own evidence state, not an ambiguity: the window is
-  // fully bracketed inside one reset, but a display at its ceiling cannot
-  // move, so no residual is measurable there ("allowance exhausted").
+  // bracketed, but a display at its ceiling cannot move, so no residual is
+  // measurable there ("allowance exhausted").
+  //
+  // Saturation is tested BEFORE the reset check, and that order is the whole
+  // reason the state is reachable. Exhausting a pool spawns a fresh one with a
+  // new `resets_at`, so the boundary changes at the very instant the ceiling is
+  // hit: behind `!sameReset` the saturated branch was shadowed by its own
+  // precondition and had never once classified a window. The peg is also the
+  // more specific fact — it names WHY the window is unmeasurable, where
+  // "boundary changed" only names when. `bracketed` still comes first, because
+  // without a reading on the start edge there is no ceiling to observe.
   const status = !bracketed ? "missing_quota_bracket"
-    : !sameReset ? "reset_or_track_change"
-      : poolSaturated === true ? "pool_saturated"
+    : poolSaturated === true ? "pool_saturated"
+      : !sameReset ? "reset_or_track_change"
         : observedValue === null ? "backward_or_ambiguous"
           : observedValue === 0 && events === 0 && cost === 0 ? "inactive"
             : observedValue > 0 && events === 0

--- a/apps/web/test/lib.test.mjs
+++ b/apps/web/test/lib.test.mjs
@@ -10527,12 +10527,12 @@ test("Trends calibration legend is a full-width row with distinct line and area 
     html.indexOf("calibration-legend") < html.indexOf('id="timeline-empty"'),
     "the legend precedes the chart body",
   );
-  // The two line series keep a stroke swatch; the four exclusion categories
+  // The two line series keep a stroke swatch; the five exclusion categories
   // carry the `area` class that renders a filled square.
   assert.match(html, /<i class="legend-dot observed">/u);
   assert.match(html, /<i class="legend-dot expected">/u);
   assert.doesNotMatch(html, /legend-dot area (?:observed|expected)/u);
-  for (const status of ["missing", "reset", "ambiguous", "saturated"]) {
+  for (const status of ["missing", "reset", "weighting", "ambiguous", "saturated"]) {
     assert.match(
       html,
       new RegExp(`<i class="legend-dot area chart-status-${status}">`, "u"),
@@ -10546,46 +10546,75 @@ test("Trends calibration legend is a full-width row with distinct line and area 
 
 // Owner polish (2026-08-11): "Missing quota bracket" and "Movement needs
 // context" shared one grey, so a shaded region could not be mapped back to its
-// exclusion. Each of the four exclusion categories now owns a distinct hue, and
-// the legend swatch carries the same hue as the band it keys.
-test("Trends exclusion bands and legend swatches use four distinct, matching hues", async () => {
+// exclusion. Each exclusion category now owns a distinct hue, and the legend
+// swatch carries the same hue as the band it keys.
+//
+// Owner sanity check (2026-08-19): distinct hues were necessary but not
+// sufficient. Every wash sat at .08-.1, where the composite over the card's
+// cream lands within a few RGB units of every other and no hue survives, so the
+// legend looked colourful and the plot did not. `quota_weighting_unavailable`
+// was also a counted exclusion with no hue at all, and fell through the
+// renderer's default into violet. Both are pinned here.
+test("Trends exclusion bands and legend swatches use five distinct, matching, legible hues", async () => {
   const styles = await readFile(new URL("../public/styles.css", import.meta.url), "utf8");
-  const names = ["missing", "reset", "ambiguous", "saturated"];
-  const bandHue = (name) =>
-    styles.match(new RegExp(`\\.chart-status-${name} \\{ fill: rgba\\((\\d+, \\d+, \\d+)`, "u"))?.[1];
-  const swatchHue = (name) =>
-    styles.match(new RegExp(`\\.legend-dot\\.chart-status-${name} \\{ background: rgba\\((\\d+, \\d+, \\d+)`, "u"))?.[1];
+  const names = ["missing", "reset", "weighting", "ambiguous", "saturated"];
+  const declaration = (selector) =>
+    styles.match(new RegExp(`${selector} \\{ (?:fill|background): rgba\\((\\d+, \\d+, \\d+), (\\.\\d+)\\)`, "u"));
+  const bandRule = (name) => declaration(`\\.chart-status-${name}`);
+  const tickRule = (name) => declaration(`\\.chart-status-tick\\.chart-status-${name}`);
+  const swatchRule = (name) => declaration(`\\.legend-dot\\.chart-status-${name}`);
 
-  const bands = names.map(bandHue);
-  const swatches = names.map(swatchHue);
-  assert.ok(bands.every(Boolean), "every exclusion band declares an rgb fill");
-  assert.ok(swatches.every(Boolean), "every legend swatch declares an rgb background");
-  assert.equal(new Set(bands).size, 4, "the four exclusion bands use four distinct hues");
-  assert.equal(new Set(swatches).size, 4, "the four legend swatches use four distinct hues");
+  const bands = names.map(bandRule);
+  const ticks = names.map(tickRule);
+  const swatches = names.map(swatchRule);
+  assert.ok(bands.every(Boolean), "every exclusion band declares an rgba fill");
+  assert.ok(ticks.every(Boolean), "every exclusion band declares an rgba tick fill");
+  assert.ok(swatches.every(Boolean), "every legend swatch declares an rgba background");
+  assert.equal(
+    new Set(bands.map((rule) => rule[1])).size,
+    5,
+    "the five exclusion bands use five distinct hues",
+  );
   for (let index = 0; index < names.length; index += 1) {
-    assert.equal(
-      swatches[index],
-      bands[index],
-      `the ${names[index]} legend swatch matches its on-chart band hue`,
+    const name = names[index];
+    // The wash has to be dense enough for the hue to survive compositing onto
+    // cream. Below roughly .12 the five bands are indistinguishable greys, which
+    // is the whole defect this test exists to prevent regressing.
+    assert.ok(
+      Number(bands[index][2]) >= 0.14,
+      `the ${name} band wash is dense enough to carry its hue (got ${bands[index][2]})`,
+    );
+    // The legend shows the reader the TICK, because at a month's zoom the tick
+    // is the mark a single excluded window actually leaves on the plot.
+    assert.equal(swatches[index][1], ticks[index][1], `${name} swatch matches its tick hue`);
+    assert.equal(swatches[index][2], ticks[index][2], `${name} swatch matches its tick alpha`);
+    assert.equal(ticks[index][1], bands[index][1], `${name} tick matches its band hue`);
+    assert.ok(
+      Number(ticks[index][2]) > Number(bands[index][2]) * 2,
+      `the ${name} tick reads at identity strength, well above its wash`,
     );
   }
 });
 
 // Owner polish (2026-08-11): verify the allowance-exhausted band is wired, not
-// silently broken — the owner never pegged their pool, so they see no such
-// band, and this proves it renders (with the saturated class the CSS colours
-// rust) the moment a pool_saturated window is present.
-test("timeline status bands render one shaded rect per exclusion, including allowance-exhausted", async () => {
+// silently broken. It renders (with the saturated class the CSS colours rust)
+// the moment a pool_saturated window is present.
+//
+// Owner sanity check (2026-08-19): each exclusion now draws TWO rects — a wash
+// at the interval's true extent, and a fixed-minimum tick along the top edge
+// carrying the hue at identity strength. Widening the wash itself was rejected:
+// it would claim a mechanism was in force for longer than it was.
+test("timeline status bands render a wash and an identity tick per exclusion", async () => {
   const documentRef = new FakeSvgDocument(900);
   const { lineChart, CHART_POINT_STYLE } = await loadLineChartRenderer(documentRef);
   const base = Date.UTC(2026, 0, 1);
   const hour = 3_600_000;
   const at = (index) => base + index * hour;
-  const points = [0, 1, 2, 3, 4].map((index) => ({
+  const points = [0, 1, 2, 3, 4, 5].map((index) => ({
     timestamp: new Date(at(index)).toISOString(),
     value: index,
   }));
-  const svg = lineChart({
+  const draw = (statusIntervals) => lineChart({
     points,
     series: [{
       key: "value",
@@ -10596,21 +10625,204 @@ test("timeline status bands render one shaded rect per exclusion, including allo
     title: { key: "chart.title" },
     description: { key: "chart.description" },
     yLabel: { key: "chart.yLabel" },
-    statusIntervals: [
-      { status: "missing_quota_bracket", startMs: at(0), endMs: at(1) },
-      { status: "reset_or_track_change", startMs: at(1), endMs: at(2) },
-      { status: "backward_or_ambiguous", startMs: at(2), endMs: at(3) },
-      { status: "pool_saturated", startMs: at(3), endMs: at(4) },
-    ],
+    statusIntervals,
   });
-  assert.equal(svg.querySelectorAll("rect.chart-status-missing").length, 1);
-  assert.equal(svg.querySelectorAll("rect.chart-status-reset").length, 1);
-  assert.equal(svg.querySelectorAll("rect.chart-status-ambiguous").length, 1);
+
+  const svg = draw([
+    { status: "missing_quota_bracket", startMs: at(0), endMs: at(1) },
+    { status: "reset_or_track_change", startMs: at(1), endMs: at(2) },
+    { status: "quota_weighting_unavailable", startMs: at(2), endMs: at(3) },
+    { status: "backward_or_ambiguous", startMs: at(3), endMs: at(4) },
+    { status: "pool_saturated", startMs: at(4), endMs: at(5) },
+  ]);
+
+  for (const band of ["missing", "reset", "weighting", "ambiguous", "saturated"]) {
+    const rects = svg.querySelectorAll(`rect.chart-status-${band}`);
+    assert.equal(rects.length, 2, `${band} draws a wash and a tick`);
+    const [wash, tick] = rects;
+    assert.equal(wash.getAttribute("class"), `chart-status-${band}`);
+    assert.equal(tick.getAttribute("class"), `chart-status-tick chart-status-${band}`);
+    assert.ok(
+      Number(wash.getAttribute("height")) > Number(tick.getAttribute("height")),
+      `the ${band} wash spans the plot and its tick does not`,
+    );
+    // Both are hoverable and name the same mechanism: at a month's zoom the
+    // wash is too narrow to be a usable pointer target on its own.
+    assert.equal(wash.children[0].tagName, "title");
+    assert.equal(tick.children[0].tagName, "title");
+    assert.equal(tick.children[0].textContent, wash.children[0].textContent);
+  }
   assert.equal(
     svg.querySelectorAll("rect.chart-status-saturated").length,
-    1,
+    2,
     "a pool_saturated window draws the allowance-exhausted band",
   );
+
+  // A sub-unit interval is what the owner's 30d view is made of: four ambiguous
+  // windows across 1,713, each well under a viewBox unit. The wash stays at its
+  // (floored) true width while the tick widens to the legibility minimum.
+  const sliver = draw([
+    { status: "backward_or_ambiguous", startMs: at(2), endMs: at(2) + 1_000 },
+  ]);
+  const [washSliver, tickSliver] = sliver.querySelectorAll("rect.chart-status-ambiguous");
+  assert.equal(Number(washSliver.getAttribute("width")), 1, "the wash never overstates extent");
+  assert.ok(
+    Number(tickSliver.getAttribute("width")) >= 3,
+    "the tick widens to stay visible",
+  );
+  // Widening is symmetric, so the marker still points at the window it keys.
+  const washCentre = Number(washSliver.getAttribute("x")) + 0.5;
+  const tickCentre = Number(tickSliver.getAttribute("x"))
+    + Number(tickSliver.getAttribute("width")) / 2;
+  assert.ok(Math.abs(washCentre - tickCentre) < 0.001, "the tick is centred on its band");
+});
+
+// Owner sanity check (2026-08-19): "Allowance exhausted" was in the legend but
+// had never once classified a window, and the cause was the classifier's order
+// rather than the owner's data. Exhausting a pool spawns a fresh pool with a
+// new `resets_at`, so the boundary changes at the instant the ceiling is hit —
+// behind `!sameReset`, the saturated branch was shadowed by its own
+// precondition. Saturation is tested first now; only `bracketed` outranks it.
+test("a pegged pool classifies as exhausted even though its reset boundary moved", () => {
+  const pegged = {
+    bracketed: true,
+    observed: null,
+    expected: 4,
+    usageEvents: 6,
+    apiCostUsd: 9,
+    poolSaturated: true,
+  };
+  assert.deepEqual(
+    classifyTimelineEvidence({ ...pegged, sameReset: false }),
+    { status: "pool_saturated", residual: null },
+    "the peg is the reason the window is unmeasurable, so it is the label",
+  );
+  assert.deepEqual(
+    classifyTimelineEvidence({ ...pegged, sameReset: true }),
+    { status: "pool_saturated", residual: null },
+  );
+  // Without a reading on the start edge there is no ceiling to have observed,
+  // so the missing bracket still outranks saturation.
+  assert.equal(
+    classifyTimelineEvidence({ ...pegged, bracketed: false, sameReset: false }).status,
+    "missing_quota_bracket",
+  );
+  // A boundary change with no peg is still a plain track change.
+  assert.equal(
+    classifyTimelineEvidence({ ...pegged, poolSaturated: false, sameReset: false }).status,
+    "reset_or_track_change",
+  );
+});
+
+// Owner sanity check (2026-08-19): the intervals were emitted one per window and
+// each is floored to a full viewBox unit by the renderer. At a month's zoom the
+// spacing between windows is under half a unit, so neighbours in a run
+// overlapped and composited their alpha repeatedly — the wash reported point
+// DENSITY, not duration. Runs are merged before they reach the renderer.
+test("timeline status intervals merge a run of one mechanism into one region", async () => {
+  const appSource = await readFile(new URL("../public/app.js", import.meta.url), "utf8");
+  const start = appSource.indexOf("function timelineStatusIntervals(");
+  const end = appSource.indexOf("\n// The weekly track is identified", start);
+  assert.ok(start >= 0 && end > start, "the interval builder is available");
+  const timelineStatusIntervals = Function(
+    "pointTimestampMs",
+    "TIMELINE_STATUS_BAND_CLASSES",
+    `${appSource.slice(start, end)}\nreturn timelineStatusIntervals;`,
+  )(
+    (point) => Date.parse(point.timestamp),
+    Object.freeze({
+      missing_quota_bracket: "missing",
+      reset_or_track_change: "reset",
+      quota_weighting_unavailable: "weighting",
+      backward_or_ambiguous: "ambiguous",
+      pool_saturated: "saturated",
+    }),
+  );
+
+  const base = Date.UTC(2026, 0, 1);
+  const hour = 3_600_000;
+  const at = (index) => base + index * hour;
+  const point = (index, status) => ({
+    timestamp: new Date(at(index)).toISOString(),
+    status,
+  });
+  const viewport = { startMs: at(0), endMs: at(9) };
+
+  const merged = timelineStatusIntervals([
+    point(0, "missing_quota_bracket"),
+    point(1, "missing_quota_bracket"),
+    point(2, "missing_quota_bracket"),
+    point(3, "matched"),
+    point(4, "missing_quota_bracket"),
+    point(5, "reset_or_track_change"),
+    point(6, "inactive"),
+    point(7, "unpriced_local_activity"),
+    point(8, "pool_saturated"),
+  ], viewport);
+
+  assert.deepEqual(
+    merged.map((interval) => interval.status),
+    [
+      "missing_quota_bracket",
+      "missing_quota_bracket",
+      "reset_or_track_change",
+      "pool_saturated",
+    ],
+    "a contiguous run collapses; a matched window in between breaks it, and a"
+      + " measured state is never shaded at all",
+  );
+  assert.equal(merged[0].startMs, at(0), "the run is clamped to the viewport");
+  assert.equal(merged[0].endMs, at(2) + hour / 2, "the run ends at its last window");
+  assert.ok(
+    merged[0].endMs - merged[0].startMs > merged[1].endMs - merged[1].startMs,
+    "the merged run spans more than the isolated window that follows it",
+  );
+  // Regions never overlap, so no span composites its own alpha twice.
+  for (let index = 1; index < merged.length; index += 1) {
+    assert.ok(
+      merged[index].startMs >= merged[index - 1].endMs,
+      "shaded regions are disjoint",
+    );
+  }
+});
+
+// Owner sanity check (2026-08-19): the renderer's status test used to end in a
+// bare `: "ambiguous"`, so three states with no legend entry drew in the violet
+// captioned "Movement needs context" — two of which carry both series and are
+// COUNTED AS MATCHED, meaning the chart shaded spans the caption beneath it
+// calls excluded. Shading is now table-driven with no fallback.
+test("timeline status bands shade only the mechanisms the legend keys", async () => {
+  const documentRef = new FakeSvgDocument(900);
+  const { lineChart, CHART_POINT_STYLE } = await loadLineChartRenderer(documentRef);
+  const base = Date.UTC(2026, 0, 1);
+  const hour = 3_600_000;
+  const at = (index) => base + index * hour;
+  const svg = lineChart({
+    points: [0, 1, 2, 3].map((index) => ({
+      timestamp: new Date(at(index)).toISOString(),
+      value: index,
+    })),
+    series: [{
+      key: "value",
+      className: "chart-line-observed",
+      label: { key: "series.observed" },
+      pointStyle: CHART_POINT_STYLE.HOVER_ONLY,
+    }],
+    title: { key: "chart.title" },
+    description: { key: "chart.description" },
+    yLabel: { key: "chart.yLabel" },
+    statusIntervals: [
+      { status: "unpriced_local_activity", startMs: at(0), endMs: at(1) },
+      { status: "unexplained_without_local_activity", startMs: at(1), endMs: at(2) },
+      { status: "matched", startMs: at(2), endMs: at(3) },
+    ],
+  });
+  assert.equal(
+    svg.querySelectorAll("rect.chart-status-ambiguous").length,
+    0,
+    "a measured window is never shaded as an exclusion",
+  );
+  assert.equal(svg.querySelectorAll("rect.chart-status-tick").length, 0);
 });
 
 // Owner polish (2026-08-11): the five calibration summary tiles laid out


### PR DESCRIPTION
The Trends calibration chart advertised four shaded exclusion categories in its legend, but they were effectively invisible on the plot and one of them had never rendered at all. Started as a sanity check on "why do I never see these colours"; four separate causes turned up.

### 1. The washes were below the compositing floor

Every band drew at `.08`–`.1` alpha. Over the card's cream, all four composited to within **two to five RGB units of each other** — below the point at which a hue is a hue. The legend swatches used the same hues at `.54`, which is why the key looked colourful and the plot read as one flat grey.

Washes are `.16`–`.22` now, graded by how much plot each mechanism typically covers (long collection gaps lightest, single-window states strongest), and the neutral lost its green cast so it can't be confused with the new teal.

### 2. The wash was reporting point density, not duration

Intervals were emitted one per window, and the renderer floors each rect to a full viewBox unit. At 30d the spacing between windows is **under half a unit**, so neighbours in a run overlapped and composited their alpha repeatedly. That's why dense collection gaps read as solid blocks while isolated windows vanished entirely. Contiguous same-mechanism runs are merged into disjoint regions before they reach the SVG.

### 3. Isolated bands now carry an identity tick

A band is only as wide as the span it excludes, and one excluded window is a fraction of a unit at 30d — no alpha makes that readable. Widening the wash was **rejected**: it would claim a mechanism was in force longer than it was.

Each region now draws two rects: the wash carries **extent** at true width, and a fixed-minimum 3×4-unit tick along the top edge carries **identity** at ~4× the wash alpha. The legend swatch is the tick's exact colour, so the key shows the mark the reader is actually hunting for.

### 4. "Allowance exhausted" had never classified a single window

Not a rendering problem — the classifier couldn't reach it. Exhausting a pool spawns a fresh pool carrying a new `resets_at`, so the boundary changes at the instant the ceiling is hit; behind the `!sameReset` branch, saturation was shadowed by its own precondition.

It's tested before the reset check now and gated on `bracketed` alone, which also restores parity with `src/simple-quota-gradient.js`, where saturation has always been read off the start edge. `observed` already required `sameReset`, so **no window changes from measured to suspended** — only the label it's suspended under.

### 5. (Found while fixing 1) Violet meant four different things

The renderer's status test ended in a bare `: "ambiguous"`, so three unrelated states drew in the violet captioned "Movement needs context" — and two of them carry both series and are **counted as matched**, meaning the chart was shading spans the caption beneath it calls excluded.

Shading is table-driven with no fallback now. The third, `quota_weighting_unavailable`, is a genuine counted exclusion that simply had no hue and no legend entry; it gets teal and a fifth legend entry, reusing the existing `chart.status.quotaWeightingUnavailable` wording verbatim in all three locales so the swatch and the band tooltip can't drift apart.

## Verification

Browser-verified against the running app: geometry and computed fills correct, the sub-unit case clamps at the plot edge rather than overflowing, both rects carry the same tooltip, the new legend entry translates (checked live in Spanish), and injected sliver probes for all five statuses read as distinct coloured marks where nothing was visible before.

`apps/web/test` **296/296 pass** after rebase onto `main`, with added coverage for the classifier order, run merging, wash-vs-tick geometry, and the no-fallback shading rule.

Full `test/*.test.js`: 2339/2367. All 6 failures are pre-existing on a clean tree (release-lane / deployment-receipt tests) — confirmed by diffing the failure list against `git stash`. A 7th, a SQLite concurrency test, is load-flaky and passes 3/3 in isolation.

## Caveat

Only the labeled demo was available to exercise, and it has 2 exclusion regions. On a real 30d view with ~223 regions the top-edge ticks will be dense where resets cluster. If that reads as too heavy a strip, the tick minimum width is one constant (`STATUS_TICK_MINIMUM_WIDTH` in `apps/web/public/app.js`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)