### PR TITLE
fix(accounting): rebuild in an isolated child and serve the prior cache labelled while it runs

### DIFF
--- a/apps/web/public/app.js
+++ b/apps/web/public/app.js
@@ -1468,6 +1468,13 @@ function matchedRollingPairs(data) {
 }
 
 function renderComparison(data) {
+  // The observed-versus-calculated comparison depends on the calibration
+  // capacity; when that capacity is served from the previous version's cache
+  // during a recalculation, the comparison says so, quietly.
+  renderStaleServeNote(
+    $("#comparison-stale-note"),
+    data?.timeline?.allowanceCapacity?.stale?.stale === true,
+  );
   const matchedPairs = matchedRollingPairs(data);
   const pair = matchedPairs.at(-1) ?? null;
   const summary = data.gradient.summary ?? {};
@@ -7092,6 +7099,12 @@ function renderWeeklyPaceForecast(data) {
 
 function renderWeekly(data) {
   renderWeeklyPaceForecast(data);
+  // A weekly estimate carried over from the previous app version while the
+  // recalculation runs announces itself here, quietly.
+  renderStaleServeNote(
+    $("#weekly-stale-note"),
+    data?.weekly?.stale?.stale === true,
+  );
   const summary = data.weekly.summary ?? {};
   const estimate = finite(summary.median_weekly_value_usd ?? summary.medianWeeklyValueUsd);
   const lower = finite(summary.lower_80_across_resets_usd ?? summary.lower80Usd);
@@ -8589,16 +8602,66 @@ function renderAccountingSideChatDetails(estimate) {
  * looking at an empty cost view with a cause the app knows and was not
  * saying (the 2026-08-19 livelock recurred hourly for a whole afternoon).
  */
-function renderAccountingRebuildDeferral(data) {
+/**
+ * True while the accounting rebuild has been deferred repeatedly — the state
+ * the stale-serve label upgrades to its "being retried" wording.
+ */
+function accountingRebuildRetrying() {
+  return Number.isSafeInteger(accountingRebuildDeferral?.consecutive)
+    && accountingRebuildDeferral.consecutive >= 2;
+}
+
+/**
+ * The prior-version period row backing the cost view while no current source
+ * exists, or null. The provenance-bearing block arrives only on the explicit
+ * stale channel, so a rendered row is labeled by construction.
+ */
+function staleAccountingServePeriod(data) {
+  const serve = data?.accounting?.staleServe;
+  if (serve?.stale !== true || !Array.isArray(serve.periods)) return null;
+  return serve.periods.find(
+    (period) => period.periodId === activeAccountingPeriod,
+  )
+    ?? serve.periods.find((period) => period.periodId === "all")
+    ?? null;
+}
+
+/**
+ * The quiet informational recalculating label over stale-served figures:
+ * "computed by the previous version", with the live rebuild state folded in
+ * ("recalculating now" while attempts proceed normally, "being retried" once
+ * the rebuild has deferred repeatedly). Deliberately an annotation, not an
+ * alert — the replaced red withheld-cache banner over-alarmed a routine
+ * update recalculation.
+ */
+function renderStaleServeNote(element, active) {
+  if (!element) return;
+  if (!active) {
+    element.hidden = true;
+    setRawText(element, "");
+    return;
+  }
+  element.hidden = false;
+  setLocalizedText(
+    element,
+    accountingRebuildRetrying()
+      ? "accounting.staleServe.retrying"
+      : "accounting.staleServe.recalculating",
+  );
+}
+
+function renderAccountingRebuildDeferral(data, { staleServeShown = false } = {}) {
   const element = $("#accounting-rebuild-deferred");
   if (!element) return;
   const deferral = accountingRebuildDeferral;
   const persistent = Number.isSafeInteger(deferral?.consecutive)
     && deferral.consecutive >= 2;
   // With a retained cache the figures still render; the honest-empty copy is
-  // for the state where no replay-safe cache exists at all.
+  // for the state where no replay-safe cache exists at all. A stale serve is
+  // likewise not an empty view — its own label already folds the retry state
+  // in — so the deferral banner stays down rather than doubling the message.
   const cacheMissing = data?.accounting?.accountingCacheStatus === "unavailable";
-  if (!persistent || !cacheMissing) {
+  if (!persistent || !cacheMissing || staleServeShown) {
     element.hidden = true;
     setRawText(element, "");
     return;
@@ -8611,8 +8674,20 @@ function renderAccountingRebuildDeferral(data) {
 
 function renderAccounting(data) {
   syncAccountingPeriodControls(data);
-  renderAccountingRebuildDeferral(data);
-  const accounting = accountingPeriod(data);
+  // The prior-version figures stand in only while the current channels are
+  // genuinely empty: no current cache AND no events from any live source for
+  // the selected period. The moment a current source serves (unified index or
+  // a fresh cache), it wins and the stale label leaves this section.
+  const livePeriod = accountingPeriod(data);
+  const staleRow = data?.accounting?.accountingCacheStatus === "unavailable"
+      && (livePeriod === null || livePeriod.events === 0)
+    ? staleAccountingServePeriod(data)
+    : null;
+  renderStaleServeNote($("#accounting-stale-serve"), staleRow !== null);
+  renderAccountingRebuildDeferral(data, {
+    staleServeShown: staleRow !== null,
+  });
+  const accounting = livePeriod;
   if (accounting === null) {
     clear($("#accounting-summary"));
     clear($("#accounting-component-counts"));
@@ -8632,22 +8707,41 @@ function renderAccounting(data) {
   // the rows that lack a price are the useful thing to be standing next to.
   const fastMode = accounting.fastMode;
   const weighted = accounting.quotaWeightedApiPriceEquivalentUsd;
-  for (const [label, explanation, value, note] of [
-    [
-      fastMode.metricShortLabel,
-      "A public API-price measuring stick for the usage observed locally. It is not a bill or a subscription limit.",
-      weighted === null ? "—" : formatApiMoney(weighted),
-      weighted === null
-        ? "No increment in this period could be weighted"
-        : `${formatApiMoney(accounting.apiPriceEquivalentUsd)} at Standard rates before Fast weighting`
-    ],
-    [
-      "Tokens",
-      "The tokens attached to those usage changes during the selected time period.",
-      compact(accounting.totalTokens),
-      accounting.periodLabel
+  // Stale substitution serves the version-stable Standard-price scalar and
+  // labels itself as previous-version output; quota weighting belongs to the
+  // current pipeline and is not reconstructed from an old artifact.
+  const headlineRows = staleRow !== null
+    ? [
+      [
+        t("accounting.staleServe.metricLabel"),
+        "A public API-price measuring stick for the usage observed locally. It is not a bill or a subscription limit.",
+        formatApiMoney(staleRow.apiPriceEquivalentUsd),
+        staleRow.periodLabel,
+      ],
+      [
+        "Tokens",
+        "The tokens attached to those usage changes during the selected time period.",
+        compact(staleRow.totalTokens),
+        staleRow.periodLabel,
+      ],
     ]
-  ]) {
+    : [
+      [
+        fastMode.metricShortLabel,
+        "A public API-price measuring stick for the usage observed locally. It is not a bill or a subscription limit.",
+        weighted === null ? "—" : formatApiMoney(weighted),
+        weighted === null
+          ? "No increment in this period could be weighted"
+          : `${formatApiMoney(accounting.apiPriceEquivalentUsd)} at Standard rates before Fast weighting`
+      ],
+      [
+        "Tokens",
+        "The tokens attached to those usage changes during the selected time period.",
+        compact(accounting.totalTokens),
+        accounting.periodLabel
+      ]
+    ];
+  for (const [label, explanation, value, note] of headlineRows) {
     const card = node("article", "metric-card compact-metric");
     const metricLabel = node("span", "metric-name");
     metricLabel.append(informationLabel(label, explanation));

--- a/apps/web/public/data-client.js
+++ b/apps/web/public/data-client.js
@@ -3580,6 +3580,26 @@ function normalizeAllowanceCapacityScenario(value, scenario) {
   };
 }
 
+// Staleness provenance attached to projections served from the previous app
+// version's cache while the current rebuild runs. Normalized as a closed
+// shape (flag, semantic version, computed-at, covered span) or null; a block
+// missing its identity is dropped rather than shown as an unlabeled serve.
+function normalizeStaleProvenance(value) {
+  if (value?.stale !== true) return null;
+  const schemaVersion = text(value.schemaVersion, "");
+  const computedAt = text(value.computedAt, "");
+  if (schemaVersion === "" || computedAt === "") return null;
+  return {
+    stale: true,
+    schemaVersion,
+    computedAt,
+    coveredAt: {
+      startAt: text(value.coveredAt?.startAt, ""),
+      endAt: text(value.coveredAt?.endAt, "")
+    }
+  };
+}
+
 function normalizeAllowanceCapacity(value) {
   if (!value || typeof value !== "object" || Array.isArray(value)
       || value.basisFamilyId !== ALLOWANCE_BASIS_FAMILY_ID
@@ -3618,6 +3638,7 @@ function normalizeAllowanceCapacity(value) {
     basisFamilyId: ALLOWANCE_BASIS_FAMILY_ID,
     selectedScenario,
     scenarios,
+    stale: normalizeStaleProvenance(value.stale),
     accountAttribution: {
       status: "historical_unattributed",
       maySpanMultipleAccounts: true
@@ -4598,6 +4619,29 @@ function normalizeSideChatEstimates(value) {
   };
 }
 
+// The labeled prior-version cost figures served while no current accounting
+// source exists. Bounded to the per-period headline scalars plus the
+// staleness provenance; anything else the old artifact carried stays behind.
+function normalizeStaleAccountingServe(value) {
+  const provenance = normalizeStaleProvenance(value);
+  if (provenance === null) return null;
+  const periods = array(value.periods).flatMap((period) => (
+    ["24h", "7d", "30d", "all"].includes(period?.periodId)
+      && typeof period.periodLabel === "string"
+      && period.periodLabel.length > 0
+      ? [{
+        periodId: period.periodId,
+        periodLabel: period.periodLabel,
+        events: count(period.events, 0),
+        totalTokens: count(period.totalTokens, 0),
+        apiPriceEquivalentUsd: nonNegative(period.apiPriceEquivalentUsd, 0)
+      }]
+      : []
+  )).slice(0, 5);
+  if (periods.length === 0) return null;
+  return { ...provenance, periods };
+}
+
 function normalizeLocalAccounting(value = {}) {
   const models = normalizeLocalModelUsage(value.byModel);
   // Both allowance tracks in one list, each row stating which track it belongs
@@ -4693,6 +4737,7 @@ function normalizeLocalAccounting(value = {}) {
     reasoningEffortAvailable: value.reasoningEffortAvailable === true,
     accountingSource: text(value.accountingSource, "unknown"),
     accountingCacheStatus: text(value.accountingCacheStatus, "unknown"),
+    staleServe: normalizeStaleAccountingServe(value.staleServe),
     historyCoverage: normalizeHistoryCoverage(value.historyCoverage),
     replayExclusionDiagnostics: {
       filesScanned: count(value?.replayExclusionDiagnostics?.filesScanned, 0),
@@ -5114,6 +5159,7 @@ function normalizeWeekly(payload = {}) {
     errorConcentration: array(source.errorConcentration ?? source.error_concentration),
     providerEpochs: array(source.providerEpochs ?? source.provider_epochs),
     dataClass: text(envelope?.dataClass, ""),
+    stale: normalizeStaleProvenance(envelope?.stale),
     paceForecast: normalizeWeeklyPaceForecast(envelope?.paceForecast),
     accountAttribution: {
       status: text(envelope?.accountAttribution?.status, ""),

--- a/apps/web/public/index.html
+++ b/apps/web/public/index.html
@@ -316,6 +316,7 @@
             <p class="plain-result" id="comparison-result">
               More observations are required before a useful comparison can be made.
             </p>
+            <p class="annotation stale-serve-note" id="comparison-stale-note" hidden></p>
             <div class="comparison-visual" id="comparison-visual">
               <div class="comparison-row">
                 <span>Observed quota movement</span>
@@ -387,6 +388,7 @@
             <small id="weekly-range">No evidence interval available</small>
           </div>
           <p id="weekly-explanation">The estimate will appear when local usage can be matched to quota changes.</p>
+          <p class="annotation stale-serve-note" id="weekly-stale-note" hidden></p>
         </div>
 
         <article class="panel weekly-history-panel lead-chart-panel">
@@ -729,6 +731,7 @@
         </div>
         <ul class="evidence-warnings" id="accounting-warnings" hidden></ul>
         <p class="evidence-warning" id="accounting-rebuild-deferred" hidden></p>
+        <p class="annotation stale-serve-note" id="accounting-stale-serve" hidden></p>
         <div class="metric-grid accounting-summary" id="accounting-summary"></div>
         <div class="two-column accounting-component-grid">
           <article class="panel">

--- a/apps/web/public/localization.js
+++ b/apps/web/public/localization.js
@@ -276,6 +276,28 @@ export const WEB_MESSAGES = Object.freeze({
     "更完整的成本核算重建已连续推迟 {count} 次，因为它会使应用超出内存上限。应用会自动重试；重启菜单栏应用可释放内存，通常能让下一次尝试完成。",
     "La reconstrucción más completa de la contabilidad de costes se ha pospuesto {count} veces seguidas porque llevaría la aplicación más allá de su límite de memoria. Se reintenta automáticamente; reiniciar la aplicación de la barra de menús libera memoria y normalmente permite completar el siguiente intento.",
   ],
+  // Quiet informational label on figures served from the previous app
+  // version's cache while the current version's local rebuild is still
+  // running. Deliberately not alert-styled: the numbers are the user's own
+  // history, merely computed by the prior semantics, and the recalculation is
+  // automatic. The "retrying" variant appears once the rebuild has deferred
+  // repeatedly, wiring the live rebuild state into the same label instead of
+  // adding a second banner.
+  "accounting.staleServe.recalculating": [
+    "Computed by the previous version — recalculating now.",
+    "由先前版本计算——正在重新计算。",
+    "Calculado por la versión anterior — recalculando ahora.",
+  ],
+  "accounting.staleServe.retrying": [
+    "Computed by the previous version — the recalculation is being retried.",
+    "由先前版本计算——正在重试重新计算。",
+    "Calculado por la versión anterior — se está reintentando el recálculo.",
+  ],
+  "accounting.staleServe.metricLabel": [
+    "API-price equivalent (previous version)",
+    "API 价格等值（先前版本）",
+    "Equivalente a precio de API (versión anterior)",
+  ],
  "accounting.pricing.partialCoverage": ["{percent} of usage changes have a reviewed price; coverage is partial.", "使用变化中有 {percent} 使用了经审核的价格；覆盖率不完整。", "El {percent} de los cambios de uso tiene un precio revisado; la cobertura es parcial."],
  "accounting.pricing.coverageReviewed": ["All usage changes in this period have reviewed pricing.", "此期间的所有使用变化都有经审核的价格。", "Todos los cambios de uso de este período tienen precios revisados."],
   "accounting.pricing.coverageShort": ["{percent} coverage", "{percent} 覆盖率", "{percent} de cobertura"],

--- a/apps/web/test/lib.test.mjs
+++ b/apps/web/test/lib.test.mjs
@@ -365,6 +365,9 @@ async function renderWeeklyHero(data, { span, rangeDays, locale = "en-US" }) {
     // renderWeekly owns the share-card re-render (owner-verified regression,
     // 2026-08-08), so the hero harness stubs it like the other renderers.
     "renderShareCard",
+    // The stale-serve recalculating note is rendered by the shared helper;
+    // the hero harness stubs it like the other side-effect renderers.
+    "renderStaleServeNote",
     "activeWeeklyRangeDays", "activeWeeklyMinimumObservedSpanPp",
     `${section}\nreturn renderWeekly;`,
   )(
@@ -394,6 +397,7 @@ async function renderWeeklyHero(data, { span, rangeDays, locale = "en-US" }) {
     () => ({ append() {}, textContent: "" }),
     (value) => new Date(value).toISOString().slice(0, 10),
     (value) => String(value),
+    () => {},
     () => {},
     () => {},
     rangeDays,

--- a/apps/web/test/stale-serve-data-client.test.mjs
+++ b/apps/web/test/stale-serve-data-client.test.mjs
@@ -1,0 +1,195 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { normalizeDashboardPayload } from "../public/data-client.js";
+import { SUPPORTED_LOCALES, translate } from "../public/localization.js";
+
+// Serve-stale-labeled (2026-08-19): projections computed by the previous app
+// version are served during the post-update recalculation, each carrying an
+// explicit staleness provenance block. These tests pin the data-client side
+// of that contract: the provenance survives normalization on every surface
+// that can serve stale (cost view, weekly allowance, trends capacity), and an
+// unlabeled block is dropped rather than rendered as current.
+
+const ALLOWANCE_BASIS_FAMILY =
+  "codex_primary:quota_weighted_api_equivalent:v1:fast_rates_2026_08_01:event_time:observed_declared_scenario";
+const allowanceBasisId = (scenario) =>
+  `${ALLOWANCE_BASIS_FAMILY}:${scenario}`;
+
+const STALE_PROVENANCE = {
+  stale: true,
+  schemaVersion: "local-replay-safe-accounting-v0.11",
+  computedAt: "2026-08-19T11:00:00.000Z",
+  coveredAt: {
+    startAt: "2026-05-07T00:00:00.000Z",
+    endAt: "2026-08-19T11:00:00.000Z",
+  },
+};
+
+function capacityScenario(scenario, medianCapacityUsd) {
+  return {
+    basisId: allowanceBasisId(scenario),
+    medianCapacityUsd,
+    plausibleRangeUsd: {
+      lower: medianCapacityUsd * 0.8,
+      upper: medianCapacityUsd * 1.2,
+    },
+    qualifyingResets: 10,
+    cohortId:
+      "c7d59f1f3fc548fa3d52726ec83f47a2a273ee6c3664dcf5ee510be8d8c455a8",
+    validation: {
+      sameResetHoldoutMeanAbsoluteErrorPercentagePoints: 2,
+      priorResetMeanAbsoluteErrorPercentagePoints: 3,
+      priorResetAbsoluteBiasPercentagePoints: 1,
+      forecastErrorP80PercentagePoints: 5,
+      scoredPriorResets: 8,
+      scoredPriorPoints: 40,
+    },
+  };
+}
+
+function staleCapacity(stale = STALE_PROVENANCE) {
+  return {
+    status: "available",
+    reason: null,
+    basisFamilyId: ALLOWANCE_BASIS_FAMILY,
+    selectedScenario: "unresolved_as_standard",
+    scenarios: {
+      unresolved_as_standard: capacityScenario("unresolved_as_standard", 100),
+      unresolved_as_fast: capacityScenario("unresolved_as_fast", 250),
+    },
+    stale,
+    accountAttribution: {
+      status: "historical_unattributed",
+      maySpanMultipleAccounts: true,
+    },
+  };
+}
+
+test("the stale cost-view serve survives normalization with its provenance, and unlabeled blocks are dropped", () => {
+  const normalized = normalizeDashboardPayload({
+    mode: "real_local_evidence",
+    accounting: {
+      accountingCacheStatus: "unavailable",
+      staleServe: {
+        ...STALE_PROVENANCE,
+        periods: [
+          {
+            periodId: "all",
+            periodLabel: "Cached 365-day window",
+            events: 4_242,
+            totalTokens: 987_654,
+            apiPriceEquivalentUsd: 1234.56,
+          },
+          // A row whose identity fails the closed period vocabulary is
+          // refused; it never renders as an unlabeled figure.
+          {
+            periodId: "made-up",
+            periodLabel: "Nope",
+            events: 1,
+            totalTokens: 1,
+            apiPriceEquivalentUsd: 1,
+          },
+        ],
+      },
+    },
+  });
+  assert.deepEqual(normalized.accounting.staleServe, {
+    ...STALE_PROVENANCE,
+    periods: [{
+      periodId: "all",
+      periodLabel: "Cached 365-day window",
+      events: 4_242,
+      totalTokens: 987_654,
+      apiPriceEquivalentUsd: 1234.56,
+    }],
+  });
+
+  // Provenance is the admission ticket: a serve without its semantic version
+  // is dropped entirely rather than shown as current.
+  const unlabeled = normalizeDashboardPayload({
+    mode: "real_local_evidence",
+    accounting: {
+      staleServe: {
+        stale: true,
+        computedAt: "2026-08-19T11:00:00.000Z",
+        periods: [{
+          periodId: "all",
+          periodLabel: "Cached 365-day window",
+          events: 1,
+          totalTokens: 1,
+          apiPriceEquivalentUsd: 1,
+        }],
+      },
+    },
+  });
+  assert.equal(unlabeled.accounting.staleServe, null);
+  // Absent entirely on a current serve.
+  const current = normalizeDashboardPayload({ mode: "real_local_evidence" });
+  assert.equal(current.accounting.staleServe, null);
+});
+
+test("the trends capacity keeps its staleness provenance through normalization", () => {
+  const normalized = normalizeDashboardPayload({
+    mode: "real_local_evidence",
+    timeline: { allowanceCapacity: staleCapacity() },
+  });
+  const capacity = normalized.timeline.allowanceCapacity;
+  assert.equal(capacity.status, "available");
+  assert.deepEqual(capacity.stale, STALE_PROVENANCE);
+  assert.equal(
+    capacity.scenarios.unresolved_as_standard.medianCapacityUsd,
+    100,
+  );
+
+  const unmarked = normalizeDashboardPayload({
+    mode: "real_local_evidence",
+    timeline: { allowanceCapacity: staleCapacity(null) },
+  });
+  assert.equal(unmarked.timeline.allowanceCapacity.stale, null);
+});
+
+test("the weekly allowance keeps its staleness provenance through normalization", () => {
+  const normalized = normalizeDashboardPayload({
+    mode: "real_local_evidence",
+    weekly: {
+      status: "available",
+      dataClass: "live_replay_safe_cache",
+      stale: STALE_PROVENANCE,
+      datasets: {
+        summary: [{ median_weekly_value_usd: 112, qualifying_resets: 8 }],
+      },
+    },
+  });
+  assert.deepEqual(normalized.weekly.stale, STALE_PROVENANCE);
+  assert.equal(normalized.weekly.summary.median_weekly_value_usd, 112);
+
+  const current = normalizeDashboardPayload({
+    mode: "real_local_evidence",
+    weekly: {
+      status: "available",
+      dataClass: "live_replay_safe_cache",
+      datasets: { summary: [{ median_weekly_value_usd: 112 }] },
+    },
+  });
+  assert.equal(current.weekly.stale, null);
+});
+
+test("the recalculating label ships in all three dashboard languages", () => {
+  for (const key of [
+    "accounting.staleServe.recalculating",
+    "accounting.staleServe.retrying",
+    "accounting.staleServe.metricLabel",
+  ]) {
+    const localized = SUPPORTED_LOCALES.map(
+      (locale) => translate(key, {}, locale),
+    );
+    for (const value of localized) {
+      assert.equal(typeof value, "string", key);
+      assert.ok(value.trim().length > 0, key);
+      // A locale falling back to the key itself means the entry is missing.
+      assert.notEqual(value, key);
+    }
+    assert.equal(new Set(localized).size, SUPPORTED_LOCALES.length, key);
+  }
+});

--- a/src/local-collector-state.js
+++ b/src/local-collector-state.js
@@ -1357,6 +1357,12 @@ export async function saveLocalCollectorCheckpoint({
   });
 }
 
+// Publication of a rebuilt accounting cache. The single-row transactional
+// replace is the retention/swap contract the stale-labeled serve relies on:
+// the prior artifact (including a semantics-outdated one being served stale)
+// remains readable until the new value COMMITS, the swap is atomic, and the
+// prior copy is gone only after that commit. A rebuild that fails never
+// reaches this call, so the stale-labeled serve stays in place untouched.
 export async function writeLocalCollectorAccountingCache({
   stateFile = defaultLocalCollectorStatePath(),
   cache,

--- a/src/local-companion-data.js
+++ b/src/local-companion-data.js
@@ -904,6 +904,68 @@ function projectAllowanceCapacity(container, preference) {
   };
 }
 
+/**
+ * The explicit staleness provenance every stale-served projection carries:
+ * the semantic version the artifact was computed under, when it was computed,
+ * and what span it covered. A consumer that renders a stale-served figure
+ * without this block cannot exist, because the block is the only channel the
+ * figures arrive on.
+ */
+function staleReplaySafeProvenance(staleCache) {
+  if (staleCache?.stale !== true
+      || typeof staleCache.schemaVersion !== "string"
+      || staleCache.schemaVersion.length === 0
+      || typeof staleCache.computedAt !== "string") {
+    return null;
+  }
+  return {
+    stale: true,
+    schemaVersion: staleCache.schemaVersion,
+    computedAt: staleCache.computedAt,
+    coveredAt: {
+      startAt: staleCache.coveredAt?.startAt ?? null,
+      endAt: staleCache.coveredAt?.endAt ?? null,
+    },
+  };
+}
+
+/**
+ * The bounded cost-view serve from a semantics-outdated prior cache: the
+ * per-period headline scalars every cache version since v0.4 has carried, and
+ * nothing else. The old artifact is never pushed through the current
+ * enrichment pipeline (its dimension/weighting shapes belong to the version
+ * that wrote it); the UI renders these labeled figures only while no current
+ * source exists, which is exactly the "$0.00 until the rebuild lands" window
+ * this replaces.
+ */
+function projectStaleAccountingServe(staleCache, provenance) {
+  if (provenance === null) return null;
+  const periods = Array.isArray(staleCache.cache?.periods)
+    ? staleCache.cache.periods.flatMap((period) => (
+      typeof period?.id === "string"
+        && ["24h", "7d", "30d", "all"].includes(period.id)
+        && typeof period.label === "string"
+        && period.label.length > 0
+        && Number.isSafeInteger(period.events)
+        && period.events >= 0
+        && Number.isSafeInteger(period.totalTokens)
+        && period.totalTokens >= 0
+        && Number.isFinite(period.apiPriceEquivalentUsd)
+        && period.apiPriceEquivalentUsd >= 0
+        ? [{
+          periodId: period.id,
+          periodLabel: period.label,
+          events: period.events,
+          totalTokens: period.totalTokens,
+          apiPriceEquivalentUsd: period.apiPriceEquivalentUsd,
+        }]
+        : []
+    ))
+    : [];
+  if (periods.length === 0) return null;
+  return { ...provenance, periods };
+}
+
 const CACHE_SWITCH_ALLOWANCE_INTERPRETATION =
   "conditional_historical_estimate_not_provider_allowance";
 
@@ -2438,15 +2500,65 @@ export async function buildLocalCompanionSnapshot({
     }),
     reportProjection(root),
   ]);
-  const allowanceWeekly = projectSelectedAllowanceWeeklyCalibration(
+  // Serve-stale-labeled (2026-08-19): when the prior cache was refused ONLY
+  // because the accounting semantics version changed — the state every
+  // updater enters — its projections are served explicitly marked stale
+  // instead of vanishing into "$0.00 / Insufficient evidence / Not
+  // comparable" until the local rebuild lands (hours at owner scale). Each
+  // stale-derived block carries staleReplaySafeProvenance; the current-cache
+  // channels stay null/unavailable, so nothing can mistake the serve for
+  // current. A fresh account with no prior cache has no stale channel and
+  // keeps today's honest empty states.
+  const staleReplaySafe =
+    replaySafeAccounting.errorCode === "cache_accounting_semantics_outdated"
+      && replaySafeAccounting.staleCache !== undefined
+      ? replaySafeAccounting.staleCache
+      : null;
+  const staleProvenance = staleReplaySafe === null
+    ? null
+    : staleReplaySafeProvenance(staleReplaySafe);
+  let allowanceWeekly = projectSelectedAllowanceWeeklyCalibration(
     replaySafeCache,
     selectedFastModePreference,
     replaySafeAccounting.errorCode,
   );
-  const allowanceCapacity = projectAllowanceCapacity(
+  let allowanceCapacity = projectAllowanceCapacity(
     replaySafeCache?.allowanceCapacityByScenario,
     selectedFastModePreference,
   );
+  if (staleProvenance !== null) {
+    // The stale artifact rides the SAME validating projections as a current
+    // cache: a block whose shape the current validators refuse projects
+    // "unavailable" and stays withheld exactly as today, so only structurally
+    // sound figures are ever stale-served. (The common updater step keeps the
+    // calibration/allowance shapes intact — the version bump names a change
+    // elsewhere in the artifact — which is what makes this serve useful.)
+    const staleWeekly = projectSelectedAllowanceWeeklyCalibration(
+      staleReplaySafe.cache,
+      selectedFastModePreference,
+      null,
+    );
+    if (staleWeekly.status !== "unavailable") {
+      allowanceWeekly = { ...staleWeekly, stale: staleProvenance };
+    }
+    const staleCapacity = projectAllowanceCapacity(
+      staleReplaySafe.cache?.allowanceCapacityByScenario,
+      selectedFastModePreference,
+    );
+    if (staleCapacity.status !== "unavailable") {
+      allowanceCapacity = { ...staleCapacity, stale: staleProvenance };
+    }
+  }
+  const staleAccountingServe = staleReplaySafe === null
+    ? null
+    : projectStaleAccountingServe(staleReplaySafe, staleProvenance);
+  // Whether anything is actually being stale-served: the quiet recalculating
+  // label then replaces the withheld-cache warning banner. If provenance
+  // exists but every extraction refused, the banner stays — a silent
+  // withhold would be worse than an alarming one.
+  const staleServeActive = staleAccountingServe !== null
+    || allowanceWeekly.stale !== undefined
+    || allowanceCapacity.stale !== undefined;
   // Retained report artifacts are Standard-priced. They remain available as
   // diagnostic reports, but cannot stand in for a quota-weighted allowance
   // capacity when the matching live scenario is unavailable.
@@ -2715,7 +2827,11 @@ export async function buildLocalCompanionSnapshot({
       "Official API prices changed. Cached price estimates are withheld until the next local replay rebuilds them with the current registry.",
     );
   }
-  if (replaySafeAccounting.errorCode === "cache_accounting_semantics_outdated") {
+  if (replaySafeAccounting.errorCode === "cache_accounting_semantics_outdated"
+      && !staleServeActive) {
+    // Only when nothing could be stale-served: with any stale serve active
+    // the quiet per-surface "computed by the previous version — recalculating"
+    // label carries this message instead of an alert-styled banner.
     warnings.push(
       "Historical event-time accounting changed. The prior cache is withheld until the next local replay rebuilds it.",
     );
@@ -2945,6 +3061,10 @@ export async function buildLocalCompanionSnapshot({
         reasoningEffortAvailable: false,
         accountingSource,
         accountingCacheStatus: accountingStatus,
+        // The labeled prior-version cost figures (or null). Rendered by the
+        // cost view only while no current source exists; its provenance block
+        // is what lets the UI say "computed by the previous version".
+        staleServe: staleAccountingServe,
         replayExclusionDiagnostics: replaySafeCache?.diagnostics ?? null,
         cacheSwitchImpact,
         cacheContinuityImpact,

--- a/src/replay-safe-accounting-cache.js
+++ b/src/replay-safe-accounting-cache.js
@@ -1,6 +1,9 @@
-import { lstat } from "node:fs/promises";
-import { homedir } from "node:os";
-import { dirname, join, resolve } from "node:path";
+import { spawn } from "node:child_process";
+import { createHash } from "node:crypto";
+import { lstat, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { homedir, tmpdir } from "node:os";
+import { dirname, isAbsolute, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
 import { scanCodexLogEvents } from "./codex-log-scan.js";
 import {
   defaultLocalUnifiedIndexPath,
@@ -235,6 +238,53 @@ const ACCOUNTING_READER_PASSTHROUGH_CODES = new Set([
   "accounting_unified_history_unavailable",
 ]);
 const ACCOUNTING_RSS_CHECK_INTERVAL = 2_048;
+// The production rebuild runs in a short-lived child process (2026-08-19).
+// The streaming corpus (#33) bounded per-batch residency, but two residuals
+// still starved the in-process rebuild at real scale: the derived transition
+// series legitimately accumulates across batches (~100-200 MB over multi-year
+// history), and the RSS guard measures the WHOLE process — a companion that
+// idles near 1.9 GiB after indexing an ~80 GB corpus reaches the 2 GiB
+// absolute target with no headroom for ANY rebuild growth, so every attempt
+// deferred and the cost surface stayed empty (dogfood 0.1.13, 2026-08-19:
+// accounting_rebuild_deferred at 23:21:26Z and 23:39:15Z on the streamed
+// code). A child starts from a clean ~60 MB baseline, the same guard polices
+// the CHILD's own RSS — which is the guard's actual purpose, keeping the
+// resident menu-bar app sane, now served even better because the parent never
+// grows at all — and exit returns every rebuild byte to the OS instead of
+// fossilizing the next attempt's baseline.
+const ACCOUNTING_REBUILD_ISOLATION_MODES = Object.freeze([
+  "auto",
+  "subprocess",
+  "in_process",
+]);
+const ACCOUNTING_REBUILD_CHILD_ENTRY = fileURLToPath(
+  new URL("./replay-safe-accounting-rebuild-child.js", import.meta.url),
+);
+// V8 old-space cap for the rebuild child. Prompt collection is what makes the
+// child's genuine RSS guard deterministic (an uncapped heap may lawfully defer
+// major GC past any tight margin — measured 147-354 MiB swing in #33), and the
+// cap turns a regression back to O(corpus) residency into a hard child failure
+// the parent converts to a deferral. 1 GiB is ~3x the multi-year working set
+// (thin stamps + one 50k-row batch slice + the accumulated transition series
+// + the fit's O(bins) sums) and sits below the child's effective RSS ceiling
+// (min(2 GiB, clean baseline + 1.25 GiB) ≈ 1.3 GiB), so V8 collects hard well
+// before the guard would trip.
+const ACCOUNTING_REBUILD_CHILD_OLD_SPACE_MIB = 1_024;
+// SIGTERM asks the child to unwind through its own abort checks (typed abort
+// envelope); a child that cannot unwind inside this grace is killed hard. The
+// value only bounds teardown after an abort — never the build itself.
+const ACCOUNTING_REBUILD_CHILD_KILL_GRACE_MS = 5_000;
+// The stdout envelope is one small JSON line. A child that prints more than
+// this is not speaking the protocol, and the read stops charging memory for
+// its output at this bound.
+const ACCOUNTING_REBUILD_ENVELOPE_LIMIT_BYTES = 64 * 1024;
+// Transport ceiling for the result payload read-back. The durable cache gate
+// stays MAX_CACHE_BYTES (enforced by the caller exactly as for an in-process
+// build); this larger bound only refuses a runaway result file before the
+// parent would buffer it.
+const ACCOUNTING_REBUILD_RESULT_LIMIT_BYTES = 64 * 1024 * 1024;
+export const REPLAY_SAFE_ACCOUNTING_REBUILD_REQUEST_VERSION =
+  "replay-safe-accounting-rebuild-request-v1";
 // This scanner runs inside the same process that immediately expands the
 // full-history calibration corpus. Four extraction workers preserve useful
 // parallelism without leaving ten V8 worker heaps resident for that second
@@ -3646,6 +3696,218 @@ export async function buildReplaySafeAccountingCache({
   };
 }
 
+// Everything the child may not say: an envelope whose error code fails the
+// bounded pattern is treated as no envelope at all, so arbitrary child text
+// can never become a refresh classification.
+const SUBPROCESS_FAILURE_CODE_PATTERN = /^[a-z0-9_]{1,64}$/u;
+const SUBPROCESS_SHA256_PATTERN = /^[a-f0-9]{64}$/u;
+
+// The child inherits almost nothing. TMPDIR is the one passthrough: inside the
+// sandboxed macOS app it names the container's writable temp root, which
+// SQLite may need for spill files. Deliberately absent: NODE_OPTIONS (nothing
+// may override the child's pinned old-space cap or preload code into the
+// rebuild), HOME (every path the child touches arrives resolved in the
+// request), and PATH (the child execs nothing).
+function minimalRebuildChildEnvironment() {
+  const environment = {};
+  if (typeof process.env.TMPDIR === "string" && process.env.TMPDIR.length > 0) {
+    environment.TMPDIR = process.env.TMPDIR;
+  }
+  return environment;
+}
+
+function parseRebuildChildEnvelope(stdoutText) {
+  const line = stdoutText.split("\n").filter((part) => part.length > 0).at(-1);
+  if (line === undefined) return null;
+  let value;
+  try {
+    value = JSON.parse(line);
+  } catch {
+    return null;
+  }
+  if (!value || typeof value !== "object" || Array.isArray(value)) return null;
+  if (value.status === "ok"
+      && Number.isSafeInteger(value.resultBytes)
+      && value.resultBytes >= 2
+      && value.resultBytes <= ACCOUNTING_REBUILD_RESULT_LIMIT_BYTES
+      && typeof value.resultSha256 === "string"
+      && SUBPROCESS_SHA256_PATTERN.test(value.resultSha256)) {
+    return { status: "ok", resultBytes: value.resultBytes, resultSha256: value.resultSha256 };
+  }
+  if (value.status === "error"
+      && typeof value.code === "string"
+      && SUBPROCESS_FAILURE_CODE_PATTERN.test(value.code)
+      && ["Error", "AbortError"].includes(value.name)) {
+    return { status: "error", code: value.code, name: value.name };
+  }
+  return null;
+}
+
+/**
+ * Runs one accounting rebuild in a short-lived child of the packaged Node
+ * runtime (process.execPath — the same binary serving the companion) and
+ * returns the parsed cache artifact. The request already carries every input
+ * resolved and serializable; the child re-verifies the unified generation and
+ * index file identity itself at corpus open and finish, exactly as the
+ * in-process build does, so the process boundary adds transport integrity
+ * (byte count + SHA-256 over the result file, then full artifact validation
+ * in the caller) rather than replacing any verification.
+ *
+ * Error surface, by construction:
+ * - a typed build failure inside the child crosses back as the SAME fixed
+ *   code the in-process build would have thrown, so the caller's existing
+ *   budget-miss/passthrough classification is untouched;
+ * - an abort — ours via SIGTERM on the caller's signal, or the child's own
+ *   graceful abort — is always the AbortError-shaped
+ *   accounting_refresh_aborted the in-process path throws;
+ * - a child that dies without a well-formed envelope (OOM kill, crash, spawn
+ *   failure, transport mismatch) becomes the single fixed code
+ *   accounting_rebuild_subprocess_failed, which the refresh wrapper defers
+ *   exactly like a memory-budget miss: the prior cache is retained and served,
+ *   and the scheduler's backoff prevents a crash loop.
+ */
+async function buildReplaySafeAccountingCacheInSubprocess({
+  request,
+  signal = null,
+  entry = ACCOUNTING_REBUILD_CHILD_ENTRY,
+}) {
+  throwIfAborted(signal);
+  const workDirectory = await mkdtemp(
+    join(tmpdir(), "usage-monitor-accounting-rebuild-"),
+  );
+  try {
+    const requestFile = join(workDirectory, "rebuild-request-v1.json");
+    const resultFile = join(workDirectory, "rebuild-result-v1.json");
+    await writeFile(requestFile, `${JSON.stringify(request)}\n`, {
+      mode: 0o600,
+      flag: "wx",
+    });
+    const closed = await new Promise((resolveClosed) => {
+      let settled = false;
+      const settle = (outcome) => {
+        if (settled) return;
+        settled = true;
+        resolveClosed(outcome);
+      };
+      let child;
+      try {
+        child = spawn(process.execPath, [
+          `--max-old-space-size=${ACCOUNTING_REBUILD_CHILD_OLD_SPACE_MIB}`,
+          entry,
+          requestFile,
+          resultFile,
+        ], {
+          cwd: workDirectory,
+          env: minimalRebuildChildEnvironment(),
+          // stdin stays piped and open for the child's whole life — its close
+          // is the child's parent-death watchdog. stderr is dropped: child
+          // failures classify by envelope and exit status only, so no crash
+          // text (which may embed paths) can reach a surface.
+          stdio: ["pipe", "pipe", "ignore"],
+        });
+      } catch {
+        settle({ code: null, killSignal: null, stdoutText: "", protocolBroken: true });
+        return;
+      }
+      let stdoutText = "";
+      let protocolBroken = false;
+      let killTimer = null;
+      const onAbort = () => {
+        try {
+          child.kill("SIGTERM");
+        } catch {
+          // Already exited; the close handler settles the outcome.
+        }
+        killTimer = setTimeout(() => {
+          try {
+            child.kill("SIGKILL");
+          } catch {
+            // Already exited.
+          }
+        }, ACCOUNTING_REBUILD_CHILD_KILL_GRACE_MS);
+        killTimer.unref?.();
+      };
+      if (signal !== null) {
+        if (signal.aborted) onAbort();
+        else signal.addEventListener("abort", onAbort, { once: true });
+      }
+      child.stdout.setEncoding("utf8");
+      child.stdout.on("data", (chunk) => {
+        if (protocolBroken) return;
+        stdoutText += chunk;
+        if (stdoutText.length > ACCOUNTING_REBUILD_ENVELOPE_LIMIT_BYTES) {
+          protocolBroken = true;
+          stdoutText = "";
+        }
+      });
+      child.once("error", () => {
+        // Spawn/kill failures may arrive without a later close event; settle
+        // as protocol breakage and let close (if it still fires) be ignored.
+        signal?.removeEventListener?.("abort", onAbort);
+        if (killTimer !== null) clearTimeout(killTimer);
+        settle({ code: null, killSignal: null, stdoutText: "", protocolBroken: true });
+      });
+      child.once("close", (code, killSignal) => {
+        signal?.removeEventListener?.("abort", onAbort);
+        if (killTimer !== null) clearTimeout(killTimer);
+        settle({ code, killSignal, stdoutText, protocolBroken });
+      });
+    });
+    const envelope = closed.protocolBroken
+      ? null
+      : parseRebuildChildEnvelope(closed.stdoutText);
+    if (envelope?.status === "ok"
+        && closed.code === 0
+        && closed.killSignal === null) {
+      let payload;
+      try {
+        payload = await readFile(resultFile);
+      } catch {
+        throw fixedError("accounting_rebuild_subprocess_failed");
+      }
+      if (payload.byteLength !== envelope.resultBytes
+          || createHash("sha256").update(payload).digest("hex")
+            !== envelope.resultSha256) {
+        throw fixedError("accounting_rebuild_subprocess_failed");
+      }
+      let cache;
+      try {
+        cache = JSON.parse(payload.toString("utf8"));
+      } catch {
+        throw fixedError("accounting_rebuild_subprocess_failed");
+      }
+      if (!cache || typeof cache !== "object" || Array.isArray(cache)) {
+        throw fixedError("accounting_rebuild_subprocess_failed");
+      }
+      // Mirror the in-process build's final abort gate: work that finished
+      // after an abort landed is still discarded before publication.
+      throwIfAborted(signal);
+      return cache;
+    }
+    if (envelope?.status === "error") {
+      if (envelope.name === "AbortError"
+          || envelope.code === "accounting_refresh_aborted") {
+        const aborted = fixedError("accounting_refresh_aborted");
+        aborted.name = "AbortError";
+        throw aborted;
+      }
+      throw fixedError(envelope.code);
+    }
+    // No usable envelope. If the caller aborted, the death is OURS (SIGTERM/
+    // SIGKILL) and the honest outcome is the abort; otherwise the child died
+    // on its own and the caller fails closed to the deferral path.
+    throwIfAborted(signal);
+    throw fixedError("accounting_rebuild_subprocess_failed");
+  } finally {
+    try {
+      await rm(workDirectory, { recursive: true, force: true });
+    } catch {
+      // Cleanup failure must never mask the rebuild outcome; the directory
+      // holds only this pass's private request/result pair.
+    }
+  }
+}
+
 export async function refreshReplaySafeAccountingCache({
   stateFile = null,
   // A JSON cache is no longer a supported durable target. Keeping this
@@ -3669,6 +3931,20 @@ export async function refreshReplaySafeAccountingCache({
   // this hook is a convenience for a caller that wants the signal inline
   // without inspecting the return shape.
   onAccountingRebuildDeferred = null,
+  // Where the rebuild executes. "auto" (the default) runs production-shaped
+  // calls — no injected scan, no injected rss meter — in a short-lived child
+  // process whose clean baseline restores the guard's headroom (see the
+  // isolation rationale on ACCOUNTING_REBUILD_ISOLATION_MODES above), and
+  // keeps every characterization call with injected function seams on the
+  // in-process build, since functions cannot cross a process boundary.
+  // "in_process" forces the old execution for a caller that must observe the
+  // build inside its own process; "subprocess" asserts isolation and refuses
+  // un-serializable seams instead of silently degrading.
+  rebuildIsolation = null,
+  // Characterization seam for the child entrypoint (crash/protocol tests
+  // substitute a misbehaving child). Production always uses the reviewed
+  // sibling module.
+  rebuildSubprocessEntry = null,
   ...options
 } = {}) {
   if (cacheFile !== undefined) {
@@ -3677,6 +3953,19 @@ export async function refreshReplaySafeAccountingCache({
   if (onAccountingRebuildDeferred !== null
       && typeof onAccountingRebuildDeferred !== "function") {
     throw new TypeError("onAccountingRebuildDeferred must be a function or null");
+  }
+  const selectedRebuildIsolation = rebuildIsolation ?? "auto";
+  if (!ACCOUNTING_REBUILD_ISOLATION_MODES.includes(selectedRebuildIsolation)) {
+    throw new TypeError(
+      "rebuildIsolation must be auto, subprocess, or in_process",
+    );
+  }
+  if (rebuildSubprocessEntry !== null
+      && (typeof rebuildSubprocessEntry !== "string"
+        || !isAbsolute(rebuildSubprocessEntry))) {
+    throw new TypeError(
+      "rebuildSubprocessEntry must be an absolute path or null",
+    );
   }
   const selectedStateFile = stateFile ?? defaultReplaySafeAccountingCachePath();
   const selectedSourceMode = normalizeAccountingSourceMode(
@@ -3727,24 +4016,125 @@ export async function refreshReplaySafeAccountingCache({
         ? {}
         : { chunkBytes: indexChunkBytes }),
     }));
+  // An injected scanner or rss meter is a function and cannot cross a process
+  // boundary; those characterization calls stay on the in-process build under
+  // "auto". Everything a production call carries is serializable, so the
+  // production paths (unified reader, legacy indexed scan) are reconstructed
+  // inside the child by value.
+  const subprocessEligible = scan === null && !Object.hasOwn(options, "rss");
+  if (selectedRebuildIsolation === "subprocess" && !subprocessEligible) {
+    throw new TypeError(
+      "rebuildIsolation subprocess cannot carry injected scan or rss seams",
+    );
+  }
+  const rebuildInSubprocess = selectedRebuildIsolation === "subprocess"
+    || (selectedRebuildIsolation === "auto" && subprocessEligible);
+  let subprocessRequest = null;
+  if (rebuildInSubprocess) {
+    // Resolve and validate the request the child will replay, mirroring the
+    // option validation the in-process build performs, so an invalid option
+    // stays a synchronous TypeError here rather than surfacing as a child
+    // failure. The clock is sampled exactly once — the same single call the
+    // in-process build makes for endMs — and crosses as a number.
+    const nowFunction = options.now ?? (() => Date.now());
+    const selectedWindowDays = options.windowDays ?? DEFAULT_WINDOW_DAYS;
+    const selectedCodexHome = options.codexHome ?? join(homedir(), ".codex");
+    const selectedMaximumRssBytes = options.maximumRssBytes
+      ?? MAX_ACCOUNTING_RSS_BYTES;
+    if (typeof nowFunction !== "function"
+        || !Number.isSafeInteger(selectedWindowDays)
+        || selectedWindowDays < MINIMUM_WINDOW_DAYS
+        || selectedWindowDays > MAXIMUM_WINDOW_DAYS
+        || typeof selectedCodexHome !== "string"
+        || selectedCodexHome.length < 1
+        || !validAbortSignal(options.signal ?? null)
+        || !Number.isSafeInteger(selectedMaximumRssBytes)
+        || selectedMaximumRssBytes < 1) {
+      throw new TypeError("Replay-safe accounting options are invalid");
+    }
+    const nowMs = nowFunction();
+    if (!Number.isFinite(nowMs)) {
+      throw new TypeError("Replay-safe accounting options are invalid");
+    }
+    if (selectedSourceMode === "legacy") {
+      const requestedWorkerCount = indexWorkerCount
+        ?? DEFAULT_ACCOUNTING_INDEX_WORKERS;
+      if (!Number.isSafeInteger(requestedWorkerCount)
+          || requestedWorkerCount < 1
+          || (indexChunkBytes !== undefined
+            && !Number.isSafeInteger(indexChunkBytes))) {
+        throw new TypeError("Replay-safe accounting options are invalid");
+      }
+    }
+    // Throws the same TypeErrors the in-process build would for a malformed
+    // limits object; the child then re-normalizes the identical value.
+    transitionResourceLimits(options.transitionResourceLimits ?? null);
+    subprocessRequest = {
+      version: REPLAY_SAFE_ACCOUNTING_REBUILD_REQUEST_VERSION,
+      nowMs,
+      windowDays: selectedWindowDays,
+      codexHome: selectedCodexHome,
+      sourceMode: selectedSourceMode,
+      contextBehavior: selectedContextBehavior,
+      expectedGeneration: expectedGeneration ?? null,
+      unifiedIndexFile: selectedSourceMode === "unified"
+        ? selectedUnifiedIndexFile
+        : unifiedIndexFile,
+      legacyIndexFile: selectedSourceMode === "legacy"
+        ? selectedIndexFile
+        : null,
+      legacyIndexSecretFile: selectedSourceMode === "legacy"
+        ? selectedIndexSecretFile
+        : null,
+      legacyIndexWorkerCount: selectedSourceMode === "legacy"
+        ? indexWorkerCount ?? DEFAULT_ACCOUNTING_INDEX_WORKERS
+        : null,
+      legacyIndexChunkBytes: selectedSourceMode === "legacy"
+          && indexChunkBytes !== undefined
+        ? indexChunkBytes
+        : null,
+      declaredSpeedBaselines: Array.isArray(options.declaredSpeedBaselines)
+        ? options.declaredSpeedBaselines
+        : [],
+      transitionResourceLimits: options.transitionResourceLimits ?? null,
+      maximumRssBytes: selectedMaximumRssBytes,
+    };
+  }
   // Converge legacy state before spending a potentially substantial raw-log
   // scan. A live old JSON collector or an unverified parity mismatch must
   // fail before we derive a cache that cannot be committed safely.
   await prepareLocalCollectorState({ stateFile: selectedStateFile });
   let cache;
   try {
-    cache = await buildReplaySafeAccountingCache({
-      ...options,
-      scan: effectiveScan,
-      sourceMode: selectedSourceMode,
-      contextBehavior: selectedContextBehavior,
-      expectedGeneration,
-      unifiedIndexFile: selectedSourceMode === "unified"
-        ? selectedUnifiedIndexFile
-        : unifiedIndexFile,
-    });
+    cache = rebuildInSubprocess
+      ? await buildReplaySafeAccountingCacheInSubprocess({
+        request: subprocessRequest,
+        signal: options.signal ?? null,
+        ...(rebuildSubprocessEntry === null
+          ? {}
+          : { entry: rebuildSubprocessEntry }),
+      })
+      : await buildReplaySafeAccountingCache({
+        ...options,
+        scan: effectiveScan,
+        sourceMode: selectedSourceMode,
+        contextBehavior: selectedContextBehavior,
+        expectedGeneration,
+        unifiedIndexFile: selectedSourceMode === "unified"
+          ? selectedUnifiedIndexFile
+          : unifiedIndexFile,
+      });
   } catch (error) {
-    if (!isAccountingBudgetMiss(error)) throw error;
+    // A child that died without a typed refusal joins the memory-budget
+    // misses on the deferral path: the failure is overwhelmingly a memory
+    // event (V8 heap-cap abort, OS OOM kill) and the deferral is the fail-
+    // closed behavior the incident taught — retain the prior cache, back
+    // off, surface the streak — never a crash loop and never a blanked
+    // dashboard.
+    if (!isAccountingBudgetMiss(error)
+        && error?.code !== "accounting_rebuild_subprocess_failed") {
+      throw error;
+    }
     // The rebuild missed its memory budget. Per owner directive the budget is
     // a TARGET, never a hard dashboard-blanker: the whole refresh must NOT
     // fail and the last good on-disk cache must survive untouched. Control

--- a/src/replay-safe-accounting-cache.js
+++ b/src/replay-safe-accounting-cache.js
@@ -4917,6 +4917,7 @@ export async function readReplaySafeAccountingCache({
       ? "cache_missing"
       : "cache_unavailable";
   }
+  let staleCache = null;
   if (parsed !== null && !validCache(parsed)) {
     const registryOutdated = (
       parsed?.priceRegistryVersion !== undefined
@@ -4932,6 +4933,34 @@ export async function readReplaySafeAccountingCache({
         || parsed?.priceEpochBasis !== HISTORICAL_PRICE_EPOCH_BASIS
         ? "cache_accounting_semantics_outdated"
         : "cache_invalid";
+    // The one refusal every updater walks through: prices are current but the
+    // accounting semantics version changed, so the artifact fails the CURRENT
+    // validator by design. Withholding it entirely is what put every
+    // large-history user on a "$0.00 until the rebuild lands" surface — and
+    // the rebuild can take a while at scale. The prior artifact is therefore
+    // returned on a SEPARATE, explicitly stale channel: provenance names the
+    // semantic version it was computed under and when, the current-cache
+    // contract (`cache`) stays null so no caller can mistake it for current,
+    // and consumers that choose to serve it must label it. A registry-outdated
+    // cache stays fully withheld — its prices are wrong, not merely
+    // differently derived — as does a structurally invalid one.
+    if (unavailableErrorCode === "cache_accounting_semantics_outdated"
+        && typeof parsed.schemaVersion === "string"
+        && parsed.schemaVersion.length > 0
+        && canonicalInstant(parsed.generatedAt) !== null
+        && canonicalInstant(parsed.coveredAt?.startAt) !== null
+        && canonicalInstant(parsed.coveredAt?.endAt) !== null) {
+      staleCache = {
+        stale: true,
+        schemaVersion: parsed.schemaVersion,
+        computedAt: parsed.generatedAt,
+        coveredAt: {
+          startAt: parsed.coveredAt.startAt,
+          endAt: parsed.coveredAt.endAt,
+        },
+        cache: parsed,
+      };
+    }
     parsed = null;
   }
   if (parsed === null) {
@@ -4939,6 +4968,7 @@ export async function readReplaySafeAccountingCache({
       status: "unavailable",
       errorCode: unavailableErrorCode ?? "cache_unavailable",
       cache: null,
+      ...(staleCache === null ? {} : { staleCache }),
     };
   }
   const descriptor = parsed.sourceDescriptor;

--- a/src/replay-safe-accounting-rebuild-child.js
+++ b/src/replay-safe-accounting-rebuild-child.js
@@ -1,0 +1,230 @@
+import { readFile, writeFile } from "node:fs/promises";
+import { createHash } from "node:crypto";
+import { resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import {
+  buildReplaySafeAccountingCache,
+  REPLAY_SAFE_ACCOUNTING_REBUILD_REQUEST_VERSION,
+} from "./replay-safe-accounting-cache.js";
+import { createIndexedCodexLogScan } from "./local-analysis-index.js";
+// The reviewed canonical-JSON entrypoint, NOT legacy storage: the child needs
+// only the stable serialization (the byte layer of the parent's integrity
+// check), and the legacy storage module's direct-caller ledger is frozen.
+import { stableJson } from "./export/canonical-json.js";
+
+// The accounting-rebuild child. refreshReplaySafeAccountingCache runs the full
+// cache build in this short-lived subprocess so the RSS budget is charged to a
+// process that starts from a clean baseline and returns every byte to the OS
+// on exit. Running the build inside the resident menu-bar companion could not
+// achieve either: after real indexing on a large corpus the companion
+// legitimately idles near the 2 GiB absolute accounting target, so the
+// budget-relative guard had no headroom left for ANY rebuild growth, and the
+// rebuild deferred forever (live 0.1.13 incident, 2026-08-19: a 4,852-source /
+// ~80 GB companion sat at 1.88 GiB whole-process RSS after indexing and logged
+// accounting_rebuild_deferred / accounting_transition_rss_limit_exceeded on
+// every attempt even after the streaming-corpus fix bounded per-batch
+// residency).
+//
+// Contract (see buildReplaySafeAccountingCacheInSubprocess, the only caller):
+// argv carries exactly two file paths — a request file the parent wrote and a
+// result file this process creates. The request is the JSON-serializable
+// subset of the build options; non-serializable characterization seams
+// (injected scan/rss functions) never cross the boundary, so those callers
+// stay on the in-process build. The child writes the finished cache artifact
+// to the result file as canonical stable JSON and prints ONE envelope line on
+// stdout naming the payload's byte count and SHA-256, which the parent
+// verifies before parsing. A build failure becomes a typed error envelope
+// carrying only the fixed error code (never message text, never paths); a
+// crash produces no envelope at all and the parent fails closed to the same
+// deferral a memory-budget miss produces.
+//
+// The generation and file-identity verification the streaming corpus performs
+// at open and at finish runs INSIDE this process, against the same index file
+// the parent named — the process boundary adds transport integrity checks on
+// top of those, it never substitutes for them.
+
+const CHILD_MODULE_FILE = fileURLToPath(import.meta.url);
+// Mirrors the refresh wrapper's bounded failure-code shape: a child error
+// whose code cannot be safely restated collapses to the subprocess-failure
+// code rather than leaking arbitrary text across the boundary.
+const CHILD_FAILURE_CODE_PATTERN = /^[a-z0-9_]{1,64}$/u;
+
+function requestPath(value, { allowNull = false } = {}) {
+  if (allowNull && value === null) return null;
+  if (typeof value !== "string" || value.length < 1) {
+    throw new TypeError("rebuild request path is invalid");
+  }
+  return value;
+}
+
+function parseRebuildRequest(text) {
+  let value;
+  try {
+    value = JSON.parse(text);
+  } catch {
+    throw new TypeError("rebuild request is not valid JSON");
+  }
+  if (!value || typeof value !== "object" || Array.isArray(value)
+      || value.version !== REPLAY_SAFE_ACCOUNTING_REBUILD_REQUEST_VERSION) {
+    throw new TypeError("rebuild request version is not supported");
+  }
+  if (!Number.isFinite(value.nowMs)
+      || !Number.isSafeInteger(value.windowDays)
+      || !["unified", "legacy"].includes(value.sourceMode)
+      || typeof value.contextBehavior !== "string"
+      || !Array.isArray(value.declaredSpeedBaselines)) {
+    throw new TypeError("rebuild request is invalid");
+  }
+  requestPath(value.codexHome);
+  requestPath(value.unifiedIndexFile, { allowNull: true });
+  if (value.sourceMode === "legacy") {
+    requestPath(value.legacyIndexFile);
+    requestPath(value.legacyIndexSecretFile);
+    if (!Number.isSafeInteger(value.legacyIndexWorkerCount)
+        || value.legacyIndexWorkerCount < 1) {
+      throw new TypeError("rebuild request legacy worker count is invalid");
+    }
+    if (value.legacyIndexChunkBytes !== null
+        && !Number.isSafeInteger(value.legacyIndexChunkBytes)) {
+      throw new TypeError("rebuild request legacy chunk bytes are invalid");
+    }
+  }
+  if (value.maximumRssBytes !== null
+      && (!Number.isSafeInteger(value.maximumRssBytes)
+        || value.maximumRssBytes < 1)) {
+    throw new TypeError("rebuild request RSS ceiling is invalid");
+  }
+  if (value.transitionResourceLimits !== null
+      && (typeof value.transitionResourceLimits !== "object"
+        || Array.isArray(value.transitionResourceLimits))) {
+    throw new TypeError("rebuild request transition limits are invalid");
+  }
+  return value;
+}
+
+function buildOptionsForRequest(request, signal) {
+  return {
+    codexHome: request.codexHome,
+    // The parent sampled its clock ONCE and the anchor crosses as a number, so
+    // the artifact's endMs/generatedAt/coveredAt stamps are exactly what the
+    // in-process build would have produced from the same clock call. The scan
+    // guard therefore sees a frozen clock (its elapsed-time arm stays inert in
+    // the child); the binding wall-clock stop remains the parent, which kills
+    // this process on abort or refresh timeout.
+    now: () => request.nowMs,
+    windowDays: request.windowDays,
+    sourceMode: request.sourceMode,
+    contextBehavior: request.contextBehavior,
+    expectedGeneration: request.expectedGeneration ?? null,
+    unifiedIndexFile: request.unifiedIndexFile,
+    declaredSpeedBaselines: request.declaredSpeedBaselines,
+    signal,
+    ...(request.transitionResourceLimits === null
+      ? {}
+      : { transitionResourceLimits: request.transitionResourceLimits }),
+    ...(request.maximumRssBytes === null
+      ? {}
+      : { maximumRssBytes: request.maximumRssBytes }),
+    // Legacy authority reconstructs the exact indexed scan the refresh wrapper
+    // builds in-process; unified authority leaves scan unset so the build
+    // constructs the unified reader itself, with identical inputs to the
+    // wrapper's own construction. Only serializable inputs exist on either
+    // arm, which is what makes this reconstruction sound.
+    ...(request.sourceMode === "legacy"
+      ? {
+        scan: createIndexedCodexLogScan({
+          indexFile: request.legacyIndexFile,
+          secretFile: request.legacyIndexSecretFile,
+          workerCount: request.legacyIndexWorkerCount,
+          ...(request.legacyIndexChunkBytes === null
+            ? {}
+            : { chunkBytes: request.legacyIndexChunkBytes }),
+        }),
+      }
+      : {}),
+  };
+}
+
+/**
+ * Runs one rebuild request end to end and returns the envelope the parent
+ * consumes. Never throws: every failure — unreadable request, invalid shape,
+ * build error, unwritable result — becomes a bounded typed-error envelope so
+ * the parent can distinguish "the build refused for reason X" (code
+ * passthrough, preserving the deferral and passthrough classifications the
+ * in-process path has) against "the child died" (no envelope at all).
+ * Exported for direct characterization; production enters through the main
+ * invocation below.
+ */
+export async function runReplaySafeAccountingRebuildChild({
+  requestFile,
+  resultFile,
+  signal = null,
+} = {}) {
+  try {
+    const request = parseRebuildRequest(
+      await readFile(requestPath(requestFile), "utf8"),
+    );
+    const cache = await buildReplaySafeAccountingCache(
+      buildOptionsForRequest(request, signal),
+    );
+    const payload = stableJson(cache);
+    // 'wx' keeps the write honest: the parent created a fresh private work
+    // directory, so a pre-existing result file means the protocol was not
+    // followed and the write must refuse rather than overwrite.
+    await writeFile(requestPath(resultFile), payload, {
+      mode: 0o600,
+      flag: "wx",
+    });
+    return {
+      status: "ok",
+      resultBytes: Buffer.byteLength(payload),
+      resultSha256: createHash("sha256").update(payload).digest("hex"),
+    };
+  } catch (error) {
+    return {
+      status: "error",
+      code: typeof error?.code === "string"
+          && CHILD_FAILURE_CODE_PATTERN.test(error.code)
+        ? error.code
+        : "accounting_rebuild_subprocess_failed",
+      name: error?.name === "AbortError" ? "AbortError" : "Error",
+    };
+  }
+}
+
+function isMainInvocation() {
+  return typeof process.argv[1] === "string"
+    && process.argv[1].length > 0
+    && resolve(process.argv[1]) === CHILD_MODULE_FILE;
+}
+
+if (isMainInvocation()) {
+  const controller = new AbortController();
+  const abort = () => controller.abort();
+  // The parent kills with SIGTERM on abort/timeout; a graceful unwind through
+  // the build's own abort checks produces the typed abort envelope instead of
+  // a signal death, so the parent can report the abort it requested.
+  process.once("SIGTERM", abort);
+  process.once("SIGINT", abort);
+  // The parent holds this pipe open for the child's whole life. End-of-input
+  // therefore means the parent is gone; abort so an orphaned rebuild can never
+  // keep grinding an index nobody will read.
+  process.stdin.once("end", abort);
+  process.stdin.once("error", abort);
+  process.stdin.resume();
+  const [requestFile = null, resultFile = null] = process.argv.slice(2, 4);
+  runReplaySafeAccountingRebuildChild({
+    requestFile,
+    resultFile,
+    signal: controller.signal,
+  }).then((envelope) => {
+    // Resumed stdin (and any legacy-scan worker threads mid-teardown) can hold
+    // the event loop open; exit explicitly once the envelope byte stream is
+    // flushed so the child stays short-lived by construction.
+    process.stdout.write(`${JSON.stringify(envelope)}\n`, () => {
+      process.exit(0);
+    });
+  }, () => {
+    process.exit(70);
+  });
+}

--- a/test/replay-safe-accounting-cache.test.js
+++ b/test/replay-safe-accounting-cache.test.js
@@ -2613,11 +2613,18 @@ test("a v0.7 cache with the permanently empty spark series is withheld for rebui
     schemaVersion: "local-replay-safe-accounting-v0.7",
   });
 
-  assert.deepEqual(await readReplaySafeAccountingCache({ cacheFile }), {
-    status: "unavailable",
-    errorCode: "cache_accounting_semantics_outdated",
-    cache: null,
-  });
+  const read = await readReplaySafeAccountingCache({ cacheFile });
+  assert.equal(read.status, "unavailable");
+  assert.equal(read.errorCode, "cache_accounting_semantics_outdated");
+  // The CURRENT-cache contract stays withheld; the artifact additionally
+  // rides the explicit stale channel so the post-update recalculation can
+  // serve it labeled (see replay-safe-accounting-stale-serve.test.js).
+  assert.equal(read.cache, null);
+  assert.equal(
+    read.staleCache.schemaVersion,
+    "local-replay-safe-accounting-v0.7",
+  );
+  assert.equal(read.staleCache.stale, true);
 });
 
 test("exact retained quota points make an eligible comparison window testable", async () => {
@@ -2787,11 +2794,16 @@ test("a cache from the former current-price basis is withheld for deterministic 
     priceEpochBasis: "current_price_sensitivity_at_registry_observation",
   });
 
-  assert.deepEqual(await readReplaySafeAccountingCache({ cacheFile }), {
-    status: "unavailable",
-    errorCode: "cache_accounting_semantics_outdated",
-    cache: null,
-  });
+  const read = await readReplaySafeAccountingCache({ cacheFile });
+  assert.equal(read.status, "unavailable");
+  assert.equal(read.errorCode, "cache_accounting_semantics_outdated");
+  assert.equal(read.cache, null);
+  // The deterministic rebuild still happens; meanwhile the artifact rides the
+  // explicit stale channel with its outdated identity named.
+  assert.equal(
+    read.staleCache.schemaVersion,
+    "local-replay-safe-accounting-v0.1",
+  );
 });
 
 test("refresh forwards AbortSignal and never writes an aborted projection", async () => {

--- a/test/replay-safe-accounting-corpus-stream.test.js
+++ b/test/replay-safe-accounting-corpus-stream.test.js
@@ -1,14 +1,22 @@
 import test from "node:test";
 import assert from "node:assert/strict";
-import { mkdtemp, rm } from "node:fs/promises";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
 import { spawnSync } from "node:child_process";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { buildReplaySafeAccountingCache } from "../src/replay-safe-accounting-cache.js";
 import {
+  buildReplaySafeAccountingCache,
+  refreshReplaySafeAccountingCache,
+  readReplaySafeAccountingCache,
+  REPLAY_SAFE_ACCOUNTING_SCHEMA_VERSION,
+} from "../src/replay-safe-accounting-cache.js";
+import {
+  beginUnifiedIndexGeneration,
   createUnifiedIndexWriter,
   openLocalUnifiedIndex,
+  readUnifiedIndexGenerationDescriptor,
 } from "../src/local-unified-index.js";
+import { stableJson } from "../src/storage.js";
 
 // The streaming calibration corpus (2026-08-19). The pre-streaming reader
 // materialized every priced compact usage row before the fit and the
@@ -458,6 +466,572 @@ test("a corpus far larger than one derivation batch completes in ONE pass under 
       outcome.rssReadings > 50,
       `the RSS guard must meter the streamed corpus (saw ${outcome.rssReadings} readings)`,
     );
+  } finally {
+    await rm(directory, { recursive: true, force: true });
+  }
+});
+
+// ---------------------------------------------------------------------------
+// The isolated-subprocess rebuild (2026-08-19). Streaming the corpus (above)
+// was necessary but insufficient at owner scale: the derived transition series
+// still accumulates across batches, and the RSS guard measures the WHOLE
+// process — a companion that legitimately idles near 1.9 GiB after indexing an
+// ~80 GB corpus reaches the 2 GiB absolute target with no headroom for ANY
+// rebuild growth, so the streamed rebuild kept deferring (dogfood 0.1.13,
+// 2026-08-19, 23:21:26Z and 23:39:15Z). Production rebuilds therefore run in a
+// short-lived child with a clean baseline. These tests pin the boundary:
+//  1. the child's artifact is BYTE-identical to the in-process build;
+//  2. a rebuild completes while the parent sits past the absolute backstop —
+//     the exact state that deferred forever in-process;
+//  3. a child that dies fails closed to the deferral (never a crash loop,
+//     never a clobbered prior cache);
+//  4. the caller's abort is an abort, not a deferral.
+// ---------------------------------------------------------------------------
+
+// A unified index with a COMPLETE published generation, accepted by the
+// production unified reader (requireComplete: true) — unlike writeCorpusIndex
+// above, whose rows carry no generation provenance and satisfy only the
+// calibration-corpus reader. Modeled on the writer fixture the unified
+// accounting source's own tests use.
+async function writeCompleteGenerationIndex(indexFile, {
+  resetStarts,
+  boundariesPerReset,
+  usagePerBoundary,
+}) {
+  const receivedAtMs = resetStarts[0];
+  const database = openLocalUnifiedIndex(indexFile, { create: true });
+  const generation = beginUnifiedIndexGeneration(database, {
+    contractVersion: "usage-event-v0.2",
+    receivedAtMs,
+    discoveredSourceCount: 1,
+    discoveredSourceBytes: 4_096,
+  });
+  const writer = createUnifiedIndexWriter(database, {
+    contractVersion: "usage-event-v0.2",
+    receivedAtMs,
+    generationId: generation.generationId,
+    parserVersionId: generation.parserVersionId,
+    ingestRunId: generation.ingestRunId,
+  });
+  writer.writeMeta("contract_version", "usage-event-v0.2");
+  writer.writeMeta("status", "complete");
+  writer.writeMeta("generated_at", new Date(receivedAtMs).toISOString());
+  writer.writeMeta("source_count", 1);
+  writer.writeMeta("source_bytes", 4_096);
+  const sourceLocal = Buffer.alloc(32, 4);
+  const sessionLocal = Buffer.alloc(32, 7);
+  const accountScopeId = writer.internAccountScope({
+    status: "unavailable",
+    reason: "missing_account",
+    planType: null,
+    scopeLocal: null,
+  });
+  const modelIds = new Map(
+    [...MODELS, "not-a-recognized-model"].map((model) => [
+      model,
+      writer.internModel(model, "recognized"),
+    ]),
+  );
+  const tierIds = new Map(SPEEDS.map((speed) => [
+    speed,
+    writer.internTier({
+      apiServiceTier: "unknown",
+      billingSurface: "chatgpt_subscription",
+      codexSpeedMode: speed,
+      tierSource: speed === "unknown" ? "unknown" : "rollout_thread_settings",
+      providerTierRaw: null,
+    }),
+  ]));
+  const surfaceId = writer.internSurface({
+    agentScope: "root",
+    surface: "cli_exec",
+    threadSource: "user",
+    lineageDisposition: "standalone",
+  });
+  let sourceOffset = 0;
+  let usageRows = 0;
+  const eventKey = (ordinal) => {
+    const key = Buffer.alloc(32, 9);
+    key.writeUInt32BE(ordinal, 28);
+    return key;
+  };
+  for (const [resetIndex, resetStartMs] of resetStarts.entries()) {
+    // One server-side slot flip across the corpus, like the real history;
+    // window identity is slot-agnostic so the derivation must not care.
+    const slot = resetIndex * 2 < resetStarts.length ? "secondary" : "primary";
+    for (let boundary = 0; boundary < boundariesPerReset; boundary += 1) {
+      const observedAtMs = resetStartMs + boundary * 60 * 60_000;
+      const quotaObservationId = writer.internQuota({
+        observedAtMs,
+        limitId: "codex",
+        slot,
+        planType: "pro",
+        usedPercent: boundary,
+        resetsAtMs: resetStartMs + WEEK_MS,
+        durationMins: 10_080,
+      });
+      writer.writeQuotaOccurrence({
+        generationId: generation.generationId,
+        sourceLocal,
+        sourceOffset,
+        sourceOrdinal: 0,
+        surfaceId,
+        canonicalObservationId: quotaObservationId,
+        observedAtMs,
+        provider: "openai_codex",
+        planType: "pro",
+        limitId: "codex",
+        slot,
+        slotOrder: 0,
+        usedPercent: boundary,
+        resetsAtMs: resetStartMs + WEEK_MS,
+        durationMins: 10_080,
+        admission: "admitted",
+      });
+      sourceOffset += 1;
+      for (let step = 0; step < usagePerBoundary; step += 1) {
+        const row = corpusUsageRow(
+          usageRows,
+          observedAtMs + 10_000 + step * 5_000,
+        );
+        writer.writeUsageEvent({
+          eventKey: eventKey(usageRows),
+          observedAtMs: row.observedAtMs,
+          generationId: generation.generationId,
+          sourceLocal,
+          sourceOffset,
+          sourceOrdinal: 0,
+          tierObservedAtMs: row.observedAtMs - 1_000,
+          sessionLocal,
+          accountScopeId,
+          modelId: modelIds.get(row.model),
+          tierId: tierIds.get(row.speed),
+          surfaceId,
+          quotaObservationId,
+          reasoningEffort: 4,
+          outcome: 5,
+          tokensInUncached: row.tokensInUncached,
+          tokensInCacheRead: row.tokensInCacheRead,
+          tokensInCacheWrite: row.tokensInCacheWrite,
+          tokensInCacheWrite5m: null,
+          tokensInCacheWrite1h: null,
+          tokensOutText: row.tokensOutText,
+          tokensOutReasoning: row.tokensOutReasoning,
+          tokensOutCombined: row.tokensOutCombined,
+          totalInputContext: row.totalInputContext,
+          partial: false,
+        });
+        usageRows += 1;
+        sourceOffset += 1;
+      }
+    }
+  }
+  writer.writeSourceCursor({
+    sourceLocal,
+    sourceOrdinal: 0,
+    sessionLocal,
+    scannedBytes: 4_096,
+    sizeBytes: 4_096,
+    mtimeMs: receivedAtMs,
+    snapshotsPersisted: true,
+    turnContextSeen: true,
+    carryModel: MODELS[0],
+    carryEffort: "high",
+    carryTierRaw: null,
+    carryTierObservedAtMs: receivedAtMs,
+    carryTotals: null,
+  });
+  writer.writeGenerationSource({
+    generationId: generation.generationId,
+    sourceLocal,
+    sourceOrdinal: 0,
+    sessionLocal,
+    surfaceId,
+    status: "complete",
+    discoveredSizeBytes: 4_096,
+    scannedBytes: 4_096,
+    mtimeMs: receivedAtMs,
+    diagnosticsComplete: true,
+  });
+  writer.writeSourceDiagnostics(sourceLocal, {}, {
+    generationId: generation.generationId,
+  });
+  writer.finalizeGeneration({
+    status: "complete",
+    blockReason: null,
+    discoveredSourceCount: 1,
+    discoveredSourceBytes: 4_096,
+    indexedSourceCount: 1,
+    indexedSourceBytes: 4_096,
+    discoveryComplete: true,
+    diagnosticsComplete: true,
+  });
+  await writer.close({ integrityCheck: true, fsyncPath: indexFile });
+  const readback = openLocalUnifiedIndex(indexFile, { readOnly: true });
+  try {
+    const descriptor = readUnifiedIndexGenerationDescriptor(readback);
+    return {
+      indexFile,
+      usageRows,
+      expectedGeneration: {
+        id: descriptor.id,
+        fingerprint: descriptor.fingerprint,
+      },
+    };
+  } finally {
+    readback.close();
+  }
+}
+
+// 4 reset windows x 99 whole-point changes keeps the corpus estimator-worthy,
+// so the equivalence below compares real estimates, and 4x100x5 usage rows
+// keep the fixture fast while exercising pricing bands, the composition fit,
+// and the batched derivation on both sides of the process boundary.
+const SUBPROCESS_FIXTURE_SHAPE = Object.freeze({
+  resetStarts: Array.from(
+    { length: 4 },
+    (_, week) => Date.parse("2026-05-07T00:00:00.000Z") + week * WEEK_MS,
+  ),
+  boundariesPerReset: 100,
+  usagePerBoundary: 5,
+});
+const SUBPROCESS_FIXTURE_TRANSITIONS = 4 * 99;
+
+test("the default production rebuild is isolated in a child and byte-identical to the in-process build", { timeout: 120_000 }, async () => {
+  const directory = await mkdtemp(join(tmpdir(), "usage-monitor-rebuild-subprocess-equivalence-"));
+  try {
+    const fixture = await writeCompleteGenerationIndex(
+      join(directory, "local-unified-index-v1.sqlite"),
+      SUBPROCESS_FIXTURE_SHAPE,
+    );
+    const stateFile = join(directory, "local-collector-state-v1.sqlite");
+    // Production-shaped call: unified authority, no injected function seams —
+    // this is exactly the shape "auto" isolates in a child (the crash test
+    // below proves the default path consults the child entry).
+    const viaSubprocess = await refreshReplaySafeAccountingCache({
+      stateFile,
+      sourceMode: "unified",
+      expectedGeneration: fixture.expectedGeneration,
+      unifiedIndexFile: fixture.indexFile,
+      now: () => NOW,
+      declaredSpeedBaselines: DECLARED_SPEED_BASELINES,
+    });
+    const inProcess = await buildReplaySafeAccountingCache({
+      sourceMode: "unified",
+      expectedGeneration: fixture.expectedGeneration,
+      unifiedIndexFile: fixture.indexFile,
+      now: () => NOW,
+      declaredSpeedBaselines: DECLARED_SPEED_BASELINES,
+    });
+    // Byte identity of the full serialized artifact — periods, history,
+    // timelines, calibration, allowance scenarios, provenance — across the
+    // process boundary, not merely calibration equality.
+    assert.equal(stableJson(viaSubprocess), stableJson(inProcess));
+    assert.equal(viaSubprocess.schemaVersion, REPLAY_SAFE_ACCOUNTING_SCHEMA_VERSION);
+    assert.equal(viaSubprocess.weeklyCalibrationInput.source, "unified_index");
+    assert.equal(
+      viaSubprocess.weeklyCalibrationInput.retainedUsageEvents,
+      fixture.usageRows,
+    );
+    assert.equal(viaSubprocess.history.status, "available");
+    // Real estimates were compared, not two empty summaries.
+    assert.equal(viaSubprocess.weeklyCalibration.status, "estimated");
+    assert.equal(
+      viaSubprocess.weeklyCalibration.sourceCounts.weeklyTransitions,
+      SUBPROCESS_FIXTURE_TRANSITIONS,
+    );
+    // The child's artifact was committed to the durable state file verbatim.
+    const written = await readReplaySafeAccountingCache({ stateFile });
+    assert.equal(written.status, "available");
+    assert.deepEqual(written.cache, viaSubprocess);
+  } finally {
+    await rm(directory, { recursive: true, force: true });
+  }
+});
+
+test("a dead or lying rebuild child fails closed to the deferral and retains the prior cache", async () => {
+  const directory = await mkdtemp(join(tmpdir(), "usage-monitor-rebuild-subprocess-crash-"));
+  try {
+    const fixture = await writeCompleteGenerationIndex(
+      join(directory, "local-unified-index-v1.sqlite"),
+      {
+        resetStarts: [Date.parse("2026-05-07T00:00:00.000Z")],
+        boundariesPerReset: 10,
+        usagePerBoundary: 2,
+      },
+    );
+    const stateFile = join(directory, "local-collector-state-v1.sqlite");
+    // A prior good cache on disk, written through the in-process
+    // characterization path (injected scanner).
+    const prior = await refreshReplaySafeAccountingCache({
+      stateFile,
+      now: () => NOW,
+      scan: async ({ onUsage }) => {
+        onUsage({
+          timestamp: "2026-08-19T11:00:00.000Z",
+          model: "gpt-5.6-sol",
+          components: { input_uncached_tokens: 1_000 },
+        });
+        return { diagnostics: {} };
+      },
+    });
+    // A child that dies without an envelope: the default production path MUST
+    // consult the child entry for this substitution to matter, so this also
+    // proves "auto" isolation actually spawns.
+    const crashingEntry = join(directory, "crashing-child.mjs");
+    await writeFile(crashingEntry, "process.exit(86);\n");
+    const deferredEvents = [];
+    const crashed = await refreshReplaySafeAccountingCache({
+      stateFile,
+      sourceMode: "unified",
+      expectedGeneration: fixture.expectedGeneration,
+      unifiedIndexFile: fixture.indexFile,
+      now: () => NOW + 1_000,
+      declaredSpeedBaselines: DECLARED_SPEED_BASELINES,
+      rebuildSubprocessEntry: crashingEntry,
+      onAccountingRebuildDeferred: (event) => {
+        deferredEvents.push(event);
+      },
+    });
+    assert.equal(crashed.status, "accounting_rebuild_deferred");
+    assert.equal(crashed.reason, "accounting_rebuild_subprocess_failed");
+    assert.equal(crashed.retained, true);
+    assert.equal(crashed.generatedAt, prior.generatedAt);
+    // A child that lies about its result: ok envelope, wrong bytes. The
+    // transport integrity check refuses it identically.
+    const lyingEntry = join(directory, "lying-child.mjs");
+    await writeFile(lyingEntry, [
+      "import { writeFile } from \"node:fs/promises\";",
+      "const payload = \"{\\\"not\\\":\\\"the artifact\\\"}\\n\";",
+      "await writeFile(process.argv[3], payload, { mode: 0o600, flag: \"wx\" });",
+      "process.stdout.write(JSON.stringify({",
+      "  status: \"ok\",",
+      "  resultBytes: Buffer.byteLength(payload),",
+      "  resultSha256: \"0\".repeat(64),",
+      "}) + \"\\n\");",
+      "",
+    ].join("\n"));
+    const lied = await refreshReplaySafeAccountingCache({
+      stateFile,
+      sourceMode: "unified",
+      expectedGeneration: fixture.expectedGeneration,
+      unifiedIndexFile: fixture.indexFile,
+      now: () => NOW + 2_000,
+      declaredSpeedBaselines: DECLARED_SPEED_BASELINES,
+      rebuildSubprocessEntry: lyingEntry,
+      onAccountingRebuildDeferred: (event) => {
+        deferredEvents.push(event);
+      },
+    });
+    assert.equal(lied.status, "accounting_rebuild_deferred");
+    assert.equal(lied.reason, "accounting_rebuild_subprocess_failed");
+    assert.equal(lied.retained, true);
+    assert.deepEqual(deferredEvents, [
+      { reason: "accounting_rebuild_subprocess_failed", retained: true },
+      { reason: "accounting_rebuild_subprocess_failed", retained: true },
+    ]);
+    // The prior cache survives both failures untouched and is still served.
+    const served = await readReplaySafeAccountingCache({ stateFile });
+    assert.equal(served.status, "available");
+    assert.deepEqual(served.cache, prior);
+  } finally {
+    await rm(directory, { recursive: true, force: true });
+  }
+});
+
+test("aborting the refresh kills the rebuild child and reports the abort, not a deferral", async () => {
+  const directory = await mkdtemp(join(tmpdir(), "usage-monitor-rebuild-subprocess-abort-"));
+  try {
+    const fixture = await writeCompleteGenerationIndex(
+      join(directory, "local-unified-index-v1.sqlite"),
+      {
+        resetStarts: [Date.parse("2026-05-07T00:00:00.000Z")],
+        boundariesPerReset: 10,
+        usagePerBoundary: 2,
+      },
+    );
+    // A child that never speaks: only the parent's SIGTERM ends it, so a
+    // settled refresh proves the abort actually killed the child.
+    const hangingEntry = join(directory, "hanging-child.mjs");
+    await writeFile(hangingEntry, "setInterval(() => {}, 1_000);\n");
+    const controller = new AbortController();
+    const pending = refreshReplaySafeAccountingCache({
+      stateFile: join(directory, "local-collector-state-v1.sqlite"),
+      sourceMode: "unified",
+      expectedGeneration: fixture.expectedGeneration,
+      unifiedIndexFile: fixture.indexFile,
+      now: () => NOW,
+      declaredSpeedBaselines: DECLARED_SPEED_BASELINES,
+      rebuildSubprocessEntry: hangingEntry,
+      signal: controller.signal,
+    });
+    setTimeout(() => controller.abort(), 250);
+    await assert.rejects(pending, (error) => (
+      error?.name === "AbortError"
+        && error?.code === "accounting_refresh_aborted"
+    ));
+  } finally {
+    await rm(directory, { recursive: true, force: true });
+  }
+});
+
+test("isolation options validate closed", async () => {
+  const directory = await mkdtemp(join(tmpdir(), "usage-monitor-rebuild-isolation-options-"));
+  try {
+    const stateFile = join(directory, "local-collector-state-v1.sqlite");
+    await assert.rejects(
+      refreshReplaySafeAccountingCache({
+        stateFile,
+        now: () => NOW,
+        rebuildIsolation: "sidecar",
+      }),
+      /rebuildIsolation must be auto, subprocess, or in_process/u,
+    );
+    // Injected function seams cannot cross a process boundary; asserting
+    // isolation with one present must refuse rather than silently degrade.
+    await assert.rejects(
+      refreshReplaySafeAccountingCache({
+        stateFile,
+        now: () => NOW,
+        rebuildIsolation: "subprocess",
+        scan: async () => ({ diagnostics: {} }),
+      }),
+      /rebuildIsolation subprocess cannot carry injected scan or rss seams/u,
+    );
+    await assert.rejects(
+      refreshReplaySafeAccountingCache({
+        stateFile,
+        now: () => NOW,
+        rebuildSubprocessEntry: "relative/path.js",
+      }),
+      /rebuildSubprocessEntry must be an absolute path or null/u,
+    );
+  } finally {
+    await rm(directory, { recursive: true, force: true });
+  }
+});
+
+// The decisive owner-scale regression. The parent process is inflated past the
+// 2 GiB absolute accounting backstop and RETAINS that ballast — the state a
+// large-history companion legitimately reaches after indexing — then runs the
+// same rebuild both ways. In-process the guard's very first check must defer
+// (that IS the 0.1.13 livelock: baseline past the target, zero headroom, every
+// attempt deferred). The default isolated rebuild must COMPLETE against the
+// same corpus while the parent stays inflated, because the guard now measures
+// the child's own clean-baseline RSS. Runs in a spawned parent so the 2 GiB
+// ballast never lives in the shared test-runner process.
+const INFLATED_PARENT = String.raw`
+const { refreshReplaySafeAccountingCache } = await import(
+  process.env.REBUILD_PARENT_MODULE
+);
+const CHUNK = 64 * 1024 * 1024;
+const ballast = Buffer.allocUnsafe(
+  Number(process.env.REBUILD_PARENT_BALLAST_BYTES),
+);
+// Touch every page with a nonzero byte so the ballast is genuinely resident.
+for (let offset = 0; offset < ballast.length; offset += CHUNK) {
+  ballast.fill(0xa5, offset, Math.min(offset + CHUNK, ballast.length));
+}
+const parentRssBytes = process.memoryUsage().rss;
+const nowMs = Number(process.env.REBUILD_PARENT_NOW_MS);
+const shared = {
+  stateFile: process.env.REBUILD_PARENT_STATE_FILE,
+  sourceMode: "unified",
+  expectedGeneration: JSON.parse(process.env.REBUILD_PARENT_EXPECTED_GENERATION),
+  unifiedIndexFile: process.env.REBUILD_PARENT_INDEX_FILE,
+  now: () => nowMs,
+  declaredSpeedBaselines: JSON.parse(process.env.REBUILD_PARENT_BASELINES),
+};
+const inProcess = await refreshReplaySafeAccountingCache({
+  ...shared,
+  rebuildIsolation: "in_process",
+});
+const isolated = await refreshReplaySafeAccountingCache({ ...shared });
+process.stdout.write(JSON.stringify({
+  parentRssBytes,
+  // Reading the ballast after both rebuilds keeps it retained throughout.
+  ballastByte: ballast[ballast.length - 1],
+  inProcess: {
+    status: inProcess?.status ?? "rebuilt",
+    reason: inProcess?.reason ?? null,
+    retained: inProcess?.retained ?? null,
+  },
+  isolated: {
+    schemaVersion: isolated?.schemaVersion ?? null,
+    source: isolated?.weeklyCalibrationInput?.source ?? null,
+    retainedUsageEvents:
+      isolated?.weeklyCalibrationInput?.retainedUsageEvents ?? null,
+    calibrationStatus: isolated?.weeklyCalibration?.status ?? null,
+    weeklyTransitions:
+      isolated?.weeklyCalibration?.sourceCounts?.weeklyTransitions ?? null,
+    historyStatus: isolated?.history?.status ?? null,
+  },
+}) + "\n");
+`;
+
+test("a rebuild completes in the child while the parent sits past the absolute RSS backstop", { timeout: 240_000 }, async (t) => {
+  const directory = await mkdtemp(join(tmpdir(), "usage-monitor-rebuild-inflated-parent-"));
+  try {
+    const fixture = await writeCompleteGenerationIndex(
+      join(directory, "local-unified-index-v1.sqlite"),
+      SUBPROCESS_FIXTURE_SHAPE,
+    );
+    // 2 GiB absolute target + 64 MiB: past the backstop, the way the owner's
+    // companion idles at 1.88 GiB and crosses during any in-process attempt.
+    const ballastBytes = (2 * 1024 + 64) * 1024 * 1024;
+    const child = spawnSync(process.execPath, [
+      "--input-type=module",
+      "--eval",
+      INFLATED_PARENT,
+    ], {
+      cwd: process.cwd(),
+      encoding: "utf8",
+      timeout: 210_000,
+      env: {
+        ...process.env,
+        REBUILD_PARENT_MODULE:
+          new URL("../src/replay-safe-accounting-cache.js", import.meta.url).href,
+        REBUILD_PARENT_STATE_FILE:
+          join(directory, "local-collector-state-v1.sqlite"),
+        REBUILD_PARENT_INDEX_FILE: fixture.indexFile,
+        REBUILD_PARENT_EXPECTED_GENERATION:
+          JSON.stringify(fixture.expectedGeneration),
+        REBUILD_PARENT_NOW_MS: String(NOW),
+        REBUILD_PARENT_BASELINES: JSON.stringify(DECLARED_SPEED_BASELINES),
+        REBUILD_PARENT_BALLAST_BYTES: String(ballastBytes),
+      },
+    });
+    assert.equal(child.error, undefined, child.error?.message);
+    assert.equal(child.signal, null, child.stderr);
+    assert.equal(child.status, 0, child.stderr);
+    const outcome = JSON.parse(child.stdout);
+    t.diagnostic(
+      `parent RSS ${(outcome.parentRssBytes / 1024 / 1024).toFixed(0)} MiB; `
+        + "in-process deferred, isolated child completed",
+    );
+    assert.equal(outcome.ballastByte, 0xa5);
+    // The parent genuinely sat past the 2 GiB absolute accounting target.
+    assert.ok(
+      outcome.parentRssBytes > 2 * 1024 * 1024 * 1024,
+      `parent RSS ${outcome.parentRssBytes} must exceed the absolute backstop`,
+    );
+    // In-process: the incident, reproduced — the guard's first check defers
+    // and no attempt could ever land (retained:false, nothing on disk yet).
+    assert.deepEqual(outcome.inProcess, {
+      status: "accounting_rebuild_deferred",
+      reason: "accounting_transition_rss_limit_exceeded",
+      retained: false,
+    });
+    // Isolated: the same rebuild against the same corpus COMPLETES, because
+    // the budget now polices the child's own clean-baseline RSS.
+    assert.deepEqual(outcome.isolated, {
+      schemaVersion: REPLAY_SAFE_ACCOUNTING_SCHEMA_VERSION,
+      source: "unified_index",
+      retainedUsageEvents: fixture.usageRows,
+      calibrationStatus: "estimated",
+      weeklyTransitions: SUBPROCESS_FIXTURE_TRANSITIONS,
+      historyStatus: "available",
+    });
   } finally {
     await rm(directory, { recursive: true, force: true });
   }

--- a/test/replay-safe-accounting-stale-serve.test.js
+++ b/test/replay-safe-accounting-stale-serve.test.js
@@ -1,0 +1,325 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { mkdir, mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  readReplaySafeAccountingCache,
+  refreshReplaySafeAccountingCache,
+  REPLAY_SAFE_ACCOUNTING_SCHEMA_VERSION,
+} from "../src/replay-safe-accounting-cache.js";
+import {
+  readLocalCollectorAccountingCache,
+  writeLocalCollectorAccountingCache,
+} from "../src/local-collector-state.js";
+import { buildLocalCompanionSnapshot } from "../src/local-companion-data.js";
+
+// Serve-stale-labeled (2026-08-19). A cache whose semantic identity mismatches
+// the current code — the exact state every updater enters, because a schema
+// bump is how an accounting-semantics change announces itself — used to be
+// withheld outright: "$0.00 / Historical event-time accounting changed" until
+// the local rebuild landed, which takes a while at large-history scale. The
+// prior artifact is now returned on an explicitly stale channel and served
+// with provenance (the semantic version it was computed under and when),
+// while the current-cache contract stays null so nothing can mistake it for
+// current. These tests pin the read channel, the snapshot projections and
+// their provenance, the banner replacement, the fresh-account non-regression,
+// and the retention/atomic-swap lifecycle around the rebuild.
+
+const NOW = Date.parse("2026-08-20T12:00:00.000Z");
+const DAY_MS = 24 * 60 * 60 * 1_000;
+const WEEK_MS = 7 * DAY_MS;
+const OUTDATED_SCHEMA_VERSION = "local-replay-safe-accounting-v0.11";
+const WITHHELD_SENTENCE =
+  "Historical event-time accounting changed. The prior cache is withheld until the next local replay rebuilds it.";
+
+// An estimator-worthy corpus scan: four weekly reset windows whose displayed
+// percent advances a whole point per hourly boundary, with usage rows between
+// boundaries. Small enough for an in-process refresh, rich enough that the
+// weekly calibration reaches "estimated" and every allowance scenario fits —
+// so the stale serve below carries REAL projections, not empty summaries.
+function estimatorWorthyScan({
+  resetStarts = Array.from(
+    { length: 4 },
+    (_, week) => Date.parse("2026-05-07T00:00:00.000Z") + week * WEEK_MS,
+  ),
+  boundariesPerReset = 100,
+  usagePerBoundary = 2,
+} = {}) {
+  return async ({ onUsage, onRateLimitSnapshot }) => {
+    for (const [resetIndex, resetStartMs] of resetStarts.entries()) {
+      const slot = resetIndex * 2 < resetStarts.length
+        ? "secondary"
+        : "primary";
+      for (let boundary = 0; boundary < boundariesPerReset; boundary += 1) {
+        const observedAtMs = resetStartMs + boundary * 60 * 60_000;
+        onRateLimitSnapshot({
+          timestamp: new Date(observedAtMs).toISOString(),
+          timestampMs: observedAtMs,
+          window: {
+            provider: "openai_codex",
+            planType: "pro",
+            limitId: "codex",
+            slot,
+            windowDurationMins: 10_080,
+            resetsAt: Math.floor((resetStartMs + WEEK_MS) / 1_000),
+            usedPercent: boundary,
+          },
+        });
+        for (let step = 0; step < usagePerBoundary; step += 1) {
+          onUsage({
+            timestamp: new Date(
+              observedAtMs + 10_000 + step * 5_000,
+            ).toISOString(),
+            model: step % 2 === 0 ? "gpt-5.6-sol" : "gpt-5.6-terra",
+            components: {
+              input_uncached_tokens: 400_000 + boundary * 1_000,
+              input_cache_read_tokens: 20_000,
+              input_cache_write_tokens: 0,
+              output_text_tokens: 900,
+              output_reasoning_tokens: 1_200,
+              output_combined_tokens: 0,
+            },
+            tierSemantics: {
+              codexSpeedMode: step % 2 === 0 ? "standard" : "fast",
+              apiServiceTier: "unknown",
+            },
+          });
+        }
+      }
+    }
+    return { diagnostics: {} };
+  };
+}
+
+// A real current cache, built through the production refresh, then re-stored
+// with only its semantic version flipped to a prior release's tag. Every
+// projection inside stays exactly what the estimator produced, which is what
+// an updater's on-disk cache looks like: sound content, outdated identity.
+async function writeOutdatedPriorCache(stateFile) {
+  const current = await refreshReplaySafeAccountingCache({
+    stateFile,
+    now: () => NOW - 60 * 60_000,
+    scan: estimatorWorthyScan(),
+  });
+  assert.equal(current.weeklyCalibration.status, "estimated");
+  const outdated = {
+    ...structuredClone(current),
+    schemaVersion: OUTDATED_SCHEMA_VERSION,
+  };
+  await writeLocalCollectorAccountingCache({ stateFile, cache: outdated });
+  return outdated;
+}
+
+async function fixtureRoot() {
+  const root = await mkdtemp(join(tmpdir(), "usage-monitor-stale-serve-"));
+  await mkdir(join(root, ".usage-monitor"), { recursive: true });
+  return root;
+}
+
+function snapshotOptions(root, stateFile) {
+  return {
+    root,
+    collectorStateFile: stateFile,
+    allowDevelopmentArtifactFallback: true,
+    now: () => NOW,
+  };
+}
+
+test("a semantics-outdated cache is returned on the explicit stale channel with provenance", async () => {
+  const root = await fixtureRoot();
+  const stateFile = join(root, ".usage-monitor", "local-collector-state-v1.sqlite");
+  try {
+    const outdated = await writeOutdatedPriorCache(stateFile);
+    const read = await readReplaySafeAccountingCache({ stateFile });
+    assert.equal(read.status, "unavailable");
+    assert.equal(read.errorCode, "cache_accounting_semantics_outdated");
+    // The current-cache contract stays null: no caller can mistake the stale
+    // artifact for a current one.
+    assert.equal(read.cache, null);
+    assert.equal(read.staleCache.stale, true);
+    assert.equal(read.staleCache.schemaVersion, OUTDATED_SCHEMA_VERSION);
+    assert.equal(read.staleCache.computedAt, outdated.generatedAt);
+    assert.deepEqual(read.staleCache.coveredAt, outdated.coveredAt);
+    assert.deepEqual(read.staleCache.cache, outdated);
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("a price-registry-outdated cache stays fully withheld: no stale channel", async () => {
+  const root = await fixtureRoot();
+  const stateFile = join(root, ".usage-monitor", "local-collector-state-v1.sqlite");
+  try {
+    const current = await refreshReplaySafeAccountingCache({
+      stateFile,
+      now: () => NOW - 60 * 60_000,
+      scan: estimatorWorthyScan(),
+    });
+    await writeLocalCollectorAccountingCache({
+      stateFile,
+      cache: {
+        ...structuredClone(current),
+        priceRegistryVersion: "price-registry-superseded-test",
+      },
+    });
+    const read = await readReplaySafeAccountingCache({ stateFile });
+    assert.equal(read.status, "unavailable");
+    assert.equal(read.errorCode, "cache_price_registry_outdated");
+    assert.equal(read.cache, null);
+    // Outdated prices are wrong figures, not merely differently derived ones;
+    // they are never served, stale-labeled or otherwise.
+    assert.equal(Object.hasOwn(read, "staleCache"), false);
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("the snapshot serves stale-labeled cost, allowance, and capacity projections instead of empty panels", async () => {
+  const root = await fixtureRoot();
+  const stateFile = join(root, ".usage-monitor", "local-collector-state-v1.sqlite");
+  try {
+    const outdated = await writeOutdatedPriorCache(stateFile);
+    const snapshot = await buildLocalCompanionSnapshot(
+      snapshotOptions(root, stateFile),
+    );
+    // The machine-readable verdict on the CURRENT cache stays honest.
+    assert.equal(
+      snapshot.overview.freshness.accountingStatus,
+      "unavailable",
+    );
+    // Cost view: the prior-version per-period headline scalars, labeled.
+    const staleServe = snapshot.overview.accounting.staleServe;
+    assert.equal(staleServe.stale, true);
+    assert.equal(staleServe.schemaVersion, OUTDATED_SCHEMA_VERSION);
+    assert.equal(staleServe.computedAt, outdated.generatedAt);
+    assert.deepEqual(staleServe.coveredAt, outdated.coveredAt);
+    const staleAll = staleServe.periods.find(
+      (period) => period.periodId === "all",
+    );
+    const priorAll = outdated.periods.find((period) => period.id === "all");
+    assert.deepEqual(staleAll, {
+      periodId: "all",
+      periodLabel: priorAll.label,
+      events: priorAll.events,
+      totalTokens: priorAll.totalTokens,
+      apiPriceEquivalentUsd: priorAll.apiPriceEquivalentUsd,
+    });
+    assert.ok(staleAll.events > 0);
+    assert.ok(staleAll.apiPriceEquivalentUsd > 0);
+    // Allowance estimate: served from the stale calibration with provenance,
+    // not "insufficient evidence".
+    assert.equal(snapshot.weekly.status, "available");
+    assert.equal(snapshot.weekly.stale.stale, true);
+    assert.equal(snapshot.weekly.stale.schemaVersion, OUTDATED_SCHEMA_VERSION);
+    // The weekly panel serves the forced allowance scenario, not the
+    // diagnostic model-selection summary — same as a current cache.
+    assert.equal(
+      snapshot.weekly.datasets.summary[0].median_weekly_value_usd,
+      outdated.allowanceCapacityByScenario.scenarios.unresolved_as_standard
+        .calibration.estimate.medianApiPriceEquivalentUsd,
+    );
+    // Trends comparability: the capacity behind the expected line is served
+    // from the stale calibration with the same provenance.
+    const capacity = snapshot.overview.timeline.allowanceCapacity;
+    assert.equal(capacity.status, "available");
+    assert.equal(capacity.stale.stale, true);
+    assert.equal(capacity.stale.schemaVersion, OUTDATED_SCHEMA_VERSION);
+    assert.ok(
+      capacity.scenarios.unresolved_as_standard.medianCapacityUsd > 0,
+    );
+    // The alert-styled withheld banner is replaced by the quiet label.
+    assert.ok(!snapshot.overview.warnings.includes(WITHHELD_SENTENCE));
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("a fresh account with no prior cache keeps today's honest empty states", async () => {
+  const root = await fixtureRoot();
+  const stateFile = join(root, ".usage-monitor", "local-collector-state-v1.sqlite");
+  try {
+    const snapshot = await buildLocalCompanionSnapshot(
+      snapshotOptions(root, stateFile),
+    );
+    assert.equal(snapshot.overview.accounting.staleServe, null);
+    assert.equal(snapshot.weekly.status, "unavailable");
+    assert.equal(Object.hasOwn(snapshot.weekly, "stale"), false);
+    assert.equal(
+      snapshot.overview.timeline.allowanceCapacity.status,
+      "unavailable",
+    );
+    assert.equal(
+      Object.hasOwn(snapshot.overview.timeline.allowanceCapacity, "stale"),
+      false,
+    );
+    assert.ok(!snapshot.overview.warnings.includes(WITHHELD_SENTENCE));
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("the stale cache survives a failed rebuild and is atomically replaced by a successful one", async () => {
+  const root = await fixtureRoot();
+  const stateFile = join(root, ".usage-monitor", "local-collector-state-v1.sqlite");
+  try {
+    const outdated = await writeOutdatedPriorCache(stateFile);
+    // A rebuild that misses its memory budget defers; control never reaches
+    // the write, so the stale artifact must survive byte-for-byte and the
+    // stale-labeled serve must remain in place.
+    const deferred = await refreshReplaySafeAccountingCache({
+      stateFile,
+      now: () => NOW,
+      maximumRssBytes: 100,
+      rss: (() => {
+        const samples = [50, 50];
+        return () => samples.shift() ?? 101;
+      })(),
+      scan: estimatorWorthyScan(),
+    });
+    assert.equal(deferred.status, "accounting_rebuild_deferred");
+    const retained = await readLocalCollectorAccountingCache({ stateFile });
+    assert.deepEqual(retained.cache, outdated);
+    const staleSnapshot = await buildLocalCompanionSnapshot(
+      snapshotOptions(root, stateFile),
+    );
+    assert.equal(
+      staleSnapshot.overview.accounting.staleServe.schemaVersion,
+      OUTDATED_SCHEMA_VERSION,
+    );
+    assert.equal(staleSnapshot.weekly.stale.stale, true);
+    // The successful rebuild publishes the new artifact in one transactional
+    // replace: the stale copy exists until the commit and not after it, and
+    // the served projections flip from stale-labeled to current.
+    const rebuilt = await refreshReplaySafeAccountingCache({
+      stateFile,
+      now: () => NOW,
+      scan: estimatorWorthyScan(),
+    });
+    assert.equal(rebuilt.schemaVersion, REPLAY_SAFE_ACCOUNTING_SCHEMA_VERSION);
+    const swapped = await readLocalCollectorAccountingCache({ stateFile });
+    assert.deepEqual(swapped.cache, rebuilt);
+    const read = await readReplaySafeAccountingCache({ stateFile });
+    assert.equal(read.status, "available");
+    assert.equal(Object.hasOwn(read, "staleCache"), false);
+    const currentSnapshot = await buildLocalCompanionSnapshot(
+      snapshotOptions(root, stateFile),
+    );
+    assert.equal(currentSnapshot.overview.accounting.staleServe, null);
+    assert.equal(currentSnapshot.weekly.status, "available");
+    assert.equal(Object.hasOwn(currentSnapshot.weekly, "stale"), false);
+    assert.equal(
+      Object.hasOwn(
+        currentSnapshot.overview.timeline.allowanceCapacity,
+        "stale",
+      ),
+      false,
+    );
+    assert.equal(
+      currentSnapshot.overview.freshness.accountingStatus,
+      "available",
+    );
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
LAUNCH BLOCKER. PR #33's streaming fix was insufficient at owner scale, verified live on dogfood 1017: a companion idling at 1.88 GiB after indexing ~80 GB reaches the 2 GiB absolute backstop with zero headroom, so min(2 GiB, baseline+1.25 GiB) binds and ANY growth defers — accounting_rebuild_deferred recorded at 23:21:26Z and 23:39:15Z on the streamed code, leaving a permanent $0.00 cost view for every large-history user.

Part 1 — isolation. Production-shaped rebuilds now run in a short-lived child of the packaged Node runtime: clean RSS baseline, memory returned to the OS on exit, and the guard applied to the child's own residency (its purpose — keeping the resident menu-bar app sane — is served better, since the parent never grows). Work crosses as an argv-named request file; results return as canonical stableJson verified against a stdout SHA-256 envelope before parsing, then through the caller's existing full-artifact validation unchanged. #33's generation and file-identity checks run inside the child. Minimal env, 1 GiB old-space cap, SIGTERM-on-abort with SIGKILL grace, stdin parent-death watchdog. Fail-closed throughout: a child that dies without a well-formed envelope becomes accounting_rebuild_subprocess_failed and defers exactly like a budget miss (prior cache retained, backoff and deferral-streak intact); abort stays an abort, never a deferral. rebuildIsolation: "in_process" is a one-line rollback.

Decisive regression: a spawned parent retains 2 GiB+64 MiB of touched ballast (2,192 MiB RSS), then the same rebuild runs both ways — in_process defers with accounting_transition_rss_limit_exceeded (the livelock, reproduced), the isolated default completes. Byte identity pinned by stableJson string equality between isolated and in-process builds over a complete-generation fixture (396 transitions).

Part 2 — serve-stale-labelled (owner decision, replaces withhold-to-$0.00). A semantics-outdated artifact returns on a separate staleCache channel with provenance (stale flag, the schemaVersion it was computed under, computedAt) — cache stays null so nothing mistakes it for current. Allowance, trends comparability, and the cost headline serve from it through the same validating projections, annotated "Computed by the previous version — recalculating now" (or "…the recalculation is being retried", wired to the live deferral streak), trilingual. Registry-outdated and structurally invalid caches stay fully withheld; fresh accounts keep today's empty states. Nothing deletes on mismatch; publication is one transactional row replace, so the stale copy is readable until the new cache commits.

Suites: corpus-stream 8/8 extended, replay-safe cache 57/57, new stale-serve 5/5, refresh 74/74, companion family 224/224, UI 312/312, architecture clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)