### PR TITLE
fix(web): outrank the summary-facts base rules for the consent review facts

### DIFF
--- a/apps/web/public/styles.css
+++ b/apps/web/public/styles.css
@@ -2260,15 +2260,19 @@ h2 { font-size: clamp(2rem, 3.8vw, 3.25rem); }
    lives in the narrow consent column, where three side-by-side tiles wrap
    one word per line; each fact is instead a full-width row with the label
    on the start edge and the value on the end edge. */
-.incremental-review-facts { grid-template-columns: 1fr; margin: 0; }
-.incremental-review-facts > div {
+/* Compound selectors on purpose: the element carries both classes and the
+   .summary-facts base rules are declared BELOW this block, so a lone
+   .incremental-review-facts override loses the cascade at equal specificity
+   (which is exactly how the 4-track squeeze shipped twice). */
+.summary-facts.incremental-review-facts { grid-template-columns: 1fr; margin: 0; }
+.summary-facts.incremental-review-facts > div {
   display: flex;
   align-items: baseline;
   justify-content: space-between;
   gap: var(--space-2);
 }
-.incremental-review-facts dt { flex-shrink: 0; }
-.incremental-review-facts dd { margin: 0; text-align: end; }
+.summary-facts.incremental-review-facts dt { flex-shrink: 0; }
+.summary-facts.incremental-review-facts dd { margin: 0; text-align: end; }
 .summary-facts { display: grid; grid-template-columns: repeat(4, 1fr); gap: var(--space-2); margin: var(--space-5) 0; }
 .sync-facts { grid-template-columns: repeat(3, 1fr); }
 .summary-facts > div { min-width: 0; padding: var(--pad-tile); border: 1px solid var(--line); border-radius: var(--radius-sm); background: var(--surface-quiet); }


### PR DESCRIPTION
The consent card's review facts carry both .summary-facts and .incremental-review-facts, and the base rules are declared below the overrides — so at equal specificity the base repeat(4, 1fr) always won and the three facts have rendered in four narrow tracks since the card shipped. A first flex-row fix (dogfood 1015) made the wrap catastrophic on a tester's fresh install (one letter per line). Compound selectors win the cascade regardless of declaration order; verified visually against the packaged stylesheet in a 320px harness, and shipped live as dogfood 1016.

UI suite green on the rebased tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)