### PR TITLE
feat(quota): name the returned Spark five-hour allowance

### DIFF
--- a/apps/web/public/app.js
+++ b/apps/web/public/app.js
@@ -2,9 +2,9 @@ import {
   CommunityClient,
   isPrimaryCodexQuotaWindow,
   isPrimaryCodexWeeklyQuotaWindow,
+  isSparkQuotaLimitId,
   LocalCompanionClient,
   CODEX_PRIMARY_LIMIT_ID,
-  CODEX_SPARK_LIMIT_ID,
   CODEX_FIVE_HOUR_ALLOWANCE_MINUTES,
   CODEX_WEEKLY_ALLOWANCE_MINUTES,
   demoDashboard,
@@ -1103,7 +1103,7 @@ function renderQuotaCards(data) {
   clear(container);
   const normalWindows = data.quotaWindows.filter(isPrimaryCodexQuotaWindow);
   const sparkWindows = data.quotaWindows.filter((window) => (
-    window?.limitId === CODEX_SPARK_LIMIT_ID
+    isSparkQuotaLimitId(window?.limitId)
       && isValidQuotaWindowDuration(finite(window?.durationMinutes))
   ));
   const primaryWindow = selectPrimaryCodexQuotaWindow(normalWindows);
@@ -1130,7 +1130,7 @@ function renderQuotaCards(data) {
   }
   for (const window of windows) {
     const remaining = finite(window.remainingPercent);
-    const spark = window.limitId === CODEX_SPARK_LIMIT_ID;
+    const spark = isSparkQuotaLimitId(window.limitId);
     const card = node("article", [
       "metric-card",
       window.status === "stale" ? "stale" : "",
@@ -1213,7 +1213,17 @@ function localizedQuotaWindowDuration(durationMinutes) {
 
 function localizedQuotaWindowLabel(window) {
   const duration = finite(window?.durationMinutes, null);
-  if (window?.limitId === CODEX_SPARK_LIMIT_ID) {
+  if (isSparkQuotaLimitId(window?.limitId)) {
+    // The provider re-introduced the 5-hour "Codex Spark" window on the Spark
+    // limit (wire: codex_bengalfox, window_minutes 300) alongside the Spark
+    // seven-day window, so the two Spark cards need distinct duration-named
+    // titles. An unfamiliar Spark duration keeps the honest generic name.
+    if (duration === CODEX_FIVE_HOUR_ALLOWANCE_MINUTES) {
+      return t("dashboard.quota.windowSparkFiveHour");
+    }
+    if (duration === CODEX_WEEKLY_ALLOWANCE_MINUTES) {
+      return t("dashboard.quota.windowSparkSevenDay");
+    }
     return t("dashboard.quota.windowSpark");
   }
   if (window?.limitId === CODEX_PRIMARY_LIMIT_ID

--- a/apps/web/public/data-client.js
+++ b/apps/web/public/data-client.js
@@ -40,9 +40,23 @@ const CENTRAL_ROOT = "/api/v1";
 // be mistaken for it.
 export const CODEX_PRIMARY_LIMIT_ID = "codex";
 export const CODEX_SPARK_LIMIT_ID = "codex_bengalfox";
+// The Spark allowance is reported as `codex_bengalfox` on the wire today;
+// `codex-spark` is the marketing token the companion reserves in case the
+// provider stabilizes on it later (mirrors SPARK_QUOTA_LIMIT_IDS in
+// src/local-companion-usage-model.js). Both identify the same separate Spark
+// limit; neither is ever rewritten into the other.
+export const CODEX_SPARK_RESERVED_LIMIT_ID = "codex-spark";
+export const CODEX_SPARK_LIMIT_IDS = Object.freeze([
+  CODEX_SPARK_LIMIT_ID,
+  CODEX_SPARK_RESERVED_LIMIT_ID
+]);
 export const CODEX_FIVE_HOUR_ALLOWANCE_MINUTES = 300;
 export const CODEX_WEEKLY_ALLOWANCE_MINUTES = 10_080;
 export const MAX_QUOTA_WINDOW_DURATION_MINUTES = 525_600;
+
+export function isSparkQuotaLimitId(value) {
+  return CODEX_SPARK_LIMIT_IDS.includes(value);
+}
 const BACKEND_LIFECYCLE_STATES = new Set([
   "never_run",
   "running",
@@ -263,7 +277,7 @@ function canonicalInstant(value) {
 
 function normalizeQuotaLimitId(value) {
   const candidate = text(value, "");
-  return candidate === CODEX_PRIMARY_LIMIT_ID || candidate === CODEX_SPARK_LIMIT_ID
+  return candidate === CODEX_PRIMARY_LIMIT_ID || isSparkQuotaLimitId(candidate)
     ? candidate
     : "unknown";
 }
@@ -317,21 +331,60 @@ export function formatQuotaWindowDuration(durationMinutes) {
   return `${duration}-minute`;
 }
 
+// Every window kind this product names, mapped from the provider's technical
+// identity (limitId, durationMinutes) alone — never from a provider label
+// string. The 5-hour Spark window ("Codex Spark") arrives on the wire as
+// limit_id "codex_bengalfox" with window_minutes 300 alongside the Spark
+// seven-day window (observed 2026-08-19, when the provider re-introduced it).
+// An unrecognized combination classifies as an honest generic kind rather
+// than borrowing the weekly or five-hour identity.
+export const QUOTA_WINDOW_KINDS = Object.freeze([
+  "codex_five_hour",
+  "codex_seven_day",
+  "codex_provider_reported",
+  "spark_five_hour",
+  "spark_seven_day",
+  "spark_other",
+  "other"
+]);
+
+export function classifyQuotaWindowKind(limitId, durationMinutes) {
+  const duration = finite(durationMinutes, null);
+  if (limitId === CODEX_PRIMARY_LIMIT_ID) {
+    if (duration === CODEX_FIVE_HOUR_ALLOWANCE_MINUTES) return "codex_five_hour";
+    if (duration === CODEX_WEEKLY_ALLOWANCE_MINUTES) return "codex_seven_day";
+    if (isValidQuotaWindowDuration(duration)) return "codex_provider_reported";
+    return "other";
+  }
+  if (isSparkQuotaLimitId(limitId)) {
+    if (duration === CODEX_FIVE_HOUR_ALLOWANCE_MINUTES) return "spark_five_hour";
+    if (duration === CODEX_WEEKLY_ALLOWANCE_MINUTES) return "spark_seven_day";
+    // The limit identity is certain even when the duration is novel or
+    // unparseable, so the window keeps the generic Spark name rather than
+    // being promoted to a named duration or demoted to "other".
+    return "spark_other";
+  }
+  return "other";
+}
+
 export function quotaWindowLabel(limitId, durationMinutes) {
   const duration = finite(durationMinutes, null);
-  if (limitId === CODEX_PRIMARY_LIMIT_ID
-      && duration === CODEX_FIVE_HOUR_ALLOWANCE_MINUTES) {
-    return "Five-hour allowance";
+  switch (classifyQuotaWindowKind(limitId, duration)) {
+    case "codex_five_hour":
+      return "Five-hour allowance";
+    case "codex_seven_day":
+      return "Seven-day allowance";
+    case "codex_provider_reported":
+      return `Provider-reported ${formatQuotaWindowDuration(duration)} window`;
+    case "spark_five_hour":
+      return "Spark five-hour allowance";
+    case "spark_seven_day":
+      return "Spark seven-day allowance";
+    case "spark_other":
+      return "Spark allowance";
+    default:
+      return "Other observed allowance";
   }
-  if (limitId === CODEX_PRIMARY_LIMIT_ID
-      && duration === CODEX_WEEKLY_ALLOWANCE_MINUTES) {
-    return "Seven-day allowance";
-  }
-  if (limitId === CODEX_PRIMARY_LIMIT_ID
-      && isValidQuotaWindowDuration(duration)) {
-    return `Provider-reported ${formatQuotaWindowDuration(duration)} window`;
-  }
-  return "Other observed allowance";
 }
 
 function count(value, fallback = null) {

--- a/apps/web/public/localization.js
+++ b/apps/web/public/localization.js
@@ -204,6 +204,12 @@ export const WEB_MESSAGES = Object.freeze({
   "dashboard.quota.windowFiveHour": ["Five-hour allowance", "五小时额度", "Asignación de cinco horas"],
   "dashboard.quota.windowSevenDay": ["Seven-day allowance", "七天额度", "Asignación de siete días"],
   "dashboard.quota.windowSpark": ["Spark allowance", "Spark 额度", "Asignación de Spark"],
+  // The provider's separate Spark limit now reports two windows at once (the
+  // re-introduced 5-hour "Codex Spark" window and its seven-day window), so
+  // each recognized duration carries its own title while windowSpark stays the
+  // honest generic name for any unfamiliar Spark duration.
+  "dashboard.quota.windowSparkFiveHour": ["Spark five-hour allowance", "Spark 五小时额度", "Asignación de Spark de cinco horas"],
+  "dashboard.quota.windowSparkSevenDay": ["Spark seven-day allowance", "Spark 七天额度", "Asignación de Spark de siete días"],
   "dashboard.quota.spark": ["Spark · separate limit", "Spark · 独立额度", "Spark · límite separado"],
   "dashboard.quota.windowProviderReported": ["Provider-reported {duration} window", "提供方报告的 {duration} 窗口", "Ventana de {duration} informada por el proveedor"],
   "dashboard.quota.windowOther": ["Other observed allowance", "其他观测到的额度", "Otra asignación observada"],

--- a/apps/web/test/lib.test.mjs
+++ b/apps/web/test/lib.test.mjs
@@ -1992,7 +1992,10 @@ test("normal Codex allowance selection uses stable identifiers, not labels", () 
   });
   assert.equal(CODEX_PRIMARY_LIMIT_ID, "codex");
   assert.equal(result.quotaWindows[0].label, "Seven-day allowance");
-  assert.equal(result.quotaWindows[1].label, "Other observed allowance");
+  // The Spark limit's recognized durations now carry their own fixed names —
+  // still derived from (limitId, duration) alone, never from the provider's
+  // label string supplied above.
+  assert.equal(result.quotaWindows[1].label, "Spark seven-day allowance");
   assert.equal(result.quotaWindows[2].label, "Other observed allowance");
   assert.equal(result.quotaWindows[0].limitId, CODEX_PRIMARY_LIMIT_ID);
   assert.equal(result.quotaWindows[1].limitId, CODEX_SPARK_LIMIT_ID);
@@ -2270,10 +2273,14 @@ test("account-scoped normalization keeps generic and seven-day tracks separate",
 
 test("quota presentation keeps Spark separate and weekly surfaces exact", async () => {
   const appSource = await readFile(new URL("../public/app.js", import.meta.url), "utf8");
-  assert.match(appSource, /CODEX_SPARK_LIMIT_ID/u);
+  assert.match(appSource, /isSparkQuotaLimitId/u);
   assert.match(appSource, /const sparkWindows = data\.quotaWindows\.filter/u);
   assert.match(appSource, /quota-card-spark/u);
   assert.match(appSource, /dashboard\.quota\.windowSpark/u);
+  // The Spark limit's two recognized windows carry duration-named titles; the
+  // duration-blind windowSpark key stays as the honest generic fallback only.
+  assert.match(appSource, /dashboard\.quota\.windowSparkFiveHour/u);
+  assert.match(appSource, /dashboard\.quota\.windowSparkSevenDay/u);
   assert.match(appSource, /dashboard\.quota\.spark/u);
   assert.match(appSource, /const normalWindows = data\.quotaWindows\.filter\(isPrimaryCodexQuotaWindow\)/u);
   assert.match(appSource, /rows\.filter\(isPrimaryCodexWeeklyQuotaWindow\)/u);

--- a/apps/web/test/quota-window-naming.test.mjs
+++ b/apps/web/test/quota-window-naming.test.mjs
@@ -1,0 +1,179 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import {
+  classifyQuotaWindowKind,
+  isSparkQuotaLimitId,
+  normalizeDashboardPayload,
+  quotaWindowLabel,
+  CODEX_FIVE_HOUR_ALLOWANCE_MINUTES,
+  CODEX_PRIMARY_LIMIT_ID,
+  CODEX_SPARK_LIMIT_ID,
+  CODEX_SPARK_LIMIT_IDS,
+  CODEX_SPARK_RESERVED_LIMIT_ID,
+  CODEX_WEEKLY_ALLOWANCE_MINUTES,
+  QUOTA_WINDOW_KINDS,
+} from "../public/data-client.js";
+import {
+  SUPPORTED_LOCALES,
+  translate,
+} from "../public/localization.js";
+
+// The provider re-introduced the 5-hour "Codex Spark" allowance window on
+// 2026-08-19. On the wire it arrives from `account/rateLimits/read` as a
+// distinct rate-limit window on the separate Spark limit — limit_id
+// "codex_bengalfox", window_minutes 300 — in the limit's `primary` slot,
+// while the Spark seven-day window moves to `secondary`, all alongside the
+// normal Codex weekly window. These tests pin that observed shape and the
+// display identity each window classifies into.
+
+test("window kinds map from technical identity alone, including the returned 5-hour Spark window", () => {
+  assert.deepEqual(CODEX_SPARK_LIMIT_IDS, ["codex_bengalfox", "codex-spark"]);
+  assert.equal(isSparkQuotaLimitId(CODEX_SPARK_LIMIT_ID), true);
+  assert.equal(isSparkQuotaLimitId(CODEX_SPARK_RESERVED_LIMIT_ID), true);
+  assert.equal(isSparkQuotaLimitId(CODEX_PRIMARY_LIMIT_ID), false);
+  assert.equal(isSparkQuotaLimitId("unknown"), false);
+
+  const expectations = [
+    // The normal Codex allowance track keeps its named durations.
+    [CODEX_PRIMARY_LIMIT_ID, CODEX_FIVE_HOUR_ALLOWANCE_MINUTES, "codex_five_hour"],
+    [CODEX_PRIMARY_LIMIT_ID, CODEX_WEEKLY_ALLOWANCE_MINUTES, "codex_seven_day"],
+    [CODEX_PRIMARY_LIMIT_ID, 43_200, "codex_provider_reported"],
+    [CODEX_PRIMARY_LIMIT_ID, 0, "other"],
+    [CODEX_PRIMARY_LIMIT_ID, null, "other"],
+    // The re-introduced 5-hour Spark window and the Spark weekly window are
+    // distinct kinds on the same separate limit.
+    [CODEX_SPARK_LIMIT_ID, CODEX_FIVE_HOUR_ALLOWANCE_MINUTES, "spark_five_hour"],
+    [CODEX_SPARK_LIMIT_ID, CODEX_WEEKLY_ALLOWANCE_MINUTES, "spark_seven_day"],
+    // A novel or unparseable Spark duration keeps the generic Spark kind
+    // rather than borrowing a named duration (525,600 minutes was the Spark
+    // limit's original observed shape).
+    [CODEX_SPARK_LIMIT_ID, 525_600, "spark_other"],
+    [CODEX_SPARK_LIMIT_ID, 0, "spark_other"],
+    [CODEX_SPARK_LIMIT_ID, null, "spark_other"],
+    // The reserved marketing token classifies identically to the wire id.
+    [CODEX_SPARK_RESERVED_LIMIT_ID, CODEX_FIVE_HOUR_ALLOWANCE_MINUTES, "spark_five_hour"],
+    [CODEX_SPARK_RESERVED_LIMIT_ID, CODEX_WEEKLY_ALLOWANCE_MINUTES, "spark_seven_day"],
+    // An unrecognized limit id never inherits a named window identity.
+    ["mystery_limit", CODEX_FIVE_HOUR_ALLOWANCE_MINUTES, "other"],
+    ["mystery_limit", CODEX_WEEKLY_ALLOWANCE_MINUTES, "other"],
+    ["unknown", 300, "other"],
+    [null, 300, "other"],
+    [undefined, undefined, "other"],
+  ];
+  for (const [limitId, durationMinutes, kind] of expectations) {
+    assert.equal(
+      classifyQuotaWindowKind(limitId, durationMinutes),
+      kind,
+      `${String(limitId)} + ${String(durationMinutes)}`,
+    );
+    assert.equal(QUOTA_WINDOW_KINDS.includes(kind), true, kind);
+  }
+});
+
+test("fixed window labels name the Spark durations and keep honest generic fallbacks", () => {
+  assert.equal(quotaWindowLabel("codex", 300), "Five-hour allowance");
+  assert.equal(quotaWindowLabel("codex", 10_080), "Seven-day allowance");
+  assert.equal(quotaWindowLabel("codex", 43_200), "Provider-reported 30-day window");
+  assert.equal(quotaWindowLabel("codex_bengalfox", 300), "Spark five-hour allowance");
+  assert.equal(quotaWindowLabel("codex_bengalfox", 10_080), "Spark seven-day allowance");
+  assert.equal(quotaWindowLabel("codex-spark", 300), "Spark five-hour allowance");
+  // Unfamiliar Spark durations stay generically Spark; a Spark window is
+  // never presented as the weekly or five-hour normal Codex allowance.
+  assert.equal(quotaWindowLabel("codex_bengalfox", 525_600), "Spark allowance");
+  assert.equal(quotaWindowLabel("codex_bengalfox", null), "Spark allowance");
+  // Unknown limits keep the pre-existing honest fallback.
+  assert.equal(quotaWindowLabel("unknown", 300), "Other observed allowance");
+  assert.equal(quotaWindowLabel(null, 10_080), "Other observed allowance");
+  assert.equal(quotaWindowLabel("codex", null), "Other observed allowance");
+});
+
+test("Spark window titles are translated in every supported locale", () => {
+  const expected = {
+    "dashboard.quota.windowSparkFiveHour": {
+      "en-US": "Spark five-hour allowance",
+      "zh-Hans": "Spark 五小时额度",
+      es: "Asignación de Spark de cinco horas",
+    },
+    "dashboard.quota.windowSparkSevenDay": {
+      "en-US": "Spark seven-day allowance",
+      "zh-Hans": "Spark 七天额度",
+      es: "Asignación de Spark de siete días",
+    },
+    "dashboard.quota.windowSpark": {
+      "en-US": "Spark allowance",
+      "zh-Hans": "Spark 额度",
+      es: "Asignación de Spark",
+    },
+    "dashboard.quota.windowOther": {
+      "en-US": "Other observed allowance",
+      "zh-Hans": "其他观测到的额度",
+      es: "Otra asignación observada",
+    },
+  };
+  for (const [key, byLocale] of Object.entries(expected)) {
+    for (const locale of SUPPORTED_LOCALES) {
+      assert.equal(translate(key, {}, locale), byLocale[locale], `${key} ${locale}`);
+    }
+  }
+});
+
+test("the observed three-window wire shape normalizes into distinctly named windows", () => {
+  // Shape recorded by the live collector on 2026-08-19T23:49:40Z (epoch
+  // resets abbreviated to ISO instants the browser contract carries).
+  const result = normalizeDashboardPayload({}, {
+    overview: {
+      schemaVersion: "local-companion-v0.1",
+      mode: "real_local_evidence",
+      evidenceStatus: "available",
+      latestEvidenceAt: "2026-08-19T23:49:40.000Z",
+      freshness: { status: "live", ageSeconds: 30 },
+      quota: {
+        observedAt: "2026-08-19T23:49:40.000Z",
+        windows: [
+          {
+            limitId: "codex",
+            slot: "primary",
+            planType: "pro",
+            usedPercent: 100,
+            durationMinutes: 10_080,
+            resetAt: "2026-08-20T05:54:08.000Z",
+          },
+          {
+            limitId: "codex_bengalfox",
+            slot: "primary",
+            planType: "pro",
+            usedPercent: 0,
+            durationMinutes: 300,
+            resetAt: "2026-08-20T04:49:39.000Z",
+          },
+          {
+            limitId: "codex_bengalfox",
+            slot: "secondary",
+            planType: "pro",
+            usedPercent: 0,
+            durationMinutes: 10_080,
+            resetAt: "2026-08-26T23:49:39.000Z",
+          },
+        ],
+      },
+      usage: [],
+    },
+  });
+  assert.deepEqual(
+    result.quotaWindows.map((window) => [window.limitId, window.durationMinutes, window.label]),
+    [
+      ["codex", 10_080, "Seven-day allowance"],
+      ["codex_bengalfox", 300, "Spark five-hour allowance"],
+      ["codex_bengalfox", 10_080, "Spark seven-day allowance"],
+    ],
+  );
+  assert.deepEqual(
+    result.quotaWindows.map((window) => classifyQuotaWindowKind(window.limitId, window.durationMinutes)),
+    ["codex_seven_day", "spark_five_hour", "spark_seven_day"],
+  );
+  // The Spark windows never join the normal Codex allowance selection.
+  assert.deepEqual(
+    result.quotaWindows.filter((window) => isSparkQuotaLimitId(window.limitId)).length,
+    2,
+  );
+});

--- a/test/fixtures/provider-quota-windows-v1.json
+++ b/test/fixtures/provider-quota-windows-v1.json
@@ -33,6 +33,20 @@
         "window_minutes": 525600,
         "resets_at": 1817001960
       }
+    },
+    {
+      "limit_id": "codex_bengalfox",
+      "plan_type": "pro",
+      "primary": {
+        "used_percent": 0,
+        "window_minutes": 300,
+        "resets_at": 1787201379
+      },
+      "secondary": {
+        "used_percent": 0,
+        "window_minutes": 10080,
+        "resets_at": 1787788179
+      }
     }
   ],
   "invalidRateLimits": [

--- a/test/quota-window-normalization.test.js
+++ b/test/quota-window-normalization.test.js
@@ -34,12 +34,22 @@ test("provider fixtures retain exact named durations and admit a 30-day-like win
       ["codex", "secondary", "pro", 10_080],
       ["codex", "primary", "unknown", 43_200],
       ["codex_bengalfox", "primary", "unknown", 525_600],
+      // The Spark limit's re-introduced shape, exactly as observed on the
+      // wire 2026-08-19: the 5-hour window in the limit's primary slot with
+      // the Spark seven-day window alongside in secondary. Both durations
+      // survive normalization verbatim so display code can name them.
+      ["codex_bengalfox", "primary", "pro", 300],
+      ["codex_bengalfox", "secondary", "pro", 10_080],
     ],
   );
   assert.equal(Object.hasOwn(windows[2], "planVariant"), false);
   assert.equal(Object.hasOwn(windows[2], "multiplier"), false);
 
   const primary = selectPrimaryQuotaWindow(windows);
+  // The Spark limit's 300-minute window never joins the normal Codex
+  // allowance selection even from a primary slot: selection is bound to the
+  // "codex" limit id, not to slot names or durations.
+  assert.equal(primary?.limitId, "codex");
   assert.equal(primary?.windowDurationMins, 43_200);
   assert.equal(formatQuotaWindowDuration(primary.windowDurationMins), "30-day");
   assert.equal(


### PR DESCRIPTION
OpenAI re-introduced the 5-hour Codex Spark allowance on 2026-08-19. Wire evidence from live collector state: it arrives on the separate Spark limit (limit_id codex_bengalfox) with windowDurationMins 300 in the primary slot, with Spark's seven-day window moved to secondary — not on the codex limit. Before this change the dashboard rendered both Spark windows with one duration-blind label (two identical 'Spark allowance' cards).

Adds classifyQuotaWindowKind(limitId, durationMinutes) with an enumerated kind vocabulary: Spark+300 → 'Spark five-hour allowance', Spark+10080 → 'Spark seven-day allowance' (en/zh-Hans/es, matching the established Five-hour/Seven-day naming pattern); unfamiliar Spark durations keep the honest generic 'Spark allowance', unknown limits keep 'Other observed allowance', and nothing ever borrows the codex weekly/five-hour identity. Classification derives from technical identity only, never provider label strings. The menu bar's deliberate codex-only filter is untouched (pinned by existing test).

Scoping: display layer only — the quota-analysis package's label mirror (no runtime consumers) is deferred to the next R7 receipt regeneration since src/ and packages/ are digest-attested. Tests: new quota-window-naming suite (kind mapping, labels, all locales, and the exact observed two-slot wire shape through normalizeDashboardPayload); fixtures extended with the observed shape; UI 312/312, i18n mirror clean; live-verified against real data in all three locales.

Found in passing, split to its own branch (in flight): Spark windows null ALL notification evidence in the collector, silently suppressing fresh-quota notifications since Jul 23.

🤖 Generated with [Claude Code](https://claude.com/claude-code)