### PR TITLE
fix(collector): survive a first-run app-server failure instead of failing every refresh

### DIFF
--- a/apps/web/public/app.js
+++ b/apps/web/public/app.js
@@ -10460,6 +10460,12 @@ const LOCAL_COMPANION_ERROR_COPY = {
     "TiboTattle refused to cancel the analysis because the request did not come from the local dashboard. The analysis is still running.",
   refresh_not_running:
     "There is no local analysis running to cancel. Nothing was changed.",
+  // A durable checkpoint that was present when the analysis started and is
+  // gone mid-run. A first-ever run without a checkpoint never reports this:
+  // it completes with a provider-quota diagnostic instead, so this code only
+  // names genuine loss of the stored analysis state.
+  app_record_checkpoint_unavailable:
+    "The analysis checkpoint stored on this Mac disappeared while the analysis was running, so TiboTattle stopped rather than continue without it. Existing results are unchanged; run the analysis again to start over safely.",
   diagnostic_note_not_authorized:
     "TiboTattle refused to write a diagnostic note because the request did not come from the local dashboard. The reference above is still quotable.",
   diagnostic_note_not_recorded:

--- a/apps/web/public/localization.js
+++ b/apps/web/public/localization.js
@@ -1878,6 +1878,10 @@ export const LEGACY_TEXT_CATALOG = Object.freeze({
   "Update running; reconnecting…": ["更新正在运行；正在重新连接…", "Actualización en curso; reconectando…"],
   "Continuing local analysis…": ["正在继续本地分析…", "Continuando el análisis local…"],
   "Finalizing bounded pause…": ["正在完成有界暂停…", "Finalizando la pausa limitada…"],
+  // The refresh failure code app_record_checkpoint_unavailable: the durable
+  // analysis checkpoint vanished mid-run. The sentence must exist in every
+  // supported language alongside the English copy map in app.js.
+  "The analysis checkpoint stored on this Mac disappeared while the analysis was running, so TiboTattle stopped rather than continue without it. Existing results are unchanged; run the analysis again to start over safely.": ["分析运行期间，这台 Mac 上保存的分析检查点丢失，TiboTattle 因此停止而不是在缺少它的情况下继续。现有结果保持不变；再次运行分析即可安全地重新开始。", "El punto de control del análisis guardado en este Mac desapareció mientras el análisis se ejecutaba, así que TiboTattle se detuvo en lugar de continuar sin él. Los resultados existentes no cambian; ejecuta el análisis de nuevo para empezar de forma segura desde el principio."],
   "Loading saved results…": ["正在加载已保存结果…", "Cargando resultados guardados…"],
   "Loading updated evidence…": ["正在加载更新后的证据…", "Cargando evidencia actualizada…"],
   "Preparing locally…": ["正在本地准备…", "Preparando localmente…"],

--- a/src/passive-collector.js
+++ b/src/passive-collector.js
@@ -1393,6 +1393,36 @@ function recordAppServerError(checkpoint, error) {
   return code;
 }
 
+// A failed app-server refresh leaves the in-memory checkpoint speculatively
+// mutated: the append records the dedupe key and observation stamp before its
+// atomic commit, so keeping either after a failed commit would make the next
+// pass skip a snapshot that was never stored. Recovery therefore rewinds to
+// the durable checkpoint — or, on a first-ever run, to the pristine baseline
+// captured at creation, because the durable row is only written after this
+// very refresh: a machine whose first quota read fails must still complete
+// the pass and record the provider error, not fail every refresh forever.
+// Records and checkpoint commit in one transaction, so a null durable row
+// also proves no record from this pass was stored and the baseline loses
+// nothing. Only a checkpoint that was durably present when the run started
+// and is gone now is a store fault; that stays fatal, under a stable code
+// the refresh surface can name.
+async function rewindCheckpointAfterAppRecordFailure({
+  stateFile,
+  checkpoint,
+  pristineCheckpoint,
+}) {
+  const restored = await readLocalCollectorCheckpoint({ stateFile });
+  if (!restored && pristineCheckpoint === null) {
+    const failure = new Error(
+      "Collector app-record recovery completed without a durable checkpoint",
+    );
+    failure.code = "app_record_checkpoint_unavailable";
+    throw failure;
+  }
+  for (const key of Object.keys(checkpoint)) delete checkpoint[key];
+  Object.assign(checkpoint, restored ?? structuredClone(pristineCheckpoint));
+}
+
 export async function runCollectorOnce({
   codexHome,
   stateFile = defaultCollectorStateFile(),
@@ -1475,6 +1505,12 @@ export async function runCollectorOnce({
       backfillSinceAt: requestedBackfillStart,
       nowIso,
     });
+    // The exact rewind target for a failed app-server refresh on a run that
+    // started with no durable checkpoint. Non-null only then: a run that read
+    // a durable row must find one again, or fail as a store fault.
+    const pristineCheckpoint = existing === null
+      ? structuredClone(checkpoint)
+      : null;
 
     if (skipRolloutIngestion) {
       // The unified index owns usage facts. Keep the existing bounded
@@ -1520,10 +1556,11 @@ export async function runCollectorOnce({
             }
           }
         } catch (error) {
-          const restored = await readLocalCollectorCheckpoint({ stateFile });
-          if (!restored) throw new Error("Collector app-record recovery completed without a durable checkpoint");
-          for (const key of Object.keys(checkpoint)) delete checkpoint[key];
-          Object.assign(checkpoint, restored);
+          await rewindCheckpointAfterAppRecordFailure({
+            stateFile,
+            checkpoint,
+            pristineCheckpoint,
+          });
           if (!signal?.aborted) refresh.errorCode = recordAppServerError(checkpoint, error);
         } finally {
           signal?.removeEventListener("abort", abortClient);
@@ -1734,10 +1771,11 @@ export async function runCollectorOnce({
           }
         }
       } catch (error) {
-        const restored = await readLocalCollectorCheckpoint({ stateFile });
-        if (!restored) throw new Error("Collector app-record recovery completed without a durable checkpoint");
-        for (const key of Object.keys(checkpoint)) delete checkpoint[key];
-        Object.assign(checkpoint, restored);
+        await rewindCheckpointAfterAppRecordFailure({
+          stateFile,
+          checkpoint,
+          pristineCheckpoint,
+        });
         if (!signal?.aborted) refresh.errorCode = recordAppServerError(checkpoint, error);
       } finally {
         signal?.removeEventListener("abort", abortClient);

--- a/test/local-companion-refresh.test.js
+++ b/test/local-companion-refresh.test.js
@@ -8,6 +8,7 @@ import {
 } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { dirname, join, relative } from "node:path";
+import { DatabaseSync } from "node:sqlite";
 import {
   createDeferredAccountingRebuildRecorder,
   createLocalCollectorRefreshRunner,
@@ -18,8 +19,15 @@ import {
   localCompanionStatePaths,
 } from "../src/local-installation-diagnostics.js";
 import {
+  readLocalCollectorCheckpoint,
   readLocalCollectorLegacyRefreshUse,
 } from "../src/local-collector-state.js";
+import {
+  runCollectorOnce,
+} from "../src/passive-collector.js";
+import {
+  CodexAppServerError,
+} from "../src/providers/codex/account.js";
 import {
   REPLAY_SAFE_ACCOUNTING_SCHEMA_VERSION,
 } from "../src/replay-safe-accounting-cache.js";
@@ -675,6 +683,169 @@ test("unified authority keeps quota-only collection prospective and softens a co
   assert.equal(result.indexing.status, "bounded_pause");
   assert.equal(result.accounting.sourceMode, "unified");
   assert.equal(result.accounting.refreshStatus, "rebuilt");
+});
+
+test("a fresh unified machine completes its first refresh when the app-server read fails", async () => {
+  const stateRoot = await mkdtemp(join(tmpdir(), "local-refresh-fresh-machine-"));
+  const expectedGeneration = {
+    id: 1,
+    fingerprint: "f".repeat(64),
+    status: "complete",
+    discoveryComplete: true,
+    diagnosticsComplete: true,
+    usageProvenanceComplete: true,
+    sourceOrderComplete: true,
+    quotaProvenanceComplete: true,
+    toolProvenanceComplete: true,
+  };
+  try {
+    // A machine on its very first pass: real session logs exist, but the
+    // Codex app-server quota read fails (no per-user Codex session). The
+    // refresh must still reach the unified index and accounting instead of
+    // aborting at the collector with nothing indexed.
+    const codexHome = join(stateRoot, "codex-home");
+    await mkdir(join(codexHome, "sessions"), { recursive: true });
+    await writeFile(
+      join(codexHome, "sessions", "rollout-2026-08-19T00-00-00-fresh.jsonl"),
+      "",
+    );
+    const stateFile = join(stateRoot, "state", "local-collector-state-v1.sqlite");
+    let unifiedIndexRuns = 0;
+    const runner = createLocalCollectorRefreshRunner({
+      accountingSourceMode: "unified",
+      codexHome,
+      stateFile,
+      unifiedIndexFile: join(stateRoot, "state", "local-unified-index-v1.sqlite"),
+      selectAccountObservationSecret: () => ({
+        loadAccountObservationSecret: null,
+      }),
+      runCollector: (options) => runCollectorOnce({
+        ...options,
+        appServerFactory: () => ({
+          async start() {
+            throw new CodexAppServerError(
+              "app_server_unavailable",
+              "Unable to start the Codex app-server",
+            );
+          },
+          close() {},
+        }),
+      }),
+      refreshUnifiedIndex: async () => {
+        unifiedIndexRuns += 1;
+        return { status: "ingested", generation: expectedGeneration };
+      },
+      refreshAccounting: async () => ({
+        generatedAt: "2026-08-19T12:00:00.000Z",
+        periods: [{ id: "7d", events: 0 }],
+        diagnostics: {},
+        sourceDescriptor: { fallbackCount: 0 },
+      }),
+      clock: () => Date.parse("2026-08-19T12:00:00.000Z"),
+    });
+
+    const first = await runner();
+    assert.equal(unifiedIndexRuns, 1);
+    assert.deepEqual(first.quotaRefresh, {
+      attempted: true,
+      recordWritten: false,
+      errorCode: "app_server_unavailable",
+    });
+    assert.equal(first.unifiedIndex.status, "ingested");
+    assert.equal(first.accounting.status, "replay_safe");
+    assert.equal(first.accounting.refreshStatus, "rebuilt");
+
+    // The failed pass still persisted its checkpoint, so the loop is broken:
+    // the next pass recovers from the durable row and completes the same way.
+    const checkpoint = await readLocalCollectorCheckpoint({ stateFile });
+    assert.equal(
+      checkpoint.diagnostics.appServerErrorCounts.app_server_unavailable,
+      1,
+    );
+    const second = await runner();
+    assert.equal(unifiedIndexRuns, 2);
+    assert.equal(second.quotaRefresh.errorCode, "app_server_unavailable");
+    assert.equal(second.unifiedIndex.status, "ingested");
+  } finally {
+    await rm(stateRoot, { recursive: true, force: true });
+  }
+});
+
+test("a mid-run checkpoint loss fails the refresh under the stable collector code", async () => {
+  const stateRoot = await mkdtemp(join(tmpdir(), "local-refresh-store-fault-"));
+  const clock = () => Date.parse("2026-08-19T12:00:00.000Z");
+  try {
+    const codexHome = join(stateRoot, "codex-home");
+    await mkdir(join(codexHome, "sessions"), { recursive: true });
+    const stateFile = join(stateRoot, "state", "local-collector-state-v1.sqlite");
+    const seed = () => runCollectorOnce({
+      codexHome,
+      stateFile,
+      refreshStale: false,
+      clock,
+    });
+    let unifiedIndexRuns = 0;
+    const runner = createLocalCollectorRefreshRunner({
+      accountingSourceMode: "unified",
+      codexHome,
+      stateFile,
+      unifiedIndexFile: join(stateRoot, "state", "local-unified-index-v1.sqlite"),
+      selectAccountObservationSecret: () => ({
+        loadAccountObservationSecret: null,
+      }),
+      runCollector: (options) => runCollectorOnce({
+        ...options,
+        appServerFactory: () => ({
+          async start() {
+            // Externally strip the durable checkpoint row mid-run. This is a
+            // real store fault, not a first run, so it must stay terminal.
+            const database = new DatabaseSync(stateFile);
+            try {
+              database.prepare("DELETE FROM meta WHERE key = 'checkpoint'").run();
+            } finally {
+              database.close();
+            }
+            throw new CodexAppServerError("temporary_disconnect", "connection lost");
+          },
+          close() {},
+        }),
+      }),
+      refreshUnifiedIndex: async () => {
+        unifiedIndexRuns += 1;
+        return { status: "ingested", generation: null };
+      },
+      clock,
+    });
+
+    await seed();
+    await assert.rejects(
+      runner(),
+      (error) => error?.code === "app_record_checkpoint_unavailable"
+        && error?.refreshStep === "collector",
+    );
+    assert.equal(unifiedIndexRuns, 0);
+
+    await seed();
+    const controller = new LocalCompanionRefreshController({
+      runner,
+      dataStore: { async reload() {} },
+      clock,
+    });
+    assert.equal(controller.start(), true);
+    // The runner performs real collector-state I/O, so settle on wall time
+    // rather than event-loop ticks.
+    for (let attempt = 0; attempt < 500; attempt += 1) {
+      if (controller.getStatus().status === "failed") break;
+      await new Promise((resolve) => setTimeout(resolve, 10));
+    }
+    const status = controller.getStatus();
+    assert.equal(status.status, "failed");
+    assert.equal(status.errorCode, "refresh_failed");
+    assert.equal(status.failedStep, "collector");
+    assert.equal(status.failureCode, "app_record_checkpoint_unavailable");
+  } finally {
+    await rm(stateRoot, { recursive: true, force: true });
+  }
 });
 
 test("unified mode fails closed when the authoritative generation is missing or incomplete", async (t) => {

--- a/test/passive-collector.test.js
+++ b/test/passive-collector.test.js
@@ -14,6 +14,7 @@ import {
 } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { DatabaseSync } from "node:sqlite";
 import {
   CodexAppServerError,
   deriveOpenAIAccountScope,
@@ -1367,6 +1368,117 @@ test("run-once distinguishes an app-server authentication failure without losing
     assert.equal((await stat(fixture.checkpointFile)).mode & 0o777, 0o600);
   } finally {
     await rm(fixture.root, { recursive: true });
+  }
+});
+
+test("a first-ever unified pass records a failed quota read instead of failing forever", async () => {
+  const fixture = await collectorFixture();
+  class UnavailableClient {
+    async start() {
+      throw new CodexAppServerError("app_server_unavailable", "Unable to start the Codex app-server");
+    }
+    close() {}
+  }
+  try {
+    // No durable checkpoint exists before the first pass: the row is only
+    // written after the quota refresh, so a failed provider read here used to
+    // abort this pass — and, because the abort also skipped the save, every
+    // later pass too.
+    const options = {
+      ...fixture,
+      backfill: false,
+      skipRolloutIngestion: true,
+      staleAfterMs: 0,
+      appServerFactory: () => new UnavailableClient(),
+      clock: () => Date.parse("2026-08-19T00:01:00.000Z"),
+    };
+    const first = await runCollectorOnce(options);
+    assert.equal(first.status, "complete");
+    assert.equal(first.refresh.attempted, true);
+    assert.equal(first.refresh.recordWritten, false);
+    assert.equal(first.refresh.errorCode, "app_server_unavailable");
+    assert.equal(first.diagnostics.appServerErrorCounts.app_server_unavailable, 1);
+    const checkpoint = JSON.parse(await readFile(fixture.checkpointFile, "utf8"));
+    assert.equal(checkpoint.diagnostics.appServerErrorCounts.app_server_unavailable, 1);
+    assert.equal(checkpoint.lastQuotaObservedAt, null);
+    assert.equal(checkpoint.recentEventKeys.length, 0);
+
+    // The pass persisted its checkpoint, so the next failing pass recovers
+    // from the durable row and keeps counting.
+    const second = await runCollectorOnce(options);
+    assert.equal(second.status, "complete");
+    assert.equal(second.refresh.errorCode, "app_server_unavailable");
+    assert.equal(second.diagnostics.appServerErrorCounts.app_server_unavailable, 2);
+  } finally {
+    await rm(fixture.root, { recursive: true });
+  }
+});
+
+test("a first-ever legacy pass with no rollouts survives a failed quota read", async () => {
+  const fixture = await collectorFixture();
+  class FailingClient {
+    async start() {
+      throw new CodexAppServerError("authentication_failure", "not authenticated");
+    }
+    close() {}
+  }
+  try {
+    // A machine with no rollout history commits no ingestion change, so
+    // nothing durable exists when the quota refresh fails.
+    await rm(fixture.rollout);
+    const result = await runCollectorOnce({
+      ...fixture,
+      staleAfterMs: 0,
+      appServerFactory: () => new FailingClient(),
+      clock: () => Date.parse("2026-08-19T00:01:00.000Z"),
+    });
+    assert.equal(result.status, "complete");
+    assert.equal(result.refresh.attempted, true);
+    assert.equal(result.refresh.errorCode, "authentication_failure");
+    assert.equal(result.diagnostics.appServerErrorCounts.authentication_failure, 1);
+    const checkpoint = JSON.parse(await readFile(fixture.checkpointFile, "utf8"));
+    assert.equal(checkpoint.diagnostics.appServerErrorCounts.authentication_failure, 1);
+  } finally {
+    await rm(fixture.root, { recursive: true });
+  }
+});
+
+test("a checkpoint that disappears mid-run still fails the pass under a stable code", async () => {
+  const fixture = await collectorFixture();
+  const clock = () => Date.parse("2026-08-19T00:01:00.000Z");
+  class VanishingCheckpointClient {
+    async start() {
+      // Externally strip the checkpoint row between the run's opening read
+      // and its recovery read, leaving the store itself healthy. First-run
+      // recovery must not soften this: the run STARTED from a durable
+      // checkpoint.
+      const database = new DatabaseSync(fixture.stateFile);
+      try {
+        database.prepare("DELETE FROM meta WHERE key = 'checkpoint'").run();
+      } finally {
+        database.close();
+      }
+      throw new CodexAppServerError("temporary_disconnect", "connection lost");
+    }
+    close() {}
+  }
+  try {
+    const seeded = await runCollectorOnce({ ...fixture, refreshStale: false, clock });
+    assert.equal(seeded.status, "complete");
+    await assert.rejects(
+      () => runCollectorOnce({
+        ...fixture,
+        staleAfterMs: 0,
+        appServerFactory: () => new VanishingCheckpointClient(),
+        clock,
+      }),
+      (error) => {
+        assert.equal(error.code, "app_record_checkpoint_unavailable");
+        return true;
+      },
+    );
+  } finally {
+    await rm(fixture.root, { recursive: true, force: true });
   }
 });
 


### PR DESCRIPTION
On a machine with no working per-user Codex app-server session and no durable checkpoint yet, every refresh failed at the collector step with an uncoded error, the unified index never ran, and the loop never healed (found live on a fresh macOS account, 2026-08-19, dogfood 0.1.13).

Recovery now rewinds to the durable checkpoint or, on a first-ever run, to a pristine baseline captured at checkpoint creation; the pass records the provider error and persists the checkpoint, breaking the loop permanently while the refresh proceeds to indexing. A checkpoint that was durably present at run start but is gone at recovery stays fatal (external tampering) under a stable code with honest UI copy in all three languages.

Tests were verified red on the unfixed code: first-run degrade + loop-break across passes (unified and legacy), and the coded store-fault path. Suites: passive-collector 50/50, local-companion-refresh 74/74, UI 307/307 on the rebased tree.

Note: touches workload sources — R7 receipts regenerate once after the last follow-up in this set lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)