### PR TITLE
fix(collector): stop the Spark allowance from suppressing all quota notification evidence

### DIFF
--- a/docs/decisions/2026-08-03-local-only-quota-notifications.md
+++ b/docs/decisions/2026-08-03-local-only-quota-notifications.md
@@ -115,6 +115,24 @@ notification-center adapters. Automated tests use fakes only and never submit a
 real macOS notification. Human release verification still needs one explicit
 macOS permission/Settings exercise with a controlled fresh provider refresh.
 
+## 2026-08-19 Spark coexistence amendment
+
+The eligible `account/rateLimits/read` receipt has carried the separate Spark
+allowance limit (`codex_bengalfox` on the wire, `codex-spark` reserved)
+alongside the codex limit in every live snapshot since 2026-07-23. The
+original projection treated any non-codex window as an unknown
+classification and suppressed the whole receipt, which silently disabled
+fresh-quota notifications for every affected account from the feature's
+first day.
+
+Notification evidence is now derived from the codex limit's windows alone. A
+recognized Spark window in the same receipt is passed over — it is a separate
+pool the notification says nothing about, and its fields are not held to the
+codex window rules — while a malformed entry or a limit id that is neither
+codex nor Spark still suppresses the receipt, and a receipt with no valid
+codex windows still yields no evidence. Threshold semantics, the continuity
+key, freshness rules, and the native contract are unchanged.
+
 ## 2026-08-04 hardening amendment
 
 Each local companion refresh now receives an opaque UUID run token. The native

--- a/src/passive-collector.js
+++ b/src/passive-collector.js
@@ -35,6 +35,7 @@ import {
   readLocalCollectorCheckpoint,
   saveLocalCollectorCheckpoint,
 } from "./local-collector-state.js";
+import { SPARK_QUOTA_LIMIT_IDS } from "./local-companion-usage-model.js";
 
 const CHECKPOINT_SCHEMA_VERSION = "0.3";
 const RECORD_SCHEMA_VERSION = "0.3";
@@ -1251,6 +1252,13 @@ export function appServerSnapshotRecord(payload, { source, receivedAt }) {
  * generic quota serializer: a missing continuity marker, unexpected schema,
  * stale timestamp, or unfamiliar quota window suppresses notifications.
  *
+ * The projection is evidence about the codex limit's windows alone.  The
+ * separate Spark allowance (`SPARK_QUOTA_LIMIT_IDS`) has ridden alongside
+ * them in every direct read since 2026-07-23, so a recognized Spark window
+ * is passed over rather than treated as the schema drift that suppresses
+ * the receipt; any other limit id still fails closed until it is
+ * deliberately modeled.
+ *
  * The continuity key is a second one-way digest of the existing local
  * account-scope HMAC.  It permits a local baseline to be partitioned without
  * exposing a provider account subject to the loopback client or notification
@@ -1281,8 +1289,14 @@ export function notificationEvidenceFromAppServerRecord(record) {
   const windows = [];
   for (const window of record.windows) {
     if (!window || typeof window !== "object"
-        || window.provider !== "openai_codex"
-        || window.limitId !== "codex"
+        || window.provider !== "openai_codex") return null;
+    // The Spark allowance is a recognized separate pool that this evidence
+    // says nothing about, not an unfamiliar window: its numeric fields are
+    // deliberately not held to the codex rules below (its live pre-2026-08-19
+    // shape was a 525,600-minute window with an unknown plan label, and its
+    // re-introduced 2026-08-19 shape mirrors the codex durations exactly).
+    if (SPARK_QUOTA_LIMIT_IDS.includes(window.limitId)) continue;
+    if (window.limitId !== "codex"
         || !["primary", "secondary"].includes(window.slot)
         || typeof window.planType !== "string"
         || window.planType.length === 0
@@ -1311,6 +1325,9 @@ export function notificationEvidenceFromAppServerRecord(record) {
       resetProofKind: "provider_reported_schedule_only",
     });
   }
+  // A snapshot whose only windows belong to the Spark pool carries no codex
+  // evidence at all; that is ineligibility, not an empty fresh observation.
+  if (windows.length === 0) return null;
   windows.sort((left, right) => left.lane.localeCompare(right.lane));
   return {
     schemaVersion: QUOTA_NOTIFICATION_EVIDENCE_SCHEMA,

--- a/test/passive-collector.test.js
+++ b/test/passive-collector.test.js
@@ -1297,6 +1297,121 @@ test("fresh direct app-server records expose a closed local notification project
   );
 });
 
+test("Spark windows in a fresh snapshot leave the codex notification evidence intact", () => {
+  const codexLimit = {
+    limitId: "codex",
+    planType: "pro",
+    primary: { usedPercent: 84, windowDurationMins: 300, resetsAt: 1784768400 },
+    secondary: { usedPercent: 21, windowDurationMins: 10080, resetsAt: 1785369600 },
+  };
+  // The Spark limit's re-introduced two-slot shape, exactly as observed on
+  // the wire 2026-08-19: the 5-hour window in the limit's primary slot with
+  // the Spark seven-day window alongside in secondary. Both durations mirror
+  // the codex ones, so only the limit id separates the pools.
+  const sparkLimit = {
+    limitId: "codex_bengalfox",
+    planType: "pro",
+    primary: { usedPercent: 0, windowDurationMins: 300, resetsAt: 1787201379 },
+    secondary: { usedPercent: 0, windowDurationMins: 10080, resetsAt: 1787788179 },
+  };
+  // The Spark shape live from 2026-07-23 to 2026-08-19: one 365-day window
+  // under a provider-private plan label that normalizes to "unknown". Every
+  // numeric and plan rule the codex windows must satisfy fails here, which is
+  // exactly why holding Spark windows to those rules suppressed evidence.
+  const earlySparkLimit = {
+    limitId: "codex_bengalfox",
+    planType: "provider-private-plan",
+    primary: { usedPercent: 40, windowDurationMins: 525600, resetsAt: 1817001960 },
+    secondary: null,
+  };
+  const recordWith = (byLimitId, canonical = codexLimit) => appServerSnapshotRecord({
+    accountScope: {
+      status: "available",
+      reason: null,
+      version: "openai-account-v1",
+      scopeId: `openai-account:v1:${"B".repeat(43)}`,
+      planType: "pro",
+    },
+    canonical,
+    byLimitId,
+  }, {
+    source: "app_server_read",
+    receivedAt: "2026-07-23T00:00:00.000Z",
+  });
+
+  const record = recordWith({ codex: codexLimit, codex_bengalfox: sparkLimit });
+  assert.equal(record.windows.length, 4);
+  const evidence = notificationEvidenceFromAppServerRecord(record);
+  assert.deepEqual(evidence, {
+    schemaVersion: "tibotattle-notification-evidence-v2",
+    status: "fresh_provider_observation",
+    provider: "openai_codex",
+    source: "app_server_read",
+    freshness: "fresh",
+    observedAt: "2026-07-23T00:00:00.000Z",
+    continuityKey: evidence.continuityKey,
+    windows: [{
+      lane: "primary",
+      usedPercent: 84,
+      durationMinutes: 300,
+      resetAt: new Date(1784768400 * 1_000).toISOString(),
+      resetProofKind: "provider_reported_schedule_only",
+    }, {
+      lane: "secondary",
+      usedPercent: 21,
+      durationMinutes: 10080,
+      resetAt: new Date(1785369600 * 1_000).toISOString(),
+      resetProofKind: "provider_reported_schedule_only",
+    }],
+  });
+  assert.equal(JSON.stringify(evidence).includes("bengalfox"), false);
+  assert.notEqual(
+    notificationEvidenceFromAppServerRecord(
+      recordWith({ codex: codexLimit, codex_bengalfox: earlySparkLimit }),
+    ),
+    null,
+  );
+  assert.notEqual(
+    notificationEvidenceFromAppServerRecord(
+      recordWith({ codex: codexLimit, "codex-spark": sparkLimit }),
+    ),
+    null,
+  );
+  // A Spark-only snapshot has no codex windows to be evidence about.
+  assert.equal(
+    notificationEvidenceFromAppServerRecord(
+      recordWith({ codex_bengalfox: sparkLimit }, sparkLimit),
+    ),
+    null,
+  );
+  // The fail-closed posture survives for genuinely unfamiliar limit ids and
+  // for corrupted entries; only the recognized Spark pool is passed over.
+  assert.equal(
+    notificationEvidenceFromAppServerRecord(
+      recordWith({ codex: codexLimit, codex_quokka: { ...sparkLimit, limitId: "codex_quokka" } }),
+    ),
+    null,
+  );
+  const sparkWindow = record.windows.find((window) => window.limitId === "codex_bengalfox");
+  assert.equal(
+    notificationEvidenceFromAppServerRecord({
+      ...record,
+      windows: [...record.windows, { ...sparkWindow, provider: "unknown" }],
+    }),
+    null,
+  );
+  // An invalid codex window still suppresses even with Spark alongside.
+  assert.equal(
+    notificationEvidenceFromAppServerRecord({
+      ...record,
+      windows: record.windows.map((window) => (window.limitId === "codex" && window.slot === "primary"
+        ? { ...window, windowDurationMins: 60 }
+        : window)),
+    }),
+    null,
+  );
+});
+
 test("a fresh app-server account marker provisionally scopes only new nearby rollout events", async () => {
   const fixture = await collectorFixture();
   const accountSecret = Buffer.alloc(32, 81);
@@ -1342,6 +1457,62 @@ test("a fresh app-server account marker provisionally scopes only new nearby rol
     assert.equal(JSON.stringify(records).includes("private.owner"), false);
     assert.equal(JSON.stringify(records).includes(accountSecret.toString("base64url")), false);
     assert.equal((await readFile(fixture.checkpointFile, "utf8")).includes(accountSecret.toString("base64url")), false);
+  } finally {
+    await rm(fixture.root, { recursive: true });
+  }
+});
+
+test("a refresh whose snapshot carries Spark windows still exposes notification evidence", async () => {
+  const fixture = await collectorFixture();
+  const accountSecret = Buffer.alloc(32, 82);
+  class SparkClient {
+    async start() {}
+    async readRateLimits() {
+      return {
+        rateLimits: {
+          limitId: "codex",
+          planType: "pro",
+          primary: { usedPercent: 61, windowDurationMins: 10080, resetsAt: 1784854800 },
+          secondary: null,
+        },
+        rateLimitsByLimitId: {
+          codex_bengalfox: {
+            limitId: "codex_bengalfox",
+            planType: "pro",
+            primary: { usedPercent: 0, windowDurationMins: 300, resetsAt: 1787201379 },
+            secondary: { usedPercent: 0, windowDurationMins: 10080, resetsAt: 1787788179 },
+          },
+        },
+      };
+    }
+    async readAccount() { return { account: { email: "spark.owner@example.test", planType: "pro" } }; }
+    async readAccountUsage() { return { dailyUsageBuckets: [] }; }
+    close() {}
+  }
+  try {
+    const result = await runCollectorOnce({
+      ...fixture,
+      staleAfterMs: 0,
+      appServerFactory: () => new SparkClient(),
+      loadAccountObservationSecret: async () => Buffer.from(accountSecret),
+      clock: () => Date.parse("2026-07-23T00:01:00.000Z"),
+    });
+    assert.equal(result.refresh.recordWritten, true);
+    assert.deepEqual(
+      result.refresh.notificationEvidence?.windows.map(
+        (window) => [window.lane, window.durationMinutes, window.usedPercent],
+      ),
+      [["primary", 10_080, 61]],
+    );
+    assert.equal(JSON.stringify(result.refresh.notificationEvidence).includes("bengalfox"), false);
+    // The evidence projection narrows; the committed record still archives
+    // the Spark windows themselves.
+    const records = await readLines(fixture.dataFile);
+    const snapshot = records.find((record) => record.kind === "codex_quota_snapshot");
+    assert.deepEqual(
+      snapshot.windows.map((window) => [window.limitId, window.slot]),
+      [["codex", "primary"], ["codex_bengalfox", "primary"], ["codex_bengalfox", "secondary"]],
+    );
   } finally {
     await rm(fixture.root, { recursive: true });
   }


### PR DESCRIPTION
Local quota notifications have never fired from live data. The notification evidence projection validated EVERY window in a snapshot against the codex rules (limitId codex, known plan, duration 300 or 10080, future reset) and nulled the whole receipt on any failure — a fail-closed schema-drift tripwire written when only the codex limit could appear. The separate Spark allowance has ridden alongside the codex limit in every direct read since 2026-07-23 (then a 525,600-minute window with a provider-private plan label that normalizes to unknown — failing three rules at once), so the guard suppressed all live evidence from the feature's first day (2026-08-04), and the 2026-08-19 Spark re-introduction made it permanent.

A window whose limitId is a recognized Spark id is now passed over — it is a separate pool this evidence says nothing about, not schema drift. Codex windows keep the exact original strict validation, any other limit id still fails closed until deliberately modeled, corrupt entries still null, and a Spark-only snapshot yields null (ineligibility, not an empty observation). Committed records are unchanged; only the notification projection narrows. The decision record carries a dated coexistence amendment.

Tests: unit coverage for both live Spark shapes (pre- and post-2026-08-19), the reserved token, Spark-only, unfamiliar-id, corrupt-entry and invalid-codex-window cases, plus an integration run asserting evidence flows while the committed record still archives all three windows. Both new suites verified failing on pre-fix code. passive-collector 52/52, refresh 74/74, quota/companion family 34/34, architecture clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)