### PR TITLE
fix(web): lead the quota cards with the Spark allowances

### DIFF
--- a/apps/web/public/app.js
+++ b/apps/web/public/app.js
@@ -1112,7 +1112,16 @@ function renderQuotaCards(data) {
     : [primaryWindow, ...normalWindows.filter((window) => window !== primaryWindow)];
   // Spark is a separate provider limit. Keep it out of the normal allowance
   // selection so it cannot be mistaken for the five-hour or seven-day track.
-  const windows = [...normalOrderedWindows, ...sparkWindows];
+  // Owner-directed 2026-08-20 card order: the Spark cards lead, shortest
+  // window first, and the normal-Codex allowance follows. Ordering on the
+  // duration rather than trusting the provider's slot assignment holds that
+  // order even if Spark's slots move again, as they did when the five-hour
+  // window returned on 2026-08-19. The filter above already required a valid
+  // duration on every window here, so the comparison never sees a null.
+  const sparkOrderedWindows = [...sparkWindows].sort((left, right) => (
+    finite(left.durationMinutes) - finite(right.durationMinutes)
+  ));
+  const windows = [...sparkOrderedWindows, ...normalOrderedWindows];
   if (!windows.length) {
     const card = node("article", "metric-card insufficient");
     const header = node("div", "metric-card-header");

--- a/apps/web/test/lib.test.mjs
+++ b/apps/web/test/lib.test.mjs
@@ -6305,6 +6305,32 @@ test("live timeline couples quota-weighted usage to the matching allowance capac
     quotaCardsMatch[1],
     /data\.quotaWindows\.filter\(isPrimaryCodexQuotaWindow\)/u,
   );
+  // Owner-directed 2026-08-20: the Spark cards lead the row and the
+  // normal-Codex allowance follows. Pinned so the grouping is not quietly
+  // reverted to normal-first by a later edit.
+  assert.match(
+    quotaCardsMatch[1],
+    /const windows = \[\.\.\.sparkOrderedWindows, \.\.\.normalOrderedWindows\];/u,
+  );
+  // Within the Spark pair the order comes from the window duration, not from
+  // the provider's slot assignment, so five-hour precedes seven-day even if
+  // Spark's slots move again as they did on 2026-08-19.
+  const sparkSortMatch = quotaCardsMatch[1].match(
+    /const sparkOrderedWindows = \[\.\.\.sparkWindows\]\.sort\(([\s\S]*?)\);\n/u,
+  );
+  assert.ok(sparkSortMatch, "Spark card ordering is available for contract review");
+  const sparkComparator = new Function(
+    "finite",
+    `return ${sparkSortMatch[1]};`,
+  )(finite);
+  assert.deepEqual(
+    [
+      { durationMinutes: 10_080 },
+      { durationMinutes: 525_600 },
+      { durationMinutes: 300 },
+    ].sort(sparkComparator).map((window) => window.durationMinutes),
+    [300, 10_080, 525_600],
+  );
 });
 
 test("community UI stays focused on one reviewed destination", async () => {


### PR DESCRIPTION
Owner-directed card order for the dashboard quota row: the two Spark cards come first — **Spark five-hour**, then **Spark seven-day** — and the normal-Codex **Seven-day allowance** follows them.

### Why the duration sort

The group swap alone would have worked *today*. The five-hour Spark window currently lands in the limit's `primary` slot and the seven-day in `secondary`, so "five-hour before seven-day" fell out of the upstream `(limitId, slot)` sort by coincidence. That is the same assumption that moved when the five-hour Spark window returned on 2026-08-19, so the Spark pair is now ordered on the window duration itself. The existing filter already requires a valid duration on every Spark window reaching this point, so the comparator never sees a null.

### Scope

- The codex side is untouched. `selectPrimaryCodexQuotaWindow` still hoists the longest window, so the weekly allowance keeps leading that group — if a codex five-hour window ever appears alongside the weekly, the row reads Spark 5h, Spark 7d, codex 7d, codex 5h.
- No styling change. There is no `:first-child` rule on `#quota-cards`, so leading with Spark does not promote it visually.

### Tests

`renderQuotaCards` had no order assertion before; the existing contract check gains one, plus a behavioral check that extracts the Spark comparator and runs it against a shuffled five-hour / seven-day / 365-day set.

- `apps/web/test/lib.test.mjs` + `apps/web/test/quota-window-naming.test.mjs` — 201/201
- `test/r7-generated-release-evidence.test.js` — 2/2

**No R7 regeneration required.** Verified rather than assumed: the workload digest attests 341 files, none under `apps/`, and `apps/web/public/app.js` is not among them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)