### PR TITLE
fix(pace): derive the forecast ETA from wall-clock pace, not working pace

### DIFF
--- a/apps/web/public/app.js
+++ b/apps/web/public/app.js
@@ -6542,20 +6542,27 @@ const PACE_STATE_LABELS = Object.freeze({
  * The two rates this card carries answer different questions and routinely
  * disagree by an order of magnitude.
  *
- * `pace.percentagePointsPerHour` is the engine's median over adjacent
+ * `pace.activePercentagePointsPerHour` is the engine's median over adjacent
  * intervals that actually moved, so it measures the pace *while working* and
  * discards every idle gap. Extrapolated across a whole window it assumes the
  * reader never stops, which is why a forecast built on it alone always lands
  * earlier than what happens - the "it always underestimates the time I have
  * left" complaint this card drew.
  *
- * `movementPp / elapsedHours` is the same window's overall rate with idle
- * time included. That is the honest headline; the active rate stays on the
- * card as the without-pausing edge, drawn as a separate mark on the track.
+ * `pace.overallPercentagePointsPerHour` is the same window's rate with idle
+ * time included, and since quota-pace-forecast-v0.2 it is what the engine's
+ * own `etaAt` and `status` are built from. That is the honest headline; the
+ * active rate stays on the card as the without-pausing edge, drawn as a
+ * separate mark on the track.
+ *
+ * The `movementPp / elapsedHours` fallback covers a payload that predates the
+ * named rates. It carries a minimum-span guard the engine field does not need,
+ * because a derived average over a few minutes is whatever the reader happened
+ * to be doing; the engine gates the same risk through `earlyEstimate` instead.
  */
 function weeklyPaceRates(pace, forecast) {
   const active = firstFiniteForecastNumber(
-    pace.percentagePointsPerHour,
+    pace.activePercentagePointsPerHour,
     pace.percentPerHour,
     pace.pacePercentPerHour,
     forecast.percentagePointsPerHour,
@@ -6564,17 +6571,21 @@ function weeklyPaceRates(pace, forecast) {
   );
   const elapsedHours = firstFiniteForecastNumber(pace.elapsedHours);
   const movementPp = firstFiniteForecastNumber(pace.movementPp);
-  const average = elapsedHours !== null
+  const derivedAverage = elapsedHours !== null
     && elapsedHours >= PACE_AVERAGE_MINIMUM_HOURS
     && movementPp !== null
     && movementPp > 0
     ? movementPp / elapsedHours
     : null;
+  const reported = firstFiniteForecastNumber(
+    pace.overallPercentagePointsPerHour,
+  );
+  const average = reported !== null && reported > 0 ? reported : derivedAverage;
   return {
     active: active !== null && active > 0 ? active : null,
     average,
-    // The overall rate leads whenever the observed span is long enough to
-    // contain a realistic mix of work and rest.
+    // The wall-clock rate leads. Falling back to the working rate keeps the
+    // card readable rather than blank when only that one is available.
     headline: average ?? (active !== null && active > 0 ? active : null),
   };
 }
@@ -6736,7 +6747,7 @@ function renderWeeklyPaceForecast(data) {
   if (remaining !== null && (remaining < 0 || remaining > 100)) remaining = null;
 
   const rates = weeklyPaceRates(pace, forecast);
-  const percentagePointsPerHour = rates.headline;
+  const headlinePace = rates.headline;
   const hoursToReset = firstFiniteForecastNumber(
     (resetAt - now) / 3_600_000,
     forecast.hoursToReset,
@@ -6756,7 +6767,7 @@ function renderWeeklyPaceForecast(data) {
     etaAt = now + suppliedHoursToExhaustion * 3_600_000;
   }
   const available = status === "available"
-    || (status === "" && etaAt !== null && percentagePointsPerHour !== null);
+    || (status === "" && etaAt !== null && headlinePace !== null);
   const reachesResetFirst = status === "will_reach_reset_first"
     || status === "reset_before_exhaustion";
   const paceIntervals = firstFiniteForecastNumber(pace.sampleCount);
@@ -6783,7 +6794,7 @@ function renderWeeklyPaceForecast(data) {
   if (collectingEvidence && remaining === null) return;
   if (!collectingEvidence
       && remaining === null
-      && percentagePointsPerHour === null
+      && headlinePace === null
       && !reachesResetFirst) return;
 
   // The standing is computed from the headline rate, so the card's colour,
@@ -6797,7 +6808,7 @@ function renderWeeklyPaceForecast(data) {
     : weeklyPaceStanding({
       remainingPercent: remaining,
       hoursToReset,
-      pacePpPerHour: percentagePointsPerHour,
+      pacePpPerHour: headlinePace,
     });
   const paceState = standing?.state
     ?? (collectingEvidence ? null : reachesResetFirst ? "under" : null);
@@ -6887,8 +6898,8 @@ function renderWeeklyPaceForecast(data) {
     addMetric("Nothing left for", dryDuration);
   } else if (standing !== null) {
     addMetric("Spare at reset", formatPercent(standing.sparePercent));
-  } else if (percentagePointsPerHour !== null && percentagePointsPerHour > 0) {
-    addMetric("Recent pace", `${formatDecimal(percentagePointsPerHour, 1)} pp/hour`);
+  } else if (headlinePace !== null && headlinePace > 0) {
+    addMetric("Recent pace", `${formatDecimal(headlinePace, 1)} pp/hour`);
   }
 
   const track = collectingEvidence

--- a/apps/web/public/data-client.js
+++ b/apps/web/public/data-client.js
@@ -4756,7 +4756,7 @@ function normalizeGradient(payload = {}) {
   };
 }
 
-const WEEKLY_PACE_FORECAST_SCHEMA_VERSION = "local-weekly-pace-forecast-v0.1";
+const WEEKLY_PACE_FORECAST_SCHEMA_VERSION = "local-weekly-pace-forecast-v0.2";
 const WEEKLY_PACE_FORECAST_STATUSES = new Set([
   "unavailable",
   "insufficient_observations",
@@ -4799,7 +4799,8 @@ function normalizeWeeklyPaceForecast(value) {
         "sampleCount",
         "elapsedHours",
         "movementPp",
-        "percentagePointsPerHour"
+        "activePercentagePointsPerHour",
+        "overallPercentagePointsPerHour"
       ])) return null;
   const currentUsedPercent = weeklyPaceNumber(value.currentUsedPercent, {
     minimum: 0,
@@ -4811,8 +4812,12 @@ function normalizeWeeklyPaceForecast(value) {
   });
   const elapsedHours = weeklyPaceNumber(value.pace.elapsedHours, { minimum: 0 });
   const movementPp = weeklyPaceNumber(value.pace.movementPp, { minimum: 0 });
-  const percentagePointsPerHour = weeklyPaceNumber(
-    value.pace.percentagePointsPerHour,
+  const activePercentagePointsPerHour = weeklyPaceNumber(
+    value.pace.activePercentagePointsPerHour,
+    { minimum: 0, maximum: 100 }
+  );
+  const overallPercentagePointsPerHour = weeklyPaceNumber(
+    value.pace.overallPercentagePointsPerHour,
     { minimum: 0, maximum: 100 }
   );
   const hoursToExhaustion = weeklyPaceNumber(value.hoursToExhaustion, {
@@ -4825,7 +4830,8 @@ function normalizeWeeklyPaceForecast(value) {
       || remainingPercent === undefined
       || elapsedHours === undefined
       || movementPp === undefined
-      || percentagePointsPerHour === undefined
+      || activePercentagePointsPerHour === undefined
+      || overallPercentagePointsPerHour === undefined
       || hoursToExhaustion === undefined
       || hoursToReset === undefined
       || (value.resetsAt !== null && resetsAt === null)
@@ -4843,8 +4849,8 @@ function normalizeWeeklyPaceForecast(value) {
         || remainingPercent === null
         || resetsAt === null
         || etaAt === null
-        || percentagePointsPerHour === null
-        || percentagePointsPerHour <= 0
+        || overallPercentagePointsPerHour === null
+        || overallPercentagePointsPerHour <= 0
         || hoursToExhaustion === null
         || hoursToReset === null
         || Date.parse(etaAt) >= Date.parse(resetsAt)) return null;
@@ -4862,7 +4868,8 @@ function normalizeWeeklyPaceForecast(value) {
       sampleCount: value.pace.sampleCount,
       elapsedHours,
       movementPp,
-      percentagePointsPerHour
+      activePercentagePointsPerHour,
+      overallPercentagePointsPerHour
     },
     observationCount: value.observationCount,
     etaAt,

--- a/apps/web/test/weekly-pace-data-client.test.mjs
+++ b/apps/web/test/weekly-pace-data-client.test.mjs
@@ -4,7 +4,7 @@ import { normalizeDashboardPayload } from "../public/data-client.js";
 
 function forecast(overrides = {}) {
   return {
-    schemaVersion: "local-weekly-pace-forecast-v0.1",
+    schemaVersion: "local-weekly-pace-forecast-v0.2",
     status: "available",
     currentUsedPercent: 30,
     remainingPercent: 70,
@@ -14,7 +14,8 @@ function forecast(overrides = {}) {
       sampleCount: 1,
       elapsedHours: 0.25,
       movementPp: 10,
-      percentagePointsPerHour: 40,
+      activePercentagePointsPerHour: 40,
+      overallPercentagePointsPerHour: 40,
     },
     observationCount: 2,
     etaAt: "2026-08-03T14:15:00.000Z",
@@ -60,7 +61,8 @@ test("weekly browser data boundary retains one clean observation as an explainab
       sampleCount: 0,
       elapsedHours: null,
       movementPp: null,
-      percentagePointsPerHour: null,
+      activePercentagePointsPerHour: null,
+      overallPercentagePointsPerHour: null,
     },
     observationCount: 1,
     etaAt: null,

--- a/apps/web/test/weekly-pace-forecast.test.mjs
+++ b/apps/web/test/weekly-pace-forecast.test.mjs
@@ -132,11 +132,28 @@ test("pace standing refuses readings it cannot classify", () => {
 });
 
 test("the headline rate counts idle time and the active rate stays separate", () => {
-  // The engine's percentagePointsPerHour is a median over intervals that
-  // moved, so it measures the pace while working. Extrapolating it alone is
-  // what made every forecast land earlier than it should.
+  // Since quota-pace-forecast-v0.2 the engine names both rates, and the
+  // wall-clock one is what its own ETA is built from. The card follows it.
   const rates = pace.weeklyPaceRates(
-    { percentagePointsPerHour: 11.3, elapsedHours: 100, movementPp: 97 },
+    {
+      activePercentagePointsPerHour: 11.3,
+      overallPercentagePointsPerHour: .97,
+      elapsedHours: 100,
+      movementPp: 97,
+    },
+    {},
+  );
+  assert.equal(rates.active, 11.3);
+  assert.equal(rates.average, .97);
+  assert.equal(rates.headline, .97);
+});
+
+test("a payload without the named wall-clock rate derives one", () => {
+  // Pre-v0.2 shape: the rate has to come from movement over elapsed time, and
+  // carries a minimum-span guard because a derived average over a few minutes
+  // is whatever the reader happened to be doing.
+  const rates = pace.weeklyPaceRates(
+    { activePercentagePointsPerHour: 11.3, elapsedHours: 100, movementPp: 97 },
     {},
   );
   assert.equal(rates.active, 11.3);
@@ -146,14 +163,14 @@ test("the headline rate counts idle time and the active rate stays separate", ()
 
 test("too short an observation span falls back to the active rate", () => {
   const rates = pace.weeklyPaceRates(
-    { percentagePointsPerHour: 4, elapsedHours: .5, movementPp: 2 },
+    { activePercentagePointsPerHour: 4, elapsedHours: .5, movementPp: 2 },
     {},
   );
   assert.equal(rates.average, null);
   assert.equal(rates.headline, 4);
 
   const noMovement = pace.weeklyPaceRates(
-    { percentagePointsPerHour: 4, elapsedHours: 12, movementPp: 0 },
+    { activePercentagePointsPerHour: 4, elapsedHours: 12, movementPp: 0 },
     {},
   );
   assert.equal(noMovement.average, null);

--- a/packages/quota-analysis/index.d.ts
+++ b/packages/quota-analysis/index.d.ts
@@ -343,11 +343,14 @@ export interface QuotaPaceEstimate {
   sampleCount: number;
   elapsedHours: number | null;
   movementPp: number | null;
-  percentagePointsPerHour: number | null;
+  /** Median of adjacent slopes that moved: pace per *working* hour. */
+  activePercentagePointsPerHour: number | null;
+  /** Total movement over total elapsed time: pace per *wall-clock* hour. */
+  overallPercentagePointsPerHour: number | null;
 }
 
 export interface QuotaPaceForecast {
-  schemaVersion: "quota-pace-forecast-v0.1";
+  schemaVersion: "quota-pace-forecast-v0.2";
   status: QuotaPaceStatus;
   refusalCodes: QuotaPaceRefusalCode[];
   accountTrackId: string;
@@ -369,8 +372,10 @@ export interface QuotaPaceForecast {
 }
 
 export const QUOTA_PACE_POLICY: Readonly<{
-  schemaVersion: "quota-pace-forecast-v0.1";
+  schemaVersion: "quota-pace-forecast-v0.2";
   method: "median_adjacent_quota_slope";
+  /** Which rate `etaAt`, `hoursToExhaustion` and `status` are derived from. */
+  etaBasis: "overall_percentage_points_per_hour";
   windowDurationMinutes: 10080;
   maximumReceiptLagMs: number;
   maximumPacePpPerHour: number;

--- a/packages/quota-analysis/src/quota-pace-forecast.js
+++ b/packages/quota-analysis/src/quota-pace-forecast.js
@@ -3,8 +3,18 @@ import {
   SEVEN_DAY_WINDOW_MINUTES,
 } from "./quota-windows.js";
 
-const SCHEMA_VERSION = "quota-pace-forecast-v0.1";
+// v0.2 (2026-08-19): the forecast carries two named rates instead of one
+// ambiguous `percentagePointsPerHour`, and the ETA is derived from the
+// wall-clock rate rather than the working-time one. The old key is removed
+// rather than redefined so a reader that never validated the shape gets
+// `undefined` instead of a silently different number.
+const SCHEMA_VERSION = "quota-pace-forecast-v0.2";
+// Names how the ACTIVE rate is derived. The overall rate is a plain
+// movement-over-elapsed quotient and needs no method label.
 const METHOD = "median_adjacent_quota_slope";
+// Which of the two rates `etaAt`, `hoursToExhaustion` and `status` are built
+// from. Stated on the policy object so a consumer never has to infer it.
+const ETA_BASIS = "overall_percentage_points_per_hour";
 const MAXIMUM_RECEIPT_LAG_MS = 5 * 60_000;
 const MAXIMUM_PACE_PP_PER_HOUR = 100;
 const HOUR_MS = 3_600_000;
@@ -130,7 +140,8 @@ function emptyPace() {
     sampleCount: 0,
     elapsedHours: null,
     movementPp: null,
-    percentagePointsPerHour: null,
+    activePercentagePointsPerHour: null,
+    overallPercentagePointsPerHour: null,
   };
 }
 
@@ -182,13 +193,53 @@ function finalResult(current, points, refusalCodes) {
       rates.push(movement / (elapsedMs / HOUR_MS));
     }
   }
-  const percentagePointsPerHour = median(rates);
+  // Two rates, because they answer two different questions and routinely
+  // disagree by an order of magnitude.
+  //
+  // The ACTIVE rate is the median of the adjacent slopes that actually moved.
+  // Dropping the still intervals is load-bearing, not incidental: at a
+  // five-minute polling cadence a normal week has far more still intervals
+  // than moving ones, so an unfiltered median would be exactly zero, trip
+  // `non_positive_pace`, and no forecast would ever be produced. Taking the
+  // median rather than a mean is equally deliberate - it keeps one burst from
+  // defining the working rate.
+  //
+  // The OVERALL rate is total movement over total elapsed time, idle included.
+  //
+  // The ETA is built from the overall rate and never from the active one. The
+  // active rate is measured per *working* hour, so dividing a remaining
+  // allowance by it and reporting the quotient as *wall-clock* hours is a unit
+  // error: it silently assumes the reader never stops. That is what made every
+  // published ETA arrive early (community report, 2026-08-18; 11.3pp/hour
+  // active against 0.97pp/hour overall on 1,109 observations over 4d 4h).
+  const activePercentagePointsPerHour = median(rates);
+  // Both rates are reported only when they are a real, positive rate. A
+  // backward observation makes `movementPp` negative and a still window makes
+  // it zero; neither is a pace, and a negative one would be read downstream as
+  // a rate rather than as the refusal it actually is. The active rate is
+  // already null in both cases - no adjacent interval moved forwards - so this
+  // just keeps the two fields agreeing.
+  const overallPercentagePointsPerHour = elapsedHours > 0 && movementPp > 0
+    ? movementPp / elapsedHours
+    : null;
   const pace = {
     method: METHOD,
     sampleCount: Math.max(0, sorted.length - 1),
     elapsedHours: round(elapsedHours),
     movementPp: round(movementPp),
-    percentagePointsPerHour: round(percentagePointsPerHour),
+    // A working rate above the cap is reported as "not stateable" rather than
+    // taken as grounds to refuse the forecast. Over a five-minute poll the cap
+    // is only 8.3pp, which an ordinary burst clears easily, and this rate no
+    // longer decides anything: it is the without-pausing marker, and the ETA
+    // is built from the wall-clock rate below. Refusing here would blank a
+    // card whose actual forecast is sound.
+    activePercentagePointsPerHour:
+      activePercentagePointsPerHour !== null
+        && activePercentagePointsPerHour > 0
+        && activePercentagePointsPerHour <= MAXIMUM_PACE_PP_PER_HOUR
+        ? round(activePercentagePointsPerHour)
+        : null,
+    overallPercentagePointsPerHour: round(overallPercentagePointsPerHour),
   };
   const result = resultBase(current, "unavailable", refusalCodes, pace);
   if (refusalCodes.length > 0) return result;
@@ -197,16 +248,21 @@ function finalResult(current, points, refusalCodes) {
     result.refusalCodes = ["insufficient_observations"];
     return result;
   }
-  if (!(elapsedHours > 0) || !(movementPp > 0) || !(percentagePointsPerHour > 0)) {
+  // Positive movement over positive elapsed time implies a positive working
+  // rate too, so the wall-clock rate is the only one worth guarding here.
+  if (!(elapsedHours > 0)
+      || !(movementPp > 0)
+      || !(overallPercentagePointsPerHour > 0)) {
     result.refusalCodes = ["non_positive_pace"];
     return result;
   }
-  if (percentagePointsPerHour > MAXIMUM_PACE_PP_PER_HOUR) {
+  // Only the rate the ETA is built from can make the ETA implausible.
+  if (overallPercentagePointsPerHour > MAXIMUM_PACE_PP_PER_HOUR) {
     result.refusalCodes = ["implausible_pace"];
     return result;
   }
   const remainingPp = Math.max(0, 100 - current.usedPercent);
-  const hoursToExhaustion = remainingPp / percentagePointsPerHour;
+  const hoursToExhaustion = remainingPp / overallPercentagePointsPerHour;
   const resetMs = Date.parse(current.resetsAt);
   const etaMs = currentMs + hoursToExhaustion * HOUR_MS;
   const etaDate = new Date(etaMs);
@@ -287,6 +343,7 @@ export function analyzeQuotaPace(input) {
 export const QUOTA_PACE_POLICY = Object.freeze({
   schemaVersion: SCHEMA_VERSION,
   method: METHOD,
+  etaBasis: ETA_BASIS,
   windowDurationMinutes: SEVEN_DAY_WINDOW_MINUTES,
   maximumReceiptLagMs: MAXIMUM_RECEIPT_LAG_MS,
   maximumPacePpPerHour: MAXIMUM_PACE_PP_PER_HOUR,

--- a/src/replay-safe-accounting-cache.js
+++ b/src/replay-safe-accounting-cache.js
@@ -97,8 +97,12 @@ import { fastQuotaMultiplier } from "./application/index.js";
 // default, record the source/generation/context contract, and attach a
 // separate full-history period. A v0.9 cache cannot prove which scanner or
 // generation produced its totals, so it is withheld and rebuilt.
+// v0.11 (2026-08-19): the retained pace forecast names its two rates
+// separately and its ETA follows the wall-clock one. A v0.10 cache carries a
+// single `percentagePointsPerHour` whose ETA assumed the reader never paused,
+// so it is withheld and rebuilt rather than reinterpreted.
 export const REPLAY_SAFE_ACCOUNTING_SCHEMA_VERSION =
-  "local-replay-safe-accounting-v0.10";
+  "local-replay-safe-accounting-v0.11";
 const ALLOWANCE_CAPACITY_SCHEMA_VERSION =
   "codex-primary-allowance-capacity-v0.1";
 const ALLOWANCE_SCENARIO_CANDIDATES = Object.freeze({
@@ -1574,7 +1578,10 @@ function paceUnavailable(row, status = "unavailable") {
     currentUsedPercent: Number(row.usedPercent.toFixed(3)),
     remainingPercent: Number(Math.max(0, 100 - row.usedPercent).toFixed(3)),
     resetsAt: row.resetsAt,
-    pace: { percentagePointsPerHour: null },
+    pace: {
+      activePercentagePointsPerHour: null,
+      overallPercentagePointsPerHour: null,
+    },
     etaAt: null,
     hoursToExhaustion: null,
     hoursToReset: Number(
@@ -1598,12 +1605,15 @@ function sanitizeWeeklyPaceForecast(result) {
       || canonicalInstant(result.resetsAt) === null) {
     return null;
   }
-  const rate = result.pace?.percentagePointsPerHour;
+  const activeRate = result.pace?.activePercentagePointsPerHour;
+  const overallRate = result.pace?.overallPercentagePointsPerHour;
   const hoursToExhaustion = result.hoursToExhaustion;
   const hoursToReset = result.hoursToReset;
   const etaAt = result.etaAt === null ? null : canonicalInstant(result.etaAt);
-  if ((rate !== null
-        && (!Number.isFinite(rate) || rate < 0 || rate > 100))
+  const invalidRate = (rate) => rate !== null
+    && (!Number.isFinite(rate) || rate < 0 || rate > 100);
+  if (invalidRate(activeRate)
+      || invalidRate(overallRate)
       || (hoursToExhaustion !== null
         && (!Number.isFinite(hoursToExhaustion) || hoursToExhaustion < 0))
       || (hoursToReset !== null
@@ -1617,8 +1627,10 @@ function sanitizeWeeklyPaceForecast(result) {
     remainingPercent: Number(result.remainingPercent.toFixed(3)),
     resetsAt: result.resetsAt,
     pace: {
-      percentagePointsPerHour:
-        rate === null ? null : Number(rate.toFixed(6)),
+      activePercentagePointsPerHour:
+        activeRate === null ? null : Number(activeRate.toFixed(6)),
+      overallPercentagePointsPerHour:
+        overallRate === null ? null : Number(overallRate.toFixed(6)),
     },
     etaAt,
     hoursToExhaustion: hoursToExhaustion === null
@@ -3650,6 +3662,11 @@ function validQuotaTimeline(
   return true;
 }
 
+function validRetainedPaceRate(rate) {
+  return rate === null
+    || (Number.isFinite(rate) && rate >= 0 && rate <= 100);
+}
+
 function validWeeklyPaceForecast(value) {
   if (!value || typeof value !== "object" || Array.isArray(value)
       || Object.keys(value).sort().join("\0") !== [
@@ -3676,11 +3693,12 @@ function validWeeklyPaceForecast(value) {
       || typeof value.pace !== "object"
       || Array.isArray(value.pace)
       || Object.keys(value.pace).sort().join("\0")
-        !== "percentagePointsPerHour"
-      || (value.pace.percentagePointsPerHour !== null
-        && (!Number.isFinite(value.pace.percentagePointsPerHour)
-          || value.pace.percentagePointsPerHour < 0
-          || value.pace.percentagePointsPerHour > 100))
+        !== [
+          "activePercentagePointsPerHour",
+          "overallPercentagePointsPerHour",
+        ].sort().join("\0")
+      || !validRetainedPaceRate(value.pace.activePercentagePointsPerHour)
+      || !validRetainedPaceRate(value.pace.overallPercentagePointsPerHour)
       || (value.etaAt !== null && canonicalInstant(value.etaAt) === null)
       || (value.hoursToExhaustion !== null
         && (!Number.isFinite(value.hoursToExhaustion)

--- a/src/weekly-pace-projection.js
+++ b/src/weekly-pace-projection.js
@@ -4,7 +4,10 @@ import {
 } from "@app-usagemonitor/quota-analysis";
 import { sanitizeAccountScope } from "./providers/codex/account.js";
 
-const SCHEMA_VERSION = "local-weekly-pace-forecast-v0.1";
+// v0.2 (2026-08-19): mirrors quota-pace-forecast-v0.2 - the single ambiguous
+// `percentagePointsPerHour` is replaced by a named working-time rate and a
+// named wall-clock rate, and the ETA follows the wall-clock one.
+const SCHEMA_VERSION = "local-weekly-pace-forecast-v0.2";
 const PROVIDER = "openai_codex";
 const LIMIT_ID = "codex";
 const SLOT_PRIORITY = Object.freeze(["primary", "secondary"]);
@@ -169,8 +172,14 @@ function publicForecast(result) {
       sampleCount,
       elapsedHours: numberOrNull(pace.elapsedHours, { minimum: 0 }),
       movementPp: numberOrNull(pace.movementPp, { minimum: 0 }),
-      percentagePointsPerHour: numberOrNull(
-        pace.percentagePointsPerHour,
+      // Both rates travel to the surface. The active one is the "if you never
+      // pause" edge; the overall one is what `etaAt` below is built from.
+      activePercentagePointsPerHour: numberOrNull(
+        pace.activePercentagePointsPerHour,
+        { minimum: 0, maximum: 100 },
+      ),
+      overallPercentagePointsPerHour: numberOrNull(
+        pace.overallPercentagePointsPerHour,
         { minimum: 0, maximum: 100 },
       ),
     },
@@ -195,7 +204,8 @@ function unavailableForecast() {
       sampleCount: 0,
       elapsedHours: null,
       movementPp: null,
-      percentagePointsPerHour: null,
+      activePercentagePointsPerHour: null,
+      overallPercentagePointsPerHour: null,
     },
     observationCount: 0,
     etaAt: null,

--- a/test/quota-analysis-package-boundary.test.js
+++ b/test/quota-analysis-package-boundary.test.js
@@ -60,8 +60,17 @@ const SOURCE_HASHES = Object.freeze({
   // track compatibility is judged by (limit, duration) — the provider's
   // primary/secondary slots are UI roles that flipped for the weekly window
   // around 2026-07-06 without the window itself changing.
+  // Re-pinned 2026-08-19 for quota-pace-forecast-v0.2. The kernel now reports
+  // a named working-time rate and a named wall-clock rate instead of one
+  // ambiguous `percentagePointsPerHour`, and `etaAt`/`status` are derived
+  // from the wall-clock one. The old ETA divided a remaining allowance by a
+  // per-working-hour rate and reported the quotient as wall-clock hours, which
+  // made every published forecast arrive early. The plausibility cap moved to
+  // the wall-clock rate with it, since that is the only rate the ETA depends
+  // on; an over-cap working rate is now reported as null rather than refusing
+  // an otherwise sound forecast.
   "quota-pace-forecast.js":
-    "7cb7e1fd014a214fd922a7f285ef976dc52189ed24a575c85be6919aa4c6156a",
+    "793ee450768a193609e1659ce62c33f11af897e5e562b8a7393f4644d0a24891",
   // Not a pre-extraction kernel: authored 2026-08-11 for the
   // composition-aware expected line (per-model NNLS calibration, design:
   // docs/design/composition-aware-expected-line.md). Pinned the same way so

--- a/test/shared-quota-pace-forecast.test.js
+++ b/test/shared-quota-pace-forecast.test.js
@@ -46,7 +46,11 @@ test("pace is order-independent and returns an ETA when it beats reset", () => {
   assert.deepEqual(expected.refusalCodes, []);
   assert.equal(expected.pace.method, "median_adjacent_quota_slope");
   assert.equal(expected.pace.sampleCount, 2);
-  assert.equal(expected.pace.percentagePointsPerHour, 0.416667);
+  // Evenly spaced points that all moved: the working rate and the wall-clock
+  // rate are the same number, so this fixture cannot tell them apart. That is
+  // exactly why the divergence needs its own test below.
+  assert.equal(expected.pace.activePercentagePointsPerHour, 0.416667);
+  assert.equal(expected.pace.overallPercentagePointsPerHour, 0.416667);
   assert.equal(expected.hoursToExhaustion, 48);
   assert.equal(expected.etaAt, "2026-08-05T00:00:00.000Z");
   assert.equal(expected.hoursToReset, 120);
@@ -101,7 +105,9 @@ test("zero movement is unavailable rather than an infinite ETA", () => {
   assert.deepEqual(result.refusalCodes, ["non_positive_pace"]);
   assert.equal(result.etaAt, null);
   assert.equal(result.hoursToExhaustion, null);
-  assert.equal(result.pace.percentagePointsPerHour, null);
+  // Neither field reports a rate for a window that did not move.
+  assert.equal(result.pace.activePercentagePointsPerHour, null);
+  assert.equal(result.pace.overallPercentagePointsPerHour, null);
 });
 
 test("backward observations fail closed", () => {
@@ -112,6 +118,12 @@ test("backward observations fail closed", () => {
   assert.equal(result.status, "unavailable");
   assert.deepEqual(result.refusalCodes, ["backward_observation"]);
   assert.equal(result.etaAt, null);
+  // Movement is negative here. Neither rate may report that as a pace, or a
+  // reader downstream would take -40pp/hour for a real rate instead of the
+  // refusal it is.
+  assert.equal(result.pace.movementPp, -10);
+  assert.equal(result.pace.activePercentagePointsPerHour, null);
+  assert.equal(result.pace.overallPercentagePointsPerHour, null);
 });
 
 test("a noisy positive spike is damped by the median adjacent slope", () => {
@@ -124,8 +136,76 @@ test("a noisy positive spike is damped by the median adjacent slope", () => {
     ],
   );
   assert.equal(result.status, "available");
-  assert.equal(result.pace.percentagePointsPerHour, 0.333333);
-  assert.equal(result.hoursToExhaustion, 6);
+  assert.equal(result.pace.activePercentagePointsPerHour, 0.333333);
+  // The ETA is deliberately NOT damped. The median answers "what is a typical
+  // working rate", and one spike should not define it. Consumption is a total,
+  // and the spike is part of the total: 88pp over 72 hours is 1.222pp/hour, so
+  // the 2pp that are left last about an hour and a half, not six.
+  assert.equal(result.pace.overallPercentagePointsPerHour, 1.222222);
+  assert.equal(result.hoursToExhaustion, 1.636364);
+});
+
+test("the ETA follows wall-clock pace, not pace while working", () => {
+  // The regression this whole change exists for. Four hours of dense polling
+  // in which only one ten-minute interval moved: the working rate is 6pp/hour,
+  // the wall-clock rate is 0.25pp/hour, and they disagree about the answer and
+  // not merely the number - at the working rate this window is already lost,
+  // at the wall-clock rate it comfortably survives.
+  const observations = [];
+  for (let minute = 0; minute < 240; minute += 10) {
+    const at = new Date(Date.parse("2026-08-03T00:00:00.000Z") + minute * 60_000);
+    observations.push(snapshot(at.toISOString(), minute < 20 ? 0 : 1));
+  }
+  const result = run(snapshot("2026-08-03T04:00:00.000Z", 1), observations);
+
+  assert.deepEqual(result.refusalCodes, []);
+  assert.equal(result.pace.activePercentagePointsPerHour, 6);
+  assert.equal(result.pace.overallPercentagePointsPerHour, 0.25);
+  // 99pp left. At the working rate that is 16.5 hours, which would land well
+  // inside the 116 hours to reset and publish "available". At the wall-clock
+  // rate it is 396 hours, which does not.
+  assert.equal(result.hoursToExhaustion, 396);
+  assert.equal(result.hoursToReset, 116);
+  assert.equal(result.status, "will_reach_reset_first");
+  assert.equal(
+    result.etaAt,
+    new Date(Date.parse("2026-08-03T04:00:00.000Z") + 396 * 3_600_000)
+      .toISOString(),
+  );
+  assert.equal(QUOTA_PACE_POLICY.etaBasis, "overall_percentage_points_per_hour");
+});
+
+test("a spiky working rate does not refuse an otherwise sound forecast", () => {
+  // Four idle hours then one heavy ten-minute interval: the working rate is
+  // 360pp/hour, well past the cap, while the wall-clock rate is a perfectly
+  // ordinary 15pp/hour. Under v0.1 the cap applied to the only rate there was
+  // and this blanked the card. The ETA no longer rides on that rate, so the
+  // forecast stands and the unstateable working rate is reported as null.
+  const observations = [];
+  for (let minute = 0; minute < 240; minute += 10) {
+    const at = new Date(Date.parse("2026-08-03T00:00:00.000Z") + minute * 60_000);
+    observations.push(snapshot(at.toISOString(), 0));
+  }
+  const result = run(snapshot("2026-08-03T04:00:00.000Z", 60), observations);
+
+  assert.deepEqual(result.refusalCodes, []);
+  assert.equal(result.status, "available");
+  assert.equal(result.pace.activePercentagePointsPerHour, null);
+  assert.equal(result.pace.overallPercentagePointsPerHour, 15);
+  // 40pp left at 15pp/hour.
+  assert.equal(result.hoursToExhaustion, 2.666667);
+});
+
+test("an implausible wall-clock rate still refuses, whatever the working rate", () => {
+  // 20pp in ten minutes is 120pp/hour by either measure, and no ETA built on
+  // it could be trusted.
+  const result = run(
+    snapshot("2026-08-03T00:10:00.000Z", 50),
+    [snapshot("2026-08-03T00:00:00.000Z", 30)],
+  );
+  assert.deepEqual(result.refusalCodes, ["implausible_pace"]);
+  assert.equal(result.pace.overallPercentagePointsPerHour, 120);
+  assert.equal(result.etaAt, null);
 });
 
 test("stale observations are excluded and refuse the forecast", () => {

--- a/test/weekly-pace-local-companion.test.js
+++ b/test/weekly-pace-local-companion.test.js
@@ -13,6 +13,9 @@ import {
   projectWeeklyPaceForecast,
   weeklyPaceSnapshotsFromCollectorRecord,
 } from "../src/weekly-pace-projection.js";
+import {
+  normalizeDashboardPayload,
+} from "../apps/web/public/data-client.js";
 
 const NOW = Date.parse("2026-08-03T12:30:00.000Z");
 const RESETS_AT = Math.floor(Date.parse("2026-08-10T12:00:00.000Z") / 1_000);
@@ -89,7 +92,7 @@ test("local companion sends a private account-scoped pace ETA as a safe public p
       allowDevelopmentArtifactFallback: false,
     });
     assert.deepEqual(snapshot.weekly.paceForecast, {
-      schemaVersion: "local-weekly-pace-forecast-v0.1",
+      schemaVersion: "local-weekly-pace-forecast-v0.2",
       status: "available",
       currentUsedPercent: 30,
       remainingPercent: 70,
@@ -99,7 +102,10 @@ test("local companion sends a private account-scoped pace ETA as a safe public p
         sampleCount: 1,
         elapsedHours: 0.25,
         movementPp: 10,
-        percentagePointsPerHour: 40,
+        // One 15-minute interval that moved, so the working rate and the
+        // wall-clock rate are the same 40pp/hour here.
+        activePercentagePointsPerHour: 40,
+        overallPercentagePointsPerHour: 40,
       },
       observationCount: 2,
       etaAt: "2026-08-03T14:15:00.000Z",
@@ -160,7 +166,7 @@ test("local companion retains one safe observation as a non-predictive waiting s
       allowDevelopmentArtifactFallback: false,
     });
     assert.deepEqual(snapshot.weekly.paceForecast, {
-      schemaVersion: "local-weekly-pace-forecast-v0.1",
+      schemaVersion: "local-weekly-pace-forecast-v0.2",
       status: "insufficient_observations",
       currentUsedPercent: 20,
       remainingPercent: 80,
@@ -170,7 +176,8 @@ test("local companion retains one safe observation as a non-predictive waiting s
         sampleCount: 0,
         elapsedHours: 0,
         movementPp: 0,
-        percentagePointsPerHour: null,
+        activePercentagePointsPerHour: null,
+        overallPercentagePointsPerHour: null,
       },
       observationCount: 1,
       etaAt: null,
@@ -180,4 +187,43 @@ test("local companion retains one safe observation as a non-predictive waiting s
   } finally {
     await rm(root, { recursive: true });
   }
+});
+
+test("the projection the companion publishes survives the browser boundary", () => {
+  // Three files hold an independent exact-key check on this payload: the
+  // engine builds it, `publicForecast` republishes it, and the browser's
+  // `normalizeWeeklyPaceForecast` refuses anything whose shape or schema
+  // version it does not recognise. Each layer has its own tests, and all of
+  // them would still pass if a field were renamed in two places out of three -
+  // the card would simply stop rendering, silently, in production only.
+  //
+  // This is the assertion that closes that gap: a real projection, run through
+  // the real browser validator, must come back byte-identical.
+  const observations = [];
+  for (let minute = 0; minute < 240; minute += 10) {
+    observations.push(quotaRecord({
+      observedAt: new Date(Date.parse("2026-08-03T08:00:00.000Z") + minute * 60_000)
+        .toISOString(),
+      usedPercent: minute < 20 ? 0 : 1,
+    }));
+  }
+  const snapshots = observations.flatMap(weeklyPaceSnapshotsFromCollectorRecord);
+  const forecast = projectWeeklyPaceForecast({
+    currentRecord: quotaRecord({
+      observedAt: "2026-08-03T12:00:00.000Z",
+      usedPercent: 1,
+    }),
+    observations: snapshots,
+    nowMs: NOW,
+  });
+
+  // Dense polling with one moving interval: the two rates must be far apart,
+  // or this fixture is not exercising the thing it exists to protect.
+  assert.equal(forecast.pace.activePercentagePointsPerHour, 6);
+  assert.equal(forecast.pace.overallPercentagePointsPerHour, 0.25);
+
+  const normalized = normalizeDashboardPayload({
+    weekly: { paceForecast: forecast },
+  });
+  assert.deepEqual(normalized.weekly.paceForecast, forecast);
 });

--- a/test/weekly-pace-refresh-integration.test.js
+++ b/test/weekly-pace-refresh-integration.test.js
@@ -69,7 +69,10 @@ test("refresh projects a safe account-scoped weekly pace ETA", async () => {
     currentUsedPercent: 30,
     remainingPercent: 70,
     resetsAt: "2026-08-10T12:00:00.000Z",
-    pace: { percentagePointsPerHour: 40 },
+    pace: {
+      activePercentagePointsPerHour: 40,
+      overallPercentagePointsPerHour: 40,
+    },
     etaAt: "2026-08-03T14:15:00.000Z",
     hoursToExhaustion: 1.75,
     hoursToReset: 167.5,
@@ -125,7 +128,14 @@ test("pace refresh never combines observations from different account scopes", a
   ]);
 
   assert.equal(cache.weekly.paceForecast.status, "insufficient_observations");
-  assert.equal(cache.weekly.paceForecast.pace.percentagePointsPerHour, null);
+  assert.equal(
+    cache.weekly.paceForecast.pace.activePercentagePointsPerHour,
+    null,
+  );
+  assert.equal(
+    cache.weekly.paceForecast.pace.overallPercentagePointsPerHour,
+    null,
+  );
   assert.equal(cache.weekly.paceForecast.etaAt, null);
 });
 
@@ -159,7 +169,14 @@ test("stale and backward account-scoped history fail closed", async (t) => {
       }),
     ], Date.parse("2026-08-03T13:30:00.000Z"));
     assert.equal(cache.weekly.paceForecast.status, "unavailable");
-    assert.equal(cache.weekly.paceForecast.pace.percentagePointsPerHour, null);
+    assert.equal(
+      cache.weekly.paceForecast.pace.activePercentagePointsPerHour,
+      null,
+    );
+    assert.equal(
+      cache.weekly.paceForecast.pace.overallPercentagePointsPerHour,
+      null,
+    );
     assert.equal(cache.weekly.paceForecast.etaAt, null);
   });
 


### PR DESCRIPTION
Follow-up to [#22](https://github.com/adamallcock/tibotattle/pull/22), which fixed the dashboard card. This fixes the engine underneath it.

## The defect is a unit mismatch

`analyzeQuotaPace` measures burn rate over **only the intervals that moved**, then computes:

```
hoursToExhaustion = remainingPp / percentagePointsPerHour
```

The rate is per *working* hour. The quotient is reported as *wall-clock* hours. That silently assumes the reader never stops. Measured gap on a real corpus: **11.3pp/hour active against 0.97pp/hour overall** (1,109 observations, 97pp over 4d 4h) — which is why every published forecast landed early.

## `status` inherited it, and that's the worse half

`will_reach_reset_first` fires only when `activePace <= remaining / hoursToReset`. The whole-window best case for that threshold is 100pp over 168h = **0.595pp/hour**. Typical active paces are 2–11pp/hour, so `available` — *"you WILL run out"* — is what essentially every active user gets, regardless of whether they will.

It's also the cheapest field for a future menubar or notification to read: a plain branch, no arithmetic. That's what made this worth fixing at source rather than leaving to consumers.

## What v0.2 publishes

| field | meaning |
|---|---|
| `pace.activePercentagePointsPerHour` | median of adjacent slopes that moved — pace per *working* hour |
| `pace.overallPercentagePointsPerHour` | total movement over total elapsed — pace per *wall-clock* hour |

`etaAt`, `hoursToExhaustion` and `status` are built from the wall-clock rate. `QUOTA_PACE_POLICY.etaBasis` states which, so a consumer never has to infer it.

**The median is unchanged**, because it is load-bearing rather than incidental: at a five-minute polling cadence a normal week has far more still intervals than moving ones, so an unfiltered median would be exactly `0`, trip `non_positive_pace`, and no forecast would ever appear. It is a deliberate robust estimator of the working rate and it stays exactly as it was.

The old `percentagePointsPerHour` key is **removed** rather than redefined, so a reader that never validated the shape gets `undefined` instead of a silently different number.

## The plausibility cap moved with the ETA

The cap exists to stop an untrustworthy rate producing an untrustworthy ETA. The ETA no longer rides on the active rate — and over a five-minute poll the cap is only **8.3pp**, which an ordinary burst clears easily.

Four idle hours followed by one heavy interval used to blank the card entirely:

```
status       : unavailable [ 'implausible_pace' ]
active pp/h  : 360   (one 10-min interval)
overall pp/h : 15    (60pp over 4h — entirely sane)
etaAt        : null
```

Now the forecast stands and the unstateable working rate is reported as `null`, so the card's "if you never pause" marker is simply withheld. This admits inputs v0.1 refused, deliberately.

Both rates are also withheld unless genuinely positive — a backward observation makes movement negative, and a negative "rate" would read downstream as a rate rather than as the refusal it is.

## Nothing changes silently

The exact-key validators in `replay-safe-accounting-cache.js` and `data-client.js` reject an unrecognised shape or version outright, so a partial rename degrades to "no card" rather than to a wrong card. Retained caches bump to `v0.11` and rebuild. The reviewed-kernel digest in `quota-analysis-package-boundary.test.js` is re-pinned with its reason, per the existing workflow.

## Tests

Two new ones, for the two gaps that let this survive:

1. **The bias itself.** Every existing engine fixture used a handful of widely-spaced points where every interval moved — in that regime the two rates are *identical*, so the suite was blind to the divergence by construction. The new fixture uses dense polling with one moving interval, where the rates disagree about the answer and not merely the number (`will_reach_reset_first` vs `available`).
2. **A partial rename.** Three files each hold an independent exact-key check on this payload, and all three suites pass while any two of them agree — the card would just stop rendering, silently, in production only. The new test runs a real projection through the real browser validator.

Plus coverage for the burst case, the backward-movement guard, and the wall-clock cap.

Full suite: **2,665 tests, 2,643 pass**. The 5 failures (R7 release evidence ×2, `deployment-endpoints`, `dogfood-update-guard-config`, `web-release-lane`) all reproduce identically on a stashed clean `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)