### PR TITLE
fix(web): recover from a stale or missing companion health read without a reload

### DIFF
--- a/apps/web/public/app.js
+++ b/apps/web/public/app.js
@@ -149,6 +149,15 @@ function paginateCacheImpactRows(rows, state, signature) {
     pageCount,
   };
 }
+// The companion's last health answer, or null when no answer has landed.
+// Health is not a constant of the page's lifetime and a single bootstrap read
+// cannot settle it. The companion derives
+// `capabilities.incrementalContributionSync` per request from two live facts —
+// a configured contribution service AND an existing unified index — so on a
+// fresh install the bootstrap read wins the race against first-run indexing
+// and gets a truthful `false` that stops being true minutes later, while a
+// read that loses the race lands as null. Both latch every capability gate
+// below into "this build has no v1.0 transport" for the life of the page.
 let localCompanionHealth = null;
 // The last refresh run's accounting-rebuild deferral, read from the local
 // refresh status alongside each dashboard load. A rebuild that keeps missing
@@ -9960,7 +9969,11 @@ async function loadLocalDashboard() {
       localClient.fastModePreference().catch(() => null),
       localClient.refreshStatus().catch(() => null)
     ]);
-    localCompanionHealth = localHealth;
+    // A read that did not land says nothing about the companion, so it may not
+    // replace one that did: the same rule the accounting-rebuild note above
+    // follows. Only the unavailable-state decision below reads THIS load's
+    // answer, because that is the one it is reporting on.
+    if (localHealth !== null) localCompanionHealth = localHealth;
     fastModePreference = speedPreference;
     if (refreshState !== null) {
       accountingRebuildDeferral =
@@ -9972,25 +9985,28 @@ async function loadLocalDashboard() {
     // disabled state bootstrap gave them when the capability was still unknown.
     renderHostedIdentity();
     renderContributionSyncStatus(sync.status);
+    // Before the consent read, because that read now also recovers whichever
+    // companion answers are still unsettled — and an onboarding verdict this
+    // load already holds is not one of them.
+    renderLocalOnboarding(onboarding);
     // Consent state is read from the companion before the queue renders, so
     // an already-approved Mac never re-prepares a review instance it no
     // longer needs.
     await loadIncrementalSyncStatus();
     renderContributionSyncPreview(sync.preview);
-    renderLocalOnboarding(onboarding);
     markLocalDashboardReady();
   } catch {
     const [localHealth, onboarding] = await Promise.all([
       localClient.health().catch(() => null),
       localClient.onboarding().catch(() => null),
     ]);
-    localCompanionHealth = localHealth;
+    if (localHealth !== null) localCompanionHealth = localHealth;
     dashboard = null;
     renderHostedIdentity();
     renderContributionSyncStatus(null);
+    renderLocalOnboarding(onboarding);
     await loadIncrementalSyncStatus();
     renderContributionSyncPreview(null);
-    renderLocalOnboarding(onboarding);
     renderDashboardUnavailableState(
       localHealth ? "dashboard-unavailable" : "companion-unavailable",
     );
@@ -11583,11 +11599,20 @@ function renderCommunityJourney() {
   // 2026-08-08: connecting is no longer a user-visible step — the ceremony
   // pairs this Mac itself). Once approval stands the line states the flow's
   // remaining truth: it syncs automatically.
-  if (localCompanionHealth === null) {
-    stage("community", "waiting", "journey.community.waitingCompanion");
+  if (localCompanionHealthUnknown()) {
+    // Never "waiting for the Mac app first": the Mac app is what serves this
+    // page, so its absence is not what a reader seeing this line is looking
+    // at. What is missing is its answer to a status check — and the line may
+    // promise another attempt only while the recovery poll still has one.
+    stage("community", "waiting", localCompanionRecoveryActive()
+      ? "journey.community.waitingHealth"
+      : "journey.community.noHealthAnswer");
   } else if (!contributionServiceConfigured()) {
     stage("community", "waiting", "journey.community.noService");
   } else if (!incrementalSyncCapabilityAdvertised()) {
+    // Here the index IS the blocker and the line may say so: the companion
+    // answered, reports a contribution service, and derives this flag from
+    // the unified index the first run has not written yet.
     // A build whose companion does not advertise the v1.0 transport has no
     // in-page ceremony; a Mac already holding upload authority still reads
     // as connected rather than pending.
@@ -11628,6 +11653,43 @@ const INCREMENTAL_SYNC_CONTRACT = "telemetry-contribution-v1.0";
 function incrementalSyncCapabilityAdvertised() {
   return localCompanionHealth?.capabilities?.incrementalContributionSync
     === INCREMENTAL_SYNC_CONTRACT;
+}
+
+/**
+ * Whether the companion has answered a health read at all. Every capability
+ * gate on this page reads a falsy answer out of a null payload, which makes an
+ * unheard companion indistinguishable from a build that carries no transport.
+ * Only surfaces that STATE a reason need the difference; the gates themselves
+ * stay closed either way, because a capability nobody confirmed may not be
+ * offered.
+ */
+function localCompanionHealthUnknown() {
+  return localCompanionHealth === null;
+}
+
+/**
+ * Whether the recovery poll still has a read left in its budget. Copy may
+ * promise another attempt only while this holds; once the budget is spent, a
+ * line that still says "checking again" is the same kind of untruth this
+ * recovery exists to remove.
+ */
+function localCompanionRecoveryActive() {
+  return incrementalSyncPollCount < INCREMENTAL_SYNC_POLL_LIMIT;
+}
+
+/**
+ * Whether the v1.0 transport's advertisement is one the page may treat as
+ * final. Three answers, not two: unknown (no read landed), advertised, and a
+ * `false` that the companion recomputes per request from the unified index the
+ * first run has not written yet. Only the last two are stable — and the third
+ * is stable only where the companion reports no contribution service at all,
+ * because `contributionDevicePairing` is fixed when the companion starts, so
+ * no amount of indexing can make the transport appear behind it.
+ */
+function incrementalSyncCapabilitySettled() {
+  if (localCompanionHealthUnknown()) return false;
+  return incrementalSyncCapabilityAdvertised()
+    || !contributionServiceConfigured();
 }
 
 /**
@@ -11938,6 +12000,11 @@ const INCREMENTAL_SYNC_POLL_INTERVAL_MS = 4_000;
 const INCREMENTAL_SYNC_POLL_LIMIT = 450;
 
 function incrementalSyncPollWorthwhile() {
+  // An unsettled companion read is itself movement worth waiting for, and it
+  // must be tested BEFORE the capability gate: the capability is exactly what
+  // an unsettled read cannot yet report, so gating recovery on it is the
+  // deadlock that left a fresh install stuck with no retry and no error.
+  if (localCompanionReadUnsettled()) return true;
   if (!incrementalSyncCapabilityAdvertised() || !incrementalConsentApproved) {
     return false;
   }
@@ -11948,6 +12015,29 @@ function incrementalSyncPollWorthwhile() {
   return status.progress.daysPending > 0;
 }
 
+/**
+ * Whether either companion read the page's gates depend on is still an answer
+ * it may not act on. Both are read once at bootstrap against a companion that
+ * is busy building its first index, and both fail closed onto a user-visible
+ * gate: the transport advertisement hides the whole approve ceremony, and the
+ * onboarding verdict disables the only analysis button on the page.
+ */
+function localCompanionReadUnsettled() {
+  return !incrementalSyncCapabilitySettled() || localOnboardingUnsettled();
+}
+
+/**
+ * Whether the onboarding verdict could be either of two different things. A
+ * failed read normalizes to the exact shape a companion with no readable Codex
+ * home reports, so `unavailable` alone cannot say which happened — and that
+ * shape disables Analyze/Update local usage. When the dashboard rendered from
+ * real evidence there is nothing else on screen to press, so re-reading is the
+ * only way out.
+ */
+function localOnboardingUnsettled() {
+  return localOnboarding === null || localOnboarding.state === "unavailable";
+}
+
 function scheduleIncrementalSyncStatusPoll({ reset = false } = {}) {
   if (reset) incrementalSyncPollCount = 0;
   if (incrementalSyncPollTimer !== null) return;
@@ -11956,8 +12046,59 @@ function scheduleIncrementalSyncStatusPoll({ reset = false } = {}) {
   incrementalSyncPollTimer = window.setTimeout(() => {
     incrementalSyncPollTimer = null;
     incrementalSyncPollCount += 1;
-    void loadIncrementalSyncStatus().catch(() => {});
+    // A failed pass may not end the chain. This poll is now the recovery path
+    // for a companion that has not been heard from, so a link that dies —
+    // on a render fault, on a torn-down node — leaves the page in exactly the
+    // stuck state the chain exists to clear. The budget and the worthwhile
+    // test still bound it.
+    void loadIncrementalSyncStatus().catch(() => {
+      scheduleIncrementalSyncStatusPoll();
+    });
   }, INCREMENTAL_SYNC_POLL_INTERVAL_MS);
+}
+
+/**
+ * Re-read the companion answers the page's gates gate on, while they are still
+ * answers it may not act on. Quiet by construction: it renders only when an
+ * answer CHANGES, so an unknown that stays unknown produces no churn, and it
+ * rides the incremental-sync poll's existing cadence and budget rather than a
+ * timer of its own. A failed re-read never downgrades an answer that already
+ * landed — a transient loopback failure must not un-advertise a transport the
+ * companion confirmed.
+ */
+async function recoverLocalCompanionReads() {
+  const [localHealth, onboarding] = await Promise.all([
+    incrementalSyncCapabilitySettled()
+      ? null
+      : localClient.health().catch(() => null),
+    localOnboardingUnsettled()
+      ? localClient.onboarding().catch(() => null)
+      : null,
+  ]);
+  let recovered = false;
+  if (localHealth !== null) {
+    const wasAdvertised = incrementalSyncCapabilityAdvertised();
+    const wasUnknown = localCompanionHealthUnknown();
+    localCompanionHealth = localHealth;
+    if (wasUnknown
+        || incrementalSyncCapabilityAdvertised() !== wasAdvertised) {
+      // The sign-in controls are gated on a capability this payload carries,
+      // and they hold whatever disabled state they were given while it was
+      // unknown until something re-renders them.
+      renderHostedIdentity();
+      recovered = true;
+    }
+    if (incrementalSyncCapabilityAdvertised() && !wasAdvertised) {
+      // The transport just landed, so the poll's real work starts now. Reads
+      // spent waiting for it must not come out of the live-progress budget.
+      incrementalSyncPollCount = 0;
+    }
+  }
+  if (onboarding !== null && onboarding.state !== localOnboarding?.state) {
+    renderLocalOnboarding(onboarding);
+    recovered = true;
+  }
+  if (recovered) renderContributionActionState();
 }
 
 /**
@@ -11966,10 +12107,15 @@ function scheduleIncrementalSyncStatusPoll({ reset = false } = {}) {
  * and the progress facts the status line prints.
  */
 async function loadIncrementalSyncStatus() {
+  await recoverLocalCompanionReads();
   if (!incrementalSyncCapabilityAdvertised()) {
     incrementalSyncStatus = null;
     incrementalConsentApproved = false;
     renderContributionActionState();
+    // An unadvertised transport is not necessarily an absent one, and this
+    // chained poll is the only thing that will notice when it lands. Leaving
+    // before scheduling it is what made the first read final.
+    scheduleIncrementalSyncStatusPoll();
     return;
   }
   // The same bounded GET the client performs, read raw once so the optional

--- a/apps/web/public/localization.js
+++ b/apps/web/public/localization.js
@@ -941,10 +941,20 @@ export const WEB_MESSAGES = Object.freeze({
     "正在等待第一次本地分析。",
     "A la espera del primer análisis local.",
   ],
-  "journey.community.waitingCompanion": [
-    "Waiting for the Mac app first.",
-    "请先等待 Mac 应用。",
-    "Primero se espera la app para Mac.",
+  // The companion's health answer, not the companion itself: this page is
+  // served BY the Mac app, so a line about waiting for the Mac app describes
+  // something the reader can see is untrue. These two state the real fact —
+  // no answer to a status check yet — and differ on the one thing the reader
+  // can act on: whether another attempt is still coming.
+  "journey.community.waitingHealth": [
+    "The Mac app has not answered a status check yet. Checking again.",
+    "Mac 应用尚未响应状态检查。正在重新检查。",
+    "La app para Mac aún no responde a una comprobación de estado. Reintentando.",
+  ],
+  "journey.community.noHealthAnswer": [
+    "The Mac app has not answered a status check. Reload to try again.",
+    "Mac 应用未响应状态检查。请重新加载页面再试。",
+    "La app para Mac no respondió a una comprobación de estado. Recarga para reintentar.",
   ],
   "journey.community.noService": [
     "This build has no contribution service.",

--- a/apps/web/test/lib.test.mjs
+++ b/apps/web/test/lib.test.mjs
@@ -6738,8 +6738,10 @@ test("the community journey states its stages and gates effort behind sign-in an
   );
   // Re-pinned 2026-08-08 (one-step flow): journey.community.connectNext left
   // with the connect step; the signed-in state points straight at the single
-  // Review-and-approve action, and waitingIndex covers a companion that has
-  // not advertised the v1.0 transport yet.
+  // Review-and-approve action. Re-pinned 2026-08-20: waitingIndex now covers
+  // only a companion that ANSWERED and reports a service without the transport
+  // — an unanswered companion has its own two lines, held to the same bar by
+  // the unanswered-health test below.
   for (const locale of SUPPORTED_LOCALES) {
     for (const key of [
       "journey.index.complete",
@@ -11843,4 +11845,518 @@ test("first-sign-in mint reproduces AUTH_REQUIRED and the relay bridge closes it
       "a fresh process starts with no captured session",
     );
   }
+});
+
+// ---------------------------------------------------------------------------
+// A companion health answer is not a constant of the page's lifetime (launch
+// blocker, reproduced on a fresh macOS account 2026-08-20). The companion
+// derives `capabilities.incrementalContributionSync` per request from the
+// unified index, so a bootstrap read taken during first-run indexing answers a
+// truthful `false` — or, having lost the race outright, does not answer at all.
+// Read once and never again, either answer latched the approve ceremony out of
+// the document for the life of the page, with no error, no retry, and a
+// journey line blaming an index that had already finished.
+// ---------------------------------------------------------------------------
+
+const ADVERTISED_HEALTH = Object.freeze({
+  capabilities: Object.freeze({
+    contributionDevicePairing: true,
+    incrementalContributionSync: "telemetry-contribution-v1.0",
+  }),
+});
+// The same companion, answering mid-index: a service is configured, the upload
+// source is not written yet, so the transport is honestly absent for now.
+const INDEXING_HEALTH = Object.freeze({
+  capabilities: Object.freeze({
+    contributionDevicePairing: true,
+    incrementalContributionSync: false,
+  }),
+});
+
+async function loadCompanionHealthRecovery(harness) {
+  const appSource = await readFile(new URL("../public/app.js", import.meta.url), "utf8");
+  const slice = (startMarker, endMarker) => {
+    const start = appSource.indexOf(startMarker);
+    assert.ok(start >= 0, `the slice starting at ${startMarker} is available`);
+    const end = appSource.indexOf(endMarker, start + startMarker.length);
+    assert.ok(end > start, `the slice ending at ${endMarker} is available`);
+    return appSource.slice(start, end);
+  };
+  // The real gates, the real recovery, and the real poll scheduler — the whole
+  // point is that the capability predicate reads the payload the recovery
+  // stored, so a stub of either would prove nothing.
+  const section = [
+    slice(
+      "// Whether this build is paired with a hosted contribution service at all.",
+      "\n/**",
+    ),
+    slice(
+      "// The incremental full-history contribution contract this dashboard is ready",
+      "\n/**\n * Whether the service refused this Mac's uploads",
+    ),
+    slice(
+      "// The live-progress poll behind the first pass",
+      "\nasync function freshReviewTokenForApproval(",
+    ),
+  ].join("\n\n");
+  // The two surfaces the reader actually sees, taken from the same source
+  // rather than restated here: whether the approve ceremony is in the document
+  // at all, and which sentence step 2 of the journey prints. A test that only
+  // watched the re-fetch happen would pass while the page stayed broken.
+  const consentVisibility = slice(
+    '  const surface = $("#incremental-consent");',
+    '\n  const approve = $("#incremental-consent-approve");',
+  );
+  const journeyChain = slice(
+    "  if (localCompanionHealthUnknown()) {",
+    "\n}\n\n// The incremental full-history contribution contract",
+  );
+
+  harness.healthReads = 0;
+  harness.onboardingReads = 0;
+  harness.identityRenders = 0;
+  harness.actionRenders = 0;
+  harness.onboardingRenders = [];
+  const pending = [];
+  const windowRef = {
+    setTimeout(callback) {
+      pending.push(callback);
+      return pending.length;
+    },
+  };
+  // Deterministic time: the poll is a chained setTimeout, so the test advances
+  // it one link at a time and lets the async chain behind each link settle.
+  harness.runScheduledPoll = async () => {
+    const callback = pending.shift();
+    assert.ok(callback, "a recovery poll was scheduled");
+    callback();
+    for (let turn = 0; turn < 5; turn += 1) {
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    }
+  };
+  harness.pollsPending = () => pending.length;
+
+  const localClient = {
+    async health() {
+      harness.healthReads += 1;
+      const answer = harness.healthAnswers.shift() ?? null;
+      if (answer === null) throw new Error("the companion did not answer");
+      return answer;
+    },
+    async onboarding() {
+      harness.onboardingReads += 1;
+      // The real client never rejects: a failed read normalizes to exactly the
+      // shape a companion with no readable Codex home reports.
+      return harness.onboardingAnswers.shift() ?? { state: "unavailable" };
+    },
+  };
+
+  // The approve ceremony ships hidden in the markup, so this is the state the
+  // reader is in before anything renders.
+  harness.consentSurface = { hidden: true };
+  harness.journeyKeys = [];
+
+  return Function(
+    "harness", "window", "localClient", "renderHostedIdentity", "fetch",
+    "normalizeIncrementalContributionSyncStatus", "boundedOutcomeDetailCode",
+    `let localCompanionHealth = harness.health;
+let localOnboarding = harness.onboarding;
+let incrementalSyncPollTimer = null;
+let incrementalSyncPollCount = 0;
+let incrementalSyncStatus = null;
+let incrementalConsentApproved = false;
+let incrementalSyncLastOutcomeDetailCode = null;
+function renderLocalOnboarding(value) {
+  localOnboarding = value;
+  harness.onboardingRenders.push(value?.state ?? null);
+}
+function $() { return harness.consentSurface; }
+function communityUploadAuthorityEvidence() { return false; }
+function incrementalUploadAuthorityLost() { return false; }
+function hostedEnrollmentIsPaused() { return false; }
+function hostedSignInRequired() { return harness.signInRequired === true; }
+function renderIncrementalConsentVisibility() {
+${consentVisibility}
+}
+function renderCommunityJourneyStage() {
+  const stage = (name, state, key) => { harness.journeyKeys.push(key); };
+${journeyChain}
+}
+// The real pair, in the real order: the ceremony's own visibility rule and the
+// journey's own stage chain.
+function renderContributionActionState() {
+  harness.actionRenders += 1;
+  if (harness.failNextRender) {
+    harness.failNextRender = false;
+    throw new Error("a render fault");
+  }
+  renderIncrementalConsentVisibility();
+  renderCommunityJourneyStage();
+}
+${section}
+return {
+  loadIncrementalSyncStatus,
+  scheduleIncrementalSyncStatusPoll,
+  incrementalSyncPollWorthwhile,
+  incrementalSyncCapabilityAdvertised,
+  incrementalSyncCapabilitySettled,
+  localCompanionHealthUnknown,
+  localCompanionRecoveryActive,
+  localOnboardingUnsettled,
+  exhaustRecoveryBudget() { incrementalSyncPollCount = INCREMENTAL_SYNC_POLL_LIMIT; },
+  state: () => ({
+    health: localCompanionHealth,
+    onboardingState: localOnboarding?.state ?? null,
+    pollScheduled: incrementalSyncPollTimer !== null,
+    pollCount: incrementalSyncPollCount,
+    // What the reader can see: is the approve ceremony in the document, and
+    // which sentence does journey step 2 currently print?
+    ceremonyVisible: harness.consentSurface.hidden === false,
+    journeyKey: harness.journeyKeys.at(-1) ?? null,
+  }),
+};`,
+  )(
+    harness,
+    windowRef,
+    localClient,
+    () => { harness.identityRenders += 1; },
+    async () => ({ ok: true, json: async () => ({}) }),
+    () => harness.normalizedStatus ?? null,
+    () => null,
+  );
+}
+
+test("the ceremony and the journey heal themselves from a health read that never landed", async () => {
+  const harness = {
+    // The launch-blocker state exactly: the FIRST read, at app launch against a
+    // companion busy building its first index, did not land at all.
+    health: null,
+    onboarding: { state: "ready" },
+    // The companion stays too busy to answer for one more read, then answers
+    // mid-index, then answers carrying the transport.
+    healthAnswers: [null, INDEXING_HEALTH, ADVERTISED_HEALTH],
+    onboardingAnswers: [],
+    normalizedStatus: {
+      status: "available",
+      paused: false,
+      running: false,
+      progress: null,
+      consent: { approved: false, current: false },
+    },
+  };
+  const scope = await loadCompanionHealthRecovery(harness);
+  assert.equal(scope.localCompanionHealthUnknown(), true);
+  assert.equal(scope.state().ceremonyVisible, false, "the markup ships it hidden");
+
+  // The bootstrap's own consent read is the entry point, and it is reached on
+  // both dashboard paths. It used to return at the capability gate WITHOUT
+  // re-reading and WITHOUT scheduling anything — the health-derived capability
+  // gated its own cure, so null health disabled recovery permanently.
+  await scope.loadIncrementalSyncStatus();
+  assert.equal(harness.healthReads, 1, "unknown health is re-read, not assumed absent");
+  assert.equal(
+    scope.incrementalSyncCapabilitySettled(),
+    false,
+    "a false the unified index has not settled yet is neither an advertisement nor an absence",
+  );
+  // The degraded first paint, stated honestly rather than blamed on the index.
+  assert.equal(scope.state().ceremonyVisible, false);
+  assert.equal(scope.state().journeyKey, "journey.community.waitingHealth");
+  assert.equal(scope.state().pollScheduled, true, "and the recovery poll is alive in this state");
+
+  // From here on NOTHING but the clock runs: no reload, no navigation, no click,
+  // no second loadLocalDashboard. Only the chained poll fires.
+  await harness.runScheduledPoll();
+  // The companion is heard for the first time, still mid-index. NOW the index
+  // is honestly what the reader is waiting on, and only now may the line say so.
+  assert.equal(scope.state().journeyKey, "journey.community.waitingIndex");
+  assert.equal(scope.state().ceremonyVisible, false);
+  assert.equal(scope.state().pollScheduled, true);
+
+  await harness.runScheduledPoll();
+
+  assert.equal(harness.healthReads, 3);
+  assert.equal(
+    scope.state().ceremonyVisible,
+    true,
+    "the approve ceremony enters the document by itself",
+  );
+  assert.equal(
+    scope.state().journeyKey,
+    "journey.community.approveNext",
+    "and step 2 points at the action that is now really available",
+  );
+  // The whole sequence in order: unheard companion, heard companion mid-index,
+  // approve. The index is never blamed while the companion was the unknown.
+  assert.equal(harness.journeyKeys[0], "journey.community.waitingHealth");
+  assert.equal(
+    harness.journeyKeys.indexOf("journey.community.waitingHealth")
+      < harness.journeyKeys.indexOf("journey.community.waitingIndex"),
+    true,
+  );
+  assert.equal(
+    harness.identityRenders,
+    2,
+    "the sign-in controls are re-rendered on both changes rather than left disabled",
+  );
+  // Recovery is over, so the cycle stops rather than polling an idle page, and
+  // the reads it spent waiting do not come out of the live-progress budget.
+  assert.equal(scope.state().pollCount, 0);
+  assert.equal(scope.state().pollScheduled, false);
+  assert.equal(harness.pollsPending(), 0);
+});
+
+test("the recovery poll is not gated on the capability it is recovering", async () => {
+  // The self-deadlock guard, stated as its own claim: with health unknown and
+  // the ceremony hidden, the poll that performs the re-read must still be
+  // worthwhile — otherwise the cure is disabled by the disease.
+  const harness = {
+    health: null,
+    onboarding: { state: "ready" },
+    healthAnswers: [],
+    onboardingAnswers: [],
+  };
+  const scope = await loadCompanionHealthRecovery(harness);
+  assert.equal(scope.incrementalSyncCapabilityAdvertised(), false);
+  assert.equal(
+    scope.incrementalSyncPollWorthwhile(),
+    true,
+    "an unsettled companion read is itself movement worth polling for",
+  );
+  // Approval is the other half of the old gate, and an unrecovered page can
+  // never have it: the poll must not require it either.
+  scope.scheduleIncrementalSyncStatusPoll();
+  assert.equal(scope.state().pollScheduled, true);
+
+  // The entry point the harness cannot reach: whichever way the dashboard load
+  // ends, it must start the chain, because a fresh install with an unheard
+  // companion takes the failing path and has no other way in.
+  const appSource = await readFile(new URL("../public/app.js", import.meta.url), "utf8");
+  const loadLocalDashboard = appSource.slice(
+    appSource.indexOf("async function loadLocalDashboard() {"),
+    appSource.indexOf("\n// The \"preparation identity\" Keychain notice"),
+  );
+  assert.ok(loadLocalDashboard.length > 0, "the dashboard load is available");
+  assert.equal(
+    loadLocalDashboard.match(/await loadIncrementalSyncStatus\(\);/gu)?.length,
+    2,
+    "both the loaded and the companion-unavailable paths start the recovery chain",
+  );
+  // And the gate that returns early must schedule before it does, or the first
+  // pass is the last one.
+  assert.match(
+    appSource,
+    /if \(!incrementalSyncCapabilityAdvertised\(\)\) \{[\s\S]{0,600}?scheduleIncrementalSyncStatusPoll\(\);\s*\n\s*return;/u,
+  );
+});
+
+test("a poll link that throws re-arms the chain instead of stranding the page", async () => {
+  const harness = {
+    health: null,
+    onboarding: { state: "ready" },
+    healthAnswers: [null, null, ADVERTISED_HEALTH],
+    onboardingAnswers: [],
+    normalizedStatus: {
+      status: "available",
+      paused: false,
+      running: false,
+      progress: null,
+      consent: { approved: false, current: false },
+    },
+  };
+  const scope = await loadCompanionHealthRecovery(harness);
+  await scope.loadIncrementalSyncStatus();
+  assert.equal(scope.state().pollScheduled, true);
+
+  // One render fault on the way through — the kind a torn-down node produces.
+  // The chain must survive it, because it is the only thing that will ever
+  // re-read the health this page is stuck without.
+  harness.failNextRender = true;
+  await harness.runScheduledPoll();
+  assert.equal(
+    scope.state().pollScheduled,
+    true,
+    "the chain re-arms rather than dying on one bad link",
+  );
+
+  await harness.runScheduledPoll();
+  assert.equal(scope.state().ceremonyVisible, true, "and the page still heals");
+});
+
+test("health that stays unknown retries quietly and never downgrades an answer that landed", async () => {
+  const harness = {
+    health: null,
+    onboarding: { state: "ready" },
+    // Four consecutive unanswered reads, then the transport.
+    healthAnswers: [null, null, null, ADVERTISED_HEALTH],
+    onboardingAnswers: [],
+    normalizedStatus: {
+      status: "available",
+      paused: false,
+      running: false,
+      progress: null,
+      consent: { approved: false, current: false },
+    },
+  };
+  const scope = await loadCompanionHealthRecovery(harness);
+  await scope.loadIncrementalSyncStatus();
+  await harness.runScheduledPoll();
+  await harness.runScheduledPoll();
+  assert.equal(harness.healthReads, 3);
+  assert.equal(
+    harness.identityRenders,
+    0,
+    "an unknown that stays unknown produces no churn on screen",
+  );
+  assert.equal(harness.actionRenders, 3, "only the unchanged gate state is redrawn");
+  assert.equal(scope.state().pollScheduled, true, "and the page keeps asking");
+
+  await harness.runScheduledPoll();
+  assert.equal(scope.incrementalSyncCapabilityAdvertised(), true);
+
+  // A later transient failure may not un-advertise a transport the companion
+  // confirmed: the recovery only ever replaces an answer with a better one.
+  harness.healthAnswers.push(null);
+  await scope.loadIncrementalSyncStatus();
+  assert.equal(scope.incrementalSyncCapabilityAdvertised(), true);
+  assert.equal(scope.state().health, ADVERTISED_HEALTH);
+});
+
+test("the onboarding verdict latches the analysis button the same way and recovers the same way", async () => {
+  const harness = {
+    // Health is fine here; the read that failed is the one that decides whether
+    // Analyze/Update local usage is clickable at all.
+    health: ADVERTISED_HEALTH,
+    onboarding: { state: "unavailable" },
+    healthAnswers: [],
+    onboardingAnswers: [{ state: "unavailable" }, { state: "ready" }],
+    normalizedStatus: {
+      status: "available",
+      paused: false,
+      running: false,
+      progress: null,
+      consent: { approved: false, current: false },
+    },
+  };
+  const scope = await loadCompanionHealthRecovery(harness);
+  assert.equal(scope.localOnboardingUnsettled(), true);
+
+  await scope.loadIncrementalSyncStatus();
+  assert.equal(harness.healthReads, 0, "a settled health answer is not re-read");
+  assert.equal(harness.onboardingReads, 1);
+  assert.deepEqual(
+    harness.onboardingRenders,
+    [],
+    "an unavailable verdict that repeats is not redrawn",
+  );
+  assert.equal(scope.state().pollScheduled, true);
+
+  await harness.runScheduledPoll();
+  assert.equal(scope.state().onboardingState, "ready");
+  assert.deepEqual(harness.onboardingRenders, ["ready"]);
+  assert.equal(scope.localOnboardingUnsettled(), false);
+});
+
+// ---------------------------------------------------------------------------
+// The step-2 line under an unanswered companion. "Approval opens once the
+// local index is ready" was rendered live on 2026-08-20 with the index already
+// complete: the copy named the one thing that was NOT the blocker, and the
+// reader had no way to tell a build without the v1.0 transport from a health
+// read that never landed.
+// ---------------------------------------------------------------------------
+
+async function communityJourneyStageFor(facts) {
+  const appSource = await readFile(new URL("../public/app.js", import.meta.url), "utf8");
+  const start = appSource.indexOf("  if (localCompanionHealthUnknown()) {");
+  const end = appSource.indexOf(
+    "\n}\n\n// The incremental full-history contribution contract",
+  );
+  assert.ok(start >= 0 && end > start, "the community journey stage chain is available");
+  const chain = appSource.slice(start, end);
+  const staged = [];
+  Function(
+    "facts", "stage",
+    `function localCompanionHealthUnknown() { return facts.healthUnknown; }
+function localCompanionRecoveryActive() { return facts.recoveryActive; }
+function contributionServiceConfigured() { return facts.serviceConfigured; }
+function incrementalSyncCapabilityAdvertised() { return facts.advertised; }
+function communityUploadAuthorityEvidence() { return facts.uploadAuthority === true; }
+function incrementalUploadAuthorityLost() { return false; }
+function hostedEnrollmentIsPaused() { return false; }
+function hostedSignInRequired() { return facts.signInRequired === true; }
+const incrementalConsentApproved = facts.approved === true;
+${chain}`,
+  )(facts, (name, state, key) => staged.push({ name, state, key }));
+  assert.equal(staged.length, 1, "the chain states exactly one community stage");
+  return staged[0];
+}
+
+test("the journey names the unanswered health, never an index that is not the blocker", async () => {
+  const retrying = await communityJourneyStageFor({
+    healthUnknown: true,
+    recoveryActive: true,
+    serviceConfigured: false,
+    advertised: false,
+  });
+  const givenUp = await communityJourneyStageFor({
+    healthUnknown: true,
+    recoveryActive: false,
+    serviceConfigured: false,
+    advertised: false,
+  });
+  // The companion answered, reports a service, and derives the transport flag
+  // from the unified index — the one branch where the index really is what the
+  // reader is waiting on.
+  const indexPending = await communityJourneyStageFor({
+    healthUnknown: false,
+    recoveryActive: true,
+    serviceConfigured: true,
+    advertised: false,
+  });
+
+  assert.equal(retrying.key, "journey.community.waitingHealth");
+  assert.equal(givenUp.key, "journey.community.noHealthAnswer");
+  assert.equal(indexPending.key, "journey.community.waitingIndex");
+  assert.equal(
+    new Set([retrying.key, givenUp.key, indexPending.key]).size,
+    3,
+    "unknown health, a spent retry budget, and a pending index are three states",
+  );
+  for (const stage of [retrying, givenUp, indexPending]) {
+    assert.equal(stage.state, "waiting");
+  }
+
+  // The word for "index" in each shipped language: the unknown-health lines may
+  // never contain it, and each must read differently from the index line.
+  const indexWord = { "en-US": /index/iu, "zh-Hans": /索引/u, es: /índice/iu };
+  for (const locale of SUPPORTED_LOCALES) {
+    const indexCopy = translate(indexPending.key, {}, locale);
+    assert.match(indexCopy, indexWord[locale], `${locale} index copy names the index`);
+    for (const key of [retrying.key, givenUp.key]) {
+      const copy = translate(key, {}, locale);
+      assert.ok(copy.length > 0 && copy.length <= 90, `${locale} ${key} stays short: ${copy}`);
+      assert.notEqual(copy, indexCopy, `${locale} ${key} is not the index sentence`);
+      assert.doesNotMatch(
+        copy,
+        indexWord[locale],
+        `${locale} ${key} must not blame the index`,
+      );
+    }
+    // Only the line backed by a budgeted retry may promise one.
+    assert.notEqual(
+      translate(retrying.key, {}, locale),
+      translate(givenUp.key, {}, locale),
+      `${locale} distinguishes a retry that is coming from one that is not`,
+    );
+  }
+
+  // The retired line claimed the Mac app itself was missing, on a page the Mac
+  // app is serving.
+  const appSource = await readFile(new URL("../public/app.js", import.meta.url), "utf8");
+  const localizationSource = await readFile(
+    new URL("../public/localization.js", import.meta.url),
+    "utf8",
+  );
+  assert.doesNotMatch(appSource, /journey\.community\.waitingCompanion/u);
+  assert.doesNotMatch(localizationSource, /journey\.community\.waitingCompanion/u);
 });


### PR DESCRIPTION
Reproduced live on a fresh macOS account (dogfood 1019): step 1 showed the index DONE while step 2 said "Approval opens once the local index is ready", the entire approve/contribution ceremony was hidden, and only a manual dashboard reload cured it. A user has no way to know that.

Root cause is broader than a failed fetch. The dashboard reads companion health exactly once at bootstrap, and there are two ways that single read goes wrong: it never lands (health stays null), or — the one that produced this screen — it lands and is truthfully wrong, because the companion computes the capability per request from a live lstat (apps/local/server.js:3638) and answers incrementalContributionSync:false while first-run indexing is still in progress. Correct at that instant, stale minutes later. Worse, the cure was unreachable from the disease: the only loop that re-reads the companion was gated on exactly the capability it needed to clear, and its scheduling link died silently on a throw.

Fixes: the capability now resolves to three answers (unknown / advertised / finally-absent, the last only where the companion reports no contribution service at all — a value fixed at companion start, so indexing can never change it); the poll tests the unsettled read before any capability or approval gate, so it cannot self-deadlock; the scheduler re-arms on a throwing link; re-reads render only on change and a failed re-read never overwrites an answer that landed. Journey copy distinguishes unknown health from absent capability, and no longer blames the index when the index is not the blocker (trilingual).

The same latch is fixed for onboarding, whose client-side catch returned a shape indistinguishable from a genuinely missing Codex home and disabled the refresh button with nothing left to press. fastModePreference and refreshStatus were checked and are benign (neither gates anything).

Verified by a live A/B in a real browser against a scripted companion that refuses, then answers mid-index, then advertises — single page load, no clicks or reloads: pre-fix the ceremony stays hidden forever, post-fix it appears on its own, with navigation entry count 1 throughout. Six regression tests assert user-visible outcomes (surface visibility, staged copy keys) rather than fetch counts, including that the poll is not gated on what it recovers and that unknown-health copy never mentions the index in any locale.

product:ui:test 323/323, i18n and architecture checks green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)