### PR TITLE
fix(accounting): render cache-switch cards on mobile

### DIFF
--- a/apps/web/public/app.js
+++ b/apps/web/public/app.js
@@ -7639,6 +7639,12 @@ function renderCacheImpactPagination(prefix, state, page) {
   if (next) next.disabled = state.page >= page.pageCount - 1;
 }
 
+function cacheSwitchDataCell(className, value, labelKey) {
+  const cell = rawNode("td", className, value);
+  cell.setAttribute("data-label", t(labelKey));
+  return cell;
+}
+
 function renderAccountingCacheSwitchDetails(impact) {
   const disclosure = $("#cache-switch-details");
   const rows = $("#cache-switch-rows");
@@ -7681,20 +7687,32 @@ function renderAccountingCacheSwitchDetails(impact) {
   for (const item of page.rows) {
     const row = node("tr");
     row.append(
-      rawNode("td", "", formatLocal(item.observedAt)),
-      rawNode("td", "cache-switch-change", cacheSwitchChangeDescription(item)),
-      rawNode(
-        "td",
+      cacheSwitchDataCell(
+        "",
+        formatLocal(item.observedAt),
+        "accounting.cacheSwitch.column.localTime",
+      ),
+      cacheSwitchDataCell(
+        "cache-switch-change",
+        cacheSwitchChangeDescription(item),
+        "accounting.cacheSwitch.column.change",
+      ),
+      cacheSwitchDataCell(
         "numeric-cell",
         `${formatCount(item.previousCacheReadTokens)} → ${formatCount(item.currentCacheReadTokens)}`,
+        "accounting.cacheSwitch.column.cacheRead",
       ),
-      rawNode("td", "numeric-cell", formatCount(item.lostCacheTokens)),
-      rawNode(
-        "td",
+      cacheSwitchDataCell(
+        "numeric-cell",
+        formatCount(item.lostCacheTokens),
+        "accounting.cacheSwitch.column.lostTokens",
+      ),
+      cacheSwitchDataCell(
         "model-api-equivalent",
         item.estimatedPremiumUsd === null
           ? "—"
           : formatApiMoney(item.estimatedPremiumUsd),
+        "accounting.cacheSwitch.column.apiEquivalent",
       ),
     );
     rows.append(row);

--- a/apps/web/public/styles.css
+++ b/apps/web/public/styles.css
@@ -1980,8 +1980,8 @@ tbody tr:last-child td { border-bottom: 0; }
   .model-disclosure-caret { transition: none; }
 }
 .cache-switch-details { margin-top: 18px; }
-.cache-switch-details th,
-.cache-switch-details td { padding-inline: var(--space-2); }
+#cache-switch-details th,
+#cache-switch-details td { padding-inline: var(--space-2); }
 .cache-switch-details th:nth-child(n + 3),
 .cache-switch-details td:nth-child(n + 3) { text-align: end; }
 .cache-continuity-details .evidence-subheading {
@@ -2031,6 +2031,55 @@ tbody tr:last-child td { border-bottom: 0; }
 .cache-switch-change {
   min-width: 15rem;
   white-space: normal;
+}
+/* A five-column evidence table is readable on a desktop but not at phone
+   width. Retain its table semantics there, then turn each row into a labelled
+   card here instead of leaving an off-screen horizontal scroller. */
+@media (max-width: 640px) {
+  #cache-switch-details .table-wrap {
+    overflow-x: visible;
+    border: 0;
+    border-radius: 0;
+  }
+  #cache-switch-details table,
+  #cache-switch-details tbody {
+    display: block;
+    width: 100%;
+  }
+  #cache-switch-details table { min-width: 0; }
+  #cache-switch-details thead { display: none; }
+  #cache-switch-details tbody { display: grid; gap: var(--space-2); }
+  #cache-switch-details tbody tr {
+    display: block;
+    padding: var(--space-3);
+    border: 1px solid var(--line);
+    border-radius: var(--radius-sm);
+    background: var(--surface-raised);
+  }
+  #cache-switch-details tbody td {
+    display: grid;
+    grid-template-columns: minmax(0, 42%) minmax(0, 1fr);
+    gap: var(--space-2);
+    padding: var(--space-2) 0;
+    text-align: end;
+    white-space: normal;
+  }
+  #cache-switch-details tbody td::before {
+    content: attr(data-label);
+    color: var(--muted);
+    font-size: .62rem;
+    font-weight: var(--weight-bold);
+    letter-spacing: .05em;
+    text-align: start;
+    text-transform: uppercase;
+  }
+  #cache-switch-details tbody td:last-child { border-bottom: 0; }
+  #cache-switch-details .cache-switch-change { min-width: 0; }
+  #cache-switch-details .empty-cell {
+    display: block;
+    text-align: center;
+  }
+  #cache-switch-details .empty-cell::before { content: none; }
 }
 .accounting-bars { display: grid; gap: 10px; }
 .accounting-dimensions {

--- a/apps/web/test/cache-switch-impact.test.mjs
+++ b/apps/web/test/cache-switch-impact.test.mjs
@@ -652,6 +652,93 @@ test("a pager is drawn only when there is more than one page to reach", async ()
   assert.equal(last.nodes["#t-page-next"].disabled, true);
 });
 
+test("cache-switch mobile cards carry their translated column labels", async () => {
+  const source = await readFile(new URL("../public/app.js", import.meta.url), "utf8");
+  const helperStart = source.indexOf("function cacheSwitchDataCell(");
+  const helperEnd = source.indexOf("\nfunction renderAccountingCacheSwitchDetails", helperStart);
+  const renderStart = helperEnd + 1;
+  const renderEnd = source.indexOf("\nfunction appendCacheContinuityAllowance", renderStart);
+  assert.ok(helperStart >= 0 && helperEnd > helperStart, "the mobile label helper is available");
+  assert.ok(renderEnd > renderStart, "the cache-switch renderer is available");
+
+  const element = (tagName, className = "", textContent = "") => ({
+    tagName,
+    className,
+    textContent,
+    children: [],
+    attributes: new Map(),
+    append(...items) { this.children.push(...items); },
+    setAttribute(name, value) { this.attributes.set(name, value); },
+    getAttribute(name) { return this.attributes.get(name) ?? null; },
+  });
+  const cacheSwitchDataCell = Function(
+    "rawNode",
+    "t",
+    `${source.slice(helperStart, helperEnd)}\nreturn cacheSwitchDataCell;`,
+  )(
+    element,
+    (key) => `translated:${key}`,
+  );
+  const disclosure = { hidden: true, open: false };
+  const rows = element("tbody");
+  const render = Function(
+    "$",
+    "clear",
+    "node",
+    "localizedNode",
+    "cacheSwitchDataCell",
+    "formatCount",
+    "formatApiMoney",
+    "formatLocal",
+    "cacheSwitchChangeDescription",
+    "paginateCacheImpactRows",
+    "cacheSwitchTablePagination",
+    "cacheImpactTableSignature",
+    "renderCacheImpactPagination",
+    `${source.slice(renderStart, renderEnd)}\nreturn renderAccountingCacheSwitchDetails;`,
+  )(
+    (selector) => ({
+      "#cache-switch-details": disclosure,
+      "#cache-switch-rows": rows,
+    })[selector] ?? null,
+    (target) => { target.children.length = 0; },
+    element,
+    (tagName, className, key) => element(tagName, className, key),
+    cacheSwitchDataCell,
+    String,
+    (value) => `$${value.toFixed(2)}`,
+    (value) => value,
+    () => "Model: GPT-5.6 Terra → GPT-5.6 Sol",
+    (values) => ({ rows: values, start: 0, end: values.length, total: values.length, pageCount: 1 }),
+    { page: 0, signature: "" },
+    () => "test",
+    () => {},
+  );
+
+  render({
+    status: "available",
+    recent: [{
+      observedAt: "Aug 16, 11:33 AM EDT",
+      previousCacheReadTokens: 207_616,
+      currentCacheReadTokens: 6_912,
+      lostCacheTokens: 200_704,
+      estimatedPremiumUsd: 0.9,
+    }],
+  });
+
+  assert.equal(disclosure.hidden, false);
+  assert.deepEqual(
+    rows.children[0].children.map((cell) => cell.getAttribute("data-label")),
+    [
+      "translated:accounting.cacheSwitch.column.localTime",
+      "translated:accounting.cacheSwitch.column.change",
+      "translated:accounting.cacheSwitch.column.cacheRead",
+      "translated:accounting.cacheSwitch.column.lostTokens",
+      "translated:accounting.cacheSwitch.column.apiEquivalent",
+    ],
+  );
+});
+
 test("accounting tables page ten rows and reset for a changed set", async () => {
   const source = await readFile(new URL("../public/app.js", import.meta.url), "utf8");
   const start = source.indexOf("const CACHE_IMPACT_TABLE_PAGE_SIZE = 10;");


### PR DESCRIPTION
## Summary

- Render cache-switch evidence rows as labeled cards on phone-width screens.
- Preserve the compact desktop table and shortened column headings.
- Cover translated mobile labels with a focused regression test.

## Why

The five-column evidence table required horizontal scrolling on narrow screens.

## Validation

- `node --test apps/web/test/cache-switch-impact.test.mjs` (16/16 passing)
- Rendered mobile and desktop checks: no horizontal table overflow and no console logs.