### PR TITLE
fix(accounting): unblock the rebuild and stop one sliver model suppressing the per-model fit

### DIFF
--- a/apps/macos/UsageMonitorApp.swift
+++ b/apps/macos/UsageMonitorApp.swift
@@ -91,8 +91,17 @@ private enum BundledNodeRuntimeMode: String {
         entrypoint: URL,
         trailing: [String] = []
     ) -> [String] {
+        // V8 defaults old-space to roughly 4 GiB, which sits BELOW the
+        // accounting rebuild's 6 GiB RSS target (MAX_ACCOUNTING_RSS_BYTES in
+        // src/replay-safe-accounting-cache.js). Without this the rebuild
+        // hard-OOMs the companion around 4 GiB instead of soft-failing into
+        // the retained cache, so the guard that exists to keep the dashboard
+        // alive never gets to run. Deliberately set AT the RSS target rather
+        // than below it: whole-process RSS always exceeds the JS heap, so the
+        // accounting ceiling still trips first and the soft-fail is preserved.
+        let heapArguments = ["--max-old-space-size=6144"]
         let runtimeArguments = self == .jitless ? ["--jitless"] : []
-        return runtimeArguments + [entrypoint.path] + trailing
+        return runtimeArguments + heapArguments + [entrypoint.path] + trailing
     }
 }
 

--- a/apps/web/public/localization.js
+++ b/apps/web/public/localization.js
@@ -37,7 +37,9 @@ export const WEEKLY_CALIBRATION_MINIMUM_DISPLAYED_SPAN_PP = 5;
 // parameter of its own and is priced at the pooled remainder rate instead.
 // Same provenance rule as the two gates above - guarded by a source contract
 // test, because the per-model card states this threshold to the reader.
-export const COMPOSITION_MINIMUM_MODEL_COST_SHARE_PERCENT = 2;
+// Moved 2 -> 3 with the kernel on 2026-08-20; the contract test is what caught
+// the drift, which is exactly what it is for.
+export const COMPOSITION_MINIMUM_MODEL_COST_SHARE_PERCENT = 3;
 
 const RTL_LANGUAGES = new Set([
   "ar",

--- a/packages/quota-analysis/src/model-composition.js
+++ b/packages/quota-analysis/src/model-composition.js
@@ -37,8 +37,15 @@ export const MODEL_COMPOSITION_POLICY = Object.freeze({
   // voided.
   maxCrossingElapsedMs: 3 * 60 * 60 * 1_000,
   // Models below this share of corpus cost fold into one "other" column so a
-  // sliver of spend can never claim its own free parameter.
-  minimumModelCostShare: 0.02,
+  // sliver of spend can never claim its own free parameter. Raised 0.02 -> 0.03
+  // on 2026-08-20: at 0.02, `codex-auto-review` cleared the floor at 2.80% of
+  // post-2026-07-30 cost, claimed a column, and its capacity swung 23,263 vs
+  // 7,121 between interleaved halves (138% drift). That tripped the split-half
+  // gate below and forced the ENTIRE window to fallback_blended even though sol
+  // (6% share) and terra (3.5%) were stable at 0.07 drift. One marginal column
+  // was suppressing an otherwise healthy per-model fit, so the floor now sits
+  // above the largest observed unstable sliver.
+  minimumModelCostShare: 0.03,
   // Fewer observations than this cannot support a multi-model fit at all.
   minimumObservations: 24,
   // The label the folded remainder fits under.

--- a/src/replay-safe-accounting-cache.js
+++ b/src/replay-safe-accounting-cache.js
@@ -185,27 +185,37 @@ const MAX_RETAINED_TRANSITION_BYTES = 320 * 1024 * 1024;
 // the transition-mining pass tripped at ~1.6 GB whole-process RSS on a
 // companion whose baseline idles near ~800 MB, and the throw hard-failed the
 // entire refresh — blanking the dashboard and flip-flopping every 5 minutes
-// as the scheduler re-ran the doomed pass. This ceiling is now a TARGET, not a
-// hard blocker: a miss degrades to a retained-cache soft-fail rather than
-// failing the refresh (see refreshReplaySafeAccountingCache and
+// as the scheduler re-ran the doomed pass. Raised 2 -> 6 GiB on owner
+// directive (2026-08-20): the 2 GiB figure was a placeholder and the corpus
+// outgrew it. Every rebuild from 2026-08-18T19:28 onward deferred on
+// accounting_transition_rss_limit_exceeded, leaving allowanceCapacity and the
+// entire per-model composition fit unavailable while the dashboard still
+// reported freshness "live" — 572,089 all-time events, 128.5 GB indexed
+// across 4,880 sources at the time. This ceiling is a TARGET, not a hard
+// blocker: a miss degrades to a retained-cache soft-fail rather than failing
+// the refresh (see refreshReplaySafeAccountingCache and
 // ACCOUNTING_BUDGET_MISS_CODES). It remains the backstop that stops the pass
-// before it can OOM the process.
-const MAX_ACCOUNTING_RSS_BYTES = Math.floor(2 * 1024 * 1024 * 1024);
+// before it can OOM the process — which is only true because the bundled
+// runtime now launches with --max-old-space-size=6144
+// (apps/macos/UsageMonitorApp.swift): V8's ~4 GiB default old-space sits
+// BELOW this target, so without that flag the pass would hard-OOM before the
+// soft-fail could ever run.
+const MAX_ACCOUNTING_RSS_BYTES = Math.floor(6 * 1024 * 1024 * 1024);
 // What one accounting rebuild may itself ADD to process RSS over the baseline
 // captured at build start. The effective ceiling is
 // min(MAX_ACCOUNTING_RSS_BYTES, baselineRss + this delta), so the delta must
-// be large enough that a NORMAL baseline reaches the 2 GiB absolute target
-// rather than capping the pass below it. The old 512 MiB delta is exactly what
-// made the incident inevitable: with the ~800 MB live baseline it capped the
-// build at ~1.3 GB — BELOW the 1.6 GB the pass actually needed — so the miss
-// was structural, not a real leak. Raised to 1.25 GiB so a typical baseline
-// lands on the absolute target (min(2 GiB, 800 MB + 1.25 GiB = 2.05 GiB) =
-// 2 GiB): the pass's own metered climb measured ~330 MB on the real corpus and
-// the composition fit is an O(bins) streaming pass, so 1.25 GiB is that
-// measured climb with generous corpus-growth headroom, while
-// MAX_ACCOUNTING_RSS_BYTES stays the absolute backstop against a leaking
+// be large enough that a NORMAL baseline reaches the absolute target rather
+// than capping the pass below it. The old 512 MiB delta is exactly what made
+// the 2026-08-11 incident inevitable: with the ~800 MB live baseline it capped
+// the build at ~1.3 GB — BELOW the 1.6 GB the pass actually needed — so the
+// miss was structural, not a real leak. That same arithmetic is why raising
+// the absolute target ALONE is inert: at an ~800 MB baseline the 1.25 GiB
+// delta pinned the effective ceiling near 2.05 GiB however high the absolute
+// went. Raised 1.25 -> 5.25 GiB alongside the 6 GiB target so a typical
+// baseline lands on it (min(6 GiB, 800 MB + 5.25 GiB = 6.05 GiB) = 6 GiB),
+// while MAX_ACCOUNTING_RSS_BYTES stays the absolute backstop against a leaking
 // baseline.
-const ACCOUNTING_RSS_DELTA_BUDGET_BYTES = Math.floor(1.25 * 1024 * 1024 * 1024);
+const ACCOUNTING_RSS_DELTA_BUDGET_BYTES = Math.floor(5.25 * 1024 * 1024 * 1024);
 // A memory-budget miss — whole-process RSS over the effective ceiling, the
 // scan guard's own RSS trip, or the per-row retained-byte meter over budget —
 // is a soft TARGET miss, not a hard failure. refreshReplaySafeAccountingCache
@@ -2543,6 +2553,12 @@ async function fitCompositionFromCorpusStream({
     r2: fit.r2,
     singleConstantUsd: fit.singleConstantUsd,
     singleConstantR2: fit.singleConstantR2,
+    // Why a fit was ACCEPTED or REJECTED. Without this a fallback_blended
+    // reaches the dashboard with no recoverable reason, and recovering it costs
+    // a full re-run of the kernel against the corpus (2026-08-20). The gate at
+    // model-composition.js reads these exact fields, so persisting them is what
+    // makes the decision auditable after the fact.
+    identification: fit.identification ?? null,
     blendedRecentMixUsd: Number.isFinite(blendedRecentMixUsd)
       ? Number(blendedRecentMixUsd.toFixed(2))
       : null,
@@ -3192,12 +3208,15 @@ export async function buildReplaySafeAccountingCache({
   checkRuntimeMemory();
   // The deep-scan guard reuses the shared, frozen export resource policy, whose
   // compatibility-bound candidate ceiling caps maximumRssBytes at 1.5 GiB. The
-  // accounting build's authoritative ceiling is the 2 GiB effective target
+  // accounting build's authoritative ceiling is the 6 GiB effective target
   // above (checkRuntimeMemory), so pass the guard the LOWER of the two: it can
-  // only tighten the transition-path target, never contradict it. In practice
-  // the heavy growth is the post-scan transition mining that checkRuntimeMemory
-  // polices at the full 2 GiB, while the scan phase stays within the export
-  // policy's own bound. A scan-phase RSS trip is likewise a soft budget miss
+  // only tighten the transition-path target, never contradict it. Since the
+  // 2026-08-20 raise the export policy's 1.5 GiB is ALWAYS the lower of the
+  // two at any realistic baseline, so the scan phase is effectively pinned
+  // there. That is deliberate and was never the failing phase: the deferrals
+  // this raise addresses were accounting_transition_rss_limit_exceeded, the
+  // post-scan transition mining that checkRuntimeMemory polices at the full
+  // target. A scan-phase RSS trip is likewise a soft budget miss
   // (accounting_scan_rss_limit_exceeded), not a hard refresh failure.
   const scanResourceGuardMaximumRssBytes = Math.min(
     effectiveMaximumRssBytes,

--- a/src/reporting/weekly-calibration.js
+++ b/src/reporting/weekly-calibration.js
@@ -1333,6 +1333,27 @@ const MAX_COMPOSITION_MODELS = 24;
 // model instead of through one blended constant. The projection is defensive:
 // a malformed block degrades to null rather than poisoning the summary, and
 // a non-"fitted" status never carries a vector.
+// The identification block decides fitted vs fallback_blended, so it travels
+// with the fit rather than being recomputed. Bounded like every other wire
+// field: unknown shapes collapse to null, never to a partial object.
+function projectCompositionIdentification(identification) {
+  if (!identification || typeof identification !== "object"
+      || Array.isArray(identification)) {
+    return null;
+  }
+  return {
+    adjustedR2: finiteOrNull(identification.adjustedR2),
+    singleConstantAdjustedR2: finiteOrNull(
+      identification.singleConstantAdjustedR2,
+    ),
+    splitHalfIdentified: identification.splitHalfIdentified === true,
+    splitHalfMaxCapacityDriftFraction: finiteOrNull(
+      identification.splitHalfMaxCapacityDriftFraction,
+      { minimum: 0 },
+    ),
+  };
+}
+
 function projectComposition(composition) {
   if (!composition || typeof composition !== "object"
       || Array.isArray(composition)
@@ -1374,6 +1395,9 @@ function projectComposition(composition) {
       { minimum: 0 },
     ),
     singleConstantR2: finiteOrNull(composition.singleConstantR2),
+    identification: projectCompositionIdentification(
+      composition.identification,
+    ),
     blendedRecentMixUsd: finiteOrNull(
       composition.blendedRecentMixUsd,
       { minimum: 0 },

--- a/test/replay-safe-accounting-cache.test.js
+++ b/test/replay-safe-accounting-cache.test.js
@@ -1540,6 +1540,7 @@ test("the streaming composition binning matches the per-event kernel path exactl
     r2: reference.fit.r2,
     singleConstantUsd: reference.fit.singleConstantUsd,
     singleConstantR2: reference.fit.singleConstantR2,
+    identification: reference.fit.identification ?? null,
     blendedRecentMixUsd: Number(reference.blendedRecentMixUsd.toFixed(2)),
     recentMixDays: 14,
   });
@@ -2908,10 +2909,13 @@ test("compact transition input ceilings fail closed without truncating or replac
   assert.equal((await stat(cacheFile)).mode & 0o777, 0o600);
 });
 
-// Effective-ceiling arithmetic mirrored from the module: absolute 2 GiB target,
-// 1.25 GiB self-growth delta, effective = min(absolute, baseline + delta).
-const ACCOUNTING_RSS_ABSOLUTE = 2 * 1024 * 1024 * 1024;
-const ACCOUNTING_RSS_DELTA = Math.floor(1.25 * 1024 * 1024 * 1024);
+// Effective-ceiling arithmetic mirrored from the module: absolute 6 GiB target,
+// 5.25 GiB self-growth delta, effective = min(absolute, baseline + delta).
+const ACCOUNTING_RSS_ABSOLUTE = 6 * 1024 * 1024 * 1024;
+const ACCOUNTING_RSS_DELTA = Math.floor(5.25 * 1024 * 1024 * 1024);
+// Mirrored from src/export/resource-policy.js: the shared export policy's own
+// RSS bound, which clamps the deep-scan guard independently of the above.
+const EXPORT_POLICY_MAX_RSS_BYTES = Math.floor(1.5 * 1024 * 1024 * 1024);
 
 test("an RSS ceiling miss during accounting is a soft target: the prior cache is retained and served", async () => {
   const directory = await mkdtemp(join(tmpdir(), "usage-monitor-rss-bound-"));
@@ -3183,13 +3187,18 @@ test("the scan resource guard inherits the budget-relative RSS ceiling", async (
     },
   });
 
-  // The deep-scan guard polices the same pass, so it must carry the same
-  // effective ceiling (baseline + delta budget here, since that is below the
-  // absolute constant) rather than the absolute constant alone.
+  // The deep-scan guard polices the same pass and carries the LOWER of the
+  // accounting effective ceiling and the shared export policy's own RSS bound.
+  // Since the 2026-08-20 raise to a 6 GiB target / 5.25 GiB delta, the export
+  // policy's 1.5 GiB is the lower of the two at any realistic baseline, so the
+  // guard pins there — it may only tighten the transition target, never exceed
+  // it. Asserted as the explicit min() so a future move in either constant
+  // fails here rather than silently loosening the scan phase.
   assert.equal(
     observedGuard?.limits.maximumRssBytes,
-    baseline + ACCOUNTING_RSS_DELTA,
+    Math.min(baseline + ACCOUNTING_RSS_DELTA, EXPORT_POLICY_MAX_RSS_BYTES),
   );
+  assert.equal(observedGuard?.limits.maximumRssBytes, EXPORT_POLICY_MAX_RSS_BYTES);
 });
 
 test("deep log scanning receives hard resource bounds and preserves the last cache when they trip", async () => {


### PR DESCRIPTION
Two defects found while auditing why the composition fit disagrees with OpenAI's published allowance table. They are independent; the first is why the fit stopped running, the second is why it sometimes refuses to run.

## 1. The accounting rebuild had outgrown its memory ceiling

Every rebuild from `2026-08-18T19:28Z` deferred on `accounting_transition_rss_limit_exceeded` — **26 of them** — leaving `allowanceCapacity` and the whole per-model composition fit unavailable while the dashboard still reported freshness `"live"`. The corpus had outgrown a placeholder: 572,089 all-time events, 128.5 GB indexed across 4,880 sources.

Three changes, and all three are required:

| | | why |
|---|---|---|
| `MAX_ACCOUNTING_RSS_BYTES` | 2 → 6 GiB | the absolute target |
| `ACCOUNTING_RSS_DELTA_BUDGET_BYTES` | 1.25 → 5.25 GiB | **without this the raise is inert** |
| `--max-old-space-size=6144` | new | **without this it crashes instead of degrading** |

The effective ceiling is `min(MAX, baselineRss + delta)`. At the ~1.07 GiB live companion baseline the 1.25 GiB delta pinned it near 2.05 GiB however high the absolute went.

The heap flag is load-bearing, not incidental: V8 defaults old-space to ~4.09 GiB, *below* the new 6 GiB target, so without it the pass hard-OOMs the companion before the soft-fail can retain the last good cache — turning a graceful degrade into a crash. It is set **at** the target rather than below it, because whole-process RSS always exceeds the JS heap, so the accounting ceiling still trips first and the soft-fail is preserved.

The deep-scan guard stays clamped at the export policy's own 1.5 GiB. That was never the failing phase — every deferral was on the transition path — so the test now asserts the explicit `min()` rather than assuming which side is lower.

## 2. One unstable sliver was forcing whole windows to `fallback_blended`

**`minimumModelCostShare` 0.02 → 0.03.** At 0.02, `codex-auto-review` cleared the floor at 2.80% of post-`2026-07-30` cost, claimed its own column, and swung 23,263 vs 7,121 between interleaved halves (138% drift). That tripped the split-half gate and forced the *entire* window to `fallback_blended` even though sol (6% share) and terra (3.5%) were stable at 0.07 drift. With the floor raised, the same window fits cleanly.

**Persist `fit.identification`.** `adjustedR2`, `singleConstantAdjustedR2`, `splitHalfIdentified` and `splitHalfMaxCapacityDriftFraction` decide whether a fit is accepted, then were dropped by both projection layers before persistence. A `fallback_blended` therefore reached the dashboard with no recoverable reason, and recovering it cost a full re-run of the kernel against the corpus. It now travels with the fit, bounded like every other wire field.

The browser mirror `COMPOSITION_MINIMUM_MODEL_COST_SHARE_PERCENT` moves with the kernel — the source-contract test in `localization-copy.test.mjs` caught the drift, which is exactly what it is for.

## Known limitation

**The 0.03 floor is a tuned constant, not a principled fix.** It works because 0.03 happens to sit above `codex-auto-review`'s 2.80% share. If a different sliver model lands at 3.5%, the same failure recurs. The principled fix is a stability-based exclusion — drop columns that individually fail split-half, rather than by cost share — but that changes the kernel's contract and is deliberately out of scope here.

## Verification

- 128/128 across the affected suites: `replay-safe-accounting-cache`, `weekly-calibration`, `local-companion-data`, `quota-analysis` package, `localization-copy`, `tool-inventory`
- `swiftc -parse` clean
- architecture boundaries: 377 production files, 1470 imports, 0 debt edges
- rebased on `ae22934`

Five other suites fail **only** when run from a git worktree and pass on a normal checkout — `jsonc-parser` is a worker-scoped dependency unresolvable from a worktree (`web-release-lane`, `deployment-endpoints`, `dogfood-update-guard-config`), and the macOS bundle tests trip `MACOS_PREVIEW_OUTPUT_FORBIDDEN` because a worktree root is not the reviewed staging path. Each was confirmed green on `main`.

## Note

`scripts/analyze-credit-drawdown.js` was deliberately left out. It is an unregistered executable, and `tools/tool-inventory.json` is a curated governance register — adding an entry means choosing a `classification`, `decision` and `provenance`, which is the owner's call. It is parked on `parked/credit-drawdown-analyzer` pending that decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)