### PR TITLE
fix(accounting): stream the calibration corpus and end the RSS-deferral livelock

### DIFF
--- a/apps/web/public/app.js
+++ b/apps/web/public/app.js
@@ -149,6 +149,13 @@ function paginateCacheImpactRows(rows, state, signature) {
   };
 }
 let localCompanionHealth = null;
+// The last refresh run's accounting-rebuild deferral, read from the local
+// refresh status alongside each dashboard load. A rebuild that keeps missing
+// its memory budget is otherwise invisible here: the refresh SUCCEEDS, the
+// cache-derived figures simply never appear, and the 2026-08-19 livelock ran
+// for hours behind that silence. Only a successful status read updates this,
+// so a transient poll failure cannot clear an honest note.
+let accountingRebuildDeferral = null;
 // This is an optional, short-lived rendering hint from the public health
 // endpoint. The Worker remains authoritative; a missing or stale health read
 // never blocks a legitimate sign-in, while an explicit paused state avoids
@@ -8573,8 +8580,37 @@ function renderAccountingSideChatDetails(estimate) {
   }
 }
 
+/**
+ * Say WHY the replay-safe accounting artifacts are missing when the rebuild
+ * keeps being postponed, instead of leaving bare zero cards. The rebuild
+ * defers softly when it would push the app past its memory ceiling; one miss
+ * is routine backoff, but a streak with no cache on disk means the reader is
+ * looking at an empty cost view with a cause the app knows and was not
+ * saying (the 2026-08-19 livelock recurred hourly for a whole afternoon).
+ */
+function renderAccountingRebuildDeferral(data) {
+  const element = $("#accounting-rebuild-deferred");
+  if (!element) return;
+  const deferral = accountingRebuildDeferral;
+  const persistent = Number.isSafeInteger(deferral?.consecutive)
+    && deferral.consecutive >= 2;
+  // With a retained cache the figures still render; the honest-empty copy is
+  // for the state where no replay-safe cache exists at all.
+  const cacheMissing = data?.accounting?.accountingCacheStatus === "unavailable";
+  if (!persistent || !cacheMissing) {
+    element.hidden = true;
+    setRawText(element, "");
+    return;
+  }
+  element.hidden = false;
+  setLocalizedText(element, "accounting.rebuildDeferred.persistent", {
+    count: formatNumber(deferral.consecutive),
+  });
+}
+
 function renderAccounting(data) {
   syncAccountingPeriodControls(data);
+  renderAccountingRebuildDeferral(data);
   const accounting = accountingPeriod(data);
   if (accounting === null) {
     clear($("#accounting-summary"));
@@ -9771,15 +9807,20 @@ async function loadLocalDashboard() {
         }
       }
     };
-    const [data, sync, localHealth, onboarding, speedPreference] = await Promise.all([
+    const [data, sync, localHealth, onboarding, speedPreference, refreshState] = await Promise.all([
       loadDashboardData(),
       syncState,
       localClient.health().catch(() => null),
       localClient.onboarding().catch(() => null),
-      localClient.fastModePreference().catch(() => null)
+      localClient.fastModePreference().catch(() => null),
+      localClient.refreshStatus().catch(() => null)
     ]);
     localCompanionHealth = localHealth;
     fastModePreference = speedPreference;
+    if (refreshState !== null) {
+      accountingRebuildDeferral =
+        refreshState?.refresh?.result?.accountingRebuildDeferred ?? null;
+    }
     renderDashboard(data);
     // Health arrives after the first paint, and the sign-in controls are gated
     // on a capability it carries. Without this re-render they keep the

--- a/apps/web/public/index.html
+++ b/apps/web/public/index.html
@@ -728,6 +728,7 @@
           </div>
         </div>
         <ul class="evidence-warnings" id="accounting-warnings" hidden></ul>
+        <p class="evidence-warning" id="accounting-rebuild-deferred" hidden></p>
         <div class="metric-grid accounting-summary" id="accounting-summary"></div>
         <div class="two-column accounting-component-grid">
           <article class="panel">

--- a/apps/web/public/localization.js
+++ b/apps/web/public/localization.js
@@ -267,6 +267,15 @@ export const WEB_MESSAGES = Object.freeze({
     "索引将在下次更新时继续；完成时间未知。",
     "La indexación continúa en la próxima actualización; no se conoce la hora de finalización.",
   ],
+  // Why the replay-safe accounting artifacts are missing when the rebuild has
+  // deferred repeatedly: the rebuild misses its memory ceiling, softly, and
+  // retries — this names the cause and the streak instead of showing bare
+  // zeros with no explanation.
+  "accounting.rebuildDeferred.persistent": [
+    "The fuller cost-accounting rebuild has been postponed {count} times in a row because it would push the app past its memory ceiling. It retries automatically; restarting the menu-bar app frees memory and usually lets the next attempt complete.",
+    "更完整的成本核算重建已连续推迟 {count} 次，因为它会使应用超出内存上限。应用会自动重试；重启菜单栏应用可释放内存，通常能让下一次尝试完成。",
+    "La reconstrucción más completa de la contabilidad de costes se ha pospuesto {count} veces seguidas porque llevaría la aplicación más allá de su límite de memoria. Se reintenta automáticamente; reiniciar la aplicación de la barra de menús libera memoria y normalmente permite completar el siguiente intento.",
+  ],
  "accounting.pricing.partialCoverage": ["{percent} of usage changes have a reviewed price; coverage is partial.", "使用变化中有 {percent} 使用了经审核的价格；覆盖率不完整。", "El {percent} de los cambios de uso tiene un precio revisado; la cobertura es parcial."],
  "accounting.pricing.coverageReviewed": ["All usage changes in this period have reviewed pricing.", "此期间的所有使用变化都有经审核的价格。", "Todos los cambios de uso de este período tienen precios revisados."],
   "accounting.pricing.coverageShort": ["{percent} coverage", "{percent} 覆盖率", "{percent} de cobertura"],

--- a/src/local-companion-refresh.js
+++ b/src/local-companion-refresh.js
@@ -920,6 +920,12 @@ export function createLocalCollectorRefreshRunner({
   // rebuild defers, the FULL rebuild is skipped (the retained cache is served)
   // until this instant passes. A successful rebuild resets it to 0.
   let accountingRebuildDeferUntilMs = 0;
+  // How many rebuild ATTEMPTS in a row deferred over budget, across ticks.
+  // Backoff passes that never attempt the rebuild do not count and do not
+  // reset it; only a completed rebuild does. The count is what lets a surface
+  // distinguish one soft miss from a rebuild that is never landing (the
+  // 2026-08-19 livelock ran for hours behind a bare unavailable estimate).
+  let accountingRebuildDeferredStreak = 0;
   return async function refreshLocalCollector({
     signal = null,
     onProgress = null,
@@ -1239,11 +1245,13 @@ export function createLocalCollectorRefreshRunner({
           // blanking.
           accountingRebuildDeferUntilMs = clock()
             + ACCOUNTING_REBUILD_BUDGET_BACKOFF_MS;
+          accountingRebuildDeferredStreak += 1;
           accountingRebuildDeferred = {
             reason: REFRESH_FAILURE_CODE_PATTERN.test(rebuilt.reason ?? "")
               ? rebuilt.reason
               : "accounting_rebuild_deferred",
             retained: rebuilt.retained === true,
+            consecutive: accountingRebuildDeferredStreak,
           };
           if (rebuilt.retained === true && signal?.aborted !== true) {
             try {
@@ -1287,8 +1295,10 @@ export function createLocalCollectorRefreshRunner({
           }
           if (accounting !== null) {
             accountingRefreshStatus = "rebuilt";
-            // A successful rebuild clears any prior budget-miss backoff.
+            // A successful rebuild clears any prior budget-miss backoff and
+            // ends the deferral streak.
             accountingRebuildDeferUntilMs = 0;
+            accountingRebuildDeferredStreak = 0;
           }
         }
       }
@@ -1673,7 +1683,9 @@ function publicRefreshResult(result, now = Date.now()) {
     // succeeded serving the retained cache. Surface it so a first-party caller
     // can show "using the estimate from <time>; a fuller rebuild is pending"
     // instead of treating the run as breakage. Content-free: a fixed status
-    // plus the bounded budget reason code.
+    // plus the bounded budget reason code, and how many rebuild attempts in a
+    // row have now deferred — the count that separates one soft miss from a
+    // rebuild that is never landing.
     projected.accountingRebuildDeferred = {
       status: "deferred",
       reason: typeof deferred.reason === "string"
@@ -1681,6 +1693,10 @@ function publicRefreshResult(result, now = Date.now()) {
         ? deferred.reason
         : "accounting_rebuild_deferred",
       retained: deferred.retained === true,
+      consecutive: Number.isSafeInteger(deferred.consecutive)
+          && deferred.consecutive >= 1
+        ? deferred.consecutive
+        : 1,
     };
   }
   return projected;

--- a/src/replay-safe-accounting-cache.js
+++ b/src/replay-safe-accounting-cache.js
@@ -2131,12 +2131,29 @@ const CALIBRATION_BATCH_USAGE_BUDGET = 50_000;
 async function deriveBoundedWeeklyCalibrationSeries({
   startAt,
   endAt,
-  rawUsageEvents,
+  // Exactly one usage source: the windowed path passes its resident compact
+  // rows; the unified path passes a streaming corpus handle so at most one
+  // batch slice of priced rows is ever resident at a time.
+  rawUsageEvents = null,
+  usageCorpus = null,
   rateLimitSnapshots,
   diagnostics,
   signal,
   resourceCheck,
 }) {
+  if ((rawUsageEvents === null) === (usageCorpus === null)) {
+    throw new TypeError(
+      "deriveBoundedWeeklyCalibrationSeries requires exactly one usage source",
+    );
+  }
+  const usageEventCount = usageCorpus === null
+    ? rawUsageEvents.length
+    : usageCorpus.count;
+  const readUsageSlice = async (low, high) => (
+    low >= high
+      ? []
+      : usageCorpus.readSlice(low, high)
+  );
   const derive = (usage, snapshots) => deriveCodexTransitionSeriesCooperatively({
     startAt,
     endAt,
@@ -2202,8 +2219,11 @@ async function deriveBoundedWeeklyCalibrationSeries({
   resourceCheck?.();
 
   if (totalTransitions <= CALIBRATION_BATCH_TRANSITION_BUDGET
-      && rawUsageEvents.length <= CALIBRATION_BATCH_USAGE_BUDGET) {
-    const series = await derive(rawUsageEvents, rateLimitSnapshots);
+      && usageEventCount <= CALIBRATION_BATCH_USAGE_BUDGET) {
+    const usage = usageCorpus === null
+      ? rawUsageEvents
+      : await readUsageSlice(0, usageEventCount);
+    const series = await derive(usage, rateLimitSnapshots);
     return {
       transitions: series.transitions,
       deduplicatedSnapshotCount: series.deduplicatedSnapshotCount,
@@ -2213,21 +2233,29 @@ async function deriveBoundedWeeklyCalibrationSeries({
   // Sort the compact usage rows once so every batch can take the contiguous
   // slice that covers its groups' windows. Rows without a parseable timestamp
   // would be dropped by the miner's own normalization, so excluding them here
-  // changes nothing.
-  const stamped = [];
-  for (let index = 0; index < rawUsageEvents.length; index += 1) {
-    if (index % 8_192 === 0) {
-      throwIfAborted(signal);
-      resourceCheck?.();
-      await cooperativeYield();
+  // changes nothing. The streaming corpus arrives already ordered and stamped,
+  // so it supplies the timestamp list directly and each batch's rows are read
+  // off the index on demand instead of being sliced out of a resident copy.
+  let sortedUsage = null;
+  let sortedMs;
+  if (usageCorpus === null) {
+    const stamped = [];
+    for (let index = 0; index < rawUsageEvents.length; index += 1) {
+      if (index % 8_192 === 0) {
+        throwIfAborted(signal);
+        resourceCheck?.();
+        await cooperativeYield();
+      }
+      const observedMs = Date.parse(rawUsageEvents[index]?.[0]);
+      if (Number.isFinite(observedMs)) stamped.push([observedMs, index]);
     }
-    const observedMs = Date.parse(rawUsageEvents[index]?.[0]);
-    if (Number.isFinite(observedMs)) stamped.push([observedMs, index]);
+    stamped.sort((left, right) => left[0] - right[0] || left[1] - right[1]);
+    sortedUsage = stamped.map(([, index]) => rawUsageEvents[index]);
+    sortedMs = stamped.map(([observedMs]) => observedMs);
+    stamped.length = 0;
+  } else {
+    sortedMs = usageCorpus.usageMs;
   }
-  stamped.sort((left, right) => left[0] - right[0] || left[1] - right[1]);
-  const sortedUsage = stamped.map(([, index]) => rawUsageEvents[index]);
-  const sortedMs = stamped.map(([observedMs]) => observedMs);
-  stamped.length = 0;
 
   const orderedGroups = [...groups.values()].sort((left, right) => (
     left.sliceStartMs - right.sliceStartMs
@@ -2277,14 +2305,16 @@ async function deriveBoundedWeeklyCalibrationSeries({
       ? 0
       : firstIndexAtLeast(sortedMs, batch.sliceStartMs);
     const high = firstIndexAbove(sortedMs, batch.sliceEndMs);
-    const usageSlice = sortedUsage.slice(low, high);
+    const usageSlice = usageCorpus === null
+      ? sortedUsage.slice(low, high)
+      : await readUsageSlice(low, high);
     const snapshotSlice = [];
     for (const group of batch.groups) snapshotSlice.push(...group.rows);
     const series = await derive(usageSlice, snapshotSlice);
     transitions.push(...series.transitions);
     deduplicatedSnapshotCount += series.deduplicatedSnapshotCount;
   }
-  rawUsageEvents.length = 0;
+  if (rawUsageEvents !== null) rawUsageEvents.length = 0;
   rateLimitSnapshots.length = 0;
   transitions.sort((left, right) => left.eventTime.localeCompare(right.eventTime)
     || left.resetIdentity.localeCompare(right.resetIdentity)
@@ -2348,6 +2378,29 @@ export async function fitCompositionFromCompactCorpus({
   signal = null,
   checkRuntimeMemory = () => {},
 }) {
+  return fitCompositionFromCorpusStream({
+    forEachUsageRow: async (consume) => {
+      for (const row of rawUsageEvents) await consume(row);
+    },
+    weeklyRateLimitSnapshots,
+    endMs,
+    signal,
+    checkRuntimeMemory,
+  });
+}
+
+// The fold behind fitCompositionFromCompactCorpus, taking the usage corpus as
+// a row visitor instead of a resident array. The unified path streams rows
+// straight off the index through this — the corpus is never resident — while
+// the windowed path drives it from its in-memory array; both fold in the same
+// order with the same cadence, so the fit is identical either way.
+async function fitCompositionFromCorpusStream({
+  forEachUsageRow,
+  weeklyRateLimitSnapshots,
+  endMs,
+  signal = null,
+  checkRuntimeMemory = () => {},
+}) {
   const grainMs = MODEL_COMPOSITION_POLICY.grainMs;
   const recentStartMs = endMs - COMPOSITION_RECENT_MIX_DAYS * 24 * 60 * 60 * 1_000;
   // binStartMs -> Map(model -> summed costUsd), Maps kept in first-encounter
@@ -2356,20 +2409,20 @@ export async function fitCompositionFromCompactCorpus({
   const binCosts = new Map();
   const recentMix = {};
   let processed = 0;
-  for (const row of rawUsageEvents) {
+  await forEachUsageRow(async (row) => {
     processed += 1;
     if (processed % ACCOUNTING_RSS_CHECK_INTERVAL === 0) {
       throwIfAborted(signal);
       checkRuntimeMemory();
       await cooperativeYield();
     }
-    if (!Array.isArray(row)) continue;
+    if (!Array.isArray(row)) return;
     const observedAtMs = Date.parse(row[0]);
     const costUsd = Number(row[10]);
     if (!Number.isFinite(observedAtMs)
         || typeof row[1] !== "string"
         || !Number.isFinite(costUsd)
-        || costUsd < 0) continue;
+        || costUsd < 0) return;
     const model = row[1];
     // The kernel's own binning refuses empty model names; the recent mix
     // mirrors the historical per-event behavior and keeps them.
@@ -2385,7 +2438,7 @@ export async function fitCompositionFromCompactCorpus({
     if (observedAtMs >= recentStartMs) {
       recentMix[model] = (recentMix[model] ?? 0) + costUsd;
     }
-  }
+  });
   const quotaRows = [];
   for (const row of weeklyRateLimitSnapshots) {
     processed += 1;
@@ -2503,8 +2556,9 @@ function publishedUnifiedGenerationTokens(database) {
 }
 
 /**
- * The full-history weekly-calibration corpus, read from the unified local
- * index in the same compact pre-priced encoding the windowed scan retains.
+ * The full-history weekly-calibration corpus, opened as a streaming source
+ * over the unified local index in the same compact pre-priced encoding the
+ * windowed scan retains.
  *
  * This is what removes the calibration's data window: `usage_event` and
  * `quota_observation` have no lower time bound, so the corpus spans everything
@@ -2515,17 +2569,34 @@ function publishedUnifiedGenerationTokens(database) {
  * the newest rows are retained and the returned `coveredAt` names the span
  * honestly.
  *
+ * Residency: the priced compact rows are NEVER all resident at once. A full
+ * corpus at the 750k ceiling measured ~635 real bytes per materialized row —
+ * ~454 MB of RSS against the 256 B/row the byte meter charges — and holding
+ * it was what pushed a large-corpus companion over the accounting RSS ceiling
+ * on every rebuild attempt: each deferred pass restarted from scratch against
+ * the same corpus and the same fossilized baseline, so the rebuild never
+ * landed (live 0.1.13 incident, 2026-08-19). The open pass therefore retains
+ * only a thin (observedMs, rowid) stamp per retained row (~16 bytes), and the
+ * fit and the batched derivation re-read priced rows off the index on demand
+ * — the fit as one streaming fold, the derivation one bounded batch slice at
+ * a time — so peak corpus residency is O(batch), not O(history).
+ *
  * Quota rows are collapsed to the first and last observation of each
  * unchanged (window, percent) run before retention. The miner derives a
  * transition only where the displayed percent changes between consecutive
  * observations of one window, so this collapse is transition-lossless while
  * shrinking hundreds of thousands of repeated readings to the boundaries the
- * calibration actually uses.
+ * calibration actually uses. The collapsed snapshots stay resident (they are
+ * the bounded, high-value rows); only the usage corpus streams.
  *
- * Failures degrade to `null` — the caller falls back to the windowed corpus —
- * except aborts and the build's own resource-guard errors, which propagate.
+ * Open failures degrade to `null` — the caller then fails the build closed,
+ * because the pre-scan probe already promised this corpus — except aborts and
+ * the build's own resource-guard errors, which propagate. The returned source
+ * holds its read handle open until `finish()` (which re-verifies the
+ * generation and the file identity, exactly the checks the one-shot reader
+ * ran at its end) or `dispose()` on an error path.
  */
-async function readUnifiedIndexCalibrationCorpus({
+async function openUnifiedIndexCalibrationCorpus({
   indexFile,
   endMs,
   limits,
@@ -2547,34 +2618,96 @@ async function readUnifiedIndexCalibrationCorpus({
   } catch {
     return null;
   }
-  try {
-    if (expectedGeneration !== null
-        && expectedGeneration !== undefined) {
-      const expected = expectedGenerationTokens(expectedGeneration);
-      const observed = publishedUnifiedGenerationTokens(database);
-      if (expected.length === 0
-          || !generationMatchesExpected(expectedGeneration, observed)) {
-        throw fixedError("accounting_unified_generation_mismatch");
-      }
+  let closed = false;
+  const dispose = () => {
+    if (closed) return;
+    closed = true;
+    try {
+      database.close();
+    } catch {
+      // A close failure cannot make the read-only handle more open.
     }
-    const usageGraceMs = endMs + 5 * 60_000;
-    const usageCount = Number(database.prepare(
-      "SELECT COUNT(*) AS c FROM usage_event WHERE observed_at_ms <= ?",
-    ).get(usageGraceMs)?.c ?? 0);
-    if (usageCount === 0) return null;
-    let retainedStartMs = null;
-    if (usageCount > limits.usageEvents) {
-      const cutoff = database.prepare(`
-        SELECT observed_at_ms AS ms FROM usage_event
-        WHERE observed_at_ms <= ?
-        ORDER BY observed_at_ms DESC
-        LIMIT 1 OFFSET ?`).get(usageGraceMs, limits.usageEvents - 1);
-      retainedStartMs = Number(cutoff?.ms);
-      if (!Number.isSafeInteger(retainedStartMs)) return null;
+  };
+  const verifyGeneration = () => {
+    if (expectedGeneration === null || expectedGeneration === undefined) return;
+    const expected = expectedGenerationTokens(expectedGeneration);
+    const observed = publishedUnifiedGenerationTokens(database);
+    if (expected.length === 0
+        || !generationMatchesExpected(expectedGeneration, observed)) {
+      throw fixedError("accounting_unified_generation_mismatch");
     }
-
-    const price = createAccountingPricer();
-    const usageStatement = database.prepare(`
+  };
+  const usageGraceMs = endMs + 5 * 60_000;
+  const price = createAccountingPricer();
+  // Shared row-count cadence across every read this source performs (the open
+  // pass and the later re-read streams continue one counter), matching the
+  // one-shot reader's single `processed` counter.
+  let processed = 0;
+  const cadence = async () => {
+    processed += 1;
+    if (processed % ACCOUNTING_RSS_CHECK_INTERVAL === 0) {
+      throwIfAborted(signal);
+      checkRuntimeMemory();
+      await cooperativeYield();
+    }
+  };
+  const tokenValue = (value) => (
+    Number.isSafeInteger(Number(value)) && Number(value) >= 0
+      ? Number(value)
+      : 0
+  );
+  // Mirrors exactly the rows the priced projection below retains, without
+  // paying for pricing: eventProjection returns null only for an all-zero
+  // component total, and Spark rows are excluded from the calibration corpus.
+  // The discovery pass and the re-read streams share this predicate, so they
+  // can never disagree about which rows the corpus contains.
+  const retainedByLightFilter = (row) => {
+    if (!Number.isSafeInteger(Number(row.observed_at_ms))) return false;
+    const anyTokens = tokenValue(row.tokens_in_uncached) > 0
+      || tokenValue(row.tokens_in_cache_read) > 0
+      || tokenValue(row.tokens_in_cache_write) > 0
+      || tokenValue(row.tokens_out_text) > 0
+      || tokenValue(row.tokens_out_reasoning) > 0
+      || tokenValue(row.tokens_out_combined) > 0;
+    return anyTokens && safeModel(row.model_id) !== SPARK_MODEL;
+  };
+  // The priced compact projection, identical to the windowed scan's retention
+  // shape. Returns null for exactly the rows retainedByLightFilter refuses.
+  const projectUsageRow = (row) => {
+    const observedMs = Number(row.observed_at_ms);
+    if (!Number.isSafeInteger(observedMs)) return null;
+    const rawEvent = {
+      timestamp: new Date(observedMs).toISOString(),
+      model: row.model_id,
+      // NULL means "the record did not report a total"; it must stay
+      // absent so the pricer bands by the summed input components exactly
+      // as it does on the scan path, instead of reading NULL as zero.
+      ...(row.total_input_context === null
+        ? {}
+        : { totalInputContextTokens: Number(row.total_input_context) }),
+      components: {
+        input_uncached_tokens: tokenValue(row.tokens_in_uncached),
+        input_cache_read_tokens: tokenValue(row.tokens_in_cache_read),
+        input_cache_write_tokens: tokenValue(row.tokens_in_cache_write),
+        output_text_tokens: tokenValue(row.tokens_out_text),
+        output_reasoning_tokens: tokenValue(row.tokens_out_reasoning),
+        output_combined_tokens: tokenValue(row.tokens_out_combined),
+      },
+      tierSemantics: {
+        codexSpeedMode: row.codex_speed_mode,
+        apiServiceTier: row.api_service_tier,
+      },
+    };
+    const event = eventProjection(rawEvent, price);
+    // The calibration corpus mirrors the scan retention exactly: no
+    // zero-token rows, and no separately metered Spark rows.
+    if (event === null || event.isSpark) return null;
+    event.declaredSpeed = event.speed === "unknown"
+      ? declaredSpeedModeAt(declaredSpeedBaselines, observedMs) ?? "unknown"
+      : "unknown";
+    return transitionUsageProjection(rawEvent, event);
+  };
+  const USAGE_COLUMNS = `
       SELECT u.rowid AS row_id,
              u.observed_at_ms AS observed_at_ms,
              m.model_id AS model_id,
@@ -2589,86 +2722,85 @@ async function readUnifiedIndexCalibrationCorpus({
              u.total_input_context AS total_input_context
       FROM usage_event u
       JOIN model m ON m.id = u.model_id
-      JOIN tier_semantics t ON t.id = u.tier_id
+      JOIN tier_semantics t ON t.id = u.tier_id`;
+  try {
+    verifyGeneration();
+    const usageCount = Number(database.prepare(
+      "SELECT COUNT(*) AS c FROM usage_event WHERE observed_at_ms <= ?",
+    ).get(usageGraceMs)?.c ?? 0);
+    if (usageCount === 0) {
+      dispose();
+      return null;
+    }
+    let retainedStartMs = null;
+    if (usageCount > limits.usageEvents) {
+      const cutoff = database.prepare(`
+        SELECT observed_at_ms AS ms FROM usage_event
+        WHERE observed_at_ms <= ?
+        ORDER BY observed_at_ms DESC
+        LIMIT 1 OFFSET ?`).get(usageGraceMs, limits.usageEvents - 1);
+      retainedStartMs = Number(cutoff?.ms);
+      if (!Number.isSafeInteger(retainedStartMs)) {
+        dispose();
+        return null;
+      }
+    }
+
+    const usageStatement = database.prepare(`${USAGE_COLUMNS}
       WHERE u.rowid > ? AND u.observed_at_ms >= ? AND u.observed_at_ms <= ?
       ORDER BY u.rowid
       LIMIT ${UNIFIED_CALIBRATION_READ_BATCH_ROWS}`);
-    const stampedUsage = [];
-    let processed = 0;
+    // Discovery pass: thin (observedMs, rowid) stamps for the rows the corpus
+    // retains, in the same rowid stream order the one-shot reader walked.
+    const stampedMs = [];
+    const stampedRowid = [];
     let afterRowId = -1;
     const lowerBoundMs = retainedStartMs ?? -1;
     for (;;) {
       const batch = usageStatement.all(afterRowId, lowerBoundMs, usageGraceMs);
       if (batch.length === 0) break;
       for (const row of batch) {
-        processed += 1;
-        if (processed % ACCOUNTING_RSS_CHECK_INTERVAL === 0) {
-          throwIfAborted(signal);
-          checkRuntimeMemory();
-          await cooperativeYield();
-        }
-        const observedMs = Number(row.observed_at_ms);
-        if (!Number.isSafeInteger(observedMs)) continue;
-        const tokenValue = (value) => (
-          Number.isSafeInteger(Number(value)) && Number(value) >= 0
-            ? Number(value)
-            : 0
-        );
-        const rawEvent = {
-          timestamp: new Date(observedMs).toISOString(),
-          model: row.model_id,
-          // NULL means "the record did not report a total"; it must stay
-          // absent so the pricer bands by the summed input components exactly
-          // as it does on the scan path, instead of reading NULL as zero.
-          ...(row.total_input_context === null
-            ? {}
-            : { totalInputContextTokens: Number(row.total_input_context) }),
-          components: {
-            input_uncached_tokens: tokenValue(row.tokens_in_uncached),
-            input_cache_read_tokens: tokenValue(row.tokens_in_cache_read),
-            input_cache_write_tokens: tokenValue(row.tokens_in_cache_write),
-            output_text_tokens: tokenValue(row.tokens_out_text),
-            output_reasoning_tokens: tokenValue(row.tokens_out_reasoning),
-            output_combined_tokens: tokenValue(row.tokens_out_combined),
-          },
-          tierSemantics: {
-            codexSpeedMode: row.codex_speed_mode,
-            apiServiceTier: row.api_service_tier,
-          },
-        };
-        const event = eventProjection(rawEvent, price);
-        // The calibration corpus mirrors the scan retention exactly: no
-        // zero-token rows, and no separately metered Spark rows.
-        if (event === null || event.isSpark) continue;
-        event.declaredSpeed = event.speed === "unknown"
-          ? declaredSpeedModeAt(declaredSpeedBaselines, observedMs) ?? "unknown"
-          : "unknown";
-        stampedUsage.push([
-          observedMs,
-          transitionUsageProjection(rawEvent, event),
-        ]);
+        await cadence();
+        if (!retainedByLightFilter(row)) continue;
+        stampedMs.push(Number(row.observed_at_ms));
+        stampedRowid.push(Number(row.row_id));
         // Projected-bytes accounting per retained row, mirroring the windowed
-        // path's reserveTransitionInput: the byte budget bounds what is
-        // RESIDENT, so the moment the materialized working set projects past
-        // it the read refuses — it never finishes materializing a corpus the
-        // final gate was always going to reject. (The retention cutoff bounds
-        // the row COUNT up to timestamp ties; only this check bounds bytes.)
-        if (stampedUsage.length * COMPACT_USAGE_RETAINED_BYTES
+        // path's reserveTransitionInput: the byte budget bounds what the
+        // derivation may RETAIN, so the moment the discovered working set
+        // projects past it the read refuses — it never finishes discovering a
+        // corpus the final gate was always going to reject. (The retention
+        // cutoff bounds the row COUNT up to timestamp ties; only this check
+        // bounds bytes.)
+        if (stampedMs.length * COMPACT_USAGE_RETAINED_BYTES
             > limits.retainedBytes) {
+          dispose();
           return null;
         }
       }
       afterRowId = Number(batch.at(-1).row_id);
       if (batch.length < UNIFIED_CALIBRATION_READ_BATCH_ROWS) break;
     }
-    if (stampedUsage.length === 0) return null;
-    stampedUsage.sort((left, right) => left[0] - right[0]);
-    if (stampedUsage.length > limits.usageEvents) {
-      stampedUsage.splice(0, stampedUsage.length - limits.usageEvents);
+    if (stampedMs.length === 0) {
+      dispose();
+      return null;
     }
-    const firstUsageMs = stampedUsage[0][0];
-    const rawUsageEvents = stampedUsage.map(([, row]) => row);
-    stampedUsage.length = 0;
+    // Retained order is (observedMs, rowid): the one-shot reader's stable
+    // ms-sort over a rowid-ordered stream produced exactly this order.
+    const order = stampedMs.map((_, index) => index);
+    order.sort((left, right) => stampedMs[left] - stampedMs[right]
+      || stampedRowid[left] - stampedRowid[right]);
+    const dropped = Math.max(0, order.length - limits.usageEvents);
+    const usageMs = new Array(order.length - dropped);
+    const usageRowid = new Array(order.length - dropped);
+    for (let index = dropped; index < order.length; index += 1) {
+      usageMs[index - dropped] = stampedMs[order[index]];
+      usageRowid[index - dropped] = stampedRowid[order[index]];
+    }
+    order.length = 0;
+    stampedMs.length = 0;
+    stampedRowid.length = 0;
+    const retainedUsageEvents = usageMs.length;
+    const firstUsageMs = usageMs[0];
 
     const snapshotLowerMs = retainedStartMs === null
       ? -1
@@ -2692,12 +2824,12 @@ async function readUnifiedIndexCalibrationCorpus({
     // unusable (null -> the caller's typed
     // accounting_calibration_corpus_unavailable).
     const retainedUsageBytes =
-      rawUsageEvents.length * COMPACT_USAGE_RETAINED_BYTES;
+      retainedUsageEvents * COMPACT_USAGE_RETAINED_BYTES;
     let retainedInputBudgetExceeded = false;
     const reserveSnapshotRetention = () => {
       const retainedSnapshots = weeklyRateLimitSnapshots.length + 1;
       if (retainedSnapshots > limits.weeklySnapshots
-          || rawUsageEvents.length + retainedSnapshots > limits.combinedInputs
+          || retainedUsageEvents + retainedSnapshots > limits.combinedInputs
           || retainedUsageBytes
             + retainedSnapshots * COMPACT_SNAPSHOT_RETAINED_BYTES
             > limits.retainedBytes) {
@@ -2729,14 +2861,11 @@ async function readUnifiedIndexCalibrationCorpus({
     )) {
       // Stop reading the stream the moment retention refused a row: every
       // later row would either be refused too or misrepresent a corpus that
-      // is already over budget as complete.
-      if (retainedInputBudgetExceeded) return null;
-      processed += 1;
-      if (processed % ACCOUNTING_RSS_CHECK_INTERVAL === 0) {
-        throwIfAborted(signal);
-        checkRuntimeMemory();
-        await cooperativeYield();
-      }
+      // is already over budget as complete. (Break rather than return: the
+      // handle cannot close while this statement iterator is live, and every
+      // later reservation attempt fails the same monotone budget check.)
+      if (retainedInputBudgetExceeded) break;
+      await cadence();
       const observedMs = Number(row.observed_at_ms);
       const resetsAtSec = Math.floor(Number(row.resets_at_ms) / 1_000);
       const usedPercent = Number(row.used_percent);
@@ -2773,14 +2902,17 @@ async function readUnifiedIndexCalibrationCorpus({
     for (const run of groupRuns.values()) {
       if (run.pending) emit(run.pending);
     }
-    if (retainedInputBudgetExceeded) return null;
-    if (weeklyRateLimitSnapshots.length === 0) return null;
+    if (retainedInputBudgetExceeded || weeklyRateLimitSnapshots.length === 0) {
+      dispose();
+      return null;
+    }
     if (weeklyRateLimitSnapshots.length > limits.weeklySnapshots
-        || rawUsageEvents.length + weeklyRateLimitSnapshots.length
+        || retainedUsageEvents + weeklyRateLimitSnapshots.length
           > limits.combinedInputs
-        || rawUsageEvents.length * COMPACT_USAGE_RETAINED_BYTES
+        || retainedUsageEvents * COMPACT_USAGE_RETAINED_BYTES
           + weeklyRateLimitSnapshots.length * COMPACT_SNAPSHOT_RETAINED_BYTES
           > limits.retainedBytes) {
+      dispose();
       return null;
     }
     throwIfAborted(signal);
@@ -2788,41 +2920,127 @@ async function readUnifiedIndexCalibrationCorpus({
     const coveredStartMs = firstSnapshotMs === null
       ? firstUsageMs
       : Math.min(firstUsageMs, firstSnapshotMs);
-    if (expectedGeneration !== null
-        && expectedGeneration !== undefined) {
-      const expected = expectedGenerationTokens(expectedGeneration);
-      const observed = publishedUnifiedGenerationTokens(database);
-      if (expected.length === 0
-          || !generationMatchesExpected(expectedGeneration, observed)) {
-        throw fixedError("accounting_unified_generation_mismatch");
-      }
-    }
-    let finalMetadata;
+    verifyGeneration();
+    let openMetadata;
     try {
-      finalMetadata = await lstat(indexFile);
+      openMetadata = await lstat(indexFile);
     } catch {
       throw fixedError("accounting_unified_generation_changed");
     }
-    if (!sameIndexFileIdentity(metadata, finalMetadata)) {
+    if (!sameIndexFileIdentity(metadata, openMetadata)) {
       throw fixedError("accounting_unified_generation_changed");
     }
+
+    // Keyset re-read over the retained (observedMs, rowid) range. The first
+    // page is inclusive of the range start; continuations resume strictly
+    // after the last row served. Rows the discovery pass refused are refused
+    // again here by the shared predicate, so a range stream yields exactly
+    // the retained rows between its bounds — verified by count below, which
+    // turns any mid-build index mutation into a typed refusal instead of a
+    // silently drifted corpus.
+    const firstPageStatement = database.prepare(`${USAGE_COLUMNS}
+      WHERE (u.observed_at_ms, u.rowid) >= (?, ?)
+        AND (u.observed_at_ms, u.rowid) <= (?, ?)
+      ORDER BY u.observed_at_ms, u.rowid
+      LIMIT ${UNIFIED_CALIBRATION_READ_BATCH_ROWS}`);
+    const nextPageStatement = database.prepare(`${USAGE_COLUMNS}
+      WHERE (u.observed_at_ms, u.rowid) > (?, ?)
+        AND (u.observed_at_ms, u.rowid) <= (?, ?)
+      ORDER BY u.observed_at_ms, u.rowid
+      LIMIT ${UNIFIED_CALIBRATION_READ_BATCH_ROWS}`);
+    const streamProjectedRange = async (low, high, consume) => {
+      if (closed) {
+        throw fixedError("accounting_calibration_corpus_unavailable");
+      }
+      const endBoundMs = usageMs[high - 1];
+      const endBoundRowid = usageRowid[high - 1];
+      let cursorMs = usageMs[low];
+      let cursorRowid = usageRowid[low];
+      let statement = firstPageStatement;
+      let served = 0;
+      try {
+        for (;;) {
+          const batch = statement.all(
+            cursorMs,
+            cursorRowid,
+            endBoundMs,
+            endBoundRowid,
+          );
+          if (batch.length === 0) break;
+          for (const row of batch) {
+            await cadence();
+            const projected = projectUsageRow(row);
+            if (projected === null) continue;
+            served += 1;
+            await consume(projected);
+          }
+          const last = batch.at(-1);
+          cursorMs = Number(last.observed_at_ms);
+          cursorRowid = Number(last.row_id);
+          statement = nextPageStatement;
+          if (batch.length < UNIFIED_CALIBRATION_READ_BATCH_ROWS) break;
+        }
+      } catch (error) {
+        if (error?.name === "AbortError"
+            || (typeof error?.code === "string"
+              && error.code.startsWith("accounting_"))) {
+          throw error;
+        }
+        // A raw read failure after open degrades to the same typed refusal
+        // the one-shot reader's caller raised, never a bare SQLite error.
+        throw fixedError("accounting_calibration_corpus_unavailable");
+      }
+      if (served !== high - low) {
+        throw fixedError("accounting_unified_generation_changed");
+      }
+    };
     return {
-      rawUsageEvents,
-      weeklyRateLimitSnapshots,
       coveredAt: {
         startAt: new Date(coveredStartMs).toISOString(),
         endAt: new Date(endMs).toISOString(),
       },
+      retainedUsageEvents,
+      weeklyRateLimitSnapshots,
+      usageMs,
+      readUsageSlice: async (low, high) => {
+        if (!Number.isSafeInteger(low) || !Number.isSafeInteger(high)
+            || low < 0 || high > retainedUsageEvents || low >= high) {
+          throw new TypeError("Calibration usage slice bounds are invalid");
+        }
+        const rows = [];
+        await streamProjectedRange(low, high, (row) => rows.push(row));
+        return rows;
+      },
+      forEachRetainedUsage: async (consume) => {
+        await streamProjectedRange(0, retainedUsageEvents, consume);
+      },
+      finish: async () => {
+        if (closed) return;
+        try {
+          verifyGeneration();
+          let finalMetadata;
+          try {
+            finalMetadata = await lstat(indexFile);
+          } catch {
+            throw fixedError("accounting_unified_generation_changed");
+          }
+          if (!sameIndexFileIdentity(metadata, finalMetadata)) {
+            throw fixedError("accounting_unified_generation_changed");
+          }
+        } finally {
+          dispose();
+        }
+      },
+      dispose,
     };
   } catch (error) {
+    dispose();
     if (error?.name === "AbortError"
         || (typeof error?.code === "string"
           && error.code.startsWith("accounting_"))) {
       throw error;
     }
     return null;
-  } finally {
-    database.close();
   }
 }
 
@@ -3186,9 +3404,9 @@ export async function buildReplaySafeAccountingCache({
       );
     }
   }
-  let unifiedCalibration = null;
+  let calibrationCorpus = null;
   if (useUnifiedCalibration) {
-    unifiedCalibration = await readUnifiedIndexCalibrationCorpus({
+    calibrationCorpus = await openUnifiedIndexCalibrationCorpus({
       indexFile: selectedUnifiedIndexFile,
       endMs,
       limits,
@@ -3203,16 +3421,19 @@ export async function buildReplaySafeAccountingCache({
     // fallback corpus. If the full read then fails, the only honest outputs
     // are a typed failure or a calibration falsely labelled complete-but-
     // empty; fail closed, and the next refresh re-probes from scratch.
-    if (unifiedCalibration === null) {
+    if (calibrationCorpus === null) {
       throw fixedError("accounting_calibration_corpus_unavailable");
     }
   }
+  let composition = null;
+  let compositionFitFailure = null;
+  let transitionSeries;
   const retainedUsageEvents = retainWindowedCalibrationInputs
     ? rawUsageEvents.length + retainedSparkUsageEvents
-    : unifiedCalibration.rawUsageEvents.length;
+    : calibrationCorpus.retainedUsageEvents;
   const retainedWeeklySnapshots = retainWindowedCalibrationInputs
     ? weeklyRateLimitSnapshots.length + retainedSparkSnapshotInputs
-    : unifiedCalibration.weeklyRateLimitSnapshots.length;
+    : calibrationCorpus.weeklyRateLimitSnapshots.length;
   const calibrationRetainedBytes = retainWindowedCalibrationInputs
     ? retainedTransitionBytes
     : retainedUsageEvents * COMPACT_USAGE_RETAINED_BYTES
@@ -3220,73 +3441,90 @@ export async function buildReplaySafeAccountingCache({
   const calibrationCoveredAt = {
     startAt: retainWindowedCalibrationInputs
       ? new Date(startMs).toISOString()
-      : unifiedCalibration.coveredAt.startAt,
+      : calibrationCorpus.coveredAt.startAt,
     endAt: new Date(endMs).toISOString(),
   };
-  // The composition fit reads the same compact corpus the derivation below
-  // will consume, so it must run first. It is strictly optional enrichment:
-  // any throw out of it (resource ceiling, abort, numerical surprise) must
-  // not cost the whole build. The cache completes with `composition: null` —
-  // the dashboard then falls back to the across-reset median headline — and
-  // the failure is recorded on the calibration block, because a refresh that
-  // dies here re-runs the same doomed pass on every scheduler tick while the
-  // on-disk cache stays a rejected older artifact.
-  let composition = null;
-  let compositionFitFailure = null;
   try {
-    composition = await fitCompositionFromCompactCorpus({
-      rawUsageEvents: retainWindowedCalibrationInputs
-        ? rawUsageEvents
-        : unifiedCalibration.rawUsageEvents,
-      weeklyRateLimitSnapshots: retainWindowedCalibrationInputs
-        ? weeklyRateLimitSnapshots
-        : unifiedCalibration.weeklyRateLimitSnapshots,
-      endMs,
-      signal,
-      checkRuntimeMemory,
-    });
-  } catch (error) {
-    compositionFitFailure = {
-      status: "fit_failed",
-      reason: compositionFitFailureReason(error),
-    };
-  }
-  throwIfAborted(signal);
-  checkRuntimeMemory();
-  let transitionSeries;
-  try {
-    transitionSeries = await deriveBoundedWeeklyCalibrationSeries({
-      startAt: calibrationCoveredAt.startAt,
-      endAt: calibrationCoveredAt.endAt,
-      rawUsageEvents: retainWindowedCalibrationInputs
-        ? rawUsageEvents
-        : unifiedCalibration.rawUsageEvents,
-      rateLimitSnapshots: retainWindowedCalibrationInputs
-        ? weeklyRateLimitSnapshots
-        : unifiedCalibration.weeklyRateLimitSnapshots,
-      // The scan diagnostics describe the windowed raw-log pass; the unified
-      // corpus was fork-replay-suppressed at ingest, so its transitions do
-      // not restate scan-level counts as their own.
-      diagnostics: retainWindowedCalibrationInputs
-        ? scanned?.diagnostics ?? {}
-        : {},
-      signal,
-      resourceCheck: checkRuntimeMemory,
-    });
-  } catch (error) {
-    if (error?.name === "AbortError"
-        || error?.code === "transition_derivation_aborted") {
-      const aborted = fixedError("accounting_refresh_aborted");
-      aborted.name = "AbortError";
-      throw aborted;
+    // The composition fit reads the same compact corpus the derivation below
+    // will consume, so it must run first. It is strictly optional enrichment:
+    // any throw out of it (resource ceiling, abort, numerical surprise) must
+    // not cost the whole build. The cache completes with `composition: null` —
+    // the dashboard then falls back to the across-reset median headline — and
+    // the failure is recorded on the calibration block, because a refresh that
+    // dies here re-runs the same doomed pass on every scheduler tick while the
+    // on-disk cache stays a rejected older artifact.
+    try {
+      composition = retainWindowedCalibrationInputs
+        ? await fitCompositionFromCompactCorpus({
+          rawUsageEvents,
+          weeklyRateLimitSnapshots,
+          endMs,
+          signal,
+          checkRuntimeMemory,
+        })
+        : await fitCompositionFromCorpusStream({
+          forEachUsageRow: calibrationCorpus.forEachRetainedUsage,
+          weeklyRateLimitSnapshots: calibrationCorpus.weeklyRateLimitSnapshots,
+          endMs,
+          signal,
+          checkRuntimeMemory,
+        });
+    } catch (error) {
+      compositionFitFailure = {
+        status: "fit_failed",
+        reason: compositionFitFailureReason(error),
+      };
     }
-    if ([
-      "transition_derivation_input_limit_exceeded",
-      "transition_derivation_row_limit_exceeded",
-      "transition_derivation_work_limit_exceeded",
-    ].includes(error?.code)) {
-      throw fixedError("accounting_transition_derivation_limit_exceeded");
+    throwIfAborted(signal);
+    checkRuntimeMemory();
+    try {
+      transitionSeries = await deriveBoundedWeeklyCalibrationSeries({
+        startAt: calibrationCoveredAt.startAt,
+        endAt: calibrationCoveredAt.endAt,
+        ...(retainWindowedCalibrationInputs
+          ? { rawUsageEvents }
+          : {
+            usageCorpus: {
+              count: calibrationCorpus.retainedUsageEvents,
+              usageMs: calibrationCorpus.usageMs,
+              readSlice: calibrationCorpus.readUsageSlice,
+            },
+          }),
+        rateLimitSnapshots: retainWindowedCalibrationInputs
+          ? weeklyRateLimitSnapshots
+          : calibrationCorpus.weeklyRateLimitSnapshots,
+        // The scan diagnostics describe the windowed raw-log pass; the unified
+        // corpus was fork-replay-suppressed at ingest, so its transitions do
+        // not restate scan-level counts as their own.
+        diagnostics: retainWindowedCalibrationInputs
+          ? scanned?.diagnostics ?? {}
+          : {},
+        signal,
+        resourceCheck: checkRuntimeMemory,
+      });
+    } catch (error) {
+      if (error?.name === "AbortError"
+          || error?.code === "transition_derivation_aborted") {
+        const aborted = fixedError("accounting_refresh_aborted");
+        aborted.name = "AbortError";
+        throw aborted;
+      }
+      if ([
+        "transition_derivation_input_limit_exceeded",
+        "transition_derivation_row_limit_exceeded",
+        "transition_derivation_work_limit_exceeded",
+      ].includes(error?.code)) {
+        throw fixedError("accounting_transition_derivation_limit_exceeded");
+      }
+      throw error;
     }
+    // The streamed corpus is fully consumed; re-verify that the index the
+    // slices were read off is still the generation the build is bound to, and
+    // release the read handle. The one-shot reader ran the same checks at its
+    // end; streaming widens the window they cover, not their meaning.
+    if (calibrationCorpus !== null) await calibrationCorpus.finish();
+  } catch (error) {
+    calibrationCorpus?.dispose();
     throw error;
   }
   const weeklyCalibrationDataset = {

--- a/src/replay-safe-accounting-cache.js
+++ b/src/replay-safe-accounting-cache.js
@@ -2104,9 +2104,13 @@ function firstIndexAbove(values, target) {
 // encoding [timestamp, timestampMs, provider, planType, limitId, slot,
 // windowDurationMins, resetsAt, usedPercent]. Transitions are derived from
 // consecutive snapshots WITHIN one of these groups, never across groups,
-// which is what makes the batched derivation below exact.
+// which is what makes the batched derivation below exact. Window identity is
+// slot-agnostic (v0.6), exactly like the miner's windowKey: slot is a UI
+// role, so grouping on it here would split one window's rows across batches
+// wherever the server-side slot flipped mid-history and silently drop the
+// transition that crosses the flip.
 function compactSnapshotGroupKey(row) {
-  return [row[2], row[3], row[4], row[5], row[6], row[7]].join("|");
+  return [row[2], row[3], row[4], row[6], row[7]].join("|");
 }
 
 // The transition miner refuses more than 10,000 derived rows per call — a

--- a/test/local-companion-refresh.test.js
+++ b/test/local-companion-refresh.test.js
@@ -1503,28 +1503,53 @@ test("a memory-budget rebuild miss serves the retained cache, reports deferred, 
   assert.deepEqual(first.accountingRebuildDeferred, {
     reason: "accounting_transition_rss_limit_exceeded",
     retained: true,
+    consecutive: 1,
   });
 
   // Second pass a minute later, still within the backoff window: the doomed
   // full rebuild is skipped entirely and the retained cache is served again.
+  // A backoff pass attempts nothing, so it neither reports a deferral nor
+  // advances the streak.
   nowMs += 60_000;
   const second = await runner();
   assert.equal(rebuildAttempts, 1);
   assert.equal(second.accounting.refreshStatus, "deferred");
+  assert.equal(second.accountingRebuildDeferred, undefined);
+
+  // Once the backoff elapses the rebuild is re-attempted and misses again:
+  // the streak counts consecutive ATTEMPTS, across backoff windows.
+  nowMs += 31 * 60_000;
+  const stillDeferred = await runner();
+  assert.equal(rebuildAttempts, 2);
+  assert.deepEqual(stillDeferred.accountingRebuildDeferred, {
+    reason: "accounting_transition_rss_limit_exceeded",
+    retained: true,
+    consecutive: 2,
+  });
 
   // Once the backoff elapses the full rebuild is re-attempted; now it fits and
   // succeeds, and the backoff is cleared so later passes rebuild immediately.
   nowMs += 31 * 60_000;
   deferForNextRebuild = false;
   const third = await runner();
-  assert.equal(rebuildAttempts, 2);
+  assert.equal(rebuildAttempts, 3);
   assert.equal(third.accounting.refreshStatus, "rebuilt");
   assert.equal(third.accounting.events, 41);
   assert.equal(third.accountingRebuildDeferred, undefined);
 
   const fourth = await runner();
-  assert.equal(rebuildAttempts, 3);
+  assert.equal(rebuildAttempts, 4);
   assert.equal(fourth.accounting.refreshStatus, "rebuilt");
+
+  // A later miss starts a fresh streak: the successful rebuild reset it.
+  deferForNextRebuild = true;
+  const fifth = await runner();
+  assert.equal(rebuildAttempts, 5);
+  assert.deepEqual(fifth.accountingRebuildDeferred, {
+    reason: "accounting_transition_rss_limit_exceeded",
+    retained: true,
+    consecutive: 1,
+  });
 });
 
 test("a budget miss with no retained cache defers without fabricating an accounting block", async () => {
@@ -1557,6 +1582,7 @@ test("a budget miss with no retained cache defers without fabricating an account
   assert.deepEqual(result.accountingRebuildDeferred, {
     reason: "accounting_transition_rss_limit_exceeded",
     retained: false,
+    consecutive: 1,
   });
 });
 
@@ -1651,6 +1677,9 @@ test("the controller files a degraded note, not a terminal one, for a soft budge
     status: "deferred",
     reason: "accounting_transition_rss_limit_exceeded",
     retained: true,
+    // The runner in this harness reports no streak, so the projection
+    // presents the one attempt it is looking at.
+    consecutive: 1,
   });
 });
 

--- a/test/replay-safe-accounting-corpus-stream.test.js
+++ b/test/replay-safe-accounting-corpus-stream.test.js
@@ -1,6 +1,7 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 import { mkdtemp, rm } from "node:fs/promises";
+import { spawnSync } from "node:child_process";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { buildReplaySafeAccountingCache } from "../src/replay-safe-accounting-cache.js";
@@ -352,16 +353,55 @@ test("retention trim keeps the newest rows across timestamp ties, identically to
   }
 });
 
-test("a corpus far larger than one derivation batch completes in ONE pass under a scaled-down whole-process RSS budget", async (t) => {
+// Runs the streamed build in a child whose V8 old space is deliberately
+// small. The cap does two jobs the parent process cannot do deterministically:
+// it forces prompt garbage collection (so the whole-process RSS budget below
+// is meaningful under any machine load, where an unconstrained heap may defer
+// major GC past any tight margin), and it turns a regression back to
+// O(corpus) residency into a hard out-of-memory crash — a 300k-row corpus
+// materialized at the measured ~635 real bytes per compact row (~190 MiB,
+// before its stamped/sorted copies) cannot fit the cap at all, while the
+// streamed working set (one <=50k-row batch slice plus thin stamps) lives
+// comfortably inside it. Same pattern as test/export-checkpoint-heap.test.js.
+const BUDGET_CHILD_OLD_SPACE_MIB = 256;
+const BUDGET_CHILD_RSS_BUDGET_MIB = 512;
+const BUDGET_CHILD = String.raw`
+const { buildReplaySafeAccountingCache } = await import(
+  process.env.CORPUS_STREAM_MODULE
+);
+const baselineRss = process.memoryUsage().rss;
+const budgetBytes = Number(process.env.CORPUS_STREAM_BUDGET_BYTES);
+let peakRss = baselineRss;
+let rssReadings = 0;
+const cache = await buildReplaySafeAccountingCache({
+  now: () => Number(process.env.CORPUS_STREAM_NOW_MS),
+  unifiedIndexFile: process.env.CORPUS_STREAM_INDEX_FILE,
+  declaredSpeedBaselines: JSON.parse(process.env.CORPUS_STREAM_BASELINES),
+  scan: async () => ({ diagnostics: {} }),
+  rss: () => {
+    rssReadings += 1;
+    const current = process.memoryUsage().rss;
+    if (current > peakRss) peakRss = current;
+    return current;
+  },
+  maximumRssBytes: baselineRss + budgetBytes,
+});
+process.stdout.write(JSON.stringify({
+  source: cache.weeklyCalibrationInput.source,
+  retainedUsageEvents: cache.weeklyCalibrationInput.retainedUsageEvents,
+  weeklyTransitions: cache.weeklyCalibration.sourceCounts.weeklyTransitions,
+  rssReadings,
+  peakGrowthMiB: Number(((peakRss - baselineRss) / 1024 / 1024).toFixed(1)),
+}) + "\n");
+`;
+
+test("a corpus far larger than one derivation batch completes in ONE pass under a scaled-down RSS budget and a capped heap", { timeout: 180_000 }, async (t) => {
   const directory = await mkdtemp(join(tmpdir(), "usage-monitor-corpus-stream-budget-"));
   try {
-    // 300k usage rows across six reset windows. Under the pre-streaming
-    // reader this corpus materialized ~190 MiB of compact rows (measured
-    // ~635 real bytes per row) plus its stamped/sorted copies BEFORE any
-    // derivation ran — past the budget below on retention alone — and a
-    // deferred pass would have re-run the identical materialization forever.
-    // The streamed corpus holds at most one <=50k-row batch slice instead,
-    // so its peak stays batch-bounded no matter how large the history grows.
+    // 300k usage rows across six reset windows: six times the 50k single-call
+    // usage budget, so the derivation must run several on-demand slices. The
+    // pre-streaming reader materialized this whole corpus before deriving,
+    // and a deferred pass re-ran the identical materialization forever.
     const corpus = syntheticCorpus({
       resetStarts: Array.from(
         { length: 6 },
@@ -376,55 +416,47 @@ test("a corpus far larger than one derivation batch completes in ONE pass under 
     const indexFile = join(directory, "local-unified-index-v1.sqlite");
     await writeCorpusIndex(indexFile, corpus);
 
-    // The scaled-down budget: the real process RSS at test start plus a
-    // margin far below the old design's resident corpus. The guard runs
-    // against genuine process.memoryUsage().rss readings, so a regression
-    // back to O(corpus) residency trips accounting_transition_rss_limit_
-    // exceeded and rejects this build.
-    // Margin calibration (2026-08-19, measured): the streamed build peaked at
-    // ~354 MiB growth on a 200k corpus — batch working sets and GC lag, all
-    // corpus-size-independent — while the retired resident reader would add
-    // ~190 MiB of corpus retention on top for THIS corpus. 512 MiB therefore
-    // sits with real headroom above the streamed peak and below any design
-    // that holds the corpus resident again.
-    const baselineRss = process.memoryUsage().rss;
-    const budgetBytes = Number(process.env.CORPUS_STREAM_BUDGET_MIB ?? 512)
-      * 1024 * 1024;
-    let peakRss = baselineRss;
-    let rssReadings = 0;
-    const cache = await buildReplaySafeAccountingCache({
-      now: () => NOW,
-      unifiedIndexFile: indexFile,
-      declaredSpeedBaselines: DECLARED_SPEED_BASELINES,
-      scan: async () => ({ diagnostics: {} }),
-      rss: () => {
-        rssReadings += 1;
-        const current = process.memoryUsage().rss;
-        if (current > peakRss) peakRss = current;
-        return current;
+    const child = spawnSync(process.execPath, [
+      `--max-old-space-size=${BUDGET_CHILD_OLD_SPACE_MIB}`,
+      "--input-type=module",
+      "--eval",
+      BUDGET_CHILD,
+    ], {
+      cwd: process.cwd(),
+      encoding: "utf8",
+      timeout: 150_000,
+      env: {
+        ...process.env,
+        CORPUS_STREAM_MODULE:
+          new URL("../src/replay-safe-accounting-cache.js", import.meta.url).href,
+        CORPUS_STREAM_INDEX_FILE: indexFile,
+        CORPUS_STREAM_NOW_MS: String(NOW),
+        CORPUS_STREAM_BASELINES: JSON.stringify(DECLARED_SPEED_BASELINES),
+        CORPUS_STREAM_BUDGET_BYTES:
+          String(BUDGET_CHILD_RSS_BUDGET_MIB * 1024 * 1024),
       },
-      maximumRssBytes: baselineRss + budgetBytes,
     });
-
+    assert.equal(child.error, undefined, child.error?.message);
+    assert.equal(child.signal, null, child.stderr);
+    // A build that holds the corpus resident again dies here: either the
+    // capped heap refuses the materialization outright, or the genuine
+    // process-RSS guard inside the child trips
+    // accounting_transition_rss_limit_exceeded.
+    assert.equal(child.status, 0, child.stderr);
+    const outcome = JSON.parse(child.stdout);
     t.diagnostic(
-      `peak RSS growth ${((peakRss - baselineRss) / 1024 / 1024).toFixed(1)} MiB `
-        + `of the ${(budgetBytes / 1024 / 1024).toFixed(0)} MiB budget`,
+      `peak RSS growth ${outcome.peakGrowthMiB} MiB of the `
+        + `${BUDGET_CHILD_RSS_BUDGET_MIB} MiB budget under a `
+        + `${BUDGET_CHILD_OLD_SPACE_MIB} MiB old-space cap`,
     );
-    assert.ok(
-      rssReadings > 50,
-      `the RSS guard must meter the streamed corpus (saw ${rssReadings} readings)`,
-    );
-    assert.equal(cache.weeklyCalibrationInput.source, "unified_index");
-    assert.equal(cache.weeklyCalibrationInput.retainedUsageEvents, 300_000);
+    assert.equal(outcome.source, "unified_index");
+    assert.equal(outcome.retainedUsageEvents, 300_000);
     // 999 percent changes per reset window x 6 windows: the whole series was
     // derived, none of it discarded to fit the budget.
-    assert.equal(
-      cache.weeklyCalibration.sourceCounts.weeklyTransitions,
-      5_994,
-    );
+    assert.equal(outcome.weeklyTransitions, 5_994);
     assert.ok(
-      peakRss - baselineRss <= budgetBytes,
-      `peak RSS growth ${((peakRss - baselineRss) / 1024 / 1024).toFixed(1)} MiB exceeded the scaled budget`,
+      outcome.rssReadings > 50,
+      `the RSS guard must meter the streamed corpus (saw ${outcome.rssReadings} readings)`,
     );
   } finally {
     await rm(directory, { recursive: true, force: true });

--- a/test/replay-safe-accounting-corpus-stream.test.js
+++ b/test/replay-safe-accounting-corpus-stream.test.js
@@ -1,0 +1,432 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { buildReplaySafeAccountingCache } from "../src/replay-safe-accounting-cache.js";
+import {
+  createUnifiedIndexWriter,
+  openLocalUnifiedIndex,
+} from "../src/local-unified-index.js";
+
+// The streaming calibration corpus (2026-08-19). The pre-streaming reader
+// materialized every priced compact usage row before the fit and the
+// derivation ran — ~635 real bytes per row against the 256 the byte meter
+// charges — and on a large corpus that residency pushed whole-process RSS
+// over the accounting ceiling on EVERY rebuild attempt. Each deferred pass
+// restarted from scratch against the same corpus and an RSS baseline
+// fossilized by the previous attempt, so the rebuild never landed (live
+// 0.1.13 incident: accounting_rebuild_deferred /
+// accounting_transition_rss_limit_exceeded recurring for hours).
+//
+// These tests pin the two facts the fix rests on:
+//  1. the streamed corpus produces byte-identical calibration artifacts to
+//     the same rows held resident (the seam the rewrite changed), and
+//  2. a corpus far larger than the old resident materialization completes in
+//     ONE pass under a scaled-down whole-process RSS budget, so repeated
+//     passes are no longer needed at all.
+
+const NOW = Date.parse("2026-08-20T12:00:00.000Z");
+const DAY_MS = 24 * 60 * 60 * 1_000;
+const WEEK_MS = 7 * DAY_MS;
+
+// Model/tier/context variety so pricing bands, the composition fit, and the
+// speed scenarios are all non-trivial. An unrecognized model is retained as
+// "unknown" identically on both paths, so a sprinkling is included.
+const MODELS = ["gpt-5.6-sol", "gpt-5.6-terra"];
+const SPEEDS = ["unknown", "fast", "standard"];
+
+function corpusUsageRow(index, observedAtMs) {
+  // Pricing-warning variety (an unrecognized model, unpriced cache writes)
+  // is confined to the earliest rows: a transition carrying any pricing
+  // warning is ineligible for the estimate, so keeping the taint inside the
+  // first reset window exercises those row shapes on both paths while the
+  // remaining windows stay estimator-worthy.
+  const tainted = index < 1_300;
+  const model = tainted && index % 9 === 0
+    ? "not-a-recognized-model"
+    : MODELS[index % MODELS.length];
+  const speed = SPEEDS[index % SPEEDS.length];
+  return {
+    observedAtMs,
+    model,
+    speed,
+    // Every third row reports a long-context total; the rest report none, so
+    // the pricer bands by summed inputs exactly as on the scan path.
+    totalInputContext: index % 3 === 0 ? 300_000 : null,
+    tokensInUncached: 400_000 + (index % 47) * 1_000,
+    tokensInCacheRead: 20_000 + (index % 211),
+    tokensInCacheWrite: tainted && index % 5 === 0 ? 3_000 : 0,
+    // A slice of combined-only output rows exercises the combined
+    // normalization on both paths.
+    tokensOutText: index % 7 === 0 ? 0 : 800 + (index % 13),
+    tokensOutReasoning: index % 7 === 0 ? 0 : 1_200,
+    tokensOutCombined: index % 7 === 0 ? 2_400 : 0,
+  };
+}
+
+// One synthetic corpus definition shared by the unified index build and the
+// resident-array oracle build. Consecutive quota readings always differ, so
+// the unified run-collapse retains every row and the windowed path (which
+// never collapses) retains the identical set. Slot flips mid-window: window
+// identity is slot-agnostic, so the batched planner must never split one
+// window's rows on the flip.
+function syntheticCorpus({
+  resetStarts,
+  boundariesPerReset,
+  usagePerBoundary,
+  boundaryStepMs = 60 * 60_000,
+  percentFor = (boundary) => boundary,
+}) {
+  const usage = [];
+  const quota = [];
+  for (const [resetIndex, resetStartMs] of resetStarts.entries()) {
+    for (let boundary = 0; boundary < boundariesPerReset; boundary += 1) {
+      const observedAtMs = resetStartMs + boundary * boundaryStepMs;
+      quota.push({
+        observedAtMs,
+        usedPercent: percentFor(boundary),
+        resetsAtMs: resetStartMs + WEEK_MS,
+        // Slot is a UI role: window identity is slot-agnostic, so the batched
+        // planner must keep a window whole regardless of its slot labels. The
+        // first window alternates slots per boundary to pin exactly that (the
+        // estimator's own simultaneous-slot guard then ignores that window);
+        // the rest flip between windows, like the real corpus's server-side
+        // flip, and stay estimator-worthy.
+        slot: resetIndex === 0
+          ? (boundary % 2 === 0 ? "secondary" : "primary")
+          : resetIndex * 2 < resetStarts.length ? "secondary" : "primary",
+        planType: "pro",
+      });
+      for (let step = 0; step < usagePerBoundary; step += 1) {
+        usage.push(corpusUsageRow(
+          usage.length,
+          observedAtMs + 10_000 + step * 5_000,
+        ));
+      }
+    }
+  }
+  return { usage, quota };
+}
+
+async function writeCorpusIndex(indexFile, { usage, quota }) {
+  const database = openLocalUnifiedIndex(indexFile, { create: true });
+  const writer = createUnifiedIndexWriter(database, {
+    contractVersion: "unified-calibration-test-v1",
+  });
+  const modelIds = new Map([...MODELS, "not-a-recognized-model"].map((model) => [
+    model,
+    writer.internModel(model, "recognized"),
+  ]));
+  const tierIds = new Map(SPEEDS.map((speed) => [
+    speed,
+    writer.internTier({
+      apiServiceTier: "unknown",
+      billingSurface: "unknown",
+      codexSpeedMode: speed,
+      tierSource: "unknown",
+      providerTierRaw: null,
+    }),
+  ]));
+  const surfaceId = writer.internSurface({
+    agentScope: "unknown",
+    surface: "unknown",
+    threadSource: "unknown",
+    lineageDisposition: "unknown",
+  });
+  const accountScopeId = writer.internAccountScope({
+    status: "unavailable",
+    reason: null,
+    planType: null,
+    scopeLocal: null,
+  });
+  const sessionLocal = Buffer.alloc(32, 5);
+  for (const [index, row] of usage.entries()) {
+    writer.writeUsageEvent({
+      eventKey: Buffer.from(`corpus-stream-event-${index}`),
+      observedAtMs: row.observedAtMs,
+      sessionLocal,
+      accountScopeId,
+      modelId: modelIds.get(row.model),
+      tierId: tierIds.get(row.speed),
+      surfaceId,
+      reasoningEffort: 8,
+      outcome: 5,
+      tokensInUncached: row.tokensInUncached,
+      tokensInCacheRead: row.tokensInCacheRead,
+      tokensInCacheWrite: row.tokensInCacheWrite,
+      tokensOutText: row.tokensOutText,
+      tokensOutReasoning: row.tokensOutReasoning,
+      tokensOutCombined: row.tokensOutCombined,
+      totalInputContext: row.totalInputContext,
+    });
+  }
+  for (const row of quota) {
+    writer.internQuota({
+      observedAtMs: row.observedAtMs,
+      limitId: "codex",
+      slot: row.slot,
+      planType: row.planType,
+      usedPercent: row.usedPercent,
+      resetsAtMs: row.resetsAtMs,
+      durationMins: 10_080,
+    });
+  }
+  await writer.close({ integrityCheck: true, fsyncPath: indexFile });
+}
+
+// The resident-array oracle: the same rows fed through the windowed scan
+// path, which retains its transition inputs in memory and drives the same
+// fit fold and the same batched derivation from arrays. The raw events mirror
+// exactly the shape the unified corpus reader reconstructs per row.
+function oracleScan({ usage, quota }) {
+  return async ({ onUsage, onRateLimitSnapshot }) => {
+    for (const row of usage) {
+      onUsage({
+        timestamp: new Date(row.observedAtMs).toISOString(),
+        model: row.model,
+        ...(row.totalInputContext === null
+          ? {}
+          : { totalInputContextTokens: row.totalInputContext }),
+        components: {
+          input_uncached_tokens: row.tokensInUncached,
+          input_cache_read_tokens: row.tokensInCacheRead,
+          input_cache_write_tokens: row.tokensInCacheWrite,
+          output_text_tokens: row.tokensOutText,
+          output_reasoning_tokens: row.tokensOutReasoning,
+          output_combined_tokens: row.tokensOutCombined,
+        },
+        tierSemantics: {
+          codexSpeedMode: row.speed,
+          apiServiceTier: "unknown",
+        },
+      });
+    }
+    for (const row of quota) {
+      onRateLimitSnapshot({
+        timestamp: new Date(row.observedAtMs).toISOString(),
+        timestampMs: row.observedAtMs,
+        window: {
+          provider: "openai_codex",
+          planType: row.planType,
+          limitId: "codex",
+          slot: row.slot,
+          windowDurationMins: 10_080,
+          resetsAt: Math.floor(row.resetsAtMs / 1_000),
+          usedPercent: row.usedPercent,
+        },
+      });
+    }
+    // The oracle deliberately reports no scan diagnostics: the unified
+    // calibration corpus passes {} into the derivation, and the calibration
+    // artifacts under comparison must not diverge on diagnostics alone.
+    return { diagnostics: {} };
+  };
+}
+
+const DECLARED_SPEED_BASELINES = [{
+  firstSeenAt: "2026-05-01T00:00:00.000Z",
+  lastSeenAt: "2026-05-20T00:00:00.000Z",
+  mode: "standard",
+}];
+
+test("streamed unified calibration is byte-identical to the same corpus held resident, across the batched derivation path", async () => {
+  const directory = await mkdtemp(join(tmpdir(), "usage-monitor-corpus-stream-equivalence-"));
+  try {
+    // 52,000 usage rows — past the 50k single-call usage budget — so the
+    // derivation must batch and the streamed path must serve multiple
+    // on-demand usage slices; 8 weekly resets x 99 whole-point changes keep
+    // the corpus estimator-worthy so real estimates are compared.
+    const corpus = syntheticCorpus({
+      resetStarts: Array.from(
+        { length: 8 },
+        (_, week) => Date.parse("2026-05-07T00:00:00.000Z") + week * WEEK_MS,
+      ),
+      boundariesPerReset: 100,
+      usagePerBoundary: 65,
+    });
+    assert.equal(corpus.usage.length, 52_000);
+    const indexFile = join(directory, "local-unified-index-v1.sqlite");
+    await writeCorpusIndex(indexFile, corpus);
+
+    const streamed = await buildReplaySafeAccountingCache({
+      now: () => NOW,
+      unifiedIndexFile: indexFile,
+      declaredSpeedBaselines: DECLARED_SPEED_BASELINES,
+      scan: async () => ({ diagnostics: {} }),
+    });
+    const resident = await buildReplaySafeAccountingCache({
+      now: () => NOW,
+      unifiedIndexFile: join(directory, "never-written.sqlite"),
+      declaredSpeedBaselines: DECLARED_SPEED_BASELINES,
+      scan: oracleScan(corpus),
+    });
+
+    assert.equal(streamed.weeklyCalibrationInput.source, "unified_index");
+    assert.equal(resident.weeklyCalibrationInput.source, "windowed_scan");
+    assert.equal(
+      streamed.weeklyCalibrationInput.retainedUsageEvents,
+      corpus.usage.length,
+    );
+    assert.equal(
+      streamed.weeklyCalibrationInput.retainedUsageEvents,
+      resident.weeklyCalibrationInput.retainedUsageEvents,
+    );
+    assert.equal(
+      streamed.weeklyCalibrationInput.retainedWeeklySnapshots,
+      resident.weeklyCalibrationInput.retainedWeeklySnapshots,
+    );
+    assert.equal(
+      streamed.weeklyCalibrationInput.estimatedRetainedBytes,
+      resident.weeklyCalibrationInput.estimatedRetainedBytes,
+    );
+    // The calibration artifacts — reset series, estimate, validation,
+    // composition fit, and every allowance scenario — must be identical to
+    // the resident-array build. This is the exact seam the streaming corpus
+    // changed: array folds and slices versus on-demand re-reads.
+    assert.deepEqual(streamed.weeklyCalibration, resident.weeklyCalibration);
+    assert.deepEqual(
+      streamed.allowanceCapacityByScenario,
+      resident.allowanceCapacityByScenario,
+    );
+    // 792 transitions crossed the batched path in both builds, and the corpus
+    // was estimator-worthy, so this compared real estimates rather than two
+    // empty summaries.
+    assert.equal(
+      streamed.weeklyCalibration.sourceCounts.weeklyTransitions,
+      792,
+    );
+    assert.equal(streamed.weeklyCalibration.status, "estimated");
+  } finally {
+    await rm(directory, { recursive: true, force: true });
+  }
+});
+
+test("retention trim keeps the newest rows across timestamp ties, identically to a resident corpus of those rows", async () => {
+  const directory = await mkdtemp(join(tmpdir(), "usage-monitor-corpus-stream-trim-"));
+  try {
+    const resetStartMs = Date.parse("2026-06-04T00:00:00.000Z");
+    const tieMs = resetStartMs + 30 * 60 * 60_000;
+    // Twelve usage rows share one timestamp; retention keeps the newest five
+    // by insertion (rowid) order. The streamed re-reads must honor the same
+    // (observedMs, rowid) cursor through the tie.
+    const usage = Array.from({ length: 12 }, (_, index) => corpusUsageRow(index, tieMs));
+    const quota = Array.from({ length: 6 }, (_, boundary) => ({
+      observedAtMs: resetStartMs + (boundary + 30) * 60 * 60_000,
+      usedPercent: boundary + 30,
+      resetsAtMs: resetStartMs + WEEK_MS,
+      slot: boundary % 2 === 0 ? "secondary" : "primary",
+      planType: "pro",
+    }));
+    const indexFile = join(directory, "local-unified-index-v1.sqlite");
+    await writeCorpusIndex(indexFile, { usage, quota });
+
+    const streamed = await buildReplaySafeAccountingCache({
+      now: () => NOW,
+      unifiedIndexFile: indexFile,
+      transitionResourceLimits: { usageEvents: 5 },
+      declaredSpeedBaselines: DECLARED_SPEED_BASELINES,
+      scan: async () => ({ diagnostics: {} }),
+    });
+    const resident = await buildReplaySafeAccountingCache({
+      now: () => NOW,
+      unifiedIndexFile: join(directory, "never-written.sqlite"),
+      declaredSpeedBaselines: DECLARED_SPEED_BASELINES,
+      // The oracle receives only the rows the trim retains: the last five
+      // inserted (highest rowids) of the tied twelve.
+      scan: oracleScan({ usage: usage.slice(7), quota }),
+    });
+
+    assert.equal(streamed.weeklyCalibrationInput.retainedUsageEvents, 5);
+    assert.equal(
+      streamed.weeklyCalibrationInput.retainedWeeklySnapshots,
+      resident.weeklyCalibrationInput.retainedWeeklySnapshots,
+    );
+    assert.deepEqual(streamed.weeklyCalibration, resident.weeklyCalibration);
+    assert.deepEqual(
+      streamed.allowanceCapacityByScenario,
+      resident.allowanceCapacityByScenario,
+    );
+  } finally {
+    await rm(directory, { recursive: true, force: true });
+  }
+});
+
+test("a corpus far larger than one derivation batch completes in ONE pass under a scaled-down whole-process RSS budget", async (t) => {
+  const directory = await mkdtemp(join(tmpdir(), "usage-monitor-corpus-stream-budget-"));
+  try {
+    // 300k usage rows across six reset windows. Under the pre-streaming
+    // reader this corpus materialized ~190 MiB of compact rows (measured
+    // ~635 real bytes per row) plus its stamped/sorted copies BEFORE any
+    // derivation ran — past the budget below on retention alone — and a
+    // deferred pass would have re-run the identical materialization forever.
+    // The streamed corpus holds at most one <=50k-row batch slice instead,
+    // so its peak stays batch-bounded no matter how large the history grows.
+    const corpus = syntheticCorpus({
+      resetStarts: Array.from(
+        { length: 6 },
+        (_, week) => Date.parse("2026-04-02T00:00:00.000Z") + week * WEEK_MS,
+      ),
+      boundariesPerReset: 1_000,
+      usagePerBoundary: 50,
+      boundaryStepMs: 60_000,
+      percentFor: (boundary) => (boundary % 200) / 2,
+    });
+    assert.equal(corpus.usage.length, 300_000);
+    const indexFile = join(directory, "local-unified-index-v1.sqlite");
+    await writeCorpusIndex(indexFile, corpus);
+
+    // The scaled-down budget: the real process RSS at test start plus a
+    // margin far below the old design's resident corpus. The guard runs
+    // against genuine process.memoryUsage().rss readings, so a regression
+    // back to O(corpus) residency trips accounting_transition_rss_limit_
+    // exceeded and rejects this build.
+    // Margin calibration (2026-08-19, measured): the streamed build peaked at
+    // ~354 MiB growth on a 200k corpus — batch working sets and GC lag, all
+    // corpus-size-independent — while the retired resident reader would add
+    // ~190 MiB of corpus retention on top for THIS corpus. 512 MiB therefore
+    // sits with real headroom above the streamed peak and below any design
+    // that holds the corpus resident again.
+    const baselineRss = process.memoryUsage().rss;
+    const budgetBytes = Number(process.env.CORPUS_STREAM_BUDGET_MIB ?? 512)
+      * 1024 * 1024;
+    let peakRss = baselineRss;
+    let rssReadings = 0;
+    const cache = await buildReplaySafeAccountingCache({
+      now: () => NOW,
+      unifiedIndexFile: indexFile,
+      declaredSpeedBaselines: DECLARED_SPEED_BASELINES,
+      scan: async () => ({ diagnostics: {} }),
+      rss: () => {
+        rssReadings += 1;
+        const current = process.memoryUsage().rss;
+        if (current > peakRss) peakRss = current;
+        return current;
+      },
+      maximumRssBytes: baselineRss + budgetBytes,
+    });
+
+    t.diagnostic(
+      `peak RSS growth ${((peakRss - baselineRss) / 1024 / 1024).toFixed(1)} MiB `
+        + `of the ${(budgetBytes / 1024 / 1024).toFixed(0)} MiB budget`,
+    );
+    assert.ok(
+      rssReadings > 50,
+      `the RSS guard must meter the streamed corpus (saw ${rssReadings} readings)`,
+    );
+    assert.equal(cache.weeklyCalibrationInput.source, "unified_index");
+    assert.equal(cache.weeklyCalibrationInput.retainedUsageEvents, 300_000);
+    // 999 percent changes per reset window x 6 windows: the whole series was
+    // derived, none of it discarded to fit the budget.
+    assert.equal(
+      cache.weeklyCalibration.sourceCounts.weeklyTransitions,
+      5_994,
+    );
+    assert.ok(
+      peakRss - baselineRss <= budgetBytes,
+      `peak RSS growth ${((peakRss - baselineRss) / 1024 / 1024).toFixed(1)} MiB exceeded the scaled budget`,
+    );
+  } finally {
+    await rm(directory, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
The full-history accounting rebuild was a deterministic livelock on large corpora: the calibration corpus was fully materialized at ~635 real bytes/row against a 256 B/row byte meter (~454 MB retained at the 750k-row ceiling while the meter said 192 MB); the RSS guard measures the whole process against min(2 GiB, baseline+1.25 GiB) while the companion idled at 1.94 GiB from its own prior failed attempts (macOS does not return freed pages); and each deferral retried the identical monolithic pass 30 minutes later with no durable progress. Observed live for hours on the owner's 4,852-source corpus as accounting_transition_rss_limit_exceeded with a bare $0.00 cost view.

Changes: the corpus now streams — the open pass retains a thin (observedMs, rowid) stamp per row, the fit folds in one pass, and batched derivation re-reads ≤50k-row slices via keyset scans with generation and file-identity verified at open and after the last slice. Peak corpus residency is O(batch); RSS budgets are untouched. A latent planner bug found on the way is fixed: batch grouping was slot-keyed while the miner's window key is slot-agnostic, silently dropping a slot-flip-crossing transition (the real corpus has one, ~Jul 6). Consecutive deferred attempts are now counted across ticks and surfaced, and the Usage-and-costs view explains a persistently deferred rebuild instead of showing bare $0.00 (en/zh-Hans/es).

Tests: stream-vs-resident calibration artifacts pinned byte-identical across the multi-slice path; a 300k-row corpus (~190 MiB if materialized) completes in one pass inside a --max-old-space-size=256 child under a real process-RSS budget. On the rebased tree: stream+refresh 75/75, UI 307/307, weekly-pace green.

Operational note: the currently-running 1.94 GiB companion keeps deferring until restarted — the next dogfood update restart clears it, after which the streamed pass lands within budget. Touches workload sources — R7 receipts regenerate once after this set lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)