### PR TITLE
fix(export): raise the source-file and directory-entry ceilings to 100k

### DIFF
--- a/generated/r7-release-decision-node24.14.0-v0.1.json
+++ b/generated/r7-release-decision-node24.14.0-v0.1.json
@@ -29,7 +29,7 @@
       "atLimit": {
         "failureCode": "not_run_profile",
         "status": "not_run",
-        "value": 20000
+        "value": 100000
       },
       "dimension": "directory_entries",
       "identification": "not_run",
@@ -37,13 +37,13 @@
       "plusOne": {
         "failureCode": "not_run_profile",
         "status": "not_run",
-        "value": 20001
+        "value": 100001
       },
       "producer": {
         "failureCode": "not_run_profile",
         "status": "not_run"
       },
-      "selectedLimit": 20000,
+      "selectedLimit": 100000,
       "unit": "entries",
       "verifier": {
         "failureCode": "not_run_profile",
@@ -54,7 +54,7 @@
       "atLimit": {
         "failureCode": "not_run_profile",
         "status": "not_run",
-        "value": 5000
+        "value": 100000
       },
       "dimension": "source_files",
       "identification": "not_run",
@@ -62,13 +62,13 @@
       "plusOne": {
         "failureCode": "not_run_profile",
         "status": "not_run",
-        "value": 5001
+        "value": 100001
       },
       "producer": {
         "failureCode": "not_run_profile",
         "status": "not_run"
       },
-      "selectedLimit": 5000,
+      "selectedLimit": 100000,
       "unit": "files",
       "verifier": {
         "failureCode": "not_run_profile",
@@ -479,10 +479,10 @@
   "contractProvenance": {
     "receiptSchemaSha256": "4683a469ad0143721eedeccc026f07929f2506339aeab7c52e1312cad93f5701",
     "resourcePolicySourceSha256": "d9748895468534062e9c8c436db75cbf5acf4ccf54f84319db37e88197627870",
-    "resourcePolicyValuesSha256": "a3dde0db440015886144b76b88a8a663095c7e5eb08f0a68f062e597e95552f6",
+    "resourcePolicyValuesSha256": "3cbe7853c8f75e96912885f64ba4ad1aeb13aff8a22e4ffbd51806b27c73b418",
     "schemaModuleSha256": "9d598e56c71be1c3257c2e25c1334e49fdc6b5e825c46ba3e1ce68a83490e54f",
     "workloadCodeFileCount": 341,
-    "workloadCodeSha256": "9c287966eca0a53c669a8ce70c9dbe49790bc9ec31b847ee0efb4884eae1384e"
+    "workloadCodeSha256": "5e517eade0a8c3231a78429a5d65c4fd018fc7ef253bbb45c9d963be1fbb9624"
   },
   "determinism": {
     "comparisons": {
@@ -824,7 +824,7 @@
         "unit": "milliseconds"
       },
       {
-        "candidateValue": 20000,
+        "candidateValue": 100000,
         "decidedValue": "not_set",
         "decision": "unresolved",
         "dimension": "directory_entries",
@@ -834,12 +834,12 @@
         "unit": "entries"
       },
       {
-        "candidateValue": 5000,
+        "candidateValue": 100000,
         "decidedValue": "not_set",
         "decision": "unresolved",
         "dimension": "source_files",
         "exactBoundaryValue": "not_identified",
-        "realHistoryValue": 2995,
+        "realHistoryValue": 3006,
         "selectionBasis": "not_identified",
         "unit": "files"
       },
@@ -849,7 +849,7 @@
         "decision": "unresolved",
         "dimension": "source_bytes",
         "exactBoundaryValue": "not_identified",
-        "realHistoryValue": 26349805633,
+        "realHistoryValue": 26361812273,
         "selectionBasis": "not_identified",
         "unit": "bytes"
       },
@@ -939,7 +939,7 @@
         "decision": "unresolved",
         "dimension": "export_set_encoded_bytes",
         "exactBoundaryValue": "not_identified",
-        "realHistoryValue": 29154395,
+        "realHistoryValue": 29153338,
         "selectionBasis": "not_identified",
         "unit": "bytes"
       },
@@ -989,7 +989,7 @@
         "decision": "unresolved",
         "dimension": "elapsed_time",
         "exactBoundaryValue": "not_identified",
-        "realHistoryValue": 358647,
+        "realHistoryValue": 387096,
         "selectionBasis": "not_identified",
         "unit": "milliseconds"
       },
@@ -999,7 +999,7 @@
         "decision": "unresolved",
         "dimension": "rss",
         "exactBoundaryValue": "not_identified",
-        "realHistoryValue": 1230782464,
+        "realHistoryValue": 1221689344,
         "selectionBasis": "not_identified",
         "unit": "bytes"
       }
@@ -1007,20 +1007,20 @@
     "headroomBasisPoints": 2000,
     "inputReceipts": {
       "materializedBoundaries": {
-        "node24Sha256": "3ac8bd14db53b69bf56557fc6072df89f9dd24a82ad509e8a9b74141e2d7be86",
-        "node26Sha256": "a844195b85a77f5fb06bce64358b88fc911489ce653fd79a6477b0a1a317a82c"
+        "node24Sha256": "9b4b4eb9b7591c77f3b9df6a9acc26035f90ff078c231fdd4c8da1deffaa45a9",
+        "node26Sha256": "5254e8f0499b91884f4afcffd0ab2ea7d617693459ecc0e9a60c737a76d7eecc"
       },
       "realLocalHistory": {
-        "node24Sha256": "11a96e29894059ae693fc5dfea676a08e8e1ae2cca249eed76f6231e8360cb36",
-        "node26Sha256": "b5e2f60007a8a620de434ad0e61cde0468ff9082cf297754eba79d1b28a1ea1c"
+        "node24Sha256": "cd316ece181609ab15c29297b211570c1101eb6d5c80f1aadce5693803b5eb1e",
+        "node26Sha256": "04043dc37aba14b2fa8ae6ae1301726962f595e139c79a9bc999b20b3993ec3a"
       },
       "syntheticPressure": {
-        "node24Sha256": "941b682947411e0dc955c8597c05527b371ce522ea68ef0e2abec6661a439fa2",
-        "node26Sha256": "a9f297db17a9ab5eb70f76eb57e0a75d59a4c8013d2c3968b8d03f2da8e06abd"
+        "node24Sha256": "8ac54d73dd6aa94b16fb9d1c3d41ca53f56e6f393627ac79eb7ef404ecfb553e",
+        "node26Sha256": "a2448ad9762a684bfcad2fcd2480b0c2868f11ed4ff9c8da11950951c57d0d6a"
       },
       "syntheticSemantics": {
-        "node24Sha256": "03d4d006993435bbacbe5d611c118f7fa47ab80f61f0e72f4fe6d31315e42d42",
-        "node26Sha256": "d1b5a0f3331cddcfac2f17e3b8525fb6479ae421b4260960f9ed8f277dae2421"
+        "node24Sha256": "22f9bc89008124bed06396428d154a5d410e7597eb9b9f98a7fe7a5ebae6be27",
+        "node26Sha256": "f794ed631281e3a389b9c44c8872864675c7e0119b7fb1ff490fad162ebb9843"
       }
     },
     "kind": "release_decision",
@@ -1039,7 +1039,7 @@
     "singleMachineLimitation": true
   },
   "protocolVersion": "g1-r7-release-evidence-v0.1",
-  "receiptSha256": "3a45a15648b80f2fbbcd838d65016e90cd0ad3d236dd8290618ef55877cd354d",
+  "receiptSha256": "b32cc691d50af3e067a7ab11df64eab421f8f18e51566b7d51bbf34f8c9add01",
   "runtimeProvenance": {
     "architecture": "arm64",
     "elapsedClock": "parent_monotonic",

--- a/generated/r7-release-decision-node26.2.0-v0.1.json
+++ b/generated/r7-release-decision-node26.2.0-v0.1.json
@@ -29,7 +29,7 @@
       "atLimit": {
         "failureCode": "not_run_profile",
         "status": "not_run",
-        "value": 20000
+        "value": 100000
       },
       "dimension": "directory_entries",
       "identification": "not_run",
@@ -37,13 +37,13 @@
       "plusOne": {
         "failureCode": "not_run_profile",
         "status": "not_run",
-        "value": 20001
+        "value": 100001
       },
       "producer": {
         "failureCode": "not_run_profile",
         "status": "not_run"
       },
-      "selectedLimit": 20000,
+      "selectedLimit": 100000,
       "unit": "entries",
       "verifier": {
         "failureCode": "not_run_profile",
@@ -54,7 +54,7 @@
       "atLimit": {
         "failureCode": "not_run_profile",
         "status": "not_run",
-        "value": 5000
+        "value": 100000
       },
       "dimension": "source_files",
       "identification": "not_run",
@@ -62,13 +62,13 @@
       "plusOne": {
         "failureCode": "not_run_profile",
         "status": "not_run",
-        "value": 5001
+        "value": 100001
       },
       "producer": {
         "failureCode": "not_run_profile",
         "status": "not_run"
       },
-      "selectedLimit": 5000,
+      "selectedLimit": 100000,
       "unit": "files",
       "verifier": {
         "failureCode": "not_run_profile",
@@ -479,10 +479,10 @@
   "contractProvenance": {
     "receiptSchemaSha256": "4683a469ad0143721eedeccc026f07929f2506339aeab7c52e1312cad93f5701",
     "resourcePolicySourceSha256": "d9748895468534062e9c8c436db75cbf5acf4ccf54f84319db37e88197627870",
-    "resourcePolicyValuesSha256": "a3dde0db440015886144b76b88a8a663095c7e5eb08f0a68f062e597e95552f6",
+    "resourcePolicyValuesSha256": "3cbe7853c8f75e96912885f64ba4ad1aeb13aff8a22e4ffbd51806b27c73b418",
     "schemaModuleSha256": "9d598e56c71be1c3257c2e25c1334e49fdc6b5e825c46ba3e1ce68a83490e54f",
     "workloadCodeFileCount": 341,
-    "workloadCodeSha256": "9c287966eca0a53c669a8ce70c9dbe49790bc9ec31b847ee0efb4884eae1384e"
+    "workloadCodeSha256": "5e517eade0a8c3231a78429a5d65c4fd018fc7ef253bbb45c9d963be1fbb9624"
   },
   "determinism": {
     "comparisons": {
@@ -824,7 +824,7 @@
         "unit": "milliseconds"
       },
       {
-        "candidateValue": 20000,
+        "candidateValue": 100000,
         "decidedValue": "not_set",
         "decision": "unresolved",
         "dimension": "directory_entries",
@@ -834,12 +834,12 @@
         "unit": "entries"
       },
       {
-        "candidateValue": 5000,
+        "candidateValue": 100000,
         "decidedValue": "not_set",
         "decision": "unresolved",
         "dimension": "source_files",
         "exactBoundaryValue": "not_identified",
-        "realHistoryValue": 2995,
+        "realHistoryValue": 3006,
         "selectionBasis": "not_identified",
         "unit": "files"
       },
@@ -849,7 +849,7 @@
         "decision": "unresolved",
         "dimension": "source_bytes",
         "exactBoundaryValue": "not_identified",
-        "realHistoryValue": 26349805633,
+        "realHistoryValue": 26361812273,
         "selectionBasis": "not_identified",
         "unit": "bytes"
       },
@@ -939,7 +939,7 @@
         "decision": "unresolved",
         "dimension": "export_set_encoded_bytes",
         "exactBoundaryValue": "not_identified",
-        "realHistoryValue": 29154395,
+        "realHistoryValue": 29153338,
         "selectionBasis": "not_identified",
         "unit": "bytes"
       },
@@ -989,7 +989,7 @@
         "decision": "unresolved",
         "dimension": "elapsed_time",
         "exactBoundaryValue": "not_identified",
-        "realHistoryValue": 358647,
+        "realHistoryValue": 387096,
         "selectionBasis": "not_identified",
         "unit": "milliseconds"
       },
@@ -999,7 +999,7 @@
         "decision": "unresolved",
         "dimension": "rss",
         "exactBoundaryValue": "not_identified",
-        "realHistoryValue": 1230782464,
+        "realHistoryValue": 1221689344,
         "selectionBasis": "not_identified",
         "unit": "bytes"
       }
@@ -1007,20 +1007,20 @@
     "headroomBasisPoints": 2000,
     "inputReceipts": {
       "materializedBoundaries": {
-        "node24Sha256": "3ac8bd14db53b69bf56557fc6072df89f9dd24a82ad509e8a9b74141e2d7be86",
-        "node26Sha256": "a844195b85a77f5fb06bce64358b88fc911489ce653fd79a6477b0a1a317a82c"
+        "node24Sha256": "9b4b4eb9b7591c77f3b9df6a9acc26035f90ff078c231fdd4c8da1deffaa45a9",
+        "node26Sha256": "5254e8f0499b91884f4afcffd0ab2ea7d617693459ecc0e9a60c737a76d7eecc"
       },
       "realLocalHistory": {
-        "node24Sha256": "11a96e29894059ae693fc5dfea676a08e8e1ae2cca249eed76f6231e8360cb36",
-        "node26Sha256": "b5e2f60007a8a620de434ad0e61cde0468ff9082cf297754eba79d1b28a1ea1c"
+        "node24Sha256": "cd316ece181609ab15c29297b211570c1101eb6d5c80f1aadce5693803b5eb1e",
+        "node26Sha256": "04043dc37aba14b2fa8ae6ae1301726962f595e139c79a9bc999b20b3993ec3a"
       },
       "syntheticPressure": {
-        "node24Sha256": "941b682947411e0dc955c8597c05527b371ce522ea68ef0e2abec6661a439fa2",
-        "node26Sha256": "a9f297db17a9ab5eb70f76eb57e0a75d59a4c8013d2c3968b8d03f2da8e06abd"
+        "node24Sha256": "8ac54d73dd6aa94b16fb9d1c3d41ca53f56e6f393627ac79eb7ef404ecfb553e",
+        "node26Sha256": "a2448ad9762a684bfcad2fcd2480b0c2868f11ed4ff9c8da11950951c57d0d6a"
       },
       "syntheticSemantics": {
-        "node24Sha256": "03d4d006993435bbacbe5d611c118f7fa47ab80f61f0e72f4fe6d31315e42d42",
-        "node26Sha256": "d1b5a0f3331cddcfac2f17e3b8525fb6479ae421b4260960f9ed8f277dae2421"
+        "node24Sha256": "22f9bc89008124bed06396428d154a5d410e7597eb9b9f98a7fe7a5ebae6be27",
+        "node26Sha256": "f794ed631281e3a389b9c44c8872864675c7e0119b7fb1ff490fad162ebb9843"
       }
     },
     "kind": "release_decision",
@@ -1039,7 +1039,7 @@
     "singleMachineLimitation": true
   },
   "protocolVersion": "g1-r7-release-evidence-v0.1",
-  "receiptSha256": "65926ac0687b82842c2bb35d8aa89896c4833562c86442d91610e5feab153c76",
+  "receiptSha256": "2c51e4b9f062866e44d9c874e8e3e0e2a49d8d7da774a30cd1119b98a774eb89",
   "runtimeProvenance": {
     "architecture": "arm64",
     "elapsedClock": "parent_monotonic",

--- a/generated/r7-release-materialized-boundaries-node24.14.0-v0.1.json
+++ b/generated/r7-release-materialized-boundaries-node24.14.0-v0.1.json
@@ -29,7 +29,7 @@
       "atLimit": {
         "failureCode": "none",
         "status": "passed",
-        "value": 20000
+        "value": 100000
       },
       "dimension": "directory_entries",
       "identification": "not_identified",
@@ -37,13 +37,13 @@
       "plusOne": {
         "failureCode": "export_resource_directory_entries",
         "status": "rejected",
-        "value": 20001
+        "value": 100001
       },
       "producer": {
         "failureCode": "not_run_profile",
         "status": "not_run"
       },
-      "selectedLimit": 20000,
+      "selectedLimit": 100000,
       "unit": "entries",
       "verifier": {
         "failureCode": "not_run_profile",
@@ -54,7 +54,7 @@
       "atLimit": {
         "failureCode": "none",
         "status": "passed",
-        "value": 5000
+        "value": 100000
       },
       "dimension": "source_files",
       "identification": "not_identified",
@@ -62,13 +62,13 @@
       "plusOne": {
         "failureCode": "export_resource_source_files",
         "status": "rejected",
-        "value": 5001
+        "value": 100001
       },
       "producer": {
         "failureCode": "not_run_profile",
         "status": "not_run"
       },
-      "selectedLimit": 5000,
+      "selectedLimit": 100000,
       "unit": "files",
       "verifier": {
         "failureCode": "not_run_profile",
@@ -479,10 +479,10 @@
   "contractProvenance": {
     "receiptSchemaSha256": "4683a469ad0143721eedeccc026f07929f2506339aeab7c52e1312cad93f5701",
     "resourcePolicySourceSha256": "d9748895468534062e9c8c436db75cbf5acf4ccf54f84319db37e88197627870",
-    "resourcePolicyValuesSha256": "a3dde0db440015886144b76b88a8a663095c7e5eb08f0a68f062e597e95552f6",
+    "resourcePolicyValuesSha256": "3cbe7853c8f75e96912885f64ba4ad1aeb13aff8a22e4ffbd51806b27c73b418",
     "schemaModuleSha256": "9d598e56c71be1c3257c2e25c1334e49fdc6b5e825c46ba3e1ce68a83490e54f",
     "workloadCodeFileCount": 341,
-    "workloadCodeSha256": "9c287966eca0a53c669a8ce70c9dbe49790bc9ec31b847ee0efb4884eae1384e"
+    "workloadCodeSha256": "5e517eade0a8c3231a78429a5d65c4fd018fc7ef253bbb45c9d963be1fbb9624"
   },
   "determinism": {
     "comparisons": {
@@ -500,8 +500,8 @@
     "projectionVersion": "g1-r7-release-deterministic-projection-v0.1",
     "runCount": 2,
     "runProjectionSha256es": [
-      "14690c199457e1263f242062d06110f88797c41bc61e8ac60cd601d987711994",
-      "14690c199457e1263f242062d06110f88797c41bc61e8ac60cd601d987711994"
+      "d5793cab76ad08dd58a133e760fb9466e475430f6db1ff687e0c1fa0e09e51b4",
+      "d5793cab76ad08dd58a133e760fb9466e475430f6db1ff687e0c1fa0e09e51b4"
     ],
     "status": "partial"
   },
@@ -822,21 +822,21 @@
       "decodedBytes": 0,
       "durablePeakRssBytes": 0,
       "encodedBytes": 0,
-      "externalPeakRssBytes": 339476480,
-      "externalRssSampleCount": 67,
-      "externalRssSampleFailureCount": 0,
+      "externalPeakRssBytes": 338116608,
+      "externalRssSampleCount": 71,
+      "externalRssSampleFailureCount": 1,
       "filesystem": {
         "afterBytes": 0,
         "beforeBytes": 0,
-        "sampledHighWaterBytes": 30819597
+        "sampledHighWaterBytes": 30832536
       },
       "outputRecords": 0,
-      "parentElapsedMs": 3400,
+      "parentElapsedMs": 3935,
       "runCount": 2,
       "sourceBytes": 0,
       "sourceFiles": 0,
-      "stderrBytes": 169,
-      "stdoutBytes": 42472
+      "stderrBytes": 168,
+      "stdoutBytes": 42487
     },
     "kind": "release_materialized_boundaries",
     "literalCandidateAllocationRequired": false,
@@ -894,7 +894,7 @@
     }
   },
   "protocolVersion": "g1-r7-release-evidence-v0.1",
-  "receiptSha256": "3ac8bd14db53b69bf56557fc6072df89f9dd24a82ad509e8a9b74141e2d7be86",
+  "receiptSha256": "9b4b4eb9b7591c77f3b9df6a9acc26035f90ff078c231fdd4c8da1deffaa45a9",
   "runtimeProvenance": {
     "architecture": "arm64",
     "elapsedClock": "parent_monotonic",

--- a/generated/r7-release-materialized-boundaries-node26.2.0-v0.1.json
+++ b/generated/r7-release-materialized-boundaries-node26.2.0-v0.1.json
@@ -29,7 +29,7 @@
       "atLimit": {
         "failureCode": "none",
         "status": "passed",
-        "value": 20000
+        "value": 100000
       },
       "dimension": "directory_entries",
       "identification": "not_identified",
@@ -37,13 +37,13 @@
       "plusOne": {
         "failureCode": "export_resource_directory_entries",
         "status": "rejected",
-        "value": 20001
+        "value": 100001
       },
       "producer": {
         "failureCode": "not_run_profile",
         "status": "not_run"
       },
-      "selectedLimit": 20000,
+      "selectedLimit": 100000,
       "unit": "entries",
       "verifier": {
         "failureCode": "not_run_profile",
@@ -54,7 +54,7 @@
       "atLimit": {
         "failureCode": "none",
         "status": "passed",
-        "value": 5000
+        "value": 100000
       },
       "dimension": "source_files",
       "identification": "not_identified",
@@ -62,13 +62,13 @@
       "plusOne": {
         "failureCode": "export_resource_source_files",
         "status": "rejected",
-        "value": 5001
+        "value": 100001
       },
       "producer": {
         "failureCode": "not_run_profile",
         "status": "not_run"
       },
-      "selectedLimit": 5000,
+      "selectedLimit": 100000,
       "unit": "files",
       "verifier": {
         "failureCode": "not_run_profile",
@@ -479,10 +479,10 @@
   "contractProvenance": {
     "receiptSchemaSha256": "4683a469ad0143721eedeccc026f07929f2506339aeab7c52e1312cad93f5701",
     "resourcePolicySourceSha256": "d9748895468534062e9c8c436db75cbf5acf4ccf54f84319db37e88197627870",
-    "resourcePolicyValuesSha256": "a3dde0db440015886144b76b88a8a663095c7e5eb08f0a68f062e597e95552f6",
+    "resourcePolicyValuesSha256": "3cbe7853c8f75e96912885f64ba4ad1aeb13aff8a22e4ffbd51806b27c73b418",
     "schemaModuleSha256": "9d598e56c71be1c3257c2e25c1334e49fdc6b5e825c46ba3e1ce68a83490e54f",
     "workloadCodeFileCount": 341,
-    "workloadCodeSha256": "9c287966eca0a53c669a8ce70c9dbe49790bc9ec31b847ee0efb4884eae1384e"
+    "workloadCodeSha256": "5e517eade0a8c3231a78429a5d65c4fd018fc7ef253bbb45c9d963be1fbb9624"
   },
   "determinism": {
     "comparisons": {
@@ -500,8 +500,8 @@
     "projectionVersion": "g1-r7-release-deterministic-projection-v0.1",
     "runCount": 2,
     "runProjectionSha256es": [
-      "f71889fcdef1385c3be192acbc7a71a32213a993f24ac09af56423e800f1703e",
-      "f71889fcdef1385c3be192acbc7a71a32213a993f24ac09af56423e800f1703e"
+      "58121b44bba48c5cc792f1a9319494c779aad991b7c44b7364a6ba0a9eba1d15",
+      "58121b44bba48c5cc792f1a9319494c779aad991b7c44b7364a6ba0a9eba1d15"
     ],
     "status": "partial"
   },
@@ -822,21 +822,21 @@
       "decodedBytes": 0,
       "durablePeakRssBytes": 0,
       "encodedBytes": 0,
-      "externalPeakRssBytes": 342917120,
-      "externalRssSampleCount": 66,
+      "externalPeakRssBytes": 352190464,
+      "externalRssSampleCount": 67,
       "externalRssSampleFailureCount": 0,
       "filesystem": {
         "afterBytes": 0,
         "beforeBytes": 0,
-        "sampledHighWaterBytes": 30819708
+        "sampledHighWaterBytes": 30819709
       },
       "outputRecords": 0,
-      "parentElapsedMs": 3292,
+      "parentElapsedMs": 3407,
       "runCount": 2,
       "sourceBytes": 0,
       "sourceFiles": 0,
       "stderrBytes": 0,
-      "stdoutBytes": 42472
+      "stdoutBytes": 42487
     },
     "kind": "release_materialized_boundaries",
     "literalCandidateAllocationRequired": false,
@@ -894,7 +894,7 @@
     }
   },
   "protocolVersion": "g1-r7-release-evidence-v0.1",
-  "receiptSha256": "a844195b85a77f5fb06bce64358b88fc911489ce653fd79a6477b0a1a317a82c",
+  "receiptSha256": "5254e8f0499b91884f4afcffd0ab2ea7d617693459ecc0e9a60c737a76d7eecc",
   "runtimeProvenance": {
     "architecture": "arm64",
     "elapsedClock": "parent_monotonic",

--- a/generated/r7-release-real-local-history-node24.14.0-v0.1.json
+++ b/generated/r7-release-real-local-history-node24.14.0-v0.1.json
@@ -29,7 +29,7 @@
       "atLimit": {
         "failureCode": "not_run_profile",
         "status": "not_run",
-        "value": 20000
+        "value": 100000
       },
       "dimension": "directory_entries",
       "identification": "not_run",
@@ -37,13 +37,13 @@
       "plusOne": {
         "failureCode": "not_run_profile",
         "status": "not_run",
-        "value": 20001
+        "value": 100001
       },
       "producer": {
         "failureCode": "not_run_profile",
         "status": "not_run"
       },
-      "selectedLimit": 20000,
+      "selectedLimit": 100000,
       "unit": "entries",
       "verifier": {
         "failureCode": "not_run_profile",
@@ -54,7 +54,7 @@
       "atLimit": {
         "failureCode": "not_run_profile",
         "status": "not_run",
-        "value": 5000
+        "value": 100000
       },
       "dimension": "source_files",
       "identification": "not_run",
@@ -62,13 +62,13 @@
       "plusOne": {
         "failureCode": "not_run_profile",
         "status": "not_run",
-        "value": 5001
+        "value": 100001
       },
       "producer": {
         "failureCode": "not_run_profile",
         "status": "not_run"
       },
-      "selectedLimit": 5000,
+      "selectedLimit": 100000,
       "unit": "files",
       "verifier": {
         "failureCode": "not_run_profile",
@@ -479,10 +479,10 @@
   "contractProvenance": {
     "receiptSchemaSha256": "4683a469ad0143721eedeccc026f07929f2506339aeab7c52e1312cad93f5701",
     "resourcePolicySourceSha256": "d9748895468534062e9c8c436db75cbf5acf4ccf54f84319db37e88197627870",
-    "resourcePolicyValuesSha256": "a3dde0db440015886144b76b88a8a663095c7e5eb08f0a68f062e597e95552f6",
+    "resourcePolicyValuesSha256": "3cbe7853c8f75e96912885f64ba4ad1aeb13aff8a22e4ffbd51806b27c73b418",
     "schemaModuleSha256": "9d598e56c71be1c3257c2e25c1334e49fdc6b5e825c46ba3e1ce68a83490e54f",
     "workloadCodeFileCount": 341,
-    "workloadCodeSha256": "9c287966eca0a53c669a8ce70c9dbe49790bc9ec31b847ee0efb4884eae1384e"
+    "workloadCodeSha256": "5e517eade0a8c3231a78429a5d65c4fd018fc7ef253bbb45c9d963be1fbb9624"
   },
   "determinism": {
     "comparisons": {
@@ -500,8 +500,8 @@
     "projectionVersion": "g1-r7-release-deterministic-projection-v0.1",
     "runCount": 2,
     "runProjectionSha256es": [
-      "f5f837e3ed3bb559165929d9345989b19301ba60bc2e3c3608c54315085257ee",
-      "f5f837e3ed3bb559165929d9345989b19301ba60bc2e3c3608c54315085257ee"
+      "139f633c47336a688f375f319f3ffc09303922a1219ea9bea0243bad986311ee",
+      "139f633c47336a688f375f319f3ffc09303922a1219ea9bea0243bad986311ee"
     ],
     "status": "passed"
   },
@@ -514,24 +514,24 @@
     {
       "failureCode": "none",
       "metrics": {
-        "childCpuMs": 336533,
-        "childMaxRssBytes": 1136672768,
+        "childCpuMs": 329224,
+        "childMaxRssBytes": 1195884544,
         "decodedBytes": 0,
-        "durablePeakRssBytes": 1136656384,
+        "durablePeakRssBytes": 1195884544,
         "encodedBytes": 0,
-        "externalPeakRssBytes": 1135050752,
-        "externalRssSampleCount": 6664,
+        "externalPeakRssBytes": 1194278912,
+        "externalRssSampleCount": 6570,
         "externalRssSampleFailureCount": 0,
         "filesystem": {
-          "afterBytes": 1142808576,
+          "afterBytes": 1143226368,
           "beforeBytes": 0,
-          "sampledHighWaterBytes": 1144231223
+          "sampledHighWaterBytes": 1143903223
         },
         "outputRecords": 437110,
-        "parentElapsedMs": 339453,
+        "parentElapsedMs": 334618,
         "runCount": 2,
-        "sourceBytes": 26349805633,
-        "sourceFiles": 2995,
+        "sourceBytes": 26361812273,
+        "sourceFiles": 3006,
         "stderrBytes": 169,
         "stdoutBytes": 1172
       },
@@ -570,77 +570,77 @@
     {
       "failureCode": "none",
       "metrics": {
-        "childCpuMs": 35250,
-        "childMaxRssBytes": 843661312,
+        "childCpuMs": 36372,
+        "childMaxRssBytes": 835551232,
         "decodedBytes": 519324335,
-        "durablePeakRssBytes": 1136656384,
-        "encodedBytes": 29154395,
-        "externalPeakRssBytes": 842579968,
-        "externalRssSampleCount": 691,
+        "durablePeakRssBytes": 1195884544,
+        "encodedBytes": 29153338,
+        "externalPeakRssBytes": 835584000,
+        "externalRssSampleCount": 743,
         "externalRssSampleFailureCount": 0,
         "filesystem": {
-          "afterBytes": 1172098027,
-          "beforeBytes": 1142808576,
-          "sampledHighWaterBytes": 1172098027
+          "afterBytes": 1172514762,
+          "beforeBytes": 1143226368,
+          "sampledHighWaterBytes": 1172514762
         },
         "outputRecords": 437110,
-        "parentElapsedMs": 37838,
+        "parentElapsedMs": 43695,
         "runCount": 2,
-        "sourceBytes": 26349805633,
-        "sourceFiles": 2995,
+        "sourceBytes": 26361812273,
+        "sourceFiles": 3006,
         "stderrBytes": 169,
         "stdoutBytes": 1261
       },
       "name": "export_set_materialize",
-      "projectionSha256": "b9c4db1177c76a12154177877ff988fab56330833bf29e4db2170acdc184a800",
+      "projectionSha256": "312d8ae168a3bc4915258255f59487d0c8ac51d5d1be2343fa16ef67a0fda0e3",
       "status": "completed"
     },
     {
       "failureCode": "none",
       "metrics": {
-        "childCpuMs": 28393,
-        "childMaxRssBytes": 1153548288,
+        "childCpuMs": 30049,
+        "childMaxRssBytes": 889290752,
         "decodedBytes": 519324335,
         "durablePeakRssBytes": 0,
-        "encodedBytes": 29154395,
-        "externalPeakRssBytes": 1082441728,
-        "externalRssSampleCount": 570,
+        "encodedBytes": 29153338,
+        "externalPeakRssBytes": 854769664,
+        "externalRssSampleCount": 575,
         "externalRssSampleFailureCount": 0,
         "filesystem": {
-          "afterBytes": 1172098027,
-          "beforeBytes": 1172098027,
-          "sampledHighWaterBytes": 1269606899
+          "afterBytes": 1172514762,
+          "beforeBytes": 1172514762,
+          "sampledHighWaterBytes": 1270020970
         },
         "outputRecords": 437110,
-        "parentElapsedMs": 29026,
+        "parentElapsedMs": 29973,
         "runCount": 2,
         "sourceBytes": 0,
         "sourceFiles": 0,
         "stderrBytes": 169,
-        "stdoutBytes": 1017
+        "stdoutBytes": 1016
       },
       "name": "export_set_verify",
-      "projectionSha256": "70a0fd9008241d39b0bd254d4a926b3246798b2b2a92ae346a48a56766684f86",
+      "projectionSha256": "1177b899a028430af787a6d56cb8b444915f84fb063f2ae447362d2b01b6913a",
       "status": "completed"
     },
     {
       "failureCode": "none",
       "metrics": {
-        "childCpuMs": 96919,
-        "childMaxRssBytes": 1230782464,
+        "childCpuMs": 92562,
+        "childMaxRssBytes": 1221689344,
         "decodedBytes": 0,
         "durablePeakRssBytes": 0,
         "encodedBytes": 0,
-        "externalPeakRssBytes": 1230782464,
-        "externalRssSampleCount": 1917,
+        "externalPeakRssBytes": 1221689344,
+        "externalRssSampleCount": 1823,
         "externalRssSampleFailureCount": 0,
         "filesystem": {
           "afterBytes": 461,
-          "beforeBytes": 1172098027,
-          "sampledHighWaterBytes": 1172111365
+          "beforeBytes": 1172514762,
+          "sampledHighWaterBytes": 1172527509
         },
         "outputRecords": 0,
-        "parentElapsedMs": 99829,
+        "parentElapsedMs": 97385,
         "runCount": 2,
         "sourceBytes": 0,
         "sourceFiles": 0,
@@ -648,7 +648,7 @@
         "stdoutBytes": 1009
       },
       "name": "complete_set_delete",
-      "projectionSha256": "f6859e999286df03c7900ef9551756379ac8c72c3349cccd763bd9d551e4eeac",
+      "projectionSha256": "ac8c1c157cb8fcf10d689d46a7aa209cfaf4b3a552522ee2ec9db1b6a2cb5e98",
       "status": "completed"
     },
     {
@@ -816,9 +816,9 @@
   "profile": "release_real_local_history",
   "profileEvidence": {
     "claude": {
-      "completeLinePrefixBytes": 1438114524,
-      "sourceBytes": 1438114524,
-      "sourceFiles": 1526
+      "completeLinePrefixBytes": 1450121164,
+      "sourceBytes": 1450121164,
+      "sourceFiles": 1537
     },
     "codex": {
       "completeLinePrefixBytes": 24911691109,
@@ -832,7 +832,7 @@
     "rawDurableCopyCreated": false
   },
   "protocolVersion": "g1-r7-release-evidence-v0.1",
-  "receiptSha256": "11a96e29894059ae693fc5dfea676a08e8e1ae2cca249eed76f6231e8360cb36",
+  "receiptSha256": "cd316ece181609ab15c29297b211570c1101eb6d5c80f1aadce5693803b5eb1e",
   "runtimeProvenance": {
     "architecture": "arm64",
     "elapsedClock": "parent_monotonic",

--- a/generated/r7-release-real-local-history-node26.2.0-v0.1.json
+++ b/generated/r7-release-real-local-history-node26.2.0-v0.1.json
@@ -29,7 +29,7 @@
       "atLimit": {
         "failureCode": "not_run_profile",
         "status": "not_run",
-        "value": 20000
+        "value": 100000
       },
       "dimension": "directory_entries",
       "identification": "not_run",
@@ -37,13 +37,13 @@
       "plusOne": {
         "failureCode": "not_run_profile",
         "status": "not_run",
-        "value": 20001
+        "value": 100001
       },
       "producer": {
         "failureCode": "not_run_profile",
         "status": "not_run"
       },
-      "selectedLimit": 20000,
+      "selectedLimit": 100000,
       "unit": "entries",
       "verifier": {
         "failureCode": "not_run_profile",
@@ -54,7 +54,7 @@
       "atLimit": {
         "failureCode": "not_run_profile",
         "status": "not_run",
-        "value": 5000
+        "value": 100000
       },
       "dimension": "source_files",
       "identification": "not_run",
@@ -62,13 +62,13 @@
       "plusOne": {
         "failureCode": "not_run_profile",
         "status": "not_run",
-        "value": 5001
+        "value": 100001
       },
       "producer": {
         "failureCode": "not_run_profile",
         "status": "not_run"
       },
-      "selectedLimit": 5000,
+      "selectedLimit": 100000,
       "unit": "files",
       "verifier": {
         "failureCode": "not_run_profile",
@@ -479,10 +479,10 @@
   "contractProvenance": {
     "receiptSchemaSha256": "4683a469ad0143721eedeccc026f07929f2506339aeab7c52e1312cad93f5701",
     "resourcePolicySourceSha256": "d9748895468534062e9c8c436db75cbf5acf4ccf54f84319db37e88197627870",
-    "resourcePolicyValuesSha256": "a3dde0db440015886144b76b88a8a663095c7e5eb08f0a68f062e597e95552f6",
+    "resourcePolicyValuesSha256": "3cbe7853c8f75e96912885f64ba4ad1aeb13aff8a22e4ffbd51806b27c73b418",
     "schemaModuleSha256": "9d598e56c71be1c3257c2e25c1334e49fdc6b5e825c46ba3e1ce68a83490e54f",
     "workloadCodeFileCount": 341,
-    "workloadCodeSha256": "9c287966eca0a53c669a8ce70c9dbe49790bc9ec31b847ee0efb4884eae1384e"
+    "workloadCodeSha256": "5e517eade0a8c3231a78429a5d65c4fd018fc7ef253bbb45c9d963be1fbb9624"
   },
   "determinism": {
     "comparisons": {
@@ -500,8 +500,8 @@
     "projectionVersion": "g1-r7-release-deterministic-projection-v0.1",
     "runCount": 2,
     "runProjectionSha256es": [
-      "b15aa11de7999dc2cf0fd34802b6ecbfb2f0a712f184324ee232954042cde74f",
-      "b15aa11de7999dc2cf0fd34802b6ecbfb2f0a712f184324ee232954042cde74f"
+      "b8ad2858204e9ed0f427e8c31322db015ca7071fbbfeda108bf95d3e2c3ab5e6",
+      "b8ad2858204e9ed0f427e8c31322db015ca7071fbbfeda108bf95d3e2c3ab5e6"
     ],
     "status": "passed"
   },
@@ -514,26 +514,26 @@
     {
       "failureCode": "none",
       "metrics": {
-        "childCpuMs": 349469,
-        "childMaxRssBytes": 1101217792,
+        "childCpuMs": 367183,
+        "childMaxRssBytes": 997703680,
         "decodedBytes": 0,
-        "durablePeakRssBytes": 1101217792,
+        "durablePeakRssBytes": 997703680,
         "encodedBytes": 0,
-        "externalPeakRssBytes": 1101217792,
-        "externalRssSampleCount": 7036,
+        "externalPeakRssBytes": 997703680,
+        "externalRssSampleCount": 7517,
         "externalRssSampleFailureCount": 0,
         "filesystem": {
-          "afterBytes": 1142808576,
+          "afterBytes": 1143226368,
           "beforeBytes": 0,
-          "sampledHighWaterBytes": 1142817431
+          "sampledHighWaterBytes": 1143226479
         },
         "outputRecords": 437110,
-        "parentElapsedMs": 358647,
+        "parentElapsedMs": 387096,
         "runCount": 2,
-        "sourceBytes": 26349805633,
-        "sourceFiles": 2995,
+        "sourceBytes": 26361812273,
+        "sourceFiles": 3006,
         "stderrBytes": 0,
-        "stdoutBytes": 1172
+        "stdoutBytes": 1170
       },
       "name": "source_scan",
       "projectionSha256": "63ad0ceba3f84f67a859f2006ed1f6b72738ddc22017025a9b23490689ecf31a",
@@ -570,49 +570,49 @@
     {
       "failureCode": "none",
       "metrics": {
-        "childCpuMs": 29589,
-        "childMaxRssBytes": 940474368,
+        "childCpuMs": 31244,
+        "childMaxRssBytes": 939786240,
         "decodedBytes": 519324335,
-        "durablePeakRssBytes": 1101217792,
-        "encodedBytes": 29154395,
-        "externalPeakRssBytes": 939589632,
-        "externalRssSampleCount": 573,
+        "durablePeakRssBytes": 997703680,
+        "encodedBytes": 29153338,
+        "externalPeakRssBytes": 939720704,
+        "externalRssSampleCount": 579,
         "externalRssSampleFailureCount": 0,
         "filesystem": {
-          "afterBytes": 1172098026,
-          "beforeBytes": 1142808576,
-          "sampledHighWaterBytes": 1173055910
+          "afterBytes": 1172514761,
+          "beforeBytes": 1143226368,
+          "sampledHighWaterBytes": 1172533861
         },
         "outputRecords": 437110,
-        "parentElapsedMs": 29247,
+        "parentElapsedMs": 30041,
         "runCount": 2,
-        "sourceBytes": 26349805633,
-        "sourceFiles": 2995,
+        "sourceBytes": 26361812273,
+        "sourceFiles": 3006,
         "stderrBytes": 0,
-        "stdoutBytes": 1261
+        "stdoutBytes": 1260
       },
       "name": "export_set_materialize",
-      "projectionSha256": "b9c4db1177c76a12154177877ff988fab56330833bf29e4db2170acdc184a800",
+      "projectionSha256": "312d8ae168a3bc4915258255f59487d0c8ac51d5d1be2343fa16ef67a0fda0e3",
       "status": "completed"
     },
     {
       "failureCode": "none",
       "metrics": {
-        "childCpuMs": 24247,
-        "childMaxRssBytes": 711475200,
+        "childCpuMs": 24213,
+        "childMaxRssBytes": 776011776,
         "decodedBytes": 519324335,
         "durablePeakRssBytes": 0,
-        "encodedBytes": 29154395,
-        "externalPeakRssBytes": 710279168,
-        "externalRssSampleCount": 487,
+        "encodedBytes": 29153338,
+        "externalPeakRssBytes": 725155840,
+        "externalRssSampleCount": 491,
         "externalRssSampleFailureCount": 0,
         "filesystem": {
-          "afterBytes": 1172098026,
-          "beforeBytes": 1172098026,
-          "sampledHighWaterBytes": 1269682146
+          "afterBytes": 1172514761,
+          "beforeBytes": 1172514761,
+          "sampledHighWaterBytes": 1270323833
         },
         "outputRecords": 437110,
-        "parentElapsedMs": 24579,
+        "parentElapsedMs": 25200,
         "runCount": 2,
         "sourceBytes": 0,
         "sourceFiles": 0,
@@ -620,35 +620,35 @@
         "stdoutBytes": 1016
       },
       "name": "export_set_verify",
-      "projectionSha256": "70a0fd9008241d39b0bd254d4a926b3246798b2b2a92ae346a48a56766684f86",
+      "projectionSha256": "1177b899a028430af787a6d56cb8b444915f84fb063f2ae447362d2b01b6913a",
       "status": "completed"
     },
     {
       "failureCode": "none",
       "metrics": {
-        "childCpuMs": 81705,
-        "childMaxRssBytes": 925925376,
+        "childCpuMs": 86182,
+        "childMaxRssBytes": 1080524800,
         "decodedBytes": 0,
         "durablePeakRssBytes": 0,
         "encodedBytes": 0,
-        "externalPeakRssBytes": 916422656,
-        "externalRssSampleCount": 1650,
+        "externalPeakRssBytes": 1078427648,
+        "externalRssSampleCount": 1843,
         "externalRssSampleFailureCount": 0,
         "filesystem": {
           "afterBytes": 461,
-          "beforeBytes": 1172098026,
-          "sampledHighWaterBytes": 1172098137
+          "beforeBytes": 1172514761,
+          "sampledHighWaterBytes": 1172527508
         },
         "outputRecords": 0,
-        "parentElapsedMs": 89373,
+        "parentElapsedMs": 108656,
         "runCount": 2,
         "sourceBytes": 0,
         "sourceFiles": 0,
         "stderrBytes": 0,
-        "stdoutBytes": 1008
+        "stdoutBytes": 1010
       },
       "name": "complete_set_delete",
-      "projectionSha256": "ea8bbd8dde9db1543e4e77f6ae563164f4896301d1652debda00af29ddf1b4b6",
+      "projectionSha256": "7dd18158693cd7b67f684fcccebfb26f04891b4065dc0dae033564bc82cec3ea",
       "status": "completed"
     },
     {
@@ -816,9 +816,9 @@
   "profile": "release_real_local_history",
   "profileEvidence": {
     "claude": {
-      "completeLinePrefixBytes": 1438114524,
-      "sourceBytes": 1438114524,
-      "sourceFiles": 1526
+      "completeLinePrefixBytes": 1450121164,
+      "sourceBytes": 1450121164,
+      "sourceFiles": 1537
     },
     "codex": {
       "completeLinePrefixBytes": 24911691109,
@@ -832,7 +832,7 @@
     "rawDurableCopyCreated": false
   },
   "protocolVersion": "g1-r7-release-evidence-v0.1",
-  "receiptSha256": "b5e2f60007a8a620de434ad0e61cde0468ff9082cf297754eba79d1b28a1ea1c",
+  "receiptSha256": "04043dc37aba14b2fa8ae6ae1301726962f595e139c79a9bc999b20b3993ec3a",
   "runtimeProvenance": {
     "architecture": "arm64",
     "elapsedClock": "parent_monotonic",

--- a/generated/r7-release-synthetic-pressure-node24.14.0-v0.1.json
+++ b/generated/r7-release-synthetic-pressure-node24.14.0-v0.1.json
@@ -29,7 +29,7 @@
       "atLimit": {
         "failureCode": "not_run_profile",
         "status": "not_run",
-        "value": 20000
+        "value": 100000
       },
       "dimension": "directory_entries",
       "identification": "not_run",
@@ -37,13 +37,13 @@
       "plusOne": {
         "failureCode": "not_run_profile",
         "status": "not_run",
-        "value": 20001
+        "value": 100001
       },
       "producer": {
         "failureCode": "not_run_profile",
         "status": "not_run"
       },
-      "selectedLimit": 20000,
+      "selectedLimit": 100000,
       "unit": "entries",
       "verifier": {
         "failureCode": "not_run_profile",
@@ -54,7 +54,7 @@
       "atLimit": {
         "failureCode": "not_run_profile",
         "status": "not_run",
-        "value": 5000
+        "value": 100000
       },
       "dimension": "source_files",
       "identification": "not_run",
@@ -62,13 +62,13 @@
       "plusOne": {
         "failureCode": "not_run_profile",
         "status": "not_run",
-        "value": 5001
+        "value": 100001
       },
       "producer": {
         "failureCode": "not_run_profile",
         "status": "not_run"
       },
-      "selectedLimit": 5000,
+      "selectedLimit": 100000,
       "unit": "files",
       "verifier": {
         "failureCode": "not_run_profile",
@@ -479,10 +479,10 @@
   "contractProvenance": {
     "receiptSchemaSha256": "4683a469ad0143721eedeccc026f07929f2506339aeab7c52e1312cad93f5701",
     "resourcePolicySourceSha256": "d9748895468534062e9c8c436db75cbf5acf4ccf54f84319db37e88197627870",
-    "resourcePolicyValuesSha256": "a3dde0db440015886144b76b88a8a663095c7e5eb08f0a68f062e597e95552f6",
+    "resourcePolicyValuesSha256": "3cbe7853c8f75e96912885f64ba4ad1aeb13aff8a22e4ffbd51806b27c73b418",
     "schemaModuleSha256": "9d598e56c71be1c3257c2e25c1334e49fdc6b5e825c46ba3e1ce68a83490e54f",
     "workloadCodeFileCount": 341,
-    "workloadCodeSha256": "9c287966eca0a53c669a8ce70c9dbe49790bc9ec31b847ee0efb4884eae1384e"
+    "workloadCodeSha256": "5e517eade0a8c3231a78429a5d65c4fd018fc7ef253bbb45c9d963be1fbb9624"
   },
   "determinism": {
     "comparisons": {
@@ -500,8 +500,8 @@
     "projectionVersion": "g1-r7-release-deterministic-projection-v0.1",
     "runCount": 2,
     "runProjectionSha256es": [
-      "0bbde0832a38e33ff014dbedf49c6c7d42bccbd44d2e76b4cdb111b752d93c37",
-      "0bbde0832a38e33ff014dbedf49c6c7d42bccbd44d2e76b4cdb111b752d93c37"
+      "0208322b7756e650b5675174df4034d9db39ad1f924b7a9b21c191815ded3ba3",
+      "0208322b7756e650b5675174df4034d9db39ad1f924b7a9b21c191815ded3ba3"
     ],
     "status": "passed"
   },
@@ -514,25 +514,25 @@
     {
       "failureCode": "none",
       "metrics": {
-        "childCpuMs": 20646,
-        "childMaxRssBytes": 686047232,
+        "childCpuMs": 22500,
+        "childMaxRssBytes": 688553984,
         "decodedBytes": 0,
-        "durablePeakRssBytes": 686047232,
+        "durablePeakRssBytes": 683327488,
         "encodedBytes": 0,
-        "externalPeakRssBytes": 673644544,
-        "externalRssSampleCount": 277,
+        "externalPeakRssBytes": 683311104,
+        "externalRssSampleCount": 284,
         "externalRssSampleFailureCount": 0,
         "filesystem": {
-          "afterBytes": 96936096,
+          "afterBytes": 96919712,
           "beforeBytes": 160,
-          "sampledHighWaterBytes": 96936096
+          "sampledHighWaterBytes": 96919712
         },
         "outputRecords": 29108,
-        "parentElapsedMs": 14091,
+        "parentElapsedMs": 15641,
         "runCount": 2,
         "sourceBytes": 47637907,
         "sourceFiles": 4096,
-        "stderrBytes": 169,
+        "stderrBytes": 168,
         "stdoutBytes": 1099
       },
       "name": "source_scan",
@@ -542,26 +542,26 @@
     {
       "failureCode": "none",
       "metrics": {
-        "childCpuMs": 12910,
-        "childMaxRssBytes": 670318592,
+        "childCpuMs": 14554,
+        "childMaxRssBytes": 501874688,
         "decodedBytes": 0,
-        "durablePeakRssBytes": 784498688,
+        "durablePeakRssBytes": 802701312,
         "encodedBytes": 0,
-        "externalPeakRssBytes": 664813568,
-        "externalRssSampleCount": 209,
+        "externalPeakRssBytes": 493404160,
+        "externalRssSampleCount": 217,
         "externalRssSampleFailureCount": 0,
         "filesystem": {
-          "afterBytes": 193872032,
-          "beforeBytes": 127045792,
-          "sampledHighWaterBytes": 193872032
+          "afterBytes": 193839264,
+          "beforeBytes": 127029408,
+          "sampledHighWaterBytes": 193839374
         },
         "outputRecords": 29108,
-        "parentElapsedMs": 10705,
+        "parentElapsedMs": 12270,
         "runCount": 2,
         "sourceBytes": 47637907,
         "sourceFiles": 4096,
-        "stderrBytes": 169,
-        "stdoutBytes": 1104
+        "stderrBytes": 168,
+        "stdoutBytes": 1105
       },
       "name": "checkpoint_resume",
       "projectionSha256": "c70ea4b8c4d71a9ee8b2a1cd72023877e32391e1f2b8fd7bfb355374b28f2395",
@@ -570,137 +570,137 @@
     {
       "failureCode": "none",
       "metrics": {
-        "childCpuMs": 4061,
-        "childMaxRssBytes": 263782400,
+        "childCpuMs": 4202,
+        "childMaxRssBytes": 262193152,
         "decodedBytes": 46019365,
-        "durablePeakRssBytes": 686047232,
-        "encodedBytes": 2072560,
-        "externalPeakRssBytes": 263766016,
-        "externalRssSampleCount": 181,
+        "durablePeakRssBytes": 683327488,
+        "encodedBytes": 2072559,
+        "externalPeakRssBytes": 261439488,
+        "externalRssSampleCount": 182,
         "externalRssSampleFailureCount": 0,
         "filesystem": {
-          "afterBytes": 196979302,
-          "beforeBytes": 193872032,
-          "sampledHighWaterBytes": 196979992
+          "afterBytes": 196946533,
+          "beforeBytes": 193839264,
+          "sampledHighWaterBytes": 196946643
         },
         "outputRecords": 29108,
-        "parentElapsedMs": 9121,
+        "parentElapsedMs": 9203,
         "runCount": 2,
         "sourceBytes": 47637907,
         "sourceFiles": 4096,
-        "stderrBytes": 169,
+        "stderrBytes": 168,
         "stdoutBytes": 1251
       },
       "name": "export_set_materialize",
-      "projectionSha256": "4d586988a6d641599590ede1d93c3c83e3efbc189563018c8ee3d31af64d3628",
+      "projectionSha256": "91de34df204dbcdfe200974df54263950ef1af38a8f41f9d3b0b3d537724fddf",
       "status": "completed"
     },
     {
       "failureCode": "none",
       "metrics": {
-        "childCpuMs": 1999,
-        "childMaxRssBytes": 268419072,
+        "childCpuMs": 2014,
+        "childMaxRssBytes": 270647296,
         "decodedBytes": 46019365,
         "durablePeakRssBytes": 0,
-        "encodedBytes": 2072560,
-        "externalPeakRssBytes": 267288576,
+        "encodedBytes": 2072559,
+        "externalPeakRssBytes": 270614528,
         "externalRssSampleCount": 40,
         "externalRssSampleFailureCount": 0,
         "filesystem": {
-          "afterBytes": 196979302,
-          "beforeBytes": 196979302,
-          "sampledHighWaterBytes": 205005014
+          "afterBytes": 196946533,
+          "beforeBytes": 196946533,
+          "sampledHighWaterBytes": 204910693
         },
         "outputRecords": 29108,
-        "parentElapsedMs": 2003,
+        "parentElapsedMs": 2073,
         "runCount": 2,
         "sourceBytes": 0,
         "sourceFiles": 0,
-        "stderrBytes": 169,
+        "stderrBytes": 168,
         "stdoutBytes": 1011
       },
       "name": "export_set_verify",
-      "projectionSha256": "f156a70e4034fed664953a43a9fbcf4b1a22404a041d6a19b578d608bfbb782e",
+      "projectionSha256": "2d1f69f67246d17be07b6b409b7498af57418257f08b43aec2917021f53d7828",
       "status": "completed"
     },
     {
       "failureCode": "none",
       "metrics": {
-        "childCpuMs": 7360,
-        "childMaxRssBytes": 311803904,
+        "childCpuMs": 6549,
+        "childMaxRssBytes": 310722560,
         "decodedBytes": 0,
         "durablePeakRssBytes": 0,
         "encodedBytes": 0,
-        "externalPeakRssBytes": 311803904,
-        "externalRssSampleCount": 180,
-        "externalRssSampleFailureCount": 0,
+        "externalPeakRssBytes": 310706176,
+        "externalRssSampleCount": 164,
+        "externalRssSampleFailureCount": 1,
         "filesystem": {
-          "afterBytes": 96938628,
-          "beforeBytes": 196981373,
-          "sampledHighWaterBytes": 197062034
+          "afterBytes": 96922244,
+          "beforeBytes": 196948604,
+          "sampledHighWaterBytes": 197030444
         },
         "outputRecords": 0,
-        "parentElapsedMs": 9439,
+        "parentElapsedMs": 8309,
         "runCount": 2,
         "sourceBytes": 0,
         "sourceFiles": 0,
-        "stderrBytes": 169,
-        "stdoutBytes": 1005
+        "stderrBytes": 168,
+        "stdoutBytes": 1004
       },
       "name": "complete_set_delete",
-      "projectionSha256": "cca24fc5f9665059af80085447da5830d60416fd9e1ee64cef0be2e1ac1255a4",
+      "projectionSha256": "309a7cd05507f4368afa27312b4082423bd54ad3706c3247907a5c24004e3793",
       "status": "completed"
     },
     {
       "failureCode": "interruption_injected",
       "metrics": {
-        "childCpuMs": 404,
-        "childMaxRssBytes": 134119424,
+        "childCpuMs": 362,
+        "childMaxRssBytes": 128368640,
         "decodedBytes": 0,
         "durablePeakRssBytes": 0,
         "encodedBytes": 0,
-        "externalPeakRssBytes": 133873664,
+        "externalPeakRssBytes": 128139264,
         "externalRssSampleCount": 49,
         "externalRssSampleFailureCount": 0,
         "filesystem": {
-          "afterBytes": 196981373,
-          "beforeBytes": 297104668,
-          "sampledHighWaterBytes": 297104668
+          "afterBytes": 196948604,
+          "beforeBytes": 297055514,
+          "sampledHighWaterBytes": 297055514
         },
         "outputRecords": 0,
-        "parentElapsedMs": 2446,
+        "parentElapsedMs": 2426,
         "runCount": 2,
         "sourceBytes": 0,
         "sourceFiles": 0,
-        "stderrBytes": 169,
+        "stderrBytes": 168,
         "stdoutBytes": 1012
       },
       "name": "complete_set_delete_recovery",
-      "projectionSha256": "cca24fc5f9665059af80085447da5830d60416fd9e1ee64cef0be2e1ac1255a4",
+      "projectionSha256": "309a7cd05507f4368afa27312b4082423bd54ad3706c3247907a5c24004e3793",
       "status": "interrupted_recovered"
     },
     {
       "failureCode": "none",
       "metrics": {
-        "childCpuMs": 146,
-        "childMaxRssBytes": 118685696,
+        "childCpuMs": 171,
+        "childMaxRssBytes": 115359744,
         "decodedBytes": 0,
         "durablePeakRssBytes": 0,
         "encodedBytes": 0,
-        "externalPeakRssBytes": 118521856,
-        "externalRssSampleCount": 8,
+        "externalPeakRssBytes": 115163136,
+        "externalRssSampleCount": 9,
         "externalRssSampleFailureCount": 0,
         "filesystem": {
-          "afterBytes": 196979837,
-          "beforeBytes": 227088998,
-          "sampledHighWaterBytes": 227089109
+          "afterBytes": 196947068,
+          "beforeBytes": 227056229,
+          "sampledHighWaterBytes": 257167267
         },
         "outputRecords": 0,
-        "parentElapsedMs": 345,
+        "parentElapsedMs": 410,
         "runCount": 2,
         "sourceBytes": 0,
         "sourceFiles": 0,
-        "stderrBytes": 169,
+        "stderrBytes": 168,
         "stdoutBytes": 996
       },
       "name": "workspace_discard",
@@ -710,25 +710,25 @@
     {
       "failureCode": "interruption_injected",
       "metrics": {
-        "childCpuMs": 99,
-        "childMaxRssBytes": 118046720,
+        "childCpuMs": 110,
+        "childMaxRssBytes": 118784000,
         "decodedBytes": 0,
         "durablePeakRssBytes": 0,
         "encodedBytes": 0,
-        "externalPeakRssBytes": 117211136,
-        "externalRssSampleCount": 6,
+        "externalPeakRssBytes": 118669312,
+        "externalRssSampleCount": 7,
         "externalRssSampleFailureCount": 0,
         "filesystem": {
-          "afterBytes": 196980372,
-          "beforeBytes": 227090765,
-          "sampledHighWaterBytes": 257200572
+          "afterBytes": 196947603,
+          "beforeBytes": 227057996,
+          "sampledHighWaterBytes": 257167802
         },
         "outputRecords": 0,
-        "parentElapsedMs": 284,
+        "parentElapsedMs": 337,
         "runCount": 2,
         "sourceBytes": 0,
         "sourceFiles": 0,
-        "stderrBytes": 169,
+        "stderrBytes": 168,
         "stdoutBytes": 1004
       },
       "name": "workspace_discard_recovery",
@@ -738,25 +738,25 @@
     {
       "failureCode": "none",
       "metrics": {
-        "childCpuMs": 7,
-        "childMaxRssBytes": 112738304,
+        "childCpuMs": 9,
+        "childMaxRssBytes": 112558080,
         "decodedBytes": 0,
         "durablePeakRssBytes": 0,
         "encodedBytes": 0,
-        "externalPeakRssBytes": 91684864,
-        "externalRssSampleCount": 4,
+        "externalPeakRssBytes": 111132672,
+        "externalRssSampleCount": 5,
         "externalRssSampleFailureCount": 0,
         "filesystem": {
-          "afterBytes": 196980642,
-          "beforeBytes": 196980821,
-          "sampledHighWaterBytes": 196980821
+          "afterBytes": 196947873,
+          "beforeBytes": 196948052,
+          "sampledHighWaterBytes": 196948052
         },
         "outputRecords": 0,
-        "parentElapsedMs": 178,
+        "parentElapsedMs": 223,
         "runCount": 2,
         "sourceBytes": 0,
         "sourceFiles": 0,
-        "stderrBytes": 169,
+        "stderrBytes": 168,
         "stdoutBytes": 993
       },
       "name": "claude_callback_uninstall",
@@ -766,25 +766,25 @@
     {
       "failureCode": "interruption_injected",
       "metrics": {
-        "childCpuMs": 6,
-        "childMaxRssBytes": 112623616,
+        "childCpuMs": 8,
+        "childMaxRssBytes": 112312320,
         "decodedBytes": 0,
         "durablePeakRssBytes": 0,
         "encodedBytes": 0,
-        "externalPeakRssBytes": 91701248,
-        "externalRssSampleCount": 4,
+        "externalPeakRssBytes": 109428736,
+        "externalRssSampleCount": 5,
         "externalRssSampleFailureCount": 0,
         "filesystem": {
-          "afterBytes": 196980912,
-          "beforeBytes": 196981100,
-          "sampledHighWaterBytes": 196981100
+          "afterBytes": 196948143,
+          "beforeBytes": 196948331,
+          "sampledHighWaterBytes": 196948331
         },
         "outputRecords": 0,
-        "parentElapsedMs": 168,
+        "parentElapsedMs": 229,
         "runCount": 2,
         "sourceBytes": 0,
         "sourceFiles": 0,
-        "stderrBytes": 169,
+        "stderrBytes": 168,
         "stdoutBytes": 992
       },
       "name": "claude_callback_recovery",
@@ -827,7 +827,7 @@
     "targetChunks": 128
   },
   "protocolVersion": "g1-r7-release-evidence-v0.1",
-  "receiptSha256": "941b682947411e0dc955c8597c05527b371ce522ea68ef0e2abec6661a439fa2",
+  "receiptSha256": "8ac54d73dd6aa94b16fb9d1c3d41ca53f56e6f393627ac79eb7ef404ecfb553e",
   "runtimeProvenance": {
     "architecture": "arm64",
     "elapsedClock": "parent_monotonic",

--- a/generated/r7-release-synthetic-pressure-node26.2.0-v0.1.json
+++ b/generated/r7-release-synthetic-pressure-node26.2.0-v0.1.json
@@ -29,7 +29,7 @@
       "atLimit": {
         "failureCode": "not_run_profile",
         "status": "not_run",
-        "value": 20000
+        "value": 100000
       },
       "dimension": "directory_entries",
       "identification": "not_run",
@@ -37,13 +37,13 @@
       "plusOne": {
         "failureCode": "not_run_profile",
         "status": "not_run",
-        "value": 20001
+        "value": 100001
       },
       "producer": {
         "failureCode": "not_run_profile",
         "status": "not_run"
       },
-      "selectedLimit": 20000,
+      "selectedLimit": 100000,
       "unit": "entries",
       "verifier": {
         "failureCode": "not_run_profile",
@@ -54,7 +54,7 @@
       "atLimit": {
         "failureCode": "not_run_profile",
         "status": "not_run",
-        "value": 5000
+        "value": 100000
       },
       "dimension": "source_files",
       "identification": "not_run",
@@ -62,13 +62,13 @@
       "plusOne": {
         "failureCode": "not_run_profile",
         "status": "not_run",
-        "value": 5001
+        "value": 100001
       },
       "producer": {
         "failureCode": "not_run_profile",
         "status": "not_run"
       },
-      "selectedLimit": 5000,
+      "selectedLimit": 100000,
       "unit": "files",
       "verifier": {
         "failureCode": "not_run_profile",
@@ -479,10 +479,10 @@
   "contractProvenance": {
     "receiptSchemaSha256": "4683a469ad0143721eedeccc026f07929f2506339aeab7c52e1312cad93f5701",
     "resourcePolicySourceSha256": "d9748895468534062e9c8c436db75cbf5acf4ccf54f84319db37e88197627870",
-    "resourcePolicyValuesSha256": "a3dde0db440015886144b76b88a8a663095c7e5eb08f0a68f062e597e95552f6",
+    "resourcePolicyValuesSha256": "3cbe7853c8f75e96912885f64ba4ad1aeb13aff8a22e4ffbd51806b27c73b418",
     "schemaModuleSha256": "9d598e56c71be1c3257c2e25c1334e49fdc6b5e825c46ba3e1ce68a83490e54f",
     "workloadCodeFileCount": 341,
-    "workloadCodeSha256": "9c287966eca0a53c669a8ce70c9dbe49790bc9ec31b847ee0efb4884eae1384e"
+    "workloadCodeSha256": "5e517eade0a8c3231a78429a5d65c4fd018fc7ef253bbb45c9d963be1fbb9624"
   },
   "determinism": {
     "comparisons": {
@@ -500,8 +500,8 @@
     "projectionVersion": "g1-r7-release-deterministic-projection-v0.1",
     "runCount": 2,
     "runProjectionSha256es": [
-      "4db9a285cf22fb237cf02e195adcd5ef0b9574a72f11a7226693045d15910673",
-      "4db9a285cf22fb237cf02e195adcd5ef0b9574a72f11a7226693045d15910673"
+      "b675cf4a4491e9f7cdff6ad0d57db9e853ece9fa5c3c2a6a4741f73514849795",
+      "b675cf4a4491e9f7cdff6ad0d57db9e853ece9fa5c3c2a6a4741f73514849795"
     ],
     "status": "passed"
   },
@@ -514,21 +514,21 @@
     {
       "failureCode": "none",
       "metrics": {
-        "childCpuMs": 21652,
-        "childMaxRssBytes": 640401408,
+        "childCpuMs": 31382,
+        "childMaxRssBytes": 986578944,
         "decodedBytes": 0,
-        "durablePeakRssBytes": 639614976,
+        "durablePeakRssBytes": 986578944,
         "encodedBytes": 0,
-        "externalPeakRssBytes": 636960768,
-        "externalRssSampleCount": 327,
+        "externalPeakRssBytes": 984825856,
+        "externalRssSampleCount": 383,
         "externalRssSampleFailureCount": 0,
         "filesystem": {
-          "afterBytes": 96927904,
+          "afterBytes": 96968864,
           "beforeBytes": 160,
-          "sampledHighWaterBytes": 96928015
+          "sampledHighWaterBytes": 96968974
         },
         "outputRecords": 29108,
-        "parentElapsedMs": 16577,
+        "parentElapsedMs": 24115,
         "runCount": 2,
         "sourceBytes": 47637907,
         "sourceFiles": 4096,
@@ -542,21 +542,21 @@
     {
       "failureCode": "none",
       "metrics": {
-        "childCpuMs": 15525,
-        "childMaxRssBytes": 712802304,
+        "childCpuMs": 14064,
+        "childMaxRssBytes": 667566080,
         "decodedBytes": 0,
-        "durablePeakRssBytes": 631259136,
+        "durablePeakRssBytes": 667566080,
         "encodedBytes": 0,
-        "externalPeakRssBytes": 630718464,
-        "externalRssSampleCount": 241,
+        "externalPeakRssBytes": 662552576,
+        "externalRssSampleCount": 269,
         "externalRssSampleFailureCount": 0,
         "filesystem": {
-          "afterBytes": 193855648,
-          "beforeBytes": 127037600,
-          "sampledHighWaterBytes": 193855648
+          "afterBytes": 193937568,
+          "beforeBytes": 127078560,
+          "sampledHighWaterBytes": 193937568
         },
         "outputRecords": 29108,
-        "parentElapsedMs": 12774,
+        "parentElapsedMs": 14572,
         "runCount": 2,
         "sourceBytes": 47637907,
         "sourceFiles": 4096,
@@ -570,21 +570,21 @@
     {
       "failureCode": "none",
       "metrics": {
-        "childCpuMs": 3771,
-        "childMaxRssBytes": 218136576,
+        "childCpuMs": 3723,
+        "childMaxRssBytes": 211320832,
         "decodedBytes": 46019365,
-        "durablePeakRssBytes": 639614976,
-        "encodedBytes": 2072548,
-        "externalPeakRssBytes": 217759744,
-        "externalRssSampleCount": 179,
+        "durablePeakRssBytes": 986578944,
+        "encodedBytes": 2072517,
+        "externalPeakRssBytes": 210944000,
+        "externalRssSampleCount": 176,
         "externalRssSampleFailureCount": 0,
         "filesystem": {
-          "afterBytes": 196962905,
-          "beforeBytes": 193855648,
-          "sampledHighWaterBytes": 196962905
+          "afterBytes": 197044794,
+          "beforeBytes": 193937568,
+          "sampledHighWaterBytes": 197045482
         },
         "outputRecords": 29108,
-        "parentElapsedMs": 9266,
+        "parentElapsedMs": 8842,
         "runCount": 2,
         "sourceBytes": 47637907,
         "sourceFiles": 4096,
@@ -592,27 +592,27 @@
         "stdoutBytes": 1250
       },
       "name": "export_set_materialize",
-      "projectionSha256": "fa0b7580c5dc7d09353b9897c704940610841405c068af5105bcd617f5d1f387",
+      "projectionSha256": "86eaf39b1f2053d6517241b78ebb6ad5826f900c075771b2abb6bf79e61f59b6",
       "status": "completed"
     },
     {
       "failureCode": "none",
       "metrics": {
-        "childCpuMs": 1956,
-        "childMaxRssBytes": 235175936,
+        "childCpuMs": 1860,
+        "childMaxRssBytes": 227442688,
         "decodedBytes": 46019365,
         "durablePeakRssBytes": 0,
-        "encodedBytes": 2072548,
-        "externalPeakRssBytes": 234979328,
-        "externalRssSampleCount": 37,
+        "encodedBytes": 2072517,
+        "externalPeakRssBytes": 227147776,
+        "externalRssSampleCount": 35,
         "externalRssSampleFailureCount": 0,
         "filesystem": {
-          "afterBytes": 196962905,
-          "beforeBytes": 196962905,
-          "sampledHighWaterBytes": 204520841
+          "afterBytes": 197044794,
+          "beforeBytes": 197044794,
+          "sampledHighWaterBytes": 204886202
         },
         "outputRecords": 29108,
-        "parentElapsedMs": 1891,
+        "parentElapsedMs": 1812,
         "runCount": 2,
         "sourceBytes": 0,
         "sourceFiles": 0,
@@ -620,55 +620,55 @@
         "stdoutBytes": 1011
       },
       "name": "export_set_verify",
-      "projectionSha256": "e130e80bf9c18cb8e2e89a2794118be8e433871f1b3d91eac10b905be7e7f9a1",
+      "projectionSha256": "fb2bf04411c2bf034fe18b73e26928ed271da5fdb9c5be445daef5e3402626a0",
       "status": "completed"
     },
     {
       "failureCode": "none",
       "metrics": {
-        "childCpuMs": 6199,
-        "childMaxRssBytes": 256065536,
+        "childCpuMs": 6058,
+        "childMaxRssBytes": 257327104,
         "decodedBytes": 0,
         "durablePeakRssBytes": 0,
         "encodedBytes": 0,
-        "externalPeakRssBytes": 255492096,
-        "externalRssSampleCount": 154,
+        "externalPeakRssBytes": 257097728,
+        "externalRssSampleCount": 152,
         "externalRssSampleFailureCount": 0,
         "filesystem": {
-          "afterBytes": 96930436,
-          "beforeBytes": 196964976,
-          "sampledHighWaterBytes": 196965087
+          "afterBytes": 96971396,
+          "beforeBytes": 197046865,
+          "sampledHighWaterBytes": 197128115
         },
         "outputRecords": 0,
-        "parentElapsedMs": 7742,
+        "parentElapsedMs": 7708,
         "runCount": 2,
         "sourceBytes": 0,
         "sourceFiles": 0,
         "stderrBytes": 0,
-        "stdoutBytes": 1005
+        "stdoutBytes": 1004
       },
       "name": "complete_set_delete",
-      "projectionSha256": "c5dc3c689422ba0778623d37f4271cdce6bb836b753cea7d7698b51299308d5b",
+      "projectionSha256": "cb611be3b4ed863cf3ac3b6fcfd283d16a31a8933bc2597807afda0131749c5f",
       "status": "completed"
     },
     {
       "failureCode": "interruption_injected",
       "metrics": {
-        "childCpuMs": 391,
-        "childMaxRssBytes": 139509760,
+        "childCpuMs": 368,
+        "childMaxRssBytes": 136413184,
         "decodedBytes": 0,
         "durablePeakRssBytes": 0,
         "encodedBytes": 0,
-        "externalPeakRssBytes": 139132928,
-        "externalRssSampleCount": 48,
+        "externalPeakRssBytes": 136298496,
+        "externalRssSampleCount": 49,
         "externalRssSampleFailureCount": 0,
         "filesystem": {
-          "afterBytes": 196964976,
-          "beforeBytes": 297080066,
-          "sampledHighWaterBytes": 297080066
+          "afterBytes": 197046865,
+          "beforeBytes": 297202884,
+          "sampledHighWaterBytes": 297202884
         },
         "outputRecords": 0,
-        "parentElapsedMs": 2392,
+        "parentElapsedMs": 2461,
         "runCount": 2,
         "sourceBytes": 0,
         "sourceFiles": 0,
@@ -676,32 +676,32 @@
         "stdoutBytes": 1012
       },
       "name": "complete_set_delete_recovery",
-      "projectionSha256": "c5dc3c689422ba0778623d37f4271cdce6bb836b753cea7d7698b51299308d5b",
+      "projectionSha256": "cb611be3b4ed863cf3ac3b6fcfd283d16a31a8933bc2597807afda0131749c5f",
       "status": "interrupted_recovered"
     },
     {
       "failureCode": "none",
       "metrics": {
-        "childCpuMs": 154,
-        "childMaxRssBytes": 122503168,
+        "childCpuMs": 144,
+        "childMaxRssBytes": 122880000,
         "decodedBytes": 0,
         "durablePeakRssBytes": 0,
         "encodedBytes": 0,
-        "externalPeakRssBytes": 122175488,
+        "externalPeakRssBytes": 122716160,
         "externalRssSampleCount": 8,
         "externalRssSampleFailureCount": 0,
         "filesystem": {
-          "afterBytes": 196963440,
-          "beforeBytes": 227072601,
-          "sampledHighWaterBytes": 227073944
+          "afterBytes": 197045329,
+          "beforeBytes": 227154490,
+          "sampledHighWaterBytes": 227154600
         },
         "outputRecords": 0,
-        "parentElapsedMs": 365,
+        "parentElapsedMs": 338,
         "runCount": 2,
         "sourceBytes": 0,
         "sourceFiles": 0,
         "stderrBytes": 0,
-        "stdoutBytes": 996
+        "stdoutBytes": 995
       },
       "name": "workspace_discard",
       "projectionSha256": "064fdfeb99edbc148aa8778a62741f99119e5abad545d4e846cb39e835736056",
@@ -710,21 +710,21 @@
     {
       "failureCode": "interruption_injected",
       "metrics": {
-        "childCpuMs": 103,
-        "childMaxRssBytes": 121208832,
+        "childCpuMs": 101,
+        "childMaxRssBytes": 121405440,
         "decodedBytes": 0,
         "durablePeakRssBytes": 0,
         "encodedBytes": 0,
-        "externalPeakRssBytes": 120766464,
+        "externalPeakRssBytes": 121028608,
         "externalRssSampleCount": 6,
         "externalRssSampleFailureCount": 0,
         "filesystem": {
-          "afterBytes": 196963975,
-          "beforeBytes": 227074368,
-          "sampledHighWaterBytes": 257184175
+          "afterBytes": 197045864,
+          "beforeBytes": 227156257,
+          "sampledHighWaterBytes": 257266063
         },
         "outputRecords": 0,
-        "parentElapsedMs": 298,
+        "parentElapsedMs": 285,
         "runCount": 2,
         "sourceBytes": 0,
         "sourceFiles": 0,
@@ -738,21 +738,21 @@
     {
       "failureCode": "none",
       "metrics": {
-        "childCpuMs": 7,
-        "childMaxRssBytes": 116326400,
+        "childCpuMs": 6,
+        "childMaxRssBytes": 116211712,
         "decodedBytes": 0,
         "durablePeakRssBytes": 0,
         "encodedBytes": 0,
-        "externalPeakRssBytes": 97452032,
+        "externalPeakRssBytes": 97140736,
         "externalRssSampleCount": 4,
         "externalRssSampleFailureCount": 0,
         "filesystem": {
-          "afterBytes": 196964245,
-          "beforeBytes": 196964424,
-          "sampledHighWaterBytes": 196964424
+          "afterBytes": 197046134,
+          "beforeBytes": 197046313,
+          "sampledHighWaterBytes": 197046313
         },
         "outputRecords": 0,
-        "parentElapsedMs": 190,
+        "parentElapsedMs": 183,
         "runCount": 2,
         "sourceBytes": 0,
         "sourceFiles": 0,
@@ -766,21 +766,21 @@
     {
       "failureCode": "interruption_injected",
       "metrics": {
-        "childCpuMs": 6,
-        "childMaxRssBytes": 116244480,
+        "childCpuMs": 5,
+        "childMaxRssBytes": 116637696,
         "decodedBytes": 0,
         "durablePeakRssBytes": 0,
         "encodedBytes": 0,
-        "externalPeakRssBytes": 97157120,
+        "externalPeakRssBytes": 97501184,
         "externalRssSampleCount": 4,
         "externalRssSampleFailureCount": 0,
         "filesystem": {
-          "afterBytes": 196964515,
-          "beforeBytes": 196964703,
-          "sampledHighWaterBytes": 196964703
+          "afterBytes": 197046404,
+          "beforeBytes": 197046592,
+          "sampledHighWaterBytes": 197046592
         },
         "outputRecords": 0,
-        "parentElapsedMs": 177,
+        "parentElapsedMs": 166,
         "runCount": 2,
         "sourceBytes": 0,
         "sourceFiles": 0,
@@ -827,7 +827,7 @@
     "targetChunks": 128
   },
   "protocolVersion": "g1-r7-release-evidence-v0.1",
-  "receiptSha256": "a9f297db17a9ab5eb70f76eb57e0a75d59a4c8013d2c3968b8d03f2da8e06abd",
+  "receiptSha256": "a2448ad9762a684bfcad2fcd2480b0c2868f11ed4ff9c8da11950951c57d0d6a",
   "runtimeProvenance": {
     "architecture": "arm64",
     "elapsedClock": "parent_monotonic",

--- a/generated/r7-release-synthetic-semantics-node24.14.0-v0.1.json
+++ b/generated/r7-release-synthetic-semantics-node24.14.0-v0.1.json
@@ -29,7 +29,7 @@
       "atLimit": {
         "failureCode": "not_run_profile",
         "status": "not_run",
-        "value": 20000
+        "value": 100000
       },
       "dimension": "directory_entries",
       "identification": "not_run",
@@ -37,13 +37,13 @@
       "plusOne": {
         "failureCode": "not_run_profile",
         "status": "not_run",
-        "value": 20001
+        "value": 100001
       },
       "producer": {
         "failureCode": "not_run_profile",
         "status": "not_run"
       },
-      "selectedLimit": 20000,
+      "selectedLimit": 100000,
       "unit": "entries",
       "verifier": {
         "failureCode": "not_run_profile",
@@ -54,7 +54,7 @@
       "atLimit": {
         "failureCode": "not_run_profile",
         "status": "not_run",
-        "value": 5000
+        "value": 100000
       },
       "dimension": "source_files",
       "identification": "not_run",
@@ -62,13 +62,13 @@
       "plusOne": {
         "failureCode": "not_run_profile",
         "status": "not_run",
-        "value": 5001
+        "value": 100001
       },
       "producer": {
         "failureCode": "not_run_profile",
         "status": "not_run"
       },
-      "selectedLimit": 5000,
+      "selectedLimit": 100000,
       "unit": "files",
       "verifier": {
         "failureCode": "not_run_profile",
@@ -479,10 +479,10 @@
   "contractProvenance": {
     "receiptSchemaSha256": "4683a469ad0143721eedeccc026f07929f2506339aeab7c52e1312cad93f5701",
     "resourcePolicySourceSha256": "d9748895468534062e9c8c436db75cbf5acf4ccf54f84319db37e88197627870",
-    "resourcePolicyValuesSha256": "a3dde0db440015886144b76b88a8a663095c7e5eb08f0a68f062e597e95552f6",
+    "resourcePolicyValuesSha256": "3cbe7853c8f75e96912885f64ba4ad1aeb13aff8a22e4ffbd51806b27c73b418",
     "schemaModuleSha256": "9d598e56c71be1c3257c2e25c1334e49fdc6b5e825c46ba3e1ce68a83490e54f",
     "workloadCodeFileCount": 341,
-    "workloadCodeSha256": "9c287966eca0a53c669a8ce70c9dbe49790bc9ec31b847ee0efb4884eae1384e"
+    "workloadCodeSha256": "5e517eade0a8c3231a78429a5d65c4fd018fc7ef253bbb45c9d963be1fbb9624"
   },
   "determinism": {
     "comparisons": {
@@ -500,8 +500,8 @@
     "projectionVersion": "g1-r7-release-deterministic-projection-v0.1",
     "runCount": 2,
     "runProjectionSha256es": [
-      "c64565dd1cf46b16c60b29a16759cbcabc7ec5890b1f3df2acdd2a98256ad903",
-      "c64565dd1cf46b16c60b29a16759cbcabc7ec5890b1f3df2acdd2a98256ad903"
+      "62af6189f258f331d2912a694ce4c3d7eba2c14d271459860ea15ed9e03e0d68",
+      "62af6189f258f331d2912a694ce4c3d7eba2c14d271459860ea15ed9e03e0d68"
     ],
     "status": "passed"
   },
@@ -514,26 +514,26 @@
     {
       "failureCode": "none",
       "metrics": {
-        "childCpuMs": 83,
-        "childMaxRssBytes": 125042688,
+        "childCpuMs": 94,
+        "childMaxRssBytes": 124993536,
         "decodedBytes": 0,
-        "durablePeakRssBytes": 125042688,
+        "durablePeakRssBytes": 124977152,
         "encodedBytes": 0,
-        "externalPeakRssBytes": 123863040,
-        "externalRssSampleCount": 6,
+        "externalPeakRssBytes": 123371520,
+        "externalRssSampleCount": 7,
         "externalRssSampleFailureCount": 0,
         "filesystem": {
           "afterBytes": 200864,
           "beforeBytes": 160,
-          "sampledHighWaterBytes": 200864
+          "sampledHighWaterBytes": 201538
         },
         "outputRecords": 27,
-        "parentElapsedMs": 245,
+        "parentElapsedMs": 394,
         "runCount": 2,
         "sourceBytes": 154645,
         "sourceFiles": 14,
-        "stderrBytes": 169,
-        "stdoutBytes": 1071
+        "stderrBytes": 168,
+        "stdoutBytes": 1073
       },
       "name": "source_scan",
       "projectionSha256": "9a32d3d160adf2c4f0f900f4583abf8c4b37c5460377fcdd74447945cfa9acd7",
@@ -542,26 +542,26 @@
     {
       "failureCode": "none",
       "metrics": {
-        "childCpuMs": 57,
-        "childMaxRssBytes": 121831424,
+        "childCpuMs": 63,
+        "childMaxRssBytes": 122650624,
         "decodedBytes": 0,
-        "durablePeakRssBytes": 158482432,
+        "durablePeakRssBytes": 165265408,
         "encodedBytes": 0,
-        "externalPeakRssBytes": 118489088,
+        "externalPeakRssBytes": 116834304,
         "externalRssSampleCount": 5,
-        "externalRssSampleFailureCount": 0,
+        "externalRssSampleFailureCount": 1,
         "filesystem": {
           "afterBytes": 401568,
           "beforeBytes": 368800,
-          "sampledHighWaterBytes": 401679
+          "sampledHighWaterBytes": 401568
         },
         "outputRecords": 27,
-        "parentElapsedMs": 212,
+        "parentElapsedMs": 282,
         "runCount": 2,
         "sourceBytes": 154645,
         "sourceFiles": 14,
-        "stderrBytes": 169,
-        "stdoutBytes": 1077
+        "stderrBytes": 168,
+        "stdoutBytes": 1079
       },
       "name": "checkpoint_resume",
       "projectionSha256": "9a32d3d160adf2c4f0f900f4583abf8c4b37c5460377fcdd74447945cfa9acd7",
@@ -570,138 +570,138 @@
     {
       "failureCode": "none",
       "metrics": {
-        "childCpuMs": 208,
-        "childMaxRssBytes": 133578752,
+        "childCpuMs": 180,
+        "childMaxRssBytes": 130252800,
         "decodedBytes": 109963,
-        "durablePeakRssBytes": 133496832,
-        "encodedBytes": 32448,
-        "externalPeakRssBytes": 133496832,
-        "externalRssSampleCount": 20,
+        "durablePeakRssBytes": 130105344,
+        "encodedBytes": 32453,
+        "externalPeakRssBytes": 130105344,
+        "externalRssSampleCount": 26,
         "externalRssSampleFailureCount": 0,
         "filesystem": {
-          "afterBytes": 554618,
+          "afterBytes": 554623,
           "beforeBytes": 401568,
-          "sampledHighWaterBytes": 555506
+          "sampledHighWaterBytes": 554733
         },
         "outputRecords": 27,
-        "parentElapsedMs": 941,
+        "parentElapsedMs": 1505,
         "runCount": 2,
         "sourceBytes": 154645,
         "sourceFiles": 14,
-        "stderrBytes": 169,
-        "stdoutBytes": 1223
+        "stderrBytes": 168,
+        "stdoutBytes": 1225
       },
       "name": "export_set_materialize",
-      "projectionSha256": "100a5b1b625686484eafb1b5de44f17918dc774389cd2de8ae9c4c80e1bf31b9",
+      "projectionSha256": "1931467afb8931ab7cd4023a5e90127e93be175f028ddbb1294684a6614376fe",
       "status": "completed"
     },
     {
       "failureCode": "none",
       "metrics": {
-        "childCpuMs": 48,
-        "childMaxRssBytes": 126648320,
+        "childCpuMs": 50,
+        "childMaxRssBytes": 122241024,
         "decodedBytes": 109963,
         "durablePeakRssBytes": 0,
-        "encodedBytes": 32448,
-        "externalPeakRssBytes": 91652096,
+        "encodedBytes": 32453,
+        "externalPeakRssBytes": 91848704,
         "externalRssSampleCount": 4,
         "externalRssSampleFailureCount": 0,
         "filesystem": {
-          "afterBytes": 554618,
-          "beforeBytes": 554618,
-          "sampledHighWaterBytes": 554618
+          "afterBytes": 554623,
+          "beforeBytes": 554623,
+          "sampledHighWaterBytes": 554623
         },
         "outputRecords": 27,
-        "parentElapsedMs": 186,
+        "parentElapsedMs": 192,
         "runCount": 2,
         "sourceBytes": 0,
         "sourceFiles": 0,
-        "stderrBytes": 169,
+        "stderrBytes": 168,
         "stdoutBytes": 997
       },
       "name": "export_set_verify",
-      "projectionSha256": "34666b359ebf5a26687a1f6061832107fb534ca97a808b6c6702c92a1a0e244f",
+      "projectionSha256": "a8971c1af10966f8bf09b93c5991facdfb1b03d94197f51502fe872e00da6513",
       "status": "completed"
     },
     {
       "failureCode": "none",
       "metrics": {
-        "childCpuMs": 165,
-        "childMaxRssBytes": 138543104,
+        "childCpuMs": 154,
+        "childMaxRssBytes": 137920512,
         "decodedBytes": 0,
         "durablePeakRssBytes": 0,
         "encodedBytes": 0,
-        "externalPeakRssBytes": 137904128,
+        "externalPeakRssBytes": 137396224,
         "externalRssSampleCount": 12,
         "externalRssSampleFailureCount": 0,
         "filesystem": {
           "afterBytes": 203384,
-          "beforeBytes": 556681,
-          "sampledHighWaterBytes": 578927
+          "beforeBytes": 556686,
+          "sampledHighWaterBytes": 556686
         },
         "outputRecords": 0,
-        "parentElapsedMs": 602,
+        "parentElapsedMs": 578,
         "runCount": 2,
         "sourceBytes": 0,
         "sourceFiles": 0,
-        "stderrBytes": 169,
+        "stderrBytes": 168,
         "stdoutBytes": 997
       },
       "name": "complete_set_delete",
-      "projectionSha256": "d8a3ff98eedc7bdc4191e26bf2b953ed7e063491b6e52c9eb31fdf4b774741fd",
+      "projectionSha256": "0c14a48f12b0bb19f3de8706e0da747b63ed0f52e579ce6852bdf4f31b671171",
       "status": "completed"
     },
     {
       "failureCode": "interruption_injected",
       "metrics": {
-        "childCpuMs": 39,
-        "childMaxRssBytes": 112672768,
+        "childCpuMs": 35,
+        "childMaxRssBytes": 115589120,
         "decodedBytes": 0,
         "durablePeakRssBytes": 0,
         "encodedBytes": 0,
-        "externalPeakRssBytes": 112558080,
+        "externalPeakRssBytes": 115195904,
         "externalRssSampleCount": 10,
         "externalRssSampleFailureCount": 0,
         "filesystem": {
-          "afterBytes": 556681,
-          "beforeBytes": 920750,
-          "sampledHighWaterBytes": 920750
+          "afterBytes": 556686,
+          "beforeBytes": 920760,
+          "sampledHighWaterBytes": 920760
         },
         "outputRecords": 0,
-        "parentElapsedMs": 434,
+        "parentElapsedMs": 471,
         "runCount": 2,
         "sourceBytes": 0,
         "sourceFiles": 0,
-        "stderrBytes": 169,
+        "stderrBytes": 168,
         "stdoutBytes": 1005
       },
       "name": "complete_set_delete_recovery",
-      "projectionSha256": "d8a3ff98eedc7bdc4191e26bf2b953ed7e063491b6e52c9eb31fdf4b774741fd",
+      "projectionSha256": "0c14a48f12b0bb19f3de8706e0da747b63ed0f52e579ce6852bdf4f31b671171",
       "status": "interrupted_recovered"
     },
     {
       "failureCode": "none",
       "metrics": {
         "childCpuMs": 22,
-        "childMaxRssBytes": 116260864,
+        "childMaxRssBytes": 116195328,
         "decodedBytes": 0,
         "durablePeakRssBytes": 0,
         "encodedBytes": 0,
-        "externalPeakRssBytes": 116228096,
+        "externalPeakRssBytes": 116015104,
         "externalRssSampleCount": 6,
         "externalRssSampleFailureCount": 0,
         "filesystem": {
-          "afterBytes": 555151,
-          "beforeBytes": 722554,
-          "sampledHighWaterBytes": 722554
+          "afterBytes": 555156,
+          "beforeBytes": 722559,
+          "sampledHighWaterBytes": 722559
         },
         "outputRecords": 0,
-        "parentElapsedMs": 226,
+        "parentElapsedMs": 252,
         "runCount": 2,
         "sourceBytes": 0,
         "sourceFiles": 0,
-        "stderrBytes": 169,
-        "stdoutBytes": 991
+        "stderrBytes": 168,
+        "stdoutBytes": 992
       },
       "name": "workspace_discard",
       "projectionSha256": "495426e69724d58733a4605ce62a0a9e61a094e67823671e64b872acf28bbea5",
@@ -710,26 +710,26 @@
     {
       "failureCode": "interruption_injected",
       "metrics": {
-        "childCpuMs": 15,
-        "childMaxRssBytes": 116031488,
+        "childCpuMs": 17,
+        "childMaxRssBytes": 113229824,
         "decodedBytes": 0,
         "durablePeakRssBytes": 0,
         "encodedBytes": 0,
-        "externalPeakRssBytes": 91111424,
-        "externalRssSampleCount": 5,
+        "externalPeakRssBytes": 113098752,
+        "externalRssSampleCount": 6,
         "externalRssSampleFailureCount": 0,
         "filesystem": {
-          "afterBytes": 555684,
-          "beforeBytes": 724315,
-          "sampledHighWaterBytes": 724315
+          "afterBytes": 555689,
+          "beforeBytes": 724320,
+          "sampledHighWaterBytes": 724320
         },
         "outputRecords": 0,
-        "parentElapsedMs": 206,
+        "parentElapsedMs": 240,
         "runCount": 2,
         "sourceBytes": 0,
         "sourceFiles": 0,
-        "stderrBytes": 169,
-        "stdoutBytes": 999
+        "stderrBytes": 168,
+        "stdoutBytes": 1000
       },
       "name": "workspace_discard_recovery",
       "projectionSha256": "495426e69724d58733a4605ce62a0a9e61a094e67823671e64b872acf28bbea5",
@@ -738,25 +738,25 @@
     {
       "failureCode": "none",
       "metrics": {
-        "childCpuMs": 7,
-        "childMaxRssBytes": 109428736,
+        "childCpuMs": 6,
+        "childMaxRssBytes": 112541696,
         "decodedBytes": 0,
         "durablePeakRssBytes": 0,
         "encodedBytes": 0,
-        "externalPeakRssBytes": 91619328,
-        "externalRssSampleCount": 4,
+        "externalPeakRssBytes": 112525312,
+        "externalRssSampleCount": 5,
         "externalRssSampleFailureCount": 0,
         "filesystem": {
-          "afterBytes": 555954,
-          "beforeBytes": 556133,
-          "sampledHighWaterBytes": 556133
+          "afterBytes": 555959,
+          "beforeBytes": 556138,
+          "sampledHighWaterBytes": 556138
         },
         "outputRecords": 0,
-        "parentElapsedMs": 176,
+        "parentElapsedMs": 213,
         "runCount": 2,
         "sourceBytes": 0,
         "sourceFiles": 0,
-        "stderrBytes": 169,
+        "stderrBytes": 168,
         "stdoutBytes": 993
       },
       "name": "claude_callback_uninstall",
@@ -767,24 +767,24 @@
       "failureCode": "interruption_injected",
       "metrics": {
         "childCpuMs": 6,
-        "childMaxRssBytes": 108822528,
+        "childMaxRssBytes": 112951296,
         "decodedBytes": 0,
         "durablePeakRssBytes": 0,
         "encodedBytes": 0,
-        "externalPeakRssBytes": 91455488,
+        "externalPeakRssBytes": 92438528,
         "externalRssSampleCount": 4,
         "externalRssSampleFailureCount": 0,
         "filesystem": {
-          "afterBytes": 556224,
-          "beforeBytes": 556412,
-          "sampledHighWaterBytes": 556412
+          "afterBytes": 556229,
+          "beforeBytes": 556417,
+          "sampledHighWaterBytes": 556417
         },
         "outputRecords": 0,
-        "parentElapsedMs": 170,
+        "parentElapsedMs": 195,
         "runCount": 2,
         "sourceBytes": 0,
         "sourceFiles": 0,
-        "stderrBytes": 169,
+        "stderrBytes": 168,
         "stdoutBytes": 992
       },
       "name": "claude_callback_recovery",
@@ -836,7 +836,7 @@
     "kind": "release_synthetic_semantics"
   },
   "protocolVersion": "g1-r7-release-evidence-v0.1",
-  "receiptSha256": "03d4d006993435bbacbe5d611c118f7fa47ab80f61f0e72f4fe6d31315e42d42",
+  "receiptSha256": "22f9bc89008124bed06396428d154a5d410e7597eb9b9f98a7fe7a5ebae6be27",
   "runtimeProvenance": {
     "architecture": "arm64",
     "elapsedClock": "parent_monotonic",

--- a/generated/r7-release-synthetic-semantics-node26.2.0-v0.1.json
+++ b/generated/r7-release-synthetic-semantics-node26.2.0-v0.1.json
@@ -29,7 +29,7 @@
       "atLimit": {
         "failureCode": "not_run_profile",
         "status": "not_run",
-        "value": 20000
+        "value": 100000
       },
       "dimension": "directory_entries",
       "identification": "not_run",
@@ -37,13 +37,13 @@
       "plusOne": {
         "failureCode": "not_run_profile",
         "status": "not_run",
-        "value": 20001
+        "value": 100001
       },
       "producer": {
         "failureCode": "not_run_profile",
         "status": "not_run"
       },
-      "selectedLimit": 20000,
+      "selectedLimit": 100000,
       "unit": "entries",
       "verifier": {
         "failureCode": "not_run_profile",
@@ -54,7 +54,7 @@
       "atLimit": {
         "failureCode": "not_run_profile",
         "status": "not_run",
-        "value": 5000
+        "value": 100000
       },
       "dimension": "source_files",
       "identification": "not_run",
@@ -62,13 +62,13 @@
       "plusOne": {
         "failureCode": "not_run_profile",
         "status": "not_run",
-        "value": 5001
+        "value": 100001
       },
       "producer": {
         "failureCode": "not_run_profile",
         "status": "not_run"
       },
-      "selectedLimit": 5000,
+      "selectedLimit": 100000,
       "unit": "files",
       "verifier": {
         "failureCode": "not_run_profile",
@@ -479,10 +479,10 @@
   "contractProvenance": {
     "receiptSchemaSha256": "4683a469ad0143721eedeccc026f07929f2506339aeab7c52e1312cad93f5701",
     "resourcePolicySourceSha256": "d9748895468534062e9c8c436db75cbf5acf4ccf54f84319db37e88197627870",
-    "resourcePolicyValuesSha256": "a3dde0db440015886144b76b88a8a663095c7e5eb08f0a68f062e597e95552f6",
+    "resourcePolicyValuesSha256": "3cbe7853c8f75e96912885f64ba4ad1aeb13aff8a22e4ffbd51806b27c73b418",
     "schemaModuleSha256": "9d598e56c71be1c3257c2e25c1334e49fdc6b5e825c46ba3e1ce68a83490e54f",
     "workloadCodeFileCount": 341,
-    "workloadCodeSha256": "9c287966eca0a53c669a8ce70c9dbe49790bc9ec31b847ee0efb4884eae1384e"
+    "workloadCodeSha256": "5e517eade0a8c3231a78429a5d65c4fd018fc7ef253bbb45c9d963be1fbb9624"
   },
   "determinism": {
     "comparisons": {
@@ -500,8 +500,8 @@
     "projectionVersion": "g1-r7-release-deterministic-projection-v0.1",
     "runCount": 2,
     "runProjectionSha256es": [
-      "0f70dfc9c91e2c2841864945a7585b0423104dcbd81c99f0ca04bcf443288d55",
-      "0f70dfc9c91e2c2841864945a7585b0423104dcbd81c99f0ca04bcf443288d55"
+      "3f9483847101b5e99bc74b6330767a81ab5cf4784aab0dd53933196a229634a9",
+      "3f9483847101b5e99bc74b6330767a81ab5cf4784aab0dd53933196a229634a9"
     ],
     "status": "passed"
   },
@@ -514,13 +514,13 @@
     {
       "failureCode": "none",
       "metrics": {
-        "childCpuMs": 85,
-        "childMaxRssBytes": 128483328,
+        "childCpuMs": 88,
+        "childMaxRssBytes": 128319488,
         "decodedBytes": 0,
-        "durablePeakRssBytes": 128450560,
+        "durablePeakRssBytes": 128319488,
         "encodedBytes": 0,
-        "externalPeakRssBytes": 126189568,
-        "externalRssSampleCount": 6,
+        "externalPeakRssBytes": 127582208,
+        "externalRssSampleCount": 7,
         "externalRssSampleFailureCount": 0,
         "filesystem": {
           "afterBytes": 200864,
@@ -528,12 +528,12 @@
           "sampledHighWaterBytes": 200864
         },
         "outputRecords": 27,
-        "parentElapsedMs": 239,
+        "parentElapsedMs": 349,
         "runCount": 2,
         "sourceBytes": 154645,
         "sourceFiles": 14,
         "stderrBytes": 0,
-        "stdoutBytes": 1071
+        "stdoutBytes": 1073
       },
       "name": "source_scan",
       "projectionSha256": "9a32d3d160adf2c4f0f900f4583abf8c4b37c5460377fcdd74447945cfa9acd7",
@@ -542,26 +542,26 @@
     {
       "failureCode": "none",
       "metrics": {
-        "childCpuMs": 60,
-        "childMaxRssBytes": 126058496,
+        "childCpuMs": 53,
+        "childMaxRssBytes": 125861888,
         "decodedBytes": 0,
-        "durablePeakRssBytes": 166674432,
+        "durablePeakRssBytes": 169410560,
         "encodedBytes": 0,
-        "externalPeakRssBytes": 126058496,
-        "externalRssSampleCount": 6,
+        "externalPeakRssBytes": 97353728,
+        "externalRssSampleCount": 4,
         "externalRssSampleFailureCount": 0,
         "filesystem": {
           "afterBytes": 401568,
           "beforeBytes": 368800,
-          "sampledHighWaterBytes": 414503
+          "sampledHighWaterBytes": 401568
         },
         "outputRecords": 27,
-        "parentElapsedMs": 213,
+        "parentElapsedMs": 196,
         "runCount": 2,
         "sourceBytes": 154645,
         "sourceFiles": 14,
         "stderrBytes": 0,
-        "stdoutBytes": 1077
+        "stdoutBytes": 1078
       },
       "name": "checkpoint_resume",
       "projectionSha256": "9a32d3d160adf2c4f0f900f4583abf8c4b37c5460377fcdd74447945cfa9acd7",
@@ -570,21 +570,21 @@
     {
       "failureCode": "none",
       "metrics": {
-        "childCpuMs": 209,
-        "childMaxRssBytes": 141066240,
+        "childCpuMs": 188,
+        "childMaxRssBytes": 137641984,
         "decodedBytes": 109963,
-        "durablePeakRssBytes": 141033472,
-        "encodedBytes": 32420,
-        "externalPeakRssBytes": 141017088,
-        "externalRssSampleCount": 20,
-        "externalRssSampleFailureCount": 0,
+        "durablePeakRssBytes": 137609216,
+        "encodedBytes": 32451,
+        "externalPeakRssBytes": 137265152,
+        "externalRssSampleCount": 19,
+        "externalRssSampleFailureCount": 1,
         "filesystem": {
-          "afterBytes": 554589,
+          "afterBytes": 554620,
           "beforeBytes": 401568,
-          "sampledHighWaterBytes": 554700
+          "sampledHighWaterBytes": 554620
         },
         "outputRecords": 27,
-        "parentElapsedMs": 932,
+        "parentElapsedMs": 913,
         "runCount": 2,
         "sourceBytes": 154645,
         "sourceFiles": 14,
@@ -592,27 +592,27 @@
         "stdoutBytes": 1223
       },
       "name": "export_set_materialize",
-      "projectionSha256": "88788369c931b24b8b84362ca86e3e761609277873db1c57c41a4cc921937b0a",
+      "projectionSha256": "e721f9bd22b90cb1958bf6adbd0a6519442dfb0b2a6d5cb6aa7c803a2f7586d1",
       "status": "completed"
     },
     {
       "failureCode": "none",
       "metrics": {
-        "childCpuMs": 48,
-        "childMaxRssBytes": 132038656,
+        "childCpuMs": 43,
+        "childMaxRssBytes": 130498560,
         "decodedBytes": 109963,
         "durablePeakRssBytes": 0,
-        "encodedBytes": 32420,
-        "externalPeakRssBytes": 97697792,
+        "encodedBytes": 32451,
+        "externalPeakRssBytes": 94797824,
         "externalRssSampleCount": 4,
         "externalRssSampleFailureCount": 0,
         "filesystem": {
-          "afterBytes": 554589,
-          "beforeBytes": 554589,
-          "sampledHighWaterBytes": 554589
+          "afterBytes": 554620,
+          "beforeBytes": 554620,
+          "sampledHighWaterBytes": 554620
         },
         "outputRecords": 27,
-        "parentElapsedMs": 189,
+        "parentElapsedMs": 185,
         "runCount": 2,
         "sourceBytes": 0,
         "sourceFiles": 0,
@@ -620,27 +620,27 @@
         "stdoutBytes": 997
       },
       "name": "export_set_verify",
-      "projectionSha256": "be0d1e54f7461dd643784ba4ad252484ff0f1cc7df88996fa90e88af3c3db521",
+      "projectionSha256": "df9bcc6af818afea19d111d35b234b93151294bbd1da72fa7339879fac42852b",
       "status": "completed"
     },
     {
       "failureCode": "none",
       "metrics": {
-        "childCpuMs": 186,
-        "childMaxRssBytes": 143491072,
+        "childCpuMs": 153,
+        "childMaxRssBytes": 144703488,
         "decodedBytes": 0,
         "durablePeakRssBytes": 0,
         "encodedBytes": 0,
-        "externalPeakRssBytes": 142901248,
-        "externalRssSampleCount": 13,
+        "externalPeakRssBytes": 144654336,
+        "externalRssSampleCount": 12,
         "externalRssSampleFailureCount": 0,
         "filesystem": {
           "afterBytes": 203384,
-          "beforeBytes": 556652,
-          "sampledHighWaterBytes": 556763
+          "beforeBytes": 556683,
+          "sampledHighWaterBytes": 556683
         },
         "outputRecords": 0,
-        "parentElapsedMs": 623,
+        "parentElapsedMs": 576,
         "runCount": 2,
         "sourceBytes": 0,
         "sourceFiles": 0,
@@ -648,27 +648,27 @@
         "stdoutBytes": 997
       },
       "name": "complete_set_delete",
-      "projectionSha256": "666263f7f5c675fede25283ce2626ed4a9b9769f9a495266e4b8f36a3e5fded7",
+      "projectionSha256": "3f742fd703c7fad7ee2f6efcfedf1916495038f5168150a34399740ee8077db4",
       "status": "completed"
     },
     {
       "failureCode": "interruption_injected",
       "metrics": {
-        "childCpuMs": 43,
-        "childMaxRssBytes": 119865344,
+        "childCpuMs": 42,
+        "childMaxRssBytes": 119341056,
         "decodedBytes": 0,
         "durablePeakRssBytes": 0,
         "encodedBytes": 0,
-        "externalPeakRssBytes": 119570432,
+        "externalPeakRssBytes": 119308288,
         "externalRssSampleCount": 10,
         "externalRssSampleFailureCount": 0,
         "filesystem": {
-          "afterBytes": 556652,
-          "beforeBytes": 920692,
-          "sampledHighWaterBytes": 920692
+          "afterBytes": 556683,
+          "beforeBytes": 920754,
+          "sampledHighWaterBytes": 920754
         },
         "outputRecords": 0,
-        "parentElapsedMs": 470,
+        "parentElapsedMs": 438,
         "runCount": 2,
         "sourceBytes": 0,
         "sourceFiles": 0,
@@ -676,27 +676,27 @@
         "stdoutBytes": 1005
       },
       "name": "complete_set_delete_recovery",
-      "projectionSha256": "666263f7f5c675fede25283ce2626ed4a9b9769f9a495266e4b8f36a3e5fded7",
+      "projectionSha256": "3f742fd703c7fad7ee2f6efcfedf1916495038f5168150a34399740ee8077db4",
       "status": "interrupted_recovered"
     },
     {
       "failureCode": "none",
       "metrics": {
-        "childCpuMs": 21,
-        "childMaxRssBytes": 120586240,
+        "childCpuMs": 18,
+        "childMaxRssBytes": 119734272,
         "decodedBytes": 0,
         "durablePeakRssBytes": 0,
         "encodedBytes": 0,
-        "externalPeakRssBytes": 120520704,
+        "externalPeakRssBytes": 97222656,
         "externalRssSampleCount": 6,
         "externalRssSampleFailureCount": 0,
         "filesystem": {
-          "afterBytes": 555122,
-          "beforeBytes": 722525,
-          "sampledHighWaterBytes": 722525
+          "afterBytes": 555153,
+          "beforeBytes": 722556,
+          "sampledHighWaterBytes": 722556
         },
         "outputRecords": 0,
-        "parentElapsedMs": 222,
+        "parentElapsedMs": 207,
         "runCount": 2,
         "sourceBytes": 0,
         "sourceFiles": 0,
@@ -710,21 +710,21 @@
     {
       "failureCode": "interruption_injected",
       "metrics": {
-        "childCpuMs": 16,
-        "childMaxRssBytes": 119799808,
+        "childCpuMs": 13,
+        "childMaxRssBytes": 123043840,
         "decodedBytes": 0,
         "durablePeakRssBytes": 0,
         "encodedBytes": 0,
-        "externalPeakRssBytes": 119799808,
-        "externalRssSampleCount": 5,
+        "externalPeakRssBytes": 98320384,
+        "externalRssSampleCount": 4,
         "externalRssSampleFailureCount": 0,
         "filesystem": {
-          "afterBytes": 555655,
-          "beforeBytes": 724286,
-          "sampledHighWaterBytes": 724286
+          "afterBytes": 555686,
+          "beforeBytes": 724317,
+          "sampledHighWaterBytes": 724317
         },
         "outputRecords": 0,
-        "parentElapsedMs": 215,
+        "parentElapsedMs": 195,
         "runCount": 2,
         "sourceBytes": 0,
         "sourceFiles": 0,
@@ -738,21 +738,21 @@
     {
       "failureCode": "none",
       "metrics": {
-        "childCpuMs": 7,
-        "childMaxRssBytes": 116867072,
+        "childCpuMs": 6,
+        "childMaxRssBytes": 118325248,
         "decodedBytes": 0,
         "durablePeakRssBytes": 0,
         "encodedBytes": 0,
-        "externalPeakRssBytes": 97648640,
+        "externalPeakRssBytes": 99221504,
         "externalRssSampleCount": 4,
         "externalRssSampleFailureCount": 0,
         "filesystem": {
-          "afterBytes": 555925,
-          "beforeBytes": 556104,
-          "sampledHighWaterBytes": 556104
+          "afterBytes": 555956,
+          "beforeBytes": 556135,
+          "sampledHighWaterBytes": 556135
         },
         "outputRecords": 0,
-        "parentElapsedMs": 185,
+        "parentElapsedMs": 178,
         "runCount": 2,
         "sourceBytes": 0,
         "sourceFiles": 0,
@@ -766,21 +766,21 @@
     {
       "failureCode": "interruption_injected",
       "metrics": {
-        "childCpuMs": 7,
-        "childMaxRssBytes": 119308288,
+        "childCpuMs": 5,
+        "childMaxRssBytes": 116588544,
         "decodedBytes": 0,
         "durablePeakRssBytes": 0,
         "encodedBytes": 0,
-        "externalPeakRssBytes": 96124928,
+        "externalPeakRssBytes": 97697792,
         "externalRssSampleCount": 4,
         "externalRssSampleFailureCount": 0,
         "filesystem": {
-          "afterBytes": 556195,
-          "beforeBytes": 556383,
-          "sampledHighWaterBytes": 556383
+          "afterBytes": 556226,
+          "beforeBytes": 556414,
+          "sampledHighWaterBytes": 556414
         },
         "outputRecords": 0,
-        "parentElapsedMs": 190,
+        "parentElapsedMs": 167,
         "runCount": 2,
         "sourceBytes": 0,
         "sourceFiles": 0,
@@ -836,7 +836,7 @@
     "kind": "release_synthetic_semantics"
   },
   "protocolVersion": "g1-r7-release-evidence-v0.1",
-  "receiptSha256": "d1b5a0f3331cddcfac2f17e3b8525fb6479ae421b4260960f9ed8f277dae2421",
+  "receiptSha256": "f794ed631281e3a389b9c44c8872864675c7e0119b7fb1ff490fad162ebb9843",
   "runtimeProvenance": {
     "architecture": "arm64",
     "elapsedClock": "parent_monotonic",

--- a/src/export/resource-policy.js
+++ b/src/export/resource-policy.js
@@ -2,8 +2,8 @@ export const EXPORT_RESOURCE_POLICY_VERSION = "g1-r3-candidate-0.5";
 
 export const DEFAULT_EXPORT_RESOURCE_LIMITS = Object.freeze({
   maximumCoveredDurationMs: 31 * 24 * 60 * 60 * 1_000,
-  maximumDirectoryEntries: 20_000,
-  maximumSourceFiles: 5_000,
+  maximumDirectoryEntries: 100_000,
+  maximumSourceFiles: 100_000,
   maximumSourceBytes: 32 * 1024 * 1024 * 1024,
   maximumLineBytes: 16 * 1024 * 1024,
   maximumOutputRecords: 100_000,

--- a/test/export-resource-policy.test.js
+++ b/test/export-resource-policy.test.js
@@ -9,6 +9,7 @@ import {
   readBoundedUtf8Lines,
 } from "../src/bounded-jsonl.js";
 import {
+  DEFAULT_EXPORT_RESOURCE_LIMITS,
   ExportResourceLimitError,
   createExportResourceGuard,
   normalizeExportResourceLimits,
@@ -18,7 +19,51 @@ import {
 test("resource policy rejects unknown or invalid limits", () => {
   assert.throws(() => normalizeExportResourceLimits({ surprise: 1 }), /Unknown export resource limit/);
   assert.throws(() => normalizeExportResourceLimits({ maximumSourceFiles: 0 }), /positive safe integer/);
-  assert.throws(() => normalizeExportResourceLimits({ maximumSourceFiles: 5_001 }), /cannot exceed/);
+  assert.throws(() => normalizeExportResourceLimits({ maximumSourceFiles: 100_001 }), /cannot exceed/);
+  assert.throws(() => normalizeExportResourceLimits({ maximumDirectoryEntries: 100_001 }), /cannot exceed/);
+});
+
+test("the source-file ceiling admits a full local rollout corpus", () => {
+  // Raised 5_000 -> 100_000 on 2026-08-19: the owner's deduped Codex rollout
+  // corpus (active + archived, all of it inside the 365-day window) measured
+  // 4,880 files, i.e. 97.6% of the old ceiling. A source_files trip is a HARD
+  // accounting refresh failure -- accounting_scan_source_files_limit_exceeded
+  // is in neither ACCOUNTING_BUDGET_MISS_CODES nor the reader passthrough set
+  // -- so crossing it would have blanked the dashboard rather than degrading.
+  assert.equal(DEFAULT_EXPORT_RESOURCE_LIMITS.maximumSourceFiles, 100_000);
+
+  const guard = createExportResourceGuard({ clock: () => 0, rss: () => 0 });
+  guard.observeSourcePlan(4_880, 0);
+  assert.equal(guard.snapshot().counters.sourceFiles, 4_880);
+
+  const atCeiling = createExportResourceGuard({ clock: () => 0, rss: () => 0 });
+  atCeiling.observeSourcePlan(DEFAULT_EXPORT_RESOURCE_LIMITS.maximumSourceFiles, 0);
+  const above = createExportResourceGuard({ clock: () => 0, rss: () => 0 });
+  assert.throws(
+    () => above.observeSourcePlan(DEFAULT_EXPORT_RESOURCE_LIMITS.maximumSourceFiles + 1, 0),
+    (error) => error.code === "export_resource_source_files",
+  );
+});
+
+test("the directory-entry ceiling admits a full local rollout walk", () => {
+  // Raised 20_000 -> 100_000 alongside the source-file ceiling. Discovery
+  // charges EVERY entry of the walked tree, not just selected sources, so this
+  // is the bound that actually caps how large a corpus can be discovered: the
+  // owner's tree measured 4,984 entries against 4,880 selected rollouts.
+  assert.equal(DEFAULT_EXPORT_RESOURCE_LIMITS.maximumDirectoryEntries, 100_000);
+
+  const guard = createExportResourceGuard({ clock: () => 0, rss: () => 0 });
+  for (let index = 0; index < DEFAULT_EXPORT_RESOURCE_LIMITS.maximumDirectoryEntries; index += 1) {
+    guard.observeDirectoryEntry();
+  }
+  assert.equal(
+    guard.snapshot().counters.directoryEntries,
+    DEFAULT_EXPORT_RESOURCE_LIMITS.maximumDirectoryEntries,
+  );
+  assert.throws(
+    () => guard.observeDirectoryEntry(),
+    (error) => error.code === "export_resource_directory_entries",
+  );
 });
 
 test("resource guard enforces source, record, byte, elapsed, and RSS ceilings with safe codes", () => {

--- a/test/local-legacy-report-storage.test.js
+++ b/test/local-legacy-report-storage.test.js
@@ -3,6 +3,7 @@ import {
   appendFile,
   mkdtemp,
   mkdir,
+  open,
   readdir,
   readFile,
   rm,
@@ -185,30 +186,85 @@ test("legacy source symlinks are blocked instead of being migrated from outside 
   }
 });
 
-test("migration fails closed when a validated legacy source grows during its descriptor read", async () => {
+// The migration read pulls bytes through FileHandle#read, and FileHandle
+// instances share one prototype per process, so wrapping that method is a
+// deterministic seam: an append awaited inside a chosen read call is
+// guaranteed to interleave with the descriptor read. A timer racing the
+// inspection (the previous simulation) could miss the whole read window under
+// CPU load, because a page-cached 16 MiB read finishes in a few milliseconds
+// while the first 1 ms tick plus the append's threadpool round-trips can land
+// later. If a refactor stops routing the migration read through
+// FileHandle#read, the seam counts zero growths and the tests fail loudly.
+async function fileHandlePrototypeFor(path) {
+  const handle = await open(path, "r");
+  try {
+    return Object.getPrototypeOf(handle);
+  } finally {
+    await handle.close();
+  }
+}
+
+test("migration fails closed when a validated legacy source grows during its descriptor read", async (t) => {
   const root = await fixtureRoot();
   const source = join(root, "artifact.json");
   const maximumBytes = 16 * 1024 * 1024;
-  let growthTimer;
-  let growthWrites = Promise.resolve();
   try {
     await writeFile(source, Buffer.alloc(maximumBytes, 0x61), { mode: 0o600 });
-    growthTimer = setInterval(() => {
-      growthWrites = growthWrites.then(() => appendFile(source, Buffer.from("x")));
-    }, 1);
+    // Growing the file inside the first bounded read pins the append after
+    // the open-descriptor validation and before the overflow probe.
+    const fileHandlePrototype = await fileHandlePrototypeFor(source);
+    const realRead = fileHandlePrototype.read;
+    let growths = 0;
+    t.mock.method(fileHandlePrototype, "read", async function interceptedRead(...args) {
+      if (growths === 0) {
+        growths += 1;
+        await appendFile(source, Buffer.from("x"));
+      }
+      return realRead.apply(this, args);
+    });
     const result = await inspectLocalLegacyReportMigration({
       files: ["artifact.json"],
       root,
     });
-    clearInterval(growthTimer);
-    growthTimer = undefined;
-    await growthWrites;
-    assert.notEqual(result.entries[0].state, "migratable");
-    assert.ok(["source_changed", "source_too_large"].includes(result.entries[0].state));
+    assert.equal(growths, 1, "the growth seam never saw a descriptor read");
+    assert.equal(result.entries[0].state, "source_changed");
     assert.equal(result.status, "nothing_to_migrate");
     await assert.rejects(readFile(localLegacyReportPath(root, "artifact.json")));
   } finally {
-    if (growthTimer) clearInterval(growthTimer);
+    await rm(root, { force: true, recursive: true });
+  }
+});
+
+test("migration fails closed when a validated legacy source grows between the overflow probe and the descriptor recheck", async (t) => {
+  const root = await fixtureRoot();
+  const source = join(root, "artifact.json");
+  const maximumBytes = 16 * 1024 * 1024;
+  try {
+    await writeFile(source, Buffer.alloc(maximumBytes, 0x61), { mode: 0o600 });
+    // The overflow probe is the only read issued at the validated size, so an
+    // append awaited right after it lands in the last window a read can no
+    // longer see; only the closing descriptor recheck can refuse it.
+    const fileHandlePrototype = await fileHandlePrototypeFor(source);
+    const realRead = fileHandlePrototype.read;
+    let growths = 0;
+    t.mock.method(fileHandlePrototype, "read", async function interceptedRead(...args) {
+      const read = await realRead.apply(this, args);
+      const [, , length, position] = args;
+      if (growths === 0 && length === 1 && position === maximumBytes) {
+        growths += 1;
+        await appendFile(source, Buffer.from("x"));
+      }
+      return read;
+    });
+    const result = await inspectLocalLegacyReportMigration({
+      files: ["artifact.json"],
+      root,
+    });
+    assert.equal(growths, 1, "the growth seam never saw the overflow probe");
+    assert.equal(result.entries[0].state, "source_changed");
+    assert.equal(result.status, "nothing_to_migrate");
+    await assert.rejects(readFile(localLegacyReportPath(root, "artifact.json")));
+  } finally {
     await rm(root, { force: true, recursive: true });
   }
 });

--- a/test/replay-safe-accounting-cache.test.js
+++ b/test/replay-safe-accounting-cache.test.js
@@ -3226,6 +3226,45 @@ test("deep log scanning receives hard resource bounds and preserves the last cac
   assert.equal((await stat(cacheFile)).mode & 0o777, 0o600);
 });
 
+test("the deep-scan guard admits a full rollout corpus and still stops above the source-file ceiling", async () => {
+  const directory = await mkdtemp(join(tmpdir(), "usage-monitor-scan-files-"));
+  const cacheFile = join(directory, "accounting.json");
+
+  // The owner's deduped Codex rollout corpus measured 4,880 files; the ceiling
+  // was raised 5_000 -> 100_000 so a real corpus is admitted with headroom.
+  let admittedGuard = null;
+  await refreshReplaySafeAccountingCache({
+    cacheFile,
+    now: () => NOW,
+    scan: async ({ resourceGuard }) => {
+      admittedGuard = resourceGuard;
+      resourceGuard.observeSourcePlan(4_880, 0);
+      return { diagnostics: {} };
+    },
+  });
+  assert.equal(admittedGuard?.counters.sourceFiles, 4_880);
+  const before = await readTestCache(cacheFile);
+
+  // Above the ceiling it still stops, and -- unlike the RSS soft miss -- a
+  // source_files trip is a hard failure that retains the prior cache intact.
+  await assert.rejects(
+    refreshReplaySafeAccountingCache({
+      cacheFile,
+      now: () => NOW + 1_000,
+      scan: async ({ resourceGuard }) => {
+        resourceGuard.observeSourcePlan(
+          resourceGuard.limits.maximumSourceFiles + 1,
+          0,
+        );
+        return { diagnostics: {} };
+      },
+    }),
+    (error) => error?.code === "accounting_scan_source_files_limit_exceeded",
+  );
+  assert.deepEqual(await readTestCache(cacheFile), before);
+  assert.equal((await stat(cacheFile)).mode & 0o777, 0o600);
+});
+
 test("an AbortSignal can interrupt cooperative derivation after a dense scan and preserves the last cache", async () => {
   const directory = await mkdtemp(join(tmpdir(), "usage-monitor-derive-abort-"));
   const cacheFile = join(directory, "accounting.json");


### PR DESCRIPTION
Launch blocker for owner-scale installs. The owner's deduped Codex rollout corpus measures 4,880 files (2,057 active + 2,823 archived, all inside the 365-day window) against maximumSourceFiles 5,000 — 97.6% of the ceiling, roughly 120 sources of headroom. A source_files trip is a HARD accounting refresh failure: accounting_scan_source_files_limit_exceeded appears in neither the budget-miss codes nor the reader passthrough set (unlike source_bytes and rss), so crossing the old ceiling blanks the dashboard rather than degrading it — the exact failure class the 0.1.13 accounting work exists to eliminate.

maximumDirectoryEntries rises with it, because discovery charges every entry of the walked tree rather than only selected sources, so a 20,000-entry bound would have capped effective discovery well below the new source bound. Both land at 100,000, which keeps this policy the tightest of the family while no longer being 25x tighter than its neighbours (passive-collector and local-archive-accounting-index bound directory entries at 500,000 and rollout files at 125,000).

Also carries a deterministic rewrite of the flaky mid-read growth simulation in the legacy-report storage tests.

Gated on this branch before merge: export-resource-policy + legacy-report-storage + replay-safe-accounting 78/78; local-companion-refresh + passive-collector + corpus-stream 134/134.

Note: the receipts committed on this branch predate the merge and are superseded — authoritative regeneration happens on the post-merge tip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)