### PR TITLE
fix(queue): stop prepared-set inflation and retire superseded pending sets

### DIFF
--- a/apps/local/server.js
+++ b/apps/local/server.js
@@ -72,6 +72,7 @@ import {
   inspectContributionSyncQueue,
   inspectNextContributionSyncUpload,
   retireAcceptedContributionArtifacts,
+  retireSupersededPendingContributionArtifacts,
   runContributionSyncQueueOnce,
   setContributionSyncPaused,
 } from "../../src/contribution-sync-queue.js";
@@ -2055,6 +2056,7 @@ const PREPARATION_ERROR_CODES = new Set([
   "prepared_spool_invalid",
   "preparation_in_progress",
   "preparation_failed",
+  "consent_already_current",
 ]);
 
 function preparationResultProjection(value) {
@@ -2154,7 +2156,8 @@ function preparationErrorProjection(error, overrideCode = null) {
 }
 
 function preparationErrorStatus(code) {
-  if (code === "preparation_in_progress") return 409;
+  if (code === "preparation_in_progress"
+      || code === "consent_already_current") return 409;
   if (code === "export_too_large") return 413;
   if (code === "coverage_unavailable"
       || code === "identity_unavailable") return 503;
@@ -2643,6 +2646,7 @@ function createPreparedLocalCompanionServer({
   contributionSyncExactReviewProvider = null,
   contributionSyncOnceRunner = null,
   automaticContributionRetirementRunner = null,
+  supersededContributionRetirementRunner = null,
   contributionSyncPauseSetter = null,
   contributionSyncTimeoutMs = 60_000,
   automaticContributionController = null,
@@ -2762,6 +2766,8 @@ function createPreparedLocalCompanionServer({
         && typeof contributionSyncOnceRunner !== "function")
       || (automaticContributionRetirementRunner !== null
         && typeof automaticContributionRetirementRunner !== "function")
+      || (supersededContributionRetirementRunner !== null
+        && typeof supersededContributionRetirementRunner !== "function")
       || (contributionSyncPauseSetter !== null
         && typeof contributionSyncPauseSetter !== "function")
       || !Number.isSafeInteger(contributionSyncTimeoutMs)
@@ -3008,6 +3014,23 @@ function createPreparedLocalCompanionServer({
           protectedPreparedSetIds,
           signal,
         }));
+  const runSupersededContributionRetirement =
+    supersededContributionRetirementRunner
+    ?? (preparedContributionDirectory === null
+      ? async () => ({
+        retiredSets: 0,
+        retiredJobs: 0,
+        interrupted: false,
+        networkActivity: false,
+      })
+      : ({ signal } = {}) =>
+        retireSupersededPendingContributionArtifacts({
+          preparedSpoolDirectory: preparedContributionDirectory,
+          reviewArchiveDirectory:
+            contributionPreparationOptions.reviewArchiveDirectory,
+          queueFile: contributionQueueFile,
+          signal,
+        }));
   const runAutomaticContributionPreparation = async (request) => {
     if (contributionPreparationInProgress) {
       const error = new Error("preparation_in_progress");
@@ -3150,6 +3173,34 @@ function createPreparedLocalCompanionServer({
       return false;
     }
   };
+  // The durable v1.0 consent verdict, read best-effort. `null` means the
+  // verdict could not be read right now — callers must treat that as unknown,
+  // never as either approved or pre-consent.
+  const incrementalConsentVerdict = async () => {
+    if (incrementalContribution === null) return null;
+    try {
+      const consent = (await incrementalContribution.inspect())?.consent;
+      return consent && typeof consent === "object" ? consent : null;
+    } catch {
+      return null;
+    }
+  };
+  // v0.1 prepared sets on a Mac whose uploads ride the approved v1.0
+  // incremental consent can never deliver — no scheduler drains that queue
+  // any more — so they only accumulate (observed live 2026-08-19: 73 pending
+  // jobs, dueNow 74, lastAcceptedAt null). One bounded pass per trigger
+  // converges such installs while keeping the oldest set: it is the instance
+  // the approve-once consent was reviewed against. Failures are swallowed —
+  // the next launch retries, and delivery state is never touched.
+  const maybeRetireSupersededPreparedSets = async () => {
+    const verdict = await incrementalConsentVerdict();
+    if (verdict?.approved !== true || verdict?.current !== true) return;
+    try {
+      await runSupersededContributionRetirement({});
+    } catch {
+      // Bounded cleanup only; the queue converges on a later pass.
+    }
+  };
   let automaticContributionInstanceLock = null;
   let automaticContributionInstanceLockRelease = null;
   let automaticContributionShutdown = null;
@@ -3222,6 +3273,9 @@ function createPreparedLocalCompanionServer({
           } catch {
             onError("incremental_contribution_start_failed");
           }
+          // Fire-and-forget: superseded v0.1 sets are cleanup, not readiness,
+          // so the snapshot never waits on (or fails with) the pass.
+          void maybeRetireSupersededPreparedSets().catch(() => {});
           snapshotState = { status: "ready", errorCode: null };
           announceSnapshotOutcome();
         } catch (error) {
@@ -3721,6 +3775,24 @@ function createPreparedLocalCompanionServer({
           response,
         );
         if (preparationRequest === null) return;
+        // The v0.1 review preparation exists only for the pre-consent
+        // ceremony. Once the v1.0 incremental consent is approved and
+        // current, a prepared set could never deliver — no scheduler drains
+        // the v0.1 queue for that model — so minting one would only strand
+        // disk and queue weight (observed live 2026-08-19: a 70-file set
+        // pending forever). A consent-version change reads current=false and
+        // legitimately prepares a fresh review; an unreadable verdict also
+        // proceeds, because refusing would deadlock a fresh Mac's ceremony.
+        const consentVerdict = await incrementalConsentVerdict();
+        if (consentVerdict?.approved === true
+            && consentVerdict?.current === true) {
+          send(
+            response,
+            409,
+            preparationErrorProjection(null, "consent_already_current"),
+          );
+          return;
+        }
         if (contributionPreparationInProgress) {
           send(
             response,
@@ -3924,6 +3996,10 @@ function createPreparedLocalCompanionServer({
         } catch {
           // deliberately ignored
         }
+        // The freshly current consent also supersedes any v0.1 sets beyond
+        // the just-reviewed provenance; converge now instead of waiting for
+        // the next launch. Same fire-and-forget contract as the run kick.
+        void maybeRetireSupersededPreparedSets().catch(() => {});
         return;
       }
       if (path === "/api/local/contribution/incremental-run") {

--- a/apps/web/public/app.js
+++ b/apps/web/public/app.js
@@ -19,6 +19,7 @@ import {
   createQuotaTimelineLookup,
   createRefreshPollingBudget,
   contributionReviewBootstrapAction,
+  contributionReviewPreparationPermitted,
   detectDeviationPeriods,
   diagnosticErrorCode,
   diagnosticReferenceSentence,
@@ -9397,11 +9398,24 @@ function maybeReviewPreparedSummary() {
     maybeReportContributionReviewUnavailable();
     return;
   }
-  contributionReviewUnavailableKey = null;
   if (action === "prepare") {
+    // Preparing mints a durable prepared set, so it needs more than "not
+    // known to be approved": the consent verdict must have been positively
+    // read as pre-consent this page load. The approved gate above is
+    // in-memory only — it starts false and a transient status-read failure
+    // leaves it false — and a set prepared on an approved Mac can never
+    // deliver, it only strands queue and disk weight (observed live
+    // 2026-08-19). An unknown verdict shows the explicit recovery instead;
+    // "Check again" re-reads the verdict before walking this path again.
+    if (!contributionReviewPreparationPermitted(incrementalSyncStatus)) {
+      maybeReportContributionReviewUnavailable();
+      return;
+    }
+    contributionReviewUnavailableKey = null;
     maybePrepareIncrementalReviewInstance();
     return;
   }
+  contributionReviewUnavailableKey = null;
   if (contributionSyncExactReview?.state === "ready") return;
   const key = preparedSummaryIdentity();
   if (key === null || key === contributionSyncAutoReviewedKey) return;
@@ -9524,6 +9538,8 @@ const INCREMENTAL_PREPARATION_ERROR_COPY = {
     "Privacy verification rejected the prepared data, so it was not queued or uploaded.",
   preparation_in_progress:
     "A local preparation is already running. Nothing has been uploaded.",
+  consent_already_current:
+    "This Mac already holds the current approval, so no new review instance is needed. Nothing was prepared or uploaded.",
   local_review_timed_out:
     "The local review did not finish within one minute. Choose Check again. If it repeats, reopen TiboTattle. Nothing was uploaded.",
   review_archive_invalid:
@@ -9592,6 +9608,11 @@ async function retryIncrementalReviewBootstrap() {
   contributionReviewUnavailableKey = null;
   setContributionReviewRecoveryVisible(false);
   try {
+    // Consent is re-read before the queue renders, exactly like page load:
+    // the prepare bootstrap requires a positively read pre-consent verdict,
+    // so a retry after a transient status failure must refresh that verdict
+    // or it would report unavailable forever.
+    await loadIncrementalSyncStatus();
     await withContributionReviewDeadline(
       refreshContributionSyncControls(generation),
     );

--- a/apps/web/public/data-client.js
+++ b/apps/web/public/data-client.js
@@ -228,7 +228,8 @@ const LOCAL_PREPARATION_ERROR_CODES = new Set([
   "review_archive_invalid",
   "prepared_spool_invalid",
   "preparation_in_progress",
-  "preparation_failed"
+  "preparation_failed",
+  "consent_already_current"
 ]);
 
 function array(value) {

--- a/apps/web/public/lib.js
+++ b/apps/web/public/lib.js
@@ -796,6 +796,22 @@ export function contributionReviewBootstrapAction(preview) {
 }
 
 /**
+ * Whether the silent bootstrap may PREPARE a new review instance. Preparing
+ * is the bootstrap's only step that mints durable state — a prepared set the
+ * v0.1 queue will hold until it delivers or is retired — so it additionally
+ * requires a positively read pre-consent verdict from the incremental sync
+ * status. An unreadable verdict must never prepare: on an approved Mac the
+ * set could never deliver and would only strand disk and queue weight
+ * (observed live 2026-08-19). A consent-version change reads approved with
+ * current=false and stays permitted — that ceremony needs its fresh review.
+ */
+export function contributionReviewPreparationPermitted(incrementalStatus) {
+  return incrementalStatus?.status === "available"
+    && !(incrementalStatus.consent?.approved === true
+      && incrementalStatus.consent?.current === true);
+}
+
+/**
  * A local preparation or exact-review read crosses native Keychain, SQLite,
  * and loopback boundaries. None may leave the contribution ceremony busy
  * forever: after one minute the page exposes its explicit retry so the caller

--- a/apps/web/test/lib.test.mjs
+++ b/apps/web/test/lib.test.mjs
@@ -24,6 +24,7 @@ import {
   createTelemetryEnvelope,
   detectDeviationPeriods,
   contributionReviewBootstrapAction,
+  contributionReviewPreparationPermitted,
   withContributionReviewDeadline,
   DEVIATION_DRIFT_THRESHOLD_PP,
   DEVIATION_MIN_DURATION_MS,
@@ -3139,6 +3140,45 @@ test("the local review bootstrap is independent of delivery scheduling", () => {
       contributionReviewBootstrapAction(preview),
       "unavailable",
       "a missing or unusable review must become an explicit recovery state",
+    );
+  }
+});
+
+test("the prepare bootstrap requires a positively read pre-consent verdict", () => {
+  assert.equal(
+    contributionReviewPreparationPermitted({
+      status: "available",
+      consent: { approved: false, current: false, consentedAt: null },
+    }),
+    true,
+    "a fresh Mac's ceremony prepares its review instance",
+  );
+  assert.equal(
+    contributionReviewPreparationPermitted({
+      status: "available",
+      consent: { approved: true, current: false, consentedAt: "2026-08-08T17:31:13.735Z" },
+    }),
+    true,
+    "a consent-version change legitimately needs a fresh review",
+  );
+  assert.equal(
+    contributionReviewPreparationPermitted({
+      status: "available",
+      consent: { approved: true, current: true, consentedAt: "2026-08-08T17:31:13.735Z" },
+    }),
+    false,
+    "an approved Mac never mints a set the v0.1 queue cannot deliver",
+  );
+  for (const status of [
+    null,
+    undefined,
+    { status: "unavailable", consent: { approved: false, current: false } },
+    { status: "not_configured", consent: { approved: false, current: false } },
+  ]) {
+    assert.equal(
+      contributionReviewPreparationPermitted(status),
+      false,
+      "an unreadable consent verdict must never prepare",
     );
   }
 });

--- a/src/application/local-contribution-sync-queue.js
+++ b/src/application/local-contribution-sync-queue.js
@@ -35,6 +35,7 @@ const MAXIMUM_RESERVED_UPLOAD_BYTES_PER_PASS = 256 * 1024 * 1024;
 const ACCEPTED_ARTIFACT_MAXIMUM_AGE_DAYS = 7;
 const ACCEPTED_ARTIFACT_MAXIMUM_RETAINED_SETS = 8;
 const ACCEPTED_ARTIFACT_MAXIMUM_RETIREMENTS_PER_PASS = 16;
+const SUPERSEDED_PENDING_MAXIMUM_RETIREMENTS_PER_PASS = 16;
 const RESERVED_UPLOAD_ENVELOPE_OVERHEAD_BYTES = 8 * 1024;
 const MINIMUM_WATCH_INTERVAL_SECONDS = 30;
 const MAXIMUM_WATCH_INTERVAL_SECONDS = 3600;
@@ -317,6 +318,134 @@ async function retireAcceptedContributionArtifacts({
       }]);
       await failpoint("before_queue_compaction", context);
       const removed = repository.deleteAcceptedSet(row.prepared_set_id);
+      if (removed.changes !== Number(row.total_jobs)) {
+        fail("retirement_invalid");
+      }
+      retiredSets += 1;
+      retiredJobs += removed.changes;
+      await failpoint("after_queue_compaction", context);
+    }
+    return Object.freeze({
+      retiredSets,
+      retiredJobs,
+      interrupted: signal?.aborted === true,
+      networkActivity: false,
+    });
+  } finally {
+    repository.close();
+  }
+}
+
+/**
+ * Retire pending prepared sets that a newer consent model has superseded.
+ *
+ * The v0.1 prepared-set queue drains only through its own delivery
+ * schedulers; on a Mac whose uploads ride the v1.0 incremental consent those
+ * schedulers never run, so every still-pending v0.1 set is disk and queue
+ * weight that can never deliver (observed live 2026-08-19: a 70-file
+ * pre-consent set plus the ceremony set, pending forever). The caller gates
+ * this pass on that superseding consent being approved and current.
+ *
+ * Two retentions are deliberate. The set holding the earliest still-
+ * deliverable job is always kept: the exact review reads exactly that job,
+ * so that set is the real instance the local approve-once consent was
+ * granted against — the same provenance role the accepted-retirement pass
+ * protects. And any set with an accepted, in-flight, or rejected job is left
+ * alone: accepted rows are the page's upload-authority evidence and belong
+ * to the accepted pass.
+ *
+ * Crash ordering matches the accepted pass: artifacts are removed before
+ * queue rows, so a crash can leave rows whose set is gone — the next pass
+ * deletes them, and discovery can never re-queue a set whose files no longer
+ * exist — but never a still-present set without its dedupe rows.
+ */
+async function retireSupersededPendingContributionArtifacts({
+  preparedSpoolDirectory,
+  reviewArchiveDirectory,
+  queueFile = undefined,
+  protectedPreparedSetIds = [],
+  maximumRetirements =
+    SUPERSEDED_PENDING_MAXIMUM_RETIREMENTS_PER_PASS,
+  now = () => new Date(),
+  signal = undefined,
+  failpoint = async () => {},
+} = {}, runtime) {
+  if (!Array.isArray(protectedPreparedSetIds)
+      || protectedPreparedSetIds.length > 8
+      || protectedPreparedSetIds.some((value) => !SHA256.test(value))
+      || new Set(protectedPreparedSetIds).size
+        !== protectedPreparedSetIds.length
+      || !integer(maximumRetirements, 1, 64)
+      || typeof failpoint !== "function"
+      || (signal !== undefined && !(signal instanceof AbortSignal))) {
+    fail("configuration_invalid");
+  }
+  const preparedRoot = await Reflect.apply(
+    runtime.storage.prepareRetentionRoot,
+    undefined,
+    [preparedSpoolDirectory],
+  );
+  const reviewRoot = await Reflect.apply(
+    runtime.storage.prepareRetentionRoot,
+    undefined,
+    [reviewArchiveDirectory],
+  );
+  const selectedQueueFile = queueFile
+    ?? defaultContributionSyncQueueFile(runtime);
+  const repository = await openQueueRepository(selectedQueueFile, now, runtime);
+  try {
+    if (signal?.aborted) {
+      return Object.freeze({
+        retiredSets: 0,
+        retiredJobs: 0,
+        interrupted: true,
+        networkActivity: false,
+      });
+    }
+    // One extra row beyond the bound and the protections, so a full page of
+    // protected sets can never starve the candidates behind them.
+    const queryLimit = maximumRetirements
+      + protectedPreparedSetIds.length
+      + 1;
+    const rows = repository.inactivePendingSets(queryLimit);
+    const protectedIds = new Set(protectedPreparedSetIds);
+    const firstReviewSetId = repository.oldestPreparedSetId();
+    const candidates = rows.filter((row) => (
+      row.prepared_set_id !== firstReviewSetId
+      && !protectedIds.has(row.prepared_set_id)
+    )).slice(0, maximumRetirements);
+    let retiredSets = 0;
+    let retiredJobs = 0;
+    for (const row of candidates) {
+      if (signal?.aborted) break;
+      if (!SHA256.test(row.prepared_set_id)
+          || !SET_NAME.test(row.set_name)
+          || !integer(Number(row.total_jobs), 1, MAX_QUEUE_JOBS)
+          || iso(row.enqueued_at) !== row.enqueued_at) {
+        fail("retirement_invalid");
+      }
+      const suffix = row.set_name.slice("prepared-set-".length);
+      const reviewName = `review-${suffix}`;
+      if (!REVIEW_NAME.test(reviewName)) fail("retirement_invalid");
+      const context = Object.freeze({
+        preparedSetId: row.prepared_set_id,
+        setName: row.set_name,
+        reviewName,
+      });
+      await failpoint("before_artifact_retirement", context);
+      await Reflect.apply(runtime.storage.retireFlatDirectory, undefined, [{
+        root: preparedRoot,
+        name: row.set_name,
+        maximumEntries: 128,
+      }]);
+      await failpoint("after_prepared_retirement", context);
+      await Reflect.apply(runtime.storage.retireFlatDirectory, undefined, [{
+        root: reviewRoot,
+        name: reviewName,
+        maximumEntries: 4,
+      }]);
+      await failpoint("before_queue_compaction", context);
+      const removed = repository.deleteInactiveSet(row.prepared_set_id);
       if (removed.changes !== Number(row.total_jobs)) {
         fail("retirement_invalid");
       }
@@ -1100,6 +1229,7 @@ export function createLocalContributionSyncQueueContext({
     ACCEPTED_ARTIFACT_MAXIMUM_AGE_DAYS,
     ACCEPTED_ARTIFACT_MAXIMUM_RETAINED_SETS,
     ACCEPTED_ARTIFACT_MAXIMUM_RETIREMENTS_PER_PASS,
+    SUPERSEDED_PENDING_MAXIMUM_RETIREMENTS_PER_PASS,
     CONTRIBUTION_SYNC_EXACT_REVIEW_SCHEMA,
     CONTRIBUTION_SYNC_PREVIEW_SCHEMA,
     CONTRIBUTION_SYNC_QUEUE_LIMITS,
@@ -1120,6 +1250,8 @@ export function createLocalContributionSyncQueueContext({
       inspectNextContributionSyncUpload(options, runtime),
     retireAcceptedContributionArtifacts: (options) =>
       retireAcceptedContributionArtifacts(options, runtime),
+    retireSupersededPendingContributionArtifacts: (options) =>
+      retireSupersededPendingContributionArtifacts(options, runtime),
     runContributionSyncQueueOnce: (options) =>
       runContributionSyncQueueOnce(options, runtime),
     runContributionSyncQueueWatch: (options) =>

--- a/src/contribution-sync-queue.js
+++ b/src/contribution-sync-queue.js
@@ -29,6 +29,8 @@ export const ACCEPTED_ARTIFACT_MAXIMUM_RETAINED_SETS =
   contributionSyncQueue.ACCEPTED_ARTIFACT_MAXIMUM_RETAINED_SETS;
 export const ACCEPTED_ARTIFACT_MAXIMUM_RETIREMENTS_PER_PASS =
   contributionSyncQueue.ACCEPTED_ARTIFACT_MAXIMUM_RETIREMENTS_PER_PASS;
+export const SUPERSEDED_PENDING_MAXIMUM_RETIREMENTS_PER_PASS =
+  contributionSyncQueue.SUPERSEDED_PENDING_MAXIMUM_RETIREMENTS_PER_PASS;
 export const CONTRIBUTION_SYNC_EXACT_REVIEW_SCHEMA =
   contributionSyncQueue.CONTRIBUTION_SYNC_EXACT_REVIEW_SCHEMA;
 export const CONTRIBUTION_SYNC_PREVIEW_SCHEMA =
@@ -57,6 +59,8 @@ export const inspectNextContributionSyncUpload =
   contributionSyncQueue.inspectNextContributionSyncUpload;
 export const retireAcceptedContributionArtifacts =
   contributionSyncQueue.retireAcceptedContributionArtifacts;
+export const retireSupersededPendingContributionArtifacts =
+  contributionSyncQueue.retireSupersededPendingContributionArtifacts;
 export const runContributionSyncQueueOnce =
   contributionSyncQueue.runContributionSyncQueueOnce;
 export const runContributionSyncQueueWatch =

--- a/src/platform/local-contribution-sync-queue-storage.js
+++ b/src/platform/local-contribution-sync-queue-storage.js
@@ -557,6 +557,54 @@ export function createLocalContributionSyncQueueStorageContext({
       `).all(limit);
     }
 
+    // The first-review provenance has no durable record of its own under the
+    // approve-once flow, but it is recoverable: the exact review always reads
+    // the oldest still-deliverable job (the same states and order as
+    // nextQueuedJob), so the set holding that job is the instance the local
+    // consent was granted against.
+    function oldestPreparedSetId() {
+      const row = database.prepare(`
+        SELECT prepared_set_id
+          FROM contribution_jobs
+         WHERE state IN ('pending', 'retryable')
+         GROUP BY prepared_set_id
+         ORDER BY MIN(created_at) ASC, prepared_set_id ASC
+         LIMIT 1
+      `).get();
+      return row?.prepared_set_id ?? null;
+    }
+
+    // Sets whose every job is still awaiting delivery. Any accepted row is
+    // upload evidence and any in-flight or rejected row is delivery history;
+    // both keep the whole set out of superseded-pending retirement.
+    function inactivePendingSets(limit) {
+      return database.prepare(`
+        SELECT prepared_set_id, set_name,
+               COUNT(*) AS total_jobs,
+               MIN(created_at) AS enqueued_at
+          FROM contribution_jobs
+         GROUP BY prepared_set_id, set_name
+        HAVING SUM(CASE WHEN state IN ('pending', 'retryable')
+                        THEN 0 ELSE 1 END) = 0
+           AND total_jobs > 0
+         ORDER BY enqueued_at ASC, prepared_set_id ASC
+         LIMIT ?
+      `).all(limit);
+    }
+
+    function deleteInactiveSet(preparedSetId) {
+      return transaction(database, () => database.prepare(`
+        DELETE FROM contribution_jobs
+         WHERE prepared_set_id = ?
+           AND NOT EXISTS (
+             SELECT 1
+               FROM contribution_jobs AS held
+              WHERE held.prepared_set_id = ?
+                AND held.state NOT IN ('pending', 'retryable')
+           )
+      `).run(preparedSetId, preparedSetId));
+    }
+
     function deleteAcceptedSet(preparedSetId) {
       return transaction(database, () => database.prepare(`
         DELETE FROM contribution_jobs
@@ -575,10 +623,13 @@ export function createLocalContributionSyncQueueStorageContext({
       claimJob,
       close: () => database.close(),
       deleteAcceptedSet,
+      deleteInactiveSet,
       enqueueJob,
       finishAccepted,
       finishFailed,
+      inactivePendingSets,
       nextQueuedJob,
+      oldestPreparedSetId,
       preparedSetNextAttemptAt,
       preparedSetStatus,
       readyJobs,

--- a/test/contribution-sync-queue.test.js
+++ b/test/contribution-sync-queue.test.js
@@ -23,6 +23,7 @@ import {
   inspectNextContributionSyncUpload,
   RETRY_BACKOFF_POLICY,
   retireAcceptedContributionArtifacts,
+  retireSupersededPendingContributionArtifacts,
   runContributionSyncQueueOnce,
   runContributionSyncQueueWatch,
   setContributionSyncPaused,
@@ -1308,6 +1309,219 @@ test("bounded retirement eventually compacts accepted sets beyond one query wind
     1,
   );
   finalDatabase.close();
+});
+
+// Superseded-pending fixture: sets are created and enqueued one at a time
+// with an advancing clock, because the first-review protection is derived
+// from enqueue order — every set enqueued in one preview pass would share
+// one created_at.
+async function supersededFixture(definitions) {
+  const root = await mkdtemp(join(tmpdir(), "usage-monitor-superseded-"));
+  const preparedRoot = join(root, "prepared");
+  const reviewRoot = join(root, "reviews");
+  const privateRoot = join(root, "private");
+  await mkdir(preparedRoot, { mode: 0o700 });
+  await mkdir(reviewRoot, { mode: 0o700 });
+  await mkdir(privateRoot, { mode: 0o700 });
+  const queueFile = join(privateRoot, "sync.sqlite3");
+  let tick = Date.parse("2026-08-06T23:00:00.000Z");
+  const sets = {};
+  for (const [key, uuid, index] of definitions) {
+    const setName = `prepared-set-${uuid}`;
+    const prepared = await createPreparedSet(preparedRoot, { setName, index });
+    await createReviewForPreparedSet(reviewRoot, setName);
+    const enqueuedAt = tick;
+    const preview = await inspectNextContributionSyncUpload({
+      directory: preparedRoot,
+      queueFile,
+      now: () => new Date(enqueuedAt),
+    });
+    assert.equal(preview.state, "ready");
+    tick += 60_000;
+    sets[key] = {
+      setName,
+      preparedSetId: preparedContributionSetId(prepared.manifest),
+    };
+  }
+  return { root, preparedRoot, reviewRoot, queueFile, sets };
+}
+
+test("superseded pending retirement keeps the first-review provenance and is crash-resumable", async () => {
+  const value = await supersededFixture([
+    ["ceremony", "00000000-0000-4000-8000-000000000031", 31],
+    ["strandedA", "00000000-0000-4000-8000-000000000032", 32],
+    ["strandedB", "00000000-0000-4000-8000-000000000033", 33],
+  ]);
+  const { preparedRoot, reviewRoot, queueFile, sets } = value;
+
+  await assert.rejects(
+    retireSupersededPendingContributionArtifacts({
+      preparedSpoolDirectory: preparedRoot,
+      reviewArchiveDirectory: reviewRoot,
+      queueFile,
+      failpoint: async (name, context) => {
+        if (name === "after_prepared_retirement"
+            && context.preparedSetId === sets.strandedA.preparedSetId) {
+          throw new Error("simulated retirement crash");
+        }
+      },
+    }),
+    /simulated retirement crash/u,
+  );
+  // The crash left rows whose prepared directory is gone. The preview stays
+  // healthy through the window because the protected first-review job still
+  // sorts first, and discovery can never re-queue the removed files.
+  await assert.rejects(
+    lstat(join(preparedRoot, sets.strandedA.setName)),
+    (error) => error?.code === "ENOENT",
+  );
+  let database = new DatabaseSync(queueFile, { readOnly: true });
+  assert.equal(
+    database.prepare(`
+      SELECT COUNT(*) AS count
+        FROM contribution_jobs
+       WHERE prepared_set_id = ?
+    `).get(sets.strandedA.preparedSetId).count,
+    1,
+  );
+  database.close();
+  const crashedPreview = await inspectNextContributionSyncUpload({
+    directory: preparedRoot,
+    queueFile,
+    now: () => new Date("2026-08-07T00:00:00.000Z"),
+  });
+  assert.equal(crashedPreview.state, "ready");
+
+  const resumed = await retireSupersededPendingContributionArtifacts({
+    preparedSpoolDirectory: preparedRoot,
+    reviewArchiveDirectory: reviewRoot,
+    queueFile,
+  });
+  assert.equal(resumed.retiredSets, 2);
+  assert.equal(resumed.retiredJobs, 2);
+  assert.deepEqual(await readdir(preparedRoot), [sets.ceremony.setName]);
+  assert.deepEqual(await readdir(reviewRoot), [
+    sets.ceremony.setName.replace("prepared-set-", "review-"),
+  ]);
+  database = new DatabaseSync(queueFile, { readOnly: true });
+  assert.deepEqual(
+    database.prepare(`
+      SELECT prepared_set_id, state FROM contribution_jobs
+    `).all().map((row) => ({ ...row })),
+    [{ prepared_set_id: sets.ceremony.preparedSetId, state: "pending" }],
+  );
+  database.close();
+
+  // Converged installs stay converged: repeated passes retire nothing, and
+  // the retained provenance still previews for a later consent ceremony.
+  const idle = await retireSupersededPendingContributionArtifacts({
+    preparedSpoolDirectory: preparedRoot,
+    reviewArchiveDirectory: reviewRoot,
+    queueFile,
+  });
+  assert.equal(idle.retiredSets, 0);
+  assert.equal(idle.retiredJobs, 0);
+  const preview = await inspectNextContributionSyncUpload({
+    directory: preparedRoot,
+    queueFile,
+    now: () => new Date("2026-08-07T01:00:00.000Z"),
+  });
+  assert.equal(preview.state, "ready");
+  assert.equal(preview.discoveredSets, 1);
+});
+
+test("superseded pending retirement is bounded per pass and never touches delivered or delivering sets", async () => {
+  const value = await supersededFixture([
+    ["oldest", "00000000-0000-4000-8000-000000000041", 41],
+    ["accepted", "00000000-0000-4000-8000-000000000042", 42],
+    ["inFlight", "00000000-0000-4000-8000-000000000043", 43],
+    ["rejected", "00000000-0000-4000-8000-000000000044", 44],
+    ["strandedA", "00000000-0000-4000-8000-000000000045", 45],
+    ["strandedB", "00000000-0000-4000-8000-000000000046", 46],
+    ["strandedC", "00000000-0000-4000-8000-000000000047", 47],
+  ]);
+  const { preparedRoot, reviewRoot, queueFile, sets } = value;
+  // Delivery-state surgery, exactly like the accepted-retention test: any
+  // accepted row is upload-authority evidence and any in-flight or rejected
+  // row is delivery history, so those whole sets must survive every pass.
+  let database = new DatabaseSync(queueFile);
+  database.prepare(`
+    UPDATE contribution_jobs
+       SET state = 'accepted',
+           accepted_at = '2026-08-06T23:30:00.000Z',
+           contribution_id = ?
+     WHERE prepared_set_id = ?
+  `).run(ACCEPTED_ID, sets.accepted.preparedSetId);
+  database.prepare(`
+    UPDATE contribution_jobs SET state = 'in_flight'
+     WHERE prepared_set_id = ?
+  `).run(sets.inFlight.preparedSetId);
+  database.prepare(`
+    UPDATE contribution_jobs SET state = 'rejected'
+     WHERE prepared_set_id = ?
+  `).run(sets.rejected.preparedSetId);
+  database.close();
+
+  // Pass one: bounded to two retirements, with strandedA additionally under
+  // the caller's protection. Only strandedB and strandedC may go.
+  const first = await retireSupersededPendingContributionArtifacts({
+    preparedSpoolDirectory: preparedRoot,
+    reviewArchiveDirectory: reviewRoot,
+    queueFile,
+    protectedPreparedSetIds: [sets.strandedA.preparedSetId],
+    maximumRetirements: 2,
+  });
+  assert.equal(first.retiredSets, 2);
+  assert.equal(first.retiredJobs, 2);
+  assert.equal(
+    (await lstat(join(preparedRoot, sets.strandedA.setName))).isDirectory(),
+    true,
+  );
+
+  // Pass two: without the protection the remaining stranded set converges;
+  // the oldest set is still held back as the first-review provenance.
+  const second = await retireSupersededPendingContributionArtifacts({
+    preparedSpoolDirectory: preparedRoot,
+    reviewArchiveDirectory: reviewRoot,
+    queueFile,
+    maximumRetirements: 2,
+  });
+  assert.equal(second.retiredSets, 1);
+  assert.equal(second.retiredJobs, 1);
+  const third = await retireSupersededPendingContributionArtifacts({
+    preparedSpoolDirectory: preparedRoot,
+    reviewArchiveDirectory: reviewRoot,
+    queueFile,
+    maximumRetirements: 2,
+  });
+  assert.equal(third.retiredSets, 0);
+
+  const retainedNames = [
+    sets.oldest.setName,
+    sets.accepted.setName,
+    sets.inFlight.setName,
+    sets.rejected.setName,
+  ].sort();
+  assert.deepEqual((await readdir(preparedRoot)).sort(), retainedNames);
+  assert.deepEqual((await readdir(reviewRoot)).sort(), retainedNames.map(
+    (name) => name.replace("prepared-set-", "review-"),
+  ));
+  database = new DatabaseSync(queueFile, { readOnly: true });
+  assert.deepEqual(
+    database.prepare(`
+      SELECT state FROM contribution_jobs ORDER BY state
+    `).all().map((row) => row.state),
+    ["accepted", "in_flight", "pending", "rejected"],
+  );
+  database.close();
+  // The accepted evidence the dashboard's upload-authority claim reads from
+  // survives retirement.
+  const status = await inspectContributionSyncQueue({
+    queueFile,
+    now: () => new Date("2026-08-07T02:00:00.000Z"),
+  });
+  assert.equal(status.counts.accepted, 1);
+  assert.equal(status.lastAcceptedAt, "2026-08-06T23:30:00.000Z");
 });
 
 test("queue refuses symlinked or non-owner-only database locations", async (t) => {

--- a/test/contribution-v1-companion-routes.test.js
+++ b/test/contribution-v1-companion-routes.test.js
@@ -1310,3 +1310,217 @@ test("the credential reset falls back to attribute delete when the read is broke
     await rm(files.root, { recursive: true });
   }
 });
+
+test("the pre-consent review preparation refuses once the v1.0 consent is current", async () => {
+  const files = await fixture();
+  const controller = fakeIncrementalController();
+  let preparations = 0;
+  const app = await startApp(files, {
+    incrementalContributionController: controller,
+    contributionPreparationRunner: async () => {
+      preparations += 1;
+      throw new Error("no coverage in this fixture");
+    },
+  });
+  try {
+    const base = `http://127.0.0.1:${app.port}`;
+    const headers = {
+      "Content-Type": "application/json",
+      "X-Usage-Monitor-Local": "1",
+      Origin: base,
+    };
+    const prepare = () => fetch(`${base}/api/local/contribution/prepare`, {
+      method: "POST",
+      headers,
+      body: JSON.stringify({ lookbackHours: 24 }),
+    });
+
+    // Pre-consent, the ceremony's silent bootstrap reaches preparation: the
+    // stub throws, which is proof the route ran it.
+    const preConsent = await prepare();
+    assert.equal(preConsent.status, 500);
+    assert.equal((await preConsent.json()).errorCode, "preparation_failed");
+    assert.equal(preparations, 1);
+
+    // Approved and current: a prepared set could never deliver — no
+    // scheduler drains the v0.1 queue for this consent model — so the route
+    // refuses before any set is minted (the owner install grew a stranded
+    // 70-file set exactly this way, observed 2026-08-19).
+    await controller.approve();
+    const refused = await prepare();
+    assert.equal(refused.status, 409);
+    const refusal = await refused.json();
+    assert.equal(
+      refusal.schemaVersion,
+      "local-contribution-preparation-error-v0.1",
+    );
+    assert.equal(refusal.errorCode, "consent_already_current");
+    assert.equal(refusal.status, "failed");
+    assert.equal(
+      preparations,
+      1,
+      "an approved Mac never mints a new prepared set",
+    );
+  } finally {
+    await app.close();
+    await rm(files.root, { recursive: true });
+  }
+});
+
+test("a consent-version change still prepares the fresh review its ceremony needs", async () => {
+  const files = await fixture();
+  // Approved under an older consent version: approved=true, current=false.
+  // The re-approval ceremony legitimately needs one fresh local review
+  // instance, so preparation must stay reachable.
+  const staleController = {
+    async start() {},
+    async stop() {},
+    async approve() {
+      throw new Error("unexpected approve");
+    },
+    async resume() {
+      throw new Error("unexpected resume");
+    },
+    async inspect() {
+      return {
+        schemaVersion: "incremental-contribution-sync-status-v1.0",
+        contractVersion: "telemetry-contribution-v1.0",
+        configured: true,
+        settingsAvailable: true,
+        consent: {
+          approved: true,
+          current: false,
+          consentedAt: "2026-08-08T17:31:13.735Z",
+        },
+        paused: false,
+        pausedReason: null,
+        running: false,
+        progress: null,
+        lastAttemptAt: null,
+        nextAttemptAt: null,
+        lastOutcome: null,
+      };
+    },
+  };
+  let preparations = 0;
+  const app = await startApp(files, {
+    incrementalContributionController: staleController,
+    contributionPreparationRunner: async () => {
+      preparations += 1;
+      throw new Error("no coverage in this fixture");
+    },
+  });
+  try {
+    const base = `http://127.0.0.1:${app.port}`;
+    const response = await fetch(`${base}/api/local/contribution/prepare`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "X-Usage-Monitor-Local": "1",
+        Origin: base,
+      },
+      body: JSON.stringify({ lookbackHours: 24 }),
+    });
+    assert.equal(response.status, 500);
+    assert.equal((await response.json()).errorCode, "preparation_failed");
+    assert.equal(preparations, 1);
+  } finally {
+    await app.close();
+    await rm(files.root, { recursive: true });
+  }
+});
+
+test("an approved consent's startup and approval converge superseded v0.1 sets", async () => {
+  const files = await fixture();
+  const controller = fakeIncrementalController();
+  const retirements = [];
+  const retirementRunner = async () => {
+    retirements.push("pass");
+    return {
+      retiredSets: 0,
+      retiredJobs: 0,
+      interrupted: false,
+      networkActivity: false,
+    };
+  };
+
+  // Pre-consent, nothing is superseded and nothing may be retired: the
+  // pending set IS the ceremony's review bootstrap.
+  let app = await startApp(files, {
+    incrementalContributionController: controller,
+    supersededContributionRetirementRunner: retirementRunner,
+  });
+  try {
+    await app.snapshotReady;
+    await settleKicks();
+    assert.equal(retirements.length, 0, "pre-consent startup retires nothing");
+  } finally {
+    await app.close();
+  }
+
+  // The approval itself converges the queue in this process, without waiting
+  // for a relaunch — the same fire-and-forget contract as the first-pass kick.
+  const reviewedPayload = exactReviewContribution();
+  app = await startApp(files, {
+    incrementalContributionController: controller,
+    supersededContributionRetirementRunner: retirementRunner,
+    contributionSyncExactReviewProvider: async () => ({
+      schemaVersion: "contribution-sync-exact-review-v0.1",
+      state: "ready",
+      networkActivity: false,
+      discoveredSets: 1,
+      enqueued: 0,
+      payloadBytes: Buffer.byteLength(JSON.stringify(reviewedPayload), "utf8"),
+      payload: reviewedPayload,
+      reviewBinding: {
+        jobId: REVIEW_JOB_ID,
+        contributionSha256: REVIEW_SHA256,
+      },
+    }),
+  });
+  try {
+    await app.snapshotReady;
+    const base = `http://127.0.0.1:${app.port}`;
+    const headers = {
+      "Content-Type": "application/json",
+      "X-Usage-Monitor-Local": "1",
+      Origin: base,
+    };
+    const review = await fetch(
+      `${base}/api/local/contribution/sync-inspect-exact`,
+      { method: "POST", headers, body: "{}" },
+    ).then((response) => response.json());
+    const approve = await fetch(
+      `${base}/api/local/contribution/incremental-approve`,
+      {
+        method: "POST",
+        headers,
+        body: JSON.stringify({ reviewToken: review.reviewToken }),
+      },
+    );
+    assert.equal(approve.status, 200);
+    await settleKicks();
+    assert.equal(
+      retirements.length,
+      1,
+      "the approval converges the queue without a relaunch",
+    );
+  } finally {
+    await app.close();
+  }
+
+  // Every later launch of the approved Mac runs one bounded pass, which is
+  // how installs that predate this fix (73 stranded jobs) converge.
+  app = await startApp(files, {
+    incrementalContributionController: controller,
+    supersededContributionRetirementRunner: retirementRunner,
+  });
+  try {
+    await app.snapshotReady;
+    await settleKicks();
+    assert.equal(retirements.length, 2, "an approved startup runs one pass");
+  } finally {
+    await app.close();
+    await rm(files.root, { recursive: true });
+  }
+});


### PR DESCRIPTION
On a v1.0-incremental account the v0.1 prepared-set delivery path never drains, so prepared sets only accumulated (observed live: 73 pending jobs from one pre-consent preparation split into 70 batches, dueNow 74, nothing ever accepted; fresh accounts stranded their ceremony set the same way).

Three changes: a bounded retirement pass (≤16 sets/pass, artifacts-before-rows crash ordering) that protects the earliest still-deliverable set — the exact instance the approve-once consent was granted against — and never touches accepted/in-flight/rejected rows; the companion prepare route answers 409 consent_already_current when the v1.0 verdict is positively approved+current (unreadable verdicts still prepare, so a fresh Mac cannot deadlock); and the page's silent bootstrap requires a positively read pre-consent verdict before minting durable state.

Dry-run against a copy of the real inflated queue converged 73→protected-set-only in one pass, second pass a no-op. Suites on the rebased tree: queue+companion+preparation 59/59, UI 308/308. Fresh-Mac bootstrap behavior (prepared-spool ENOENT) explicitly preserved and re-tested.

Note: touches workload sources — R7 receipts regenerate once after the last follow-up in this set lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)