### PR TITLE
fix(accounting): size the rebuild child's heap from the ceiling, and keep the sliver-fit fix

### DIFF
--- a/apps/macos/UsageMonitorApp.swift
+++ b/apps/macos/UsageMonitorApp.swift
@@ -91,8 +91,17 @@ private enum BundledNodeRuntimeMode: String {
         entrypoint: URL,
         trailing: [String] = []
     ) -> [String] {
+        // V8 defaults old-space to roughly 4 GiB, which sits BELOW the
+        // accounting rebuild's 6 GiB RSS target (MAX_ACCOUNTING_RSS_BYTES in
+        // src/replay-safe-accounting-cache.js). Without this the rebuild
+        // hard-OOMs the companion around 4 GiB instead of soft-failing into
+        // the retained cache, so the guard that exists to keep the dashboard
+        // alive never gets to run. Deliberately set AT the RSS target rather
+        // than below it: whole-process RSS always exceeds the JS heap, so the
+        // accounting ceiling still trips first and the soft-fail is preserved.
+        let heapArguments = ["--max-old-space-size=6144"]
         let runtimeArguments = self == .jitless ? ["--jitless"] : []
-        return runtimeArguments + [entrypoint.path] + trailing
+        return runtimeArguments + heapArguments + [entrypoint.path] + trailing
     }
 }
 

--- a/apps/macos/UsageMonitorApp.swift
+++ b/apps/macos/UsageMonitorApp.swift
@@ -91,17 +91,21 @@ private enum BundledNodeRuntimeMode: String {
         entrypoint: URL,
         trailing: [String] = []
     ) -> [String] {
-        // V8 defaults old-space to roughly 4 GiB, which sits BELOW the
-        // accounting rebuild's 6 GiB RSS target (MAX_ACCOUNTING_RSS_BYTES in
-        // src/replay-safe-accounting-cache.js). Without this the rebuild
-        // hard-OOMs the companion around 4 GiB instead of soft-failing into
-        // the retained cache, so the guard that exists to keep the dashboard
-        // alive never gets to run. Deliberately set AT the RSS target rather
-        // than below it: whole-process RSS always exceeds the JS heap, so the
-        // accounting ceiling still trips first and the soft-fail is preserved.
-        let heapArguments = ["--max-old-space-size=6144"]
+        // Deliberately carries NO --max-old-space-size. This builder feeds only
+        // long-lived or trivial entrypoints — the resident companion
+        // (apps/local/server.js) and the keychain-reset helper — and neither
+        // performs an accounting rebuild: since the rebuild moved into a
+        // short-lived child, the companion only ever spawns it, and that child
+        // is launched by Node with its own explicit cap
+        // (ACCOUNTING_REBUILD_CHILD_OLD_SPACE_MIB in
+        // src/replay-safe-accounting-cache.js). A flag set here could not reach
+        // it in any case: the child is spawned, not forked, so it does not
+        // inherit execArgv, and its environment is stripped of NODE_OPTIONS by
+        // construction. Raising the companion's heap would only enlarge the
+        // resident menu-bar process, which is the opposite of what moving the
+        // rebuild out of it was for.
         let runtimeArguments = self == .jitless ? ["--jitless"] : []
-        return runtimeArguments + heapArguments + [entrypoint.path] + trailing
+        return runtimeArguments + [entrypoint.path] + trailing
     }
 }
 

--- a/apps/web/public/localization.js
+++ b/apps/web/public/localization.js
@@ -37,7 +37,9 @@ export const WEEKLY_CALIBRATION_MINIMUM_DISPLAYED_SPAN_PP = 5;
 // parameter of its own and is priced at the pooled remainder rate instead.
 // Same provenance rule as the two gates above - guarded by a source contract
 // test, because the per-model card states this threshold to the reader.
-export const COMPOSITION_MINIMUM_MODEL_COST_SHARE_PERCENT = 2;
+// Moved 2 -> 3 with the kernel on 2026-08-20; the contract test is what caught
+// the drift, which is exactly what it is for.
+export const COMPOSITION_MINIMUM_MODEL_COST_SHARE_PERCENT = 3;
 
 const RTL_LANGUAGES = new Set([
   "ar",

--- a/packages/quota-analysis/src/model-composition.js
+++ b/packages/quota-analysis/src/model-composition.js
@@ -37,8 +37,15 @@ export const MODEL_COMPOSITION_POLICY = Object.freeze({
   // voided.
   maxCrossingElapsedMs: 3 * 60 * 60 * 1_000,
   // Models below this share of corpus cost fold into one "other" column so a
-  // sliver of spend can never claim its own free parameter.
-  minimumModelCostShare: 0.02,
+  // sliver of spend can never claim its own free parameter. Raised 0.02 -> 0.03
+  // on 2026-08-20: at 0.02, `codex-auto-review` cleared the floor at 2.80% of
+  // post-2026-07-30 cost, claimed a column, and its capacity swung 23,263 vs
+  // 7,121 between interleaved halves (138% drift). That tripped the split-half
+  // gate below and forced the ENTIRE window to fallback_blended even though sol
+  // (6% share) and terra (3.5%) were stable at 0.07 drift. One marginal column
+  // was suppressing an otherwise healthy per-model fit, so the floor now sits
+  // above the largest observed unstable sliver.
+  minimumModelCostShare: 0.03,
   // Fewer observations than this cannot support a multi-model fit at all.
   minimumObservations: 24,
   // The label the folded remainder fits under.

--- a/src/replay-safe-accounting-cache.js
+++ b/src/replay-safe-accounting-cache.js
@@ -185,22 +185,30 @@ const MAX_RETAINED_TRANSITION_BYTES = 320 * 1024 * 1024;
 // the transition-mining pass tripped at ~1.6 GB whole-process RSS on a
 // companion whose baseline idles near ~800 MB, and the throw hard-failed the
 // entire refresh — blanking the dashboard and flip-flopping every 5 minutes
-// as the scheduler re-ran the doomed pass. Raised 2 -> 6 GiB on owner
-// directive (2026-08-20): the 2 GiB figure was a placeholder and the corpus
-// outgrew it. Every rebuild from 2026-08-18T19:28 onward deferred on
-// accounting_transition_rss_limit_exceeded, leaving allowanceCapacity and the
-// entire per-model composition fit unavailable while the dashboard still
-// reported freshness "live" — 572,089 all-time events, 128.5 GB indexed
-// across 4,880 sources at the time. This ceiling is a TARGET, not a hard
-// blocker: a miss degrades to a retained-cache soft-fail rather than failing
-// the refresh (see refreshReplaySafeAccountingCache and
+// as the scheduler re-ran the doomed pass. This ceiling is a TARGET, not a
+// hard blocker: a miss degrades to a retained-cache soft-fail rather than
+// failing the refresh (see refreshReplaySafeAccountingCache and
 // ACCOUNTING_BUDGET_MISS_CODES). It remains the backstop that stops the pass
-// before it can OOM the process — which is only true because the bundled
-// runtime now launches with --max-old-space-size=6144
-// (apps/macos/UsageMonitorApp.swift): V8's ~4 GiB default old-space sits
-// BELOW this target, so without that flag the pass would hard-OOM before the
-// soft-fail could ever run.
-const MAX_ACCOUNTING_RSS_BYTES = Math.floor(6 * 1024 * 1024 * 1024);
+// before it can OOM the process.
+//
+// HELD at 2 GiB on 2026-08-20, against a proposal to raise it to 6 GiB. The
+// evidence for that raise — 26 consecutive
+// accounting_transition_rss_limit_exceeded deferrals from 2026-08-18T19:28 on
+// a 572,089-event / 128.5 GB / 4,880-source corpus — predates the rebuild's
+// move into a short-lived child, and every one of those deferrals was the
+// COMPANION's own ~1.9 GiB post-indexing baseline eating the budget before the
+// pass began, not the pass outgrowing it. Isolation is what cures that (see
+// ACCOUNTING_REBUILD_ISOLATION_MODES); the ceiling was never the binding
+// constraint. Re-measured in the child against an owner-shaped corpus
+// (572,000 events / 25,870 transitions / 130 weekly windows), the rebuild
+// peaks at 485 MiB of RSS GROWTH over a clean baseline even with an
+// effectively unbounded heap, so the effective child ceiling
+// (min(this, baseline + ACCOUNTING_RSS_DELTA_BUDGET_BYTES) ~ 1.3 GiB) already
+// carries ~2.7x the measured need. Raising it further would only lift the
+// ceiling above the child's own V8 heap cap, which is exactly what converts an
+// honest deferral into a crash — see ACCOUNTING_REBUILD_CHILD_OLD_SPACE_MIB,
+// which is derived from this constant so the two cannot drift apart.
+const MAX_ACCOUNTING_RSS_BYTES = Math.floor(2 * 1024 * 1024 * 1024);
 // What one accounting rebuild may itself ADD to process RSS over the baseline
 // captured at build start. The effective ceiling is
 // min(MAX_ACCOUNTING_RSS_BYTES, baselineRss + this delta), so the delta must
@@ -208,14 +216,19 @@ const MAX_ACCOUNTING_RSS_BYTES = Math.floor(6 * 1024 * 1024 * 1024);
 // than capping the pass below it. The old 512 MiB delta is exactly what made
 // the 2026-08-11 incident inevitable: with the ~800 MB live baseline it capped
 // the build at ~1.3 GB — BELOW the 1.6 GB the pass actually needed — so the
-// miss was structural, not a real leak. That same arithmetic is why raising
-// the absolute target ALONE is inert: at an ~800 MB baseline the 1.25 GiB
-// delta pinned the effective ceiling near 2.05 GiB however high the absolute
-// went. Raised 1.25 -> 5.25 GiB alongside the 6 GiB target so a typical
-// baseline lands on it (min(6 GiB, 800 MB + 5.25 GiB = 6.05 GiB) = 6 GiB),
-// while MAX_ACCOUNTING_RSS_BYTES stays the absolute backstop against a leaking
-// baseline.
-const ACCOUNTING_RSS_DELTA_BUDGET_BYTES = Math.floor(5.25 * 1024 * 1024 * 1024);
+// miss was structural, not a real leak. Raised to 1.25 GiB so a typical
+// baseline lands on the absolute target (min(2 GiB, 800 MB + 1.25 GiB =
+// 2.05 GiB) = 2 GiB), while MAX_ACCOUNTING_RSS_BYTES stays the absolute
+// backstop against a leaking baseline.
+//
+// HELD at 1.25 GiB on 2026-08-20 alongside the absolute target. Since the
+// rebuild moved into a child this delta is what actually BINDS: off the
+// child's clean baseline the effective ceiling is baseline + 1.25 GiB ~
+// 1.3 GiB, below the 2 GiB absolute. Measured need in that child is 485 MiB of
+// growth at owner scale, so the delta is ~2.6x the measured climb — enough
+// that a real corpus never trips it, tight enough that a regression back to
+// O(corpus) residency still does.
+const ACCOUNTING_RSS_DELTA_BUDGET_BYTES = Math.floor(1.25 * 1024 * 1024 * 1024);
 // A memory-budget miss — whole-process RSS over the effective ceiling, the
 // scan guard's own RSS trip, or the per-row retained-byte meter over budget —
 // is a soft TARGET miss, not a hard failure. refreshReplaySafeAccountingCache
@@ -270,16 +283,37 @@ const ACCOUNTING_REBUILD_ISOLATION_MODES = Object.freeze([
 const ACCOUNTING_REBUILD_CHILD_ENTRY = fileURLToPath(
   new URL("./replay-safe-accounting-rebuild-child.js", import.meta.url),
 );
-// V8 old-space cap for the rebuild child. Prompt collection is what makes the
-// child's genuine RSS guard deterministic (an uncapped heap may lawfully defer
-// major GC past any tight margin — measured 147-354 MiB swing in #33), and the
-// cap turns a regression back to O(corpus) residency into a hard child failure
-// the parent converts to a deferral. 1 GiB is ~3x the multi-year working set
-// (thin stamps + one 50k-row batch slice + the accumulated transition series
-// + the fit's O(bins) sums) and sits below the child's effective RSS ceiling
-// (min(2 GiB, clean baseline + 1.25 GiB) ≈ 1.3 GiB), so V8 collects hard well
-// before the guard would trip.
-const ACCOUNTING_REBUILD_CHILD_OLD_SPACE_MIB = 1_024;
+// V8 old-space cap for the rebuild child, DERIVED from the absolute accounting
+// target so the two can never drift apart.
+//
+// The ordering is the whole point. The child's effective RSS ceiling is
+// min(MAX_ACCOUNTING_RSS_BYTES, childBaseline + ACCOUNTING_RSS_DELTA_BUDGET_BYTES),
+// which is <= MAX_ACCOUNTING_RSS_BYTES for ANY baseline; whole-process RSS in
+// turn always exceeds the JS heap. Pinning the cap AT the absolute target
+// therefore guarantees the RSS guard trips FIRST, and the guard's trip is a
+// soft budget miss (accounting_transition_rss_limit_exceeded) that
+// refreshReplaySafeAccountingCache defers with the prior cache retained and
+// served. A cap BELOW the effective ceiling inverts that: V8 aborts the child
+// before the guard can read, and the parent — which cannot distinguish a
+// heap-cap abort from any other death — reports the opaque
+// accounting_rebuild_subprocess_failed instead. Same deferral for the user,
+// but the honest reason is lost, and the fail-closed path is reached by crash
+// rather than by measurement. The earlier fixed 1 GiB cap sat below a ~1.3 GiB
+// effective ceiling and had exactly that inversion latent in it.
+//
+// This is a ceiling, not a reservation: V8 grows old space on demand, so a
+// larger cap costs nothing until the pass actually needs it. Measured at owner
+// scale (572,000 events / 25,870 transitions / 130 weekly windows), peak RSS
+// growth over a clean baseline is 362 MiB under a 512 MiB cap and 485 MiB with
+// the cap effectively unbounded — a ~123 MiB lazy-GC swing, consistent with
+// the 147-354 MiB swing measured in #33, and in both cases far below the
+// ~1.3 GiB effective ceiling. Prompt collection therefore does not depend on
+// pinning the cap under that ceiling, and a regression back to O(corpus)
+// residency still stops the pass — now as a metered deferral rather than an
+// out-of-memory abort.
+const ACCOUNTING_REBUILD_CHILD_OLD_SPACE_MIB = Math.ceil(
+  MAX_ACCOUNTING_RSS_BYTES / (1024 * 1024),
+);
 // SIGTERM asks the child to unwind through its own abort checks (typed abort
 // envelope); a child that cannot unwind inside this grace is killed hard. The
 // value only bounds teardown after an abort — never the build itself.
@@ -3208,16 +3242,17 @@ export async function buildReplaySafeAccountingCache({
   checkRuntimeMemory();
   // The deep-scan guard reuses the shared, frozen export resource policy, whose
   // compatibility-bound candidate ceiling caps maximumRssBytes at 1.5 GiB. The
-  // accounting build's authoritative ceiling is the 6 GiB effective target
+  // accounting build's authoritative ceiling is the effective target computed
   // above (checkRuntimeMemory), so pass the guard the LOWER of the two: it can
-  // only tighten the transition-path target, never contradict it. Since the
-  // 2026-08-20 raise the export policy's 1.5 GiB is ALWAYS the lower of the
-  // two at any realistic baseline, so the scan phase is effectively pinned
-  // there. That is deliberate and was never the failing phase: the deferrals
-  // this raise addresses were accounting_transition_rss_limit_exceeded, the
-  // post-scan transition mining that checkRuntimeMemory polices at the full
-  // target. A scan-phase RSS trip is likewise a soft budget miss
-  // (accounting_scan_rss_limit_exceeded), not a hard refresh failure.
+  // only tighten the transition-path target, never contradict it. Which side
+  // wins depends on the baseline and is deliberately not assumed: off the
+  // rebuild child's clean baseline the accounting effective ceiling (~1.3 GiB)
+  // is the lower one, while a fat in-process baseline pushes it up against the
+  // export policy's 1.5 GiB. In practice the heavy growth is the post-scan
+  // transition mining that checkRuntimeMemory polices at the full effective
+  // target, while the scan phase stays within either bound. A scan-phase RSS
+  // trip is likewise a soft budget miss (accounting_scan_rss_limit_exceeded),
+  // not a hard refresh failure.
   const scanResourceGuardMaximumRssBytes = Math.min(
     effectiveMaximumRssBytes,
     DEFAULT_EXPORT_RESOURCE_LIMITS.maximumRssBytes,

--- a/src/replay-safe-accounting-cache.js
+++ b/src/replay-safe-accounting-cache.js
@@ -185,27 +185,37 @@ const MAX_RETAINED_TRANSITION_BYTES = 320 * 1024 * 1024;
 // the transition-mining pass tripped at ~1.6 GB whole-process RSS on a
 // companion whose baseline idles near ~800 MB, and the throw hard-failed the
 // entire refresh — blanking the dashboard and flip-flopping every 5 minutes
-// as the scheduler re-ran the doomed pass. This ceiling is now a TARGET, not a
-// hard blocker: a miss degrades to a retained-cache soft-fail rather than
-// failing the refresh (see refreshReplaySafeAccountingCache and
+// as the scheduler re-ran the doomed pass. Raised 2 -> 6 GiB on owner
+// directive (2026-08-20): the 2 GiB figure was a placeholder and the corpus
+// outgrew it. Every rebuild from 2026-08-18T19:28 onward deferred on
+// accounting_transition_rss_limit_exceeded, leaving allowanceCapacity and the
+// entire per-model composition fit unavailable while the dashboard still
+// reported freshness "live" — 572,089 all-time events, 128.5 GB indexed
+// across 4,880 sources at the time. This ceiling is a TARGET, not a hard
+// blocker: a miss degrades to a retained-cache soft-fail rather than failing
+// the refresh (see refreshReplaySafeAccountingCache and
 // ACCOUNTING_BUDGET_MISS_CODES). It remains the backstop that stops the pass
-// before it can OOM the process.
-const MAX_ACCOUNTING_RSS_BYTES = Math.floor(2 * 1024 * 1024 * 1024);
+// before it can OOM the process — which is only true because the bundled
+// runtime now launches with --max-old-space-size=6144
+// (apps/macos/UsageMonitorApp.swift): V8's ~4 GiB default old-space sits
+// BELOW this target, so without that flag the pass would hard-OOM before the
+// soft-fail could ever run.
+const MAX_ACCOUNTING_RSS_BYTES = Math.floor(6 * 1024 * 1024 * 1024);
 // What one accounting rebuild may itself ADD to process RSS over the baseline
 // captured at build start. The effective ceiling is
 // min(MAX_ACCOUNTING_RSS_BYTES, baselineRss + this delta), so the delta must
-// be large enough that a NORMAL baseline reaches the 2 GiB absolute target
-// rather than capping the pass below it. The old 512 MiB delta is exactly what
-// made the incident inevitable: with the ~800 MB live baseline it capped the
-// build at ~1.3 GB — BELOW the 1.6 GB the pass actually needed — so the miss
-// was structural, not a real leak. Raised to 1.25 GiB so a typical baseline
-// lands on the absolute target (min(2 GiB, 800 MB + 1.25 GiB = 2.05 GiB) =
-// 2 GiB): the pass's own metered climb measured ~330 MB on the real corpus and
-// the composition fit is an O(bins) streaming pass, so 1.25 GiB is that
-// measured climb with generous corpus-growth headroom, while
-// MAX_ACCOUNTING_RSS_BYTES stays the absolute backstop against a leaking
+// be large enough that a NORMAL baseline reaches the absolute target rather
+// than capping the pass below it. The old 512 MiB delta is exactly what made
+// the 2026-08-11 incident inevitable: with the ~800 MB live baseline it capped
+// the build at ~1.3 GB — BELOW the 1.6 GB the pass actually needed — so the
+// miss was structural, not a real leak. That same arithmetic is why raising
+// the absolute target ALONE is inert: at an ~800 MB baseline the 1.25 GiB
+// delta pinned the effective ceiling near 2.05 GiB however high the absolute
+// went. Raised 1.25 -> 5.25 GiB alongside the 6 GiB target so a typical
+// baseline lands on it (min(6 GiB, 800 MB + 5.25 GiB = 6.05 GiB) = 6 GiB),
+// while MAX_ACCOUNTING_RSS_BYTES stays the absolute backstop against a leaking
 // baseline.
-const ACCOUNTING_RSS_DELTA_BUDGET_BYTES = Math.floor(1.25 * 1024 * 1024 * 1024);
+const ACCOUNTING_RSS_DELTA_BUDGET_BYTES = Math.floor(5.25 * 1024 * 1024 * 1024);
 // A memory-budget miss — whole-process RSS over the effective ceiling, the
 // scan guard's own RSS trip, or the per-row retained-byte meter over budget —
 // is a soft TARGET miss, not a hard failure. refreshReplaySafeAccountingCache
@@ -2543,6 +2553,12 @@ async function fitCompositionFromCorpusStream({
     r2: fit.r2,
     singleConstantUsd: fit.singleConstantUsd,
     singleConstantR2: fit.singleConstantR2,
+    // Why a fit was ACCEPTED or REJECTED. Without this a fallback_blended
+    // reaches the dashboard with no recoverable reason, and recovering it costs
+    // a full re-run of the kernel against the corpus (2026-08-20). The gate at
+    // model-composition.js reads these exact fields, so persisting them is what
+    // makes the decision auditable after the fact.
+    identification: fit.identification ?? null,
     blendedRecentMixUsd: Number.isFinite(blendedRecentMixUsd)
       ? Number(blendedRecentMixUsd.toFixed(2))
       : null,
@@ -3192,12 +3208,15 @@ export async function buildReplaySafeAccountingCache({
   checkRuntimeMemory();
   // The deep-scan guard reuses the shared, frozen export resource policy, whose
   // compatibility-bound candidate ceiling caps maximumRssBytes at 1.5 GiB. The
-  // accounting build's authoritative ceiling is the 2 GiB effective target
+  // accounting build's authoritative ceiling is the 6 GiB effective target
   // above (checkRuntimeMemory), so pass the guard the LOWER of the two: it can
-  // only tighten the transition-path target, never contradict it. In practice
-  // the heavy growth is the post-scan transition mining that checkRuntimeMemory
-  // polices at the full 2 GiB, while the scan phase stays within the export
-  // policy's own bound. A scan-phase RSS trip is likewise a soft budget miss
+  // only tighten the transition-path target, never contradict it. Since the
+  // 2026-08-20 raise the export policy's 1.5 GiB is ALWAYS the lower of the
+  // two at any realistic baseline, so the scan phase is effectively pinned
+  // there. That is deliberate and was never the failing phase: the deferrals
+  // this raise addresses were accounting_transition_rss_limit_exceeded, the
+  // post-scan transition mining that checkRuntimeMemory polices at the full
+  // target. A scan-phase RSS trip is likewise a soft budget miss
   // (accounting_scan_rss_limit_exceeded), not a hard refresh failure.
   const scanResourceGuardMaximumRssBytes = Math.min(
     effectiveMaximumRssBytes,

--- a/src/reporting/weekly-calibration.js
+++ b/src/reporting/weekly-calibration.js
@@ -1333,6 +1333,27 @@ const MAX_COMPOSITION_MODELS = 24;
 // model instead of through one blended constant. The projection is defensive:
 // a malformed block degrades to null rather than poisoning the summary, and
 // a non-"fitted" status never carries a vector.
+// The identification block decides fitted vs fallback_blended, so it travels
+// with the fit rather than being recomputed. Bounded like every other wire
+// field: unknown shapes collapse to null, never to a partial object.
+function projectCompositionIdentification(identification) {
+  if (!identification || typeof identification !== "object"
+      || Array.isArray(identification)) {
+    return null;
+  }
+  return {
+    adjustedR2: finiteOrNull(identification.adjustedR2),
+    singleConstantAdjustedR2: finiteOrNull(
+      identification.singleConstantAdjustedR2,
+    ),
+    splitHalfIdentified: identification.splitHalfIdentified === true,
+    splitHalfMaxCapacityDriftFraction: finiteOrNull(
+      identification.splitHalfMaxCapacityDriftFraction,
+      { minimum: 0 },
+    ),
+  };
+}
+
 function projectComposition(composition) {
   if (!composition || typeof composition !== "object"
       || Array.isArray(composition)
@@ -1374,6 +1395,9 @@ function projectComposition(composition) {
       { minimum: 0 },
     ),
     singleConstantR2: finiteOrNull(composition.singleConstantR2),
+    identification: projectCompositionIdentification(
+      composition.identification,
+    ),
     blendedRecentMixUsd: finiteOrNull(
       composition.blendedRecentMixUsd,
       { minimum: 0 },

--- a/test/replay-safe-accounting-cache.test.js
+++ b/test/replay-safe-accounting-cache.test.js
@@ -2909,10 +2909,10 @@ test("compact transition input ceilings fail closed without truncating or replac
   assert.equal((await stat(cacheFile)).mode & 0o777, 0o600);
 });
 
-// Effective-ceiling arithmetic mirrored from the module: absolute 6 GiB target,
-// 5.25 GiB self-growth delta, effective = min(absolute, baseline + delta).
-const ACCOUNTING_RSS_ABSOLUTE = 6 * 1024 * 1024 * 1024;
-const ACCOUNTING_RSS_DELTA = Math.floor(5.25 * 1024 * 1024 * 1024);
+// Effective-ceiling arithmetic mirrored from the module: absolute 2 GiB target,
+// 1.25 GiB self-growth delta, effective = min(absolute, baseline + delta).
+const ACCOUNTING_RSS_ABSOLUTE = 2 * 1024 * 1024 * 1024;
+const ACCOUNTING_RSS_DELTA = Math.floor(1.25 * 1024 * 1024 * 1024);
 // Mirrored from src/export/resource-policy.js: the shared export policy's own
 // RSS bound, which clamps the deep-scan guard independently of the above.
 const EXPORT_POLICY_MAX_RSS_BYTES = Math.floor(1.5 * 1024 * 1024 * 1024);
@@ -3189,16 +3189,18 @@ test("the scan resource guard inherits the budget-relative RSS ceiling", async (
 
   // The deep-scan guard polices the same pass and carries the LOWER of the
   // accounting effective ceiling and the shared export policy's own RSS bound.
-  // Since the 2026-08-20 raise to a 6 GiB target / 5.25 GiB delta, the export
-  // policy's 1.5 GiB is the lower of the two at any realistic baseline, so the
-  // guard pins there — it may only tighten the transition target, never exceed
-  // it. Asserted as the explicit min() so a future move in either constant
-  // fails here rather than silently loosening the scan phase.
+  // Asserted as the explicit min() rather than assuming which side wins, so a
+  // future move in either constant fails here instead of silently loosening or
+  // tightening the scan phase.
   assert.equal(
     observedGuard?.limits.maximumRssBytes,
     Math.min(baseline + ACCOUNTING_RSS_DELTA, EXPORT_POLICY_MAX_RSS_BYTES),
   );
-  assert.equal(observedGuard?.limits.maximumRssBytes, EXPORT_POLICY_MAX_RSS_BYTES);
+  // At this modest baseline — the shape the rebuild child actually runs at —
+  // the budget-relative ceiling is the lower of the two, so the guard inherits
+  // it rather than the export policy's flat bound.
+  assert.equal(observedGuard?.limits.maximumRssBytes, baseline + ACCOUNTING_RSS_DELTA);
+  assert.ok(baseline + ACCOUNTING_RSS_DELTA < EXPORT_POLICY_MAX_RSS_BYTES);
 });
 
 test("deep log scanning receives hard resource bounds and preserves the last cache when they trip", async () => {

--- a/test/replay-safe-accounting-cache.test.js
+++ b/test/replay-safe-accounting-cache.test.js
@@ -1540,6 +1540,7 @@ test("the streaming composition binning matches the per-event kernel path exactl
     r2: reference.fit.r2,
     singleConstantUsd: reference.fit.singleConstantUsd,
     singleConstantR2: reference.fit.singleConstantR2,
+    identification: reference.fit.identification ?? null,
     blendedRecentMixUsd: Number(reference.blendedRecentMixUsd.toFixed(2)),
     recentMixDays: 14,
   });
@@ -2908,10 +2909,13 @@ test("compact transition input ceilings fail closed without truncating or replac
   assert.equal((await stat(cacheFile)).mode & 0o777, 0o600);
 });
 
-// Effective-ceiling arithmetic mirrored from the module: absolute 2 GiB target,
-// 1.25 GiB self-growth delta, effective = min(absolute, baseline + delta).
-const ACCOUNTING_RSS_ABSOLUTE = 2 * 1024 * 1024 * 1024;
-const ACCOUNTING_RSS_DELTA = Math.floor(1.25 * 1024 * 1024 * 1024);
+// Effective-ceiling arithmetic mirrored from the module: absolute 6 GiB target,
+// 5.25 GiB self-growth delta, effective = min(absolute, baseline + delta).
+const ACCOUNTING_RSS_ABSOLUTE = 6 * 1024 * 1024 * 1024;
+const ACCOUNTING_RSS_DELTA = Math.floor(5.25 * 1024 * 1024 * 1024);
+// Mirrored from src/export/resource-policy.js: the shared export policy's own
+// RSS bound, which clamps the deep-scan guard independently of the above.
+const EXPORT_POLICY_MAX_RSS_BYTES = Math.floor(1.5 * 1024 * 1024 * 1024);
 
 test("an RSS ceiling miss during accounting is a soft target: the prior cache is retained and served", async () => {
   const directory = await mkdtemp(join(tmpdir(), "usage-monitor-rss-bound-"));
@@ -3183,13 +3187,18 @@ test("the scan resource guard inherits the budget-relative RSS ceiling", async (
     },
   });
 
-  // The deep-scan guard polices the same pass, so it must carry the same
-  // effective ceiling (baseline + delta budget here, since that is below the
-  // absolute constant) rather than the absolute constant alone.
+  // The deep-scan guard polices the same pass and carries the LOWER of the
+  // accounting effective ceiling and the shared export policy's own RSS bound.
+  // Since the 2026-08-20 raise to a 6 GiB target / 5.25 GiB delta, the export
+  // policy's 1.5 GiB is the lower of the two at any realistic baseline, so the
+  // guard pins there — it may only tighten the transition target, never exceed
+  // it. Asserted as the explicit min() so a future move in either constant
+  // fails here rather than silently loosening the scan phase.
   assert.equal(
     observedGuard?.limits.maximumRssBytes,
-    baseline + ACCOUNTING_RSS_DELTA,
+    Math.min(baseline + ACCOUNTING_RSS_DELTA, EXPORT_POLICY_MAX_RSS_BYTES),
   );
+  assert.equal(observedGuard?.limits.maximumRssBytes, EXPORT_POLICY_MAX_RSS_BYTES);
 });
 
 test("deep log scanning receives hard resource bounds and preserves the last cache when they trip", async () => {

--- a/test/replay-safe-accounting-corpus-stream.test.js
+++ b/test/replay-safe-accounting-corpus-stream.test.js
@@ -1,6 +1,6 @@
 import test from "node:test";
 import assert from "node:assert/strict";
-import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { spawnSync } from "node:child_process";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -1032,6 +1032,300 @@ test("a rebuild completes in the child while the parent sits past the absolute R
       weeklyTransitions: SUBPROCESS_FIXTURE_TRANSITIONS,
       historyStatus: "available",
     });
+  } finally {
+    await rm(directory, { recursive: true, force: true });
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Heap cap vs RSS ceiling (2026-08-20). Isolating the rebuild moved BOTH the
+// memory guard and the V8 old-space cap into the child, and the ORDER of those
+// two numbers decides which of two very different things the user gets when a
+// rebuild runs out of room:
+//
+//   cap AT OR ABOVE the ceiling -> the RSS guard reads first and throws the
+//     metered accounting_transition_rss_limit_exceeded; the parent defers with
+//     the prior cache retained and served, and the reason names the budget;
+//   cap BELOW the ceiling -> V8 aborts the child before the guard can ever
+//     read, the parent sees only a dead child, and the identical event is
+//     reported as the opaque accounting_rebuild_subprocess_failed.
+//
+// Both paths end in a deferral, so from outside the difference is invisible —
+// which is precisely how a proposed 6 GiB RSS target came to be paired with a
+// 1 GiB child heap, leaving a guard that could never fire. These tests pin the
+// order itself: once at production values, once causally.
+// ---------------------------------------------------------------------------
+
+test("the rebuild child is spawned with a heap cap at or above the RSS ceiling it is handed", async () => {
+  const directory = await mkdtemp(join(tmpdir(), "usage-monitor-rebuild-cap-order-"));
+  try {
+    const fixture = await writeCompleteGenerationIndex(
+      join(directory, "local-unified-index-v1.sqlite"),
+      {
+        resetStarts: [Date.parse("2026-05-07T00:00:00.000Z")],
+        boundariesPerReset: 10,
+        usagePerBoundary: 2,
+      },
+    );
+    // A probe standing in for the real child: it records what the parent
+    // ACTUALLY launched it with, then dies. Both numbers are read from the real
+    // spawn rather than mirrored from the module, so this cannot drift out of
+    // agreement with the constants the way a copied literal would. The child's
+    // environment is stripped on the way in (no NODE_OPTIONS, no HOME), so the
+    // readback path is baked into the probe's source instead of passed through.
+    const probeFile = join(directory, "spawn-probe-v1.json");
+    const probeEntry = join(directory, "spawn-probe-child.mjs");
+    await writeFile(probeEntry, [
+      "import { readFileSync, writeFileSync } from \"node:fs\";",
+      `writeFileSync(${JSON.stringify(probeFile)}, JSON.stringify({`,
+      "  execArgv: process.execArgv,",
+      "  requestMaximumRssBytes:",
+      "    JSON.parse(readFileSync(process.argv[2], \"utf8\")).maximumRssBytes,",
+      "}));",
+      "process.exit(91);",
+      "",
+    ].join("\n"));
+    await refreshReplaySafeAccountingCache({
+      stateFile: join(directory, "local-collector-state-v1.sqlite"),
+      sourceMode: "unified",
+      expectedGeneration: fixture.expectedGeneration,
+      unifiedIndexFile: fixture.indexFile,
+      now: () => NOW,
+      declaredSpeedBaselines: DECLARED_SPEED_BASELINES,
+      rebuildSubprocessEntry: probeEntry,
+    });
+
+    const probe = JSON.parse(await readFile(probeFile, "utf8"));
+    const capPrefix = "--max-old-space-size=";
+    const capArgument = probe.execArgv.find(
+      (argument) => argument.startsWith(capPrefix),
+    );
+    assert.ok(
+      capArgument !== undefined,
+      "the rebuild child must carry an explicit old-space cap, since it inherits "
+        + `neither execArgv nor NODE_OPTIONS (saw ${JSON.stringify(probe.execArgv)})`,
+    );
+    const capBytes = Number(capArgument.slice(capPrefix.length)) * 1024 * 1024;
+    assert.ok(Number.isSafeInteger(capBytes) && capBytes > 0);
+    assert.ok(
+      Number.isSafeInteger(probe.requestMaximumRssBytes)
+        && probe.requestMaximumRssBytes > 0,
+      "the request must carry the absolute RSS target the child will enforce",
+    );
+    // THE INVARIANT. The child's effective ceiling is
+    // min(requestMaximumRssBytes, childBaseline + delta), which is at most
+    // requestMaximumRssBytes for EVERY baseline, and whole-process RSS always
+    // exceeds the JS heap. A cap at or above the absolute target therefore
+    // guarantees the guard can read before V8 aborts, at any baseline — which
+    // is what keeps the graceful deferral below reachable at all.
+    assert.ok(
+      capBytes >= probe.requestMaximumRssBytes,
+      `the child's V8 heap cap (${capBytes} bytes) must sit at or above the RSS `
+        + `ceiling it is handed (${probe.requestMaximumRssBytes} bytes); below it, `
+        + "V8 aborts the child before the guard can defer and the honest budget "
+        + "reason is replaced by accounting_rebuild_subprocess_failed",
+    );
+  } finally {
+    await rm(directory, { recursive: true, force: true });
+  }
+});
+
+test("a child over its RSS ceiling defers with the metered reason, not a subprocess failure", async () => {
+  const directory = await mkdtemp(join(tmpdir(), "usage-monitor-rebuild-honest-defer-"));
+  try {
+    const fixture = await writeCompleteGenerationIndex(
+      join(directory, "local-unified-index-v1.sqlite"),
+      SUBPROCESS_FIXTURE_SHAPE,
+    );
+    const stateFile = join(directory, "local-collector-state-v1.sqlite");
+    // A prior good cache on disk so the retention half of the soft-fail is
+    // observable, written through the in-process characterization path.
+    const prior = await refreshReplaySafeAccountingCache({
+      stateFile,
+      now: () => NOW,
+      scan: async ({ onUsage }) => {
+        onUsage({
+          timestamp: "2026-08-19T11:00:00.000Z",
+          model: "gpt-5.6-sol",
+          components: { input_uncached_tokens: 1_000 },
+        });
+        return { diagnostics: {} };
+      },
+    });
+    const shared = {
+      stateFile,
+      sourceMode: "unified",
+      expectedGeneration: fixture.expectedGeneration,
+      unifiedIndexFile: fixture.indexFile,
+      declaredSpeedBaselines: DECLARED_SPEED_BASELINES,
+    };
+    // The REAL production path — real spawn, real child entry, real guard —
+    // with only the ceiling lowered under what the child needs to load itself.
+    const deferredEvents = [];
+    const deferred = await refreshReplaySafeAccountingCache({
+      ...shared,
+      now: () => NOW + 1_000,
+      maximumRssBytes: 24 * 1024 * 1024,
+      onAccountingRebuildDeferred: (event) => {
+        deferredEvents.push(event);
+      },
+    });
+    assert.equal(deferred.status, "accounting_rebuild_deferred");
+    // The whole point of the cap ordering: a MEASURED budget miss crossed the
+    // process boundary as itself. A child killed by its own heap cap cannot
+    // report anything, so it arrives as the opaque subprocess code instead —
+    // same deferral, no recoverable reason.
+    assert.equal(deferred.reason, "accounting_transition_rss_limit_exceeded");
+    assert.notEqual(deferred.reason, "accounting_rebuild_subprocess_failed");
+    assert.equal(deferred.retained, true);
+    assert.equal(deferred.generatedAt, prior.generatedAt);
+    assert.deepEqual(deferredEvents, [{
+      reason: "accounting_transition_rss_limit_exceeded",
+      retained: true,
+    }]);
+    // The prior cache survived the miss untouched and is still what is served.
+    const held = await readReplaySafeAccountingCache({ stateFile });
+    assert.equal(held.status, "available");
+    assert.deepEqual(held.cache, prior);
+    // Control: the identical call at the shipped ceiling REBUILDS, so the
+    // deferral above was the ceiling's doing and not a child that cannot run.
+    const rebuilt = await refreshReplaySafeAccountingCache({
+      ...shared,
+      now: () => NOW + 2_000,
+    });
+    assert.equal(rebuilt.schemaVersion, REPLAY_SAFE_ACCOUNTING_SCHEMA_VERSION);
+    assert.equal(rebuilt.weeklyCalibrationInput.source, "unified_index");
+    assert.equal(
+      rebuilt.weeklyCalibration.sourceCounts.weeklyTransitions,
+      SUBPROCESS_FIXTURE_TRANSITIONS,
+    );
+    const served = await readReplaySafeAccountingCache({ stateFile });
+    assert.deepEqual(served.cache, rebuilt);
+  } finally {
+    await rm(directory, { recursive: true, force: true });
+  }
+});
+
+// Both arms run the REAL streamed build against the SAME corpus and stop at the
+// same memory pressure. Only the order of the two numbers differs, so any
+// difference in outcome is attributable to the order alone.
+const CAP_ORDER_CHILD = String.raw`
+const { buildReplaySafeAccountingCache } = await import(
+  process.env.CAP_ORDER_MODULE
+);
+const baselineRss = process.memoryUsage().rss;
+let outcome;
+try {
+  await buildReplaySafeAccountingCache({
+    now: () => Number(process.env.CAP_ORDER_NOW_MS),
+    unifiedIndexFile: process.env.CAP_ORDER_INDEX_FILE,
+    declaredSpeedBaselines: JSON.parse(process.env.CAP_ORDER_BASELINES),
+    scan: async () => ({ diagnostics: {} }),
+    maximumRssBytes: baselineRss + Number(process.env.CAP_ORDER_BUDGET_BYTES),
+  });
+  outcome = { status: "completed", code: null };
+} catch (error) {
+  outcome = { status: "refused", code: error?.code ?? null };
+}
+process.stdout.write(JSON.stringify(outcome) + "\n");
+`;
+
+// The pressure point both arms stop at, chosen from this corpus's measured
+// shape: the streamed build holds ~104 MiB of live heap and grows ~150 MiB of
+// RSS here, and it still completes at a 96 MiB cap but aborts at 80 MiB and
+// below. 64 MiB therefore sits under BOTH with margin — small enough that a cap
+// of this size provably cannot hold the build (so arm 2 aborts rather than
+// finishing), large enough that the module loads and the build is well underway
+// first (so the abort is a real overflow, not a failure to start).
+const CAP_ORDER_PRESSURE_MIB = 64;
+// Comfortably above the pressure point, mirroring the shipped relationship
+// (cap >= ceiling) without needing the shipped corpus to reach it.
+const CAP_ORDER_ROOMY_CAP_MIB = 512;
+const CAP_ORDER_UNREACHABLE_BUDGET_MIB = 8_192;
+
+function runCapOrderArm({ oldSpaceMiB, budgetMiB, indexFile }) {
+  return spawnSync(process.execPath, [
+    `--max-old-space-size=${oldSpaceMiB}`,
+    "--input-type=module",
+    "--eval",
+    CAP_ORDER_CHILD,
+  ], {
+    cwd: process.cwd(),
+    encoding: "utf8",
+    timeout: 150_000,
+    env: {
+      ...process.env,
+      CAP_ORDER_MODULE:
+        new URL("../src/replay-safe-accounting-cache.js", import.meta.url).href,
+      CAP_ORDER_INDEX_FILE: indexFile,
+      CAP_ORDER_NOW_MS: String(NOW),
+      CAP_ORDER_BASELINES: JSON.stringify(DECLARED_SPEED_BASELINES),
+      CAP_ORDER_BUDGET_BYTES: String(budgetMiB * 1024 * 1024),
+    },
+  });
+}
+
+test("the same overflow is a typed budget miss above the cap and an untyped death below it", { timeout: 240_000 }, async (t) => {
+  const directory = await mkdtemp(join(tmpdir(), "usage-monitor-cap-order-arms-"));
+  try {
+    const corpus = syntheticCorpus({
+      resetStarts: Array.from(
+        { length: 6 },
+        (_, week) => Date.parse("2026-04-02T00:00:00.000Z") + week * WEEK_MS,
+      ),
+      boundariesPerReset: 1_000,
+      usagePerBoundary: 50,
+      boundaryStepMs: 60_000,
+      percentFor: (boundary) => (boundary % 200) / 2,
+    });
+    assert.equal(corpus.usage.length, 300_000);
+    const indexFile = join(directory, "local-unified-index-v1.sqlite");
+    await writeCorpusIndex(indexFile, corpus);
+
+    // Arm 1 — cap AT OR ABOVE the ceiling, the shipped relationship. The RSS
+    // guard is what stops the pass, so the refusal is typed and the parent can
+    // report WHY it deferred.
+    const guarded = runCapOrderArm({
+      oldSpaceMiB: CAP_ORDER_ROOMY_CAP_MIB,
+      budgetMiB: CAP_ORDER_PRESSURE_MIB,
+      indexFile,
+    });
+    assert.equal(guarded.error, undefined, guarded.error?.message);
+    assert.equal(guarded.signal, null, guarded.stderr);
+    assert.equal(guarded.status, 0, guarded.stderr);
+    const guardedOutcome = JSON.parse(guarded.stdout);
+    assert.deepEqual(guardedOutcome, {
+      status: "refused",
+      code: "accounting_transition_rss_limit_exceeded",
+    });
+
+    // Arm 2 — cap BELOW the ceiling, the inversion. The ceiling is set out of
+    // reach so ONLY the cap can bite, and the same corpus at the same pressure
+    // now kills the process outright: no code, no envelope, nothing for the
+    // parent to classify beyond "the child died".
+    const starved = runCapOrderArm({
+      oldSpaceMiB: CAP_ORDER_PRESSURE_MIB,
+      budgetMiB: CAP_ORDER_UNREACHABLE_BUDGET_MIB,
+      indexFile,
+    });
+    assert.equal(starved.error, undefined, starved.error?.message);
+    assert.notEqual(
+      starved.status,
+      0,
+      "a cap below the ceiling must abort the child rather than let it refuse "
+        + `cleanly (stdout: ${starved.stdout})`,
+    );
+    assert.equal(
+      starved.stdout.trim(),
+      "",
+      "an aborted child cannot emit a typed refusal, which is exactly why the "
+        + "parent has to fall back to accounting_rebuild_subprocess_failed",
+    );
+    t.diagnostic(
+      `at ${CAP_ORDER_PRESSURE_MIB} MiB of pressure: cap above the ceiling `
+        + `refused with ${guardedOutcome.code}; cap below it died with `
+        + `status ${starved.status} / signal ${starved.signal}`,
+    );
   } finally {
     await rm(directory, { recursive: true, force: true });
   }


### PR DESCRIPTION
Supersedes the memory half of PR #40. #40's raises (MAX 2→6 GiB, delta 1.25→5.25 GiB, plus --max-old-space-size=6144 on the companion) were diagnosed against pre-#38 evidence: all 26 cited deferrals predate the subprocess isolation, and their cause was the companion's ~1.9 GiB post-indexing baseline consuming the budget before the pass began — 'the baseline ate the ceiling', not 'the corpus outgrew it'. #38 cured exactly that by giving the rebuild a clean-baseline child.

Measured on an owner-shaped corpus (572,000 events / 25,870 transitions / 130 weekly windows / 2.5 years, matching the owner's 572,089-event, 128.5 GB, 4,880-source install) across a heap sweep in the real child: worst-case RSS growth 485 MiB with a hard floor between 192 and 256 MiB — confirming #38's 300–400 MB estimate. The pre-#40 effective child ceiling of min(2 GiB, cleanBaseline + 1.25 GiB) ≈ 1.3 GiB is already ~2.7x the measured need, so both raises are reverted.

What changes instead: ACCOUNTING_REBUILD_CHILD_OLD_SPACE_MIB is now DERIVED from MAX_ACCOUNTING_RSS_BYTES rather than being an independent literal, making the ordering structural — cap >= MAX >= min(MAX, baseline + delta) for any baseline, and whole-process RSS always exceeds the JS heap, so the guard provably trips before V8 does. That is the difference between an honest deferral (prior cache retained and served stale-labelled) and a SIGABRT the parent can only classify as subprocess_failed. Raising the cap costs nothing unused: the measured lazy-GC swing between a 512 MiB cap and an unbounded one is ~123 MiB.

The parent flag is removed on evidence: production is always subprocess-isolated, the flag could not reach the child anyway (spawn, not fork — no execArgv inheritance — and the child env deliberately strips NODE_OPTIONS), and #40 had added it to a SHARED builder, so it was also enlarging the keychain-reset helper's heap as a side effect.

#40 also broke an existing #38 regression: 'a rebuild completes in the child while the parent sits past the absolute RSS backstop' failed on its branch, because the hoisted ceiling cleared the test's 2,191 MiB ballast and the in-process arm returned rebuilt instead of deferring. It passes again.

#40's sliver-fit commit (one unstable sliver suppressing the per-model fit) is preserved byte-for-byte, verified by matching git patch-id --stable against the original.

Three new regressions: the cap-vs-ceiling invariant read from the real spawn's execArgv and the real request (so it cannot drift from the constants); an honest deferral through the production child asserting accounting_transition_rss_limit_exceeded and NOT subprocess_failed, with a control at the shipped ceiling that rebuilds; and a causal pair where only the cap ordering differs — above the ceiling gives the typed deferral, below it gives SIGABRT with empty stdout.

Gates: 143/143 on the three required suites, macos-source 46 pass, UI 324/324, architecture clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)