### PR TITLE
fix(web): threshold-stating copy and informational styling for self-resolving notes

### DIFF
--- a/apps/web/public/app.js
+++ b/apps/web/public/app.js
@@ -1413,6 +1413,15 @@ const EVIDENCE_WARNING_FALLBACK = "#evidence-warnings";
 // as it.
 const EVIDENCE_WARNING_PROGRESS =
   /\b(?:advance|advances|advancing|expand|expands|still)\b/iu;
+// A load already in flight, and tracking that simply started fresh, are
+// information, not faults: the sentence names its own resolution. These share
+// the quiet blue treatment, so the alert color is reserved for caveats on
+// figures that are actually degraded (owner-directed, 2026-08-19: degraded
+// notes read as errors in dogfood). Deliberately absent: the withheld-cache
+// sentences and their vocabulary — that state is being replaced wholesale by
+// serve-stale-while-recalculating, and its rendering is owned there.
+const EVIDENCE_WARNING_INFORMATIONAL =
+  /\b(?:loading|started fresh)\b/iu;
 
 function evidenceWarningTarget(message) {
   return EVIDENCE_WARNING_ROUTES
@@ -1439,7 +1448,9 @@ function renderEvidenceWarnings(data) {
     for (const message of messages) {
       const item = node("li", EVIDENCE_WARNING_PROGRESS.test(message)
         ? "evidence-warning progress"
-        : "evidence-warning");
+        : EVIDENCE_WARNING_INFORMATIONAL.test(message)
+          ? "evidence-warning informational"
+          : "evidence-warning");
       setRawText(item, message);
       list.append(item);
     }

--- a/apps/web/public/styles.css
+++ b/apps/web/public/styles.css
@@ -1131,7 +1131,8 @@ h2 {
   font-size: .74rem;
   line-height: 1.5;
 }
-.evidence-warning.progress {
+.evidence-warning.progress,
+.evidence-warning.informational {
   border-inline-start-color: var(--blue);
   background: var(--blue-soft);
   color: #31536d;

--- a/apps/web/test/lib.test.mjs
+++ b/apps/web/test/lib.test.mjs
@@ -8879,6 +8879,81 @@ test("a chart says so when its series does not reach back as far as its label", 
 });
 
 // ---------------------------------------------------------------------------
+// Degraded-state register (owner dogfood, 2026-08-19). A companion note whose
+// state resolves by itself — a load already in flight, tracking that simply
+// started fresh — is information, and must not wear the alert treatment that
+// belongs to genuine caveats on degraded figures. The classing is matched on
+// the companion's own vocabulary, so the published sentences and the matcher
+// are pinned together: rewording either alone fails here instead of silently
+// restyling the note. The withheld-cache sentences are deliberately not
+// pinned in either direction — serve-stale-while-recalculating replaces that
+// state wholesale, and its copy and rendering are owned there.
+// ---------------------------------------------------------------------------
+
+test("self-resolving degraded notes are classed informational and keep the quiet style", async () => {
+  const appSource = await readFile(new URL("../public/app.js", import.meta.url), "utf8");
+  const styles = await readFile(new URL("../public/styles.css", import.meta.url), "utf8");
+  const companionSource = await readFile(
+    new URL("../../../src/local-companion-data.js", import.meta.url),
+    "utf8",
+  );
+
+  // The renderer consults the informational matcher and emits the class.
+  const matcherSource = appSource.match(
+    /const EVIDENCE_WARNING_INFORMATIONAL =\n  \/(.*)\/(\w+);/u,
+  );
+  assert.ok(matcherSource, "the informational matcher is available");
+  const informational = new RegExp(matcherSource[1], matcherSource[2]);
+  assert.match(
+    appSource,
+    /EVIDENCE_WARNING_INFORMATIONAL\.test\(message\)\s*\n\s*\? "evidence-warning informational"/u,
+  );
+  // The quiet treatment is the shared progress blue, not a third palette.
+  assert.match(
+    styles,
+    /\.evidence-warning\.progress,\n\.evidence-warning\.informational \{\n  border-inline-start-color: var\(--blue\);/u,
+  );
+
+  // The self-resolving sentences the companion actually publishes. Each must
+  // exist verbatim in the companion source and fall inside the matcher's
+  // vocabulary, so a reword cannot silently drop one back to the alert style.
+  const informationalSentences = [
+    "Quota tracking started fresh on this Mac, so its retained records begin"
+      + " on ${trackingStartDate}. Coverage of anything earlier is not claimed.",
+    "Full indexed history is loading. The latest replay-safe snapshot is shown"
+      + " meanwhile and will be replaced only by the completed full projection.",
+  ];
+  for (const sentence of informationalSentences) {
+    assert.ok(
+      companionSource.includes(sentence),
+      `the companion publishes: ${sentence}`,
+    );
+    assert.match(sentence, informational);
+  }
+
+  // Genuine caveats on the figures being shown (or genuinely missing) keep
+  // the alert treatment: none may drift into the informational vocabulary.
+  const alertSentences = [
+    "The newest retained collector evidence is more than"
+      + " ${Math.round(MAX_COLLECTOR_LIVE_AGE_MS / 60_000)} minutes old. This"
+      + " is expected after an idle stretch; any newer usage is counted on the"
+      + " next collector pass.",
+    "Recent cost figures come from the live collector projection until the"
+      + " replay-safe cache is refreshed. They may double-count usage that"
+      + " forked child sessions inherited.",
+    "Usage accounting is complete, but typed tool history is partial. Tool"
+      + " totals are withheld rather than reported as zero.",
+  ];
+  for (const sentence of alertSentences) {
+    assert.ok(
+      companionSource.includes(sentence),
+      `the companion publishes: ${sentence}`,
+    );
+    assert.doesNotMatch(sentence, informational);
+  }
+});
+
+// ---------------------------------------------------------------------------
 // Session-rejected repair fallback (owner-reported repair loop, 2026-08-08).
 // A stored session the service no longer recognizes must produce ONE sign-in
 // gate, never a repeated step-2 failure paragraph, and the ceremony must

--- a/src/local-companion-data.js
+++ b/src/local-companion-data.js
@@ -2697,9 +2697,17 @@ export async function buildLocalCompanionSnapshot({
   const pricingCoveragePercent = (displayUsage?.events ?? 0) === 0
     ? null
     : Number(((pricedEvents / displayUsage.events) * 100).toFixed(3));
+  // Each warning is a finished sentence in the register the dashboard reserves
+  // for degraded states: what happened, what it means for the figures on
+  // screen, and when or how it resolves — the voice the allowance and trends
+  // panels already use (owner-directed, 2026-08-19). The two withheld-cache
+  // sentences below are deliberately untouched: the serve-stale-while-
+  // recalculating work replaces them wholesale.
   const warnings = [];
   if (collectorFreshnessStatus === "stale") {
-    warnings.push("The newest retained collector evidence is stale.");
+    warnings.push(
+      `The newest retained collector evidence is more than ${Math.round(MAX_COLLECTOR_LIVE_AGE_MS / 60_000)} minutes old. This is expected after an idle stretch; any newer usage is counted on the next collector pass.`,
+    );
   }
   // The "Replay-safe cost accounting is N minutes old and is shown as stale
   // until refreshed" banner is gone (owner-directed, 2026-08-10). Trace: it
@@ -2723,7 +2731,7 @@ export async function buildLocalCompanionSnapshot({
   if (replaySafeCache === null && !unifiedAvailable
       && (displayUsage?.events ?? 0) > 0) {
     warnings.push(
-      "Recent cost accounting is using the live collector projection. It may include inherited snapshots from forked child rollouts until the replay-safe cache is refreshed.",
+      "Recent cost figures come from the live collector projection until the replay-safe cache is refreshed. They may double-count usage that forked child sessions inherited.",
     );
   }
   if (unifiedAccountingWithheld) {
@@ -2765,7 +2773,17 @@ export async function buildLocalCompanionSnapshot({
     );
   }
   if (indexing.status === "prospective_only") {
-    warnings.push("The retained collector state began prospectively and does not prove recent-history coverage.");
+    // "Prospective" is the collector's own vocabulary; the reader needs the
+    // consequence: tracking began fresh rather than by indexing what came
+    // before, so the retained records start at a date — named when known —
+    // and nothing earlier is asserted. The disclosure itself must survive
+    // the plainer words.
+    const trackingStartDate = typeof indexing.coveredAt?.startAt === "string"
+      ? indexing.coveredAt.startAt.slice(0, 10)
+      : null;
+    warnings.push(trackingStartDate === null
+      ? "Quota tracking started fresh on this Mac, so its retained records begin when the collector first ran. Coverage of anything earlier is not claimed."
+      : `Quota tracking started fresh on this Mac, so its retained records begin on ${trackingStartDate}. Coverage of anything earlier is not claimed.`);
   }
   const displayUnknownModelEvents = displayUsage?.byModel
     ?.find((row) => row.model === "unknown")?.events ?? 0;


### PR DESCRIPTION
Owner feedback from live dogfood: degraded-state notes read like error messages. Three companion warnings rewritten into the threshold-stating voice the allowance/trends panels already use: the prospective-coverage note now names the actual start date of retained records ('Quota tracking started fresh on this Mac, so its retained records begin on {date}…'), the stale-evidence note names its real 30-minute threshold and when it self-resolves, and the projection-fallback note says plainly what may be double-counted and until when. Disclosures preserved verbatim in meaning; error copy (failure codes, TT- sentences) untouched.

Self-resolving notes also stop wearing alert styling: a deliberately narrow informational matcher (loading|started fresh, word-bounded) renders them in the quiet informational blue; genuine caveats keep the rust alert style. Verified live against a served dashboard (computed styles + screenshot).

Deliberately excluded: all withheld-accounting-cache copy — reverted byte-identical to main with ownership comments, because the serve-stale-while-recalculating work on fix/accounting-rebuild-isolation deletes that banner entirely; the new source-contract test pins the informational/alert vocabulary without referencing any withheld-cache sentence so the branches cannot collide.

Suites re-run post-descope: UI 309/309, local 221/221, i18n mirror clean, architecture clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)