### PR TITLE
fix(release): retry transient Wrangler reads and quote their output without identity

### DIFF
--- a/scripts/publish-sparkle-update.js
+++ b/scripts/publish-sparkle-update.js
@@ -16,6 +16,7 @@ import {
 } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { basename, dirname, join, resolve } from "node:path";
+import { setTimeout as sleepFor } from "node:timers/promises";
 import { fileURLToPath } from "node:url";
 import { PRODUCT_BRAND } from "../config/product-brand.js";
 import { CANONICAL_STABLE_APPCAST_POLICY } from "../config/sparkle-appcast-policy.js";
@@ -93,6 +94,23 @@ const ED25519_SPKI_PREFIX = Buffer.from(
 );
 const SAFE_RELEASE_OBJECT_FILE_NAME_PATTERN =
   /^[A-Za-z0-9][A-Za-z0-9._-]{0,127}\.(?:dmg|delta)$/u;
+// Wrangler's OAuth access token lives about an hour, and the first invocation
+// after it expires refreshes the token while its own API call is already in
+// flight. That race answered four consecutive dogfood publishes with
+// `401: Unauthorized; {"code":10000,"message":"Authentication error"}` on the
+// pre-publish read, which an immediate rerun never reproduced because the
+// refreshed token was on disk by then. Every Wrangler failure that is not an
+// explicitly reported missing object is therefore retried a bounded number of
+// times, so a publish aborts only on a fault that outlives the whole budget.
+const WRANGLER_ATTEMPTS = 3;
+const WRANGLER_RETRY_BASE_DELAY_MS = 750;
+// Wrangler emits a few hundred bytes per invocation; the cap only bounds a
+// runaway stream so the failure message stays readable.
+const WRANGLER_DIAGNOSTIC_STREAM_LIMIT = 2000;
+// Wrangler colours its output even when stdout and stderr are pipes, so the
+// missing-object classifier and the failure diagnostic both read the text
+// with the SGR escapes removed.
+const ANSI_ESCAPE_PATTERN = /\u001B\[[0-9;]*m/gu;
 
 function fail(message, code = "SPARKLE_UPDATE_PUBLICATION_INVALID") {
   const error = new Error(message);
@@ -1176,11 +1194,89 @@ function wranglerObjectPath(bucket, key) {
   return `${bucket}/${key}`;
 }
 
+function wranglerStreamText(value) {
+  return typeof value === "string"
+    ? value.replace(ANSI_ESCAPE_PATTERN, "")
+    : "";
+}
+
+/**
+ * Wrangler names a missing R2 object outright ("The specified key does not
+ * exist."). The classifier matches that sentence rather than any "not found"
+ * substring anywhere in the output, because a false missing-object verdict is
+ * the expensive direction: the caller then believes the object is absent,
+ * skips retained-object verification, and leaves the resume path unexercised.
+ * The loose form matched unrelated lines — the `.env file not found at ...`
+ * notice Wrangler prints at debug level, or a bucket that does not exist. A
+ * future wording change fails closed instead: the operation exhausts its retry
+ * budget and aborts with Wrangler's own output attached, which names the new
+ * wording on the first occurrence.
+ */
+const WRANGLER_MISSING_OBJECT_PATTERN =
+  /the specified key does not exist|no such key|nosuchkey|object not found/iu;
+
 function resultWasNotFound(result) {
   return result.status !== 0
-    && /(?:not found|does not exist|nosuchkey)/iu.test(
-      `${result.stdout ?? ""}\n${result.stderr ?? ""}`,
+    && WRANGLER_MISSING_OBJECT_PATTERN.test(
+      `${wranglerStreamText(result.stdout)}\n${wranglerStreamText(result.stderr)}`,
     );
+}
+
+/**
+ * Wrangler's status and both streams carry the entire diagnosis — a 401 auth
+ * race, a 5xx, a renamed bucket — and they hold object keys and CLI text, not
+ * secrets. Four masked publish failures produced no evidence at all, so every
+ * hard failure now quotes them. The owner guard secret is deleted from the
+ * environment before any Wrangler child is spawned; it is scrubbed by value
+ * here as well so no future call order can surface it.
+ */
+function describeWranglerResult(result) {
+  const guardToken = process.env[APPCAST_ATOMIC_GUARD_TOKEN_ENV];
+  const scrubbable = typeof guardToken === "string" && guardToken.length >= 32;
+  const present = (value) => {
+    const text = scrubbable
+      ? wranglerStreamText(value).split(guardToken).join("[redacted]")
+      : wranglerStreamText(value);
+    const trimmed = text.trim();
+    if (trimmed.length === 0) return "(empty)";
+    return trimmed.length > WRANGLER_DIAGNOSTIC_STREAM_LIMIT
+      ? `${trimmed.slice(0, WRANGLER_DIAGNOSTIC_STREAM_LIMIT)} (truncated)`
+      : trimmed;
+  };
+  return `status ${result?.status ?? "unknown"}`
+    + `; stdout: ${present(result?.stdout)}`
+    + `; stderr: ${present(result?.stderr)}`;
+}
+
+/**
+ * Runs one Wrangler operation with a bounded retry. `isExpectedFailure` marks
+ * the outcomes that are answers rather than faults — a reported missing object
+ * for a read — so they return on the first attempt and never consume the
+ * budget. Everything else is retried with a linear backoff and announced on
+ * stderr, keeping stdout reserved for the publication receipt.
+ */
+async function runWranglerOperation({
+  arguments_,
+  attempts = WRANGLER_ATTEMPTS,
+  isExpectedFailure = () => false,
+  label,
+  runWrangler,
+  sleep = sleepFor,
+}) {
+  let result = {};
+  for (let attempt = 1; attempt <= attempts; attempt += 1) {
+    result = (await runWrangler(arguments_)) ?? {};
+    if (result.status === 0 || isExpectedFailure(result)) return result;
+    if (attempt === attempts) break;
+    const backoff = WRANGLER_RETRY_BASE_DELAY_MS * attempt;
+    console.warn(
+      `publish-sparkle-update: ${label} failed on Wrangler attempt `
+      + `${attempt} of ${attempts}; retrying in ${backoff}ms `
+      + `(${describeWranglerResult(result)})`,
+    );
+    await sleep(backoff);
+  }
+  return result;
 }
 
 function defaultRunWrangler(arguments_) {
@@ -1190,7 +1286,10 @@ function defaultRunWrangler(arguments_) {
     maxBuffer: 1024 * 1024,
   });
   if (result.error) {
-    fail("Pinned local Wrangler is unavailable", "SPARKLE_UPDATE_WRANGLER_FAILED");
+    fail(
+      `Pinned local Wrangler is unavailable: ${result.error.code ?? "unknown"}: ${result.error.message}`,
+      "SPARKLE_UPDATE_WRANGLER_FAILED",
+    );
   }
   return Object.freeze({
     status: result.status ?? 1,
@@ -1204,6 +1303,7 @@ async function readRemoteObject({
   key,
   maximumBytes = MAX_DMG_BYTES,
   runWrangler,
+  sleep,
   temporaryRoot,
 }) {
   const destination = join(
@@ -1211,19 +1311,27 @@ async function readRemoteObject({
     createHash("sha256").update(`read:${key}`).digest("hex"),
   );
   await rm(destination, { force: true });
-  const result = await runWrangler([
-    "r2",
-    "object",
-    "get",
-    wranglerObjectPath(bucket, key),
-    "--file",
-    destination,
-    "--remote",
-  ]);
-  if (result?.status !== 0) {
-    if (resultWasNotFound(result ?? {})) return null;
+  const result = await runWranglerOperation({
+    arguments_: [
+      "r2",
+      "object",
+      "get",
+      wranglerObjectPath(bucket, key),
+      "--file",
+      destination,
+      "--remote",
+    ],
+    // An absent object is the expected answer on a first publish, so it is
+    // returned immediately and never spends the retry budget.
+    isExpectedFailure: resultWasNotFound,
+    label: `reading R2 object ${key}`,
+    runWrangler,
+    sleep,
+  });
+  if (result.status !== 0) {
+    if (resultWasNotFound(result)) return null;
     fail(
-      `Unable to read R2 object ${key}`,
+      `Unable to read R2 object ${key} after ${WRANGLER_ATTEMPTS} Wrangler attempts: ${describeWranglerResult(result)}`,
       "SPARKLE_UPDATE_WRANGLER_FAILED",
     );
   }
@@ -1329,6 +1437,7 @@ async function validatePublishedEnclosureObjects({
   dmg,
   publishedObjectKeys = new Set(),
   runWrangler,
+  sleep,
   sparklePublicKey,
   temporaryRoot,
 }) {
@@ -1345,6 +1454,7 @@ async function validatePublishedEnclosureObjects({
           bucket,
           key: enclosure.objectKey,
           runWrangler,
+          sleep,
           temporaryRoot,
         }),
       );
@@ -1382,22 +1492,42 @@ async function validatePublishedEnclosureObjects({
   }
 }
 
-async function putObject({ bucket, key, path, contentType, cacheControl, runWrangler }) {
-  const result = await runWrangler([
-    "r2",
-    "object",
-    "put",
-    wranglerObjectPath(bucket, key),
-    "--file",
-    path,
-    "--content-type",
-    contentType,
-    "--cache-control",
-    cacheControl,
-    "--remote",
-  ]);
-  if (result?.status !== 0) {
-    fail("Wrangler could not publish the validated update object", "SPARKLE_UPDATE_WRANGLER_FAILED");
+async function putObject({
+  bucket,
+  key,
+  path,
+  contentType,
+  cacheControl,
+  runWrangler,
+  sleep,
+}) {
+  // The same expired-token race can answer an upload, and a spurious abort
+  // here strands a partial publication. Re-putting is safe to repeat: every
+  // key this function writes is content-addressed by the SHA-256 of the bytes
+  // being sent, so a retry can only rewrite identical content.
+  const result = await runWranglerOperation({
+    arguments_: [
+      "r2",
+      "object",
+      "put",
+      wranglerObjectPath(bucket, key),
+      "--file",
+      path,
+      "--content-type",
+      contentType,
+      "--cache-control",
+      cacheControl,
+      "--remote",
+    ],
+    label: `publishing R2 object ${key}`,
+    runWrangler,
+    sleep,
+  });
+  if (result.status !== 0) {
+    fail(
+      `Wrangler could not publish the validated update object ${key} after ${WRANGLER_ATTEMPTS} attempts: ${describeWranglerResult(result)}`,
+      "SPARKLE_UPDATE_WRANGLER_FAILED",
+    );
   }
 }
 
@@ -1700,6 +1830,9 @@ export async function publishSparkleUpdate({
   sparklePublicEdKey,
   stableBootstrap = false,
   runWrangler = defaultRunWrangler,
+  // Injectable like runWrangler so specs exercise the bounded retry without
+  // spending its backoff.
+  sleep = sleepFor,
   fetchPublic = defaultPublicFetch,
   fetchGuard = defaultPublicFetch,
   validateDMG = validateMacOSDMG,
@@ -1709,6 +1842,7 @@ export async function publishSparkleUpdate({
       || (previousStableManifestPath !== null
         && typeof previousStableManifestPath !== "string")
       || typeof runWrangler !== "function"
+      || typeof sleep !== "function"
       || typeof fetchPublic !== "function"
       || typeof fetchGuard !== "function"
       || typeof validateDMG !== "function"
@@ -1928,6 +2062,7 @@ export async function publishSparkleUpdate({
         key: immutableObject.object.key,
         maximumBytes: immutableObject.maximumBytes,
         runWrangler,
+        sleep,
         temporaryRoot,
       });
       if (remote !== null) {
@@ -1944,6 +2079,7 @@ export async function publishSparkleUpdate({
       key: publication.appcast.key,
       maximumBytes: MAX_APPCAST_BYTES,
       runWrangler,
+      sleep,
       temporaryRoot,
     });
     resumedPublication = assertExactCandidateAppcast({
@@ -2030,6 +2166,7 @@ export async function publishSparkleUpdate({
         publication.deltas.map((delta) => delta.key),
       ),
       runWrangler,
+      sleep,
       sparklePublicKey: normalizedSparklePublicKey,
       temporaryRoot,
     });
@@ -2043,6 +2180,7 @@ export async function publishSparkleUpdate({
           contentType: immutableObject.object.contentType,
           cacheControl: immutableObject.object.cacheControl,
           runWrangler,
+          sleep,
         });
       }
       const appcastBeforeWrite = await readRemoteObject({
@@ -2050,6 +2188,7 @@ export async function publishSparkleUpdate({
         key: publication.appcast.key,
         maximumBytes: MAX_APPCAST_BYTES,
         runWrangler,
+        sleep,
         temporaryRoot,
       });
       assertAppcastStateUnchanged(

--- a/scripts/publish-sparkle-update.js
+++ b/scripts/publish-sparkle-update.js
@@ -1222,21 +1222,52 @@ function resultWasNotFound(result) {
     );
 }
 
+// Wrangler answers an authentication failure by printing its whoami block:
+// the account email, the account id, the account-name/id table, and the full
+// token scope list. None of it diagnoses a publish failure — the error line,
+// the HTTP status, the API error body and the object key all arrive on stderr
+// or ahead of this block — and publish logs get pasted into issues, so the
+// block is dropped at its own marker and replaced by a visible note.
+const WRANGLER_IDENTITY_BLOCK_PATTERN =
+  /^.*Getting User settings\.\.\.[\s\S]*/mu;
+const WRANGLER_IDENTITY_BLOCK_REDACTION =
+  "[redacted: Wrangler account identity block]";
+const WRANGLER_EMAIL_PATTERN =
+  /[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}/gu;
+// A Cloudflare account id is exactly 32 hexadecimal characters, and one is
+// embedded in the `/accounts/<id>/…` path of every R2 error line. The
+// surrounding guards keep the 64-character content-addressed SHA-256 inside an
+// object key — which is load-bearing evidence and must survive — from being
+// mistaken for an account id. An R2 etag is also 32 hex characters and would
+// be redacted with it; no failure message quotes one.
+const WRANGLER_ACCOUNT_ID_PATTERN =
+  /(?<![0-9a-f])[0-9a-f]{32}(?![0-9a-f])/giu;
+const WRANGLER_ACCOUNT_ID_REDACTION = "[redacted-account-id]";
+const WRANGLER_EMAIL_REDACTION = "[redacted-email]";
+
 /**
  * Wrangler's status and both streams carry the entire diagnosis — a 401 auth
- * race, a 5xx, a renamed bucket — and they hold object keys and CLI text, not
- * secrets. Four masked publish failures produced no evidence at all, so every
- * hard failure now quotes them. The owner guard secret is deleted from the
- * environment before any Wrangler child is spawned; it is scrubbed by value
- * here as well so no future call order can surface it.
+ * race, a 5xx, a renamed bucket — and the parts that diagnose it are object
+ * keys and CLI text. Four masked publish failures produced no evidence at all,
+ * so every hard failure now quotes them. Everything that identifies the owner
+ * or the account is removed on the way out, each with a visible marker, so a
+ * publish log stays safe to share: the owner guard secret by value (it is also
+ * deleted from the environment before any Wrangler child is spawned, so no
+ * future call order can surface it), and the account identity by pattern.
  */
 function describeWranglerResult(result) {
   const guardToken = process.env[APPCAST_ATOMIC_GUARD_TOKEN_ENV];
   const scrubbable = typeof guardToken === "string" && guardToken.length >= 32;
   const present = (value) => {
-    const text = scrubbable
-      ? wranglerStreamText(value).split(guardToken).join("[redacted]")
-      : wranglerStreamText(value);
+    const streamed = wranglerStreamText(value).replace(
+      WRANGLER_IDENTITY_BLOCK_PATTERN,
+      WRANGLER_IDENTITY_BLOCK_REDACTION,
+    );
+    const text = (scrubbable
+      ? streamed.split(guardToken).join("[redacted]")
+      : streamed)
+      .replace(WRANGLER_EMAIL_PATTERN, WRANGLER_EMAIL_REDACTION)
+      .replace(WRANGLER_ACCOUNT_ID_PATTERN, WRANGLER_ACCOUNT_ID_REDACTION);
     const trimmed = text.trim();
     if (trimmed.length === 0) return "(empty)";
     return trimmed.length > WRANGLER_DIAGNOSTIC_STREAM_LIMIT

--- a/test/publish-sparkle-update.test.js
+++ b/test/publish-sparkle-update.test.js
@@ -35,6 +35,10 @@ const DOGFOOD_CHANNEL = getReleaseChannel("internal-dogfood");
 const TEST_PUBLIC_ED_KEY_SHA256 = sha256(
   Buffer.from(TEST_PUBLIC_ED_KEY, "base64"),
 );
+// The reviewed bound on the publisher's Wrangler retry. It is restated here
+// rather than imported so that widening the publisher's budget has to be
+// reviewed against these specs instead of silently relaxing them.
+const WRANGLER_ATTEMPT_BOUND = 3;
 
 function sha256(value) {
   return createHash("sha256").update(value).digest("hex");
@@ -45,6 +49,9 @@ async function publishSparkleUpdate(options) {
     atomicAppcastGuard: options.atomicAppcastGuard
       ?? options.runWrangler?.atomicAppcastGuard
       ?? null,
+    // Specs assert the bounded Wrangler retry by attempt count, never by
+    // elapsed time, so the backoff is waived unless a spec records it.
+    sleep: async () => {},
     stableBootstrap: true,
     ...options,
   });
@@ -288,6 +295,71 @@ function statefulRemoteObjectRunner({
   const runner = { calls, objects: remoteObjects, run };
   run.atomicAppcastGuard = createTestAtomicAppcastGuard(runner);
   return runner;
+}
+
+// The literal stderr the pinned Wrangler emits for an absent R2 object: SGR
+// coloured even when stderr is a pipe, with one sentence as the whole missing
+// object signal.
+const WRANGLER_MISSING_OBJECT_STDERR =
+  "\u001B[31m✘ \u001B[41;31m[\u001B[41;97mERROR\u001B[41;31m]\u001B[0m"
+  + " \u001B[1mThe specified key does not exist.\u001B[0m\n";
+// The literal output of the expired-token race that hard-failed four
+// consecutive dogfood publishes: Wrangler refreshes its hour-long OAuth access
+// token while the R2 request it already issued is in flight, and that request
+// answers 401 before the refreshed token lands. The debug-level `.env file not
+// found` notice rides along in stdout whenever WRANGLER_LOG is raised, and is
+// the reason the missing-object classifier may not match a bare "not found".
+const WRANGLER_EXPIRED_TOKEN_STDOUT =
+  ".env file not found at \"/repo/.env\". Continuing...\n"
+  + " wrangler 4.114.0\nDownloading \"object\" from \"bucket\".\n";
+
+function wranglerExpiredTokenStderr(objectPath) {
+  return "\u001B[31m✘ \u001B[41;31m[\u001B[41;97mERROR\u001B[41;31m]\u001B[0m"
+    + ` \u001B[1mFailed to fetch /accounts/account/r2/buckets/${objectPath}`
+    + " - 401: Unauthorized;\u001B[0m\n\n"
+    + "  {\"result\":null,\"success\":false,\"errors\":"
+    + "[{\"code\":10000,\"message\":\"Authentication error\"}],\"messages\":[]}\n";
+}
+
+/**
+ * A stateful runner that answers reads the way the real Wrangler does: an
+ * absent object gets the coloured missing-object sentence, and the first
+ * `readFailures` reads of a key get the expired-token 401 instead.
+ */
+function wranglerFaultRunner({
+  objects = new Map(),
+  readFailures = new Map(),
+} = {}) {
+  const inner = statefulRemoteObjectRunner({ objects });
+  const remaining = new Map(readFailures);
+  const run = async (arguments_) => {
+    const objectPath = arguments_.at(3);
+    if (arguments_.at(2) === "get") {
+      const pending = remaining.get(objectPath) ?? 0;
+      if (pending > 0) {
+        remaining.set(objectPath, pending - 1);
+        inner.calls.push(arguments_);
+        return {
+          status: 1,
+          stdout: WRANGLER_EXPIRED_TOKEN_STDOUT,
+          stderr: wranglerExpiredTokenStderr(objectPath),
+        };
+      }
+      if (!inner.objects.has(objectPath)) {
+        inner.calls.push(arguments_);
+        return { status: 1, stdout: "", stderr: WRANGLER_MISSING_OBJECT_STDERR };
+      }
+    }
+    return inner.run(arguments_);
+  };
+  run.atomicAppcastGuard = inner.run.atomicAppcastGuard;
+  return { calls: inner.calls, objects: inner.objects, run };
+}
+
+function objectPathCallCount(runner, operation, objectPath) {
+  return runner.calls.filter(
+    (call) => call[2] === operation && call[3] === objectPath,
+  ).length;
 }
 
 function createTestAtomicAppcastGuard(runner, { beforeCompare = null } = {}) {
@@ -1041,14 +1113,217 @@ test("rejects a concurrent appcast change through the owner atomic guard", async
   }
 });
 
+test("retries a transient Wrangler read failure and publishes", async () => {
+  const fixture = await createReleaseFixture();
+  const digest = sha256(fixture.dmgBytes);
+  const artifactObjectPath = `${APPROVED_R2_BUCKET}/releases/1/${digest}/${RELEASE_MANIFEST.macOS.arm64DmgFileName}`;
+  const runner = wranglerFaultRunner({
+    readFailures: new Map([[artifactObjectPath, 1]]),
+  });
+  const publicReadback = publicReadbackFixture(fixture);
+  const delays = [];
+  try {
+    const publication = await publishSparkleUpdate({
+      appcastPath: fixture.appcastPath,
+      bucket: APPROVED_R2_BUCKET,
+      channel: "stable",
+      dmgPath: fixture.dmgPath,
+      publish: true,
+      releaseManifestPath: fixture.releaseManifestPath,
+      sparklePublicEdKey: TEST_PUBLIC_ED_KEY,
+      runWrangler: runner.run,
+      sleep: async (milliseconds) => { delays.push(milliseconds); },
+      fetchPublic: publicReadback.fetch,
+      validateDMG: async () => {},
+    });
+    assert.equal(publication.published, true);
+    assert.equal(publication.status, "published");
+    assert.equal(objectPathCallCount(runner, "get", artifactObjectPath), 2);
+    assert.equal(delays.length, 1);
+    assert.ok(delays[0] > 0);
+    assert.deepEqual(runner.objects.get(artifactObjectPath), fixture.dmgBytes);
+  } finally {
+    await fixture.cleanup();
+  }
+});
+
+test("returns a reported missing object without spending a retry", async () => {
+  const fixture = await createReleaseFixture();
+  const digest = sha256(fixture.dmgBytes);
+  const artifactObjectPath = `${APPROVED_R2_BUCKET}/releases/1/${digest}/${RELEASE_MANIFEST.macOS.arm64DmgFileName}`;
+  const manifestObjectPath = `${APPROVED_R2_BUCKET}/releases/1/${digest}/release-manifest.json`;
+  const appcastObjectPath = `${APPROVED_R2_BUCKET}/appcast.xml`;
+  const runner = wranglerFaultRunner();
+  const publicReadback = publicReadbackFixture(fixture);
+  const delays = [];
+  try {
+    const publication = await publishSparkleUpdate({
+      appcastPath: fixture.appcastPath,
+      bucket: APPROVED_R2_BUCKET,
+      channel: "stable",
+      dmgPath: fixture.dmgPath,
+      publish: true,
+      releaseManifestPath: fixture.releaseManifestPath,
+      sparklePublicEdKey: TEST_PUBLIC_ED_KEY,
+      runWrangler: runner.run,
+      sleep: async (milliseconds) => { delays.push(milliseconds); },
+      fetchPublic: publicReadback.fetch,
+      validateDMG: async () => {},
+    });
+    assert.equal(publication.published, true);
+    // A first publish of a new version reads every object before it exists.
+    // Wrangler's coloured missing-object sentence is an answer, not a fault:
+    // each read resolves on its first attempt and never waits.
+    assert.equal(objectPathCallCount(runner, "get", artifactObjectPath), 1);
+    assert.equal(objectPathCallCount(runner, "get", manifestObjectPath), 1);
+    // The appcast is read once for the preflight state and once again
+    // immediately before the guarded write.
+    assert.equal(objectPathCallCount(runner, "get", appcastObjectPath), 2);
+    assert.deepEqual(delays, []);
+  } finally {
+    await fixture.cleanup();
+  }
+});
+
+test("fails closed with Wrangler's own output after a bounded retry", async () => {
+  const fixture = await createReleaseFixture();
+  const digest = sha256(fixture.dmgBytes);
+  const artifactObjectPath = `${APPROVED_R2_BUCKET}/releases/1/${digest}/${RELEASE_MANIFEST.macOS.arm64DmgFileName}`;
+  const runner = wranglerFaultRunner({
+    readFailures: new Map([[artifactObjectPath, Number.MAX_SAFE_INTEGER]]),
+  });
+  const delays = [];
+  try {
+    await assert.rejects(
+      publishSparkleUpdate({
+        appcastPath: fixture.appcastPath,
+        bucket: APPROVED_R2_BUCKET,
+        channel: "stable",
+        dmgPath: fixture.dmgPath,
+        publish: true,
+        releaseManifestPath: fixture.releaseManifestPath,
+        sparklePublicEdKey: TEST_PUBLIC_ED_KEY,
+        runWrangler: runner.run,
+        sleep: async (milliseconds) => { delays.push(milliseconds); },
+        validateDMG: async () => {},
+      }),
+      (error) => {
+        assert.equal(error.code, "SPARKLE_UPDATE_WRANGLER_FAILED");
+        // The whole diagnosis, quoted: four masked occurrences of this exact
+        // fault produced no evidence at all.
+        assert.match(error.message, /status 1/u);
+        assert.match(error.message, /401: Unauthorized/u);
+        assert.match(error.message, /Authentication error/u);
+        assert.match(error.message, /\.env file not found/u);
+        assert.ok(error.message.includes(artifactObjectPath));
+        // Wrangler colours its output; the quoted text is readable.
+        assert.equal(error.message.includes("\u001B["), false);
+        return true;
+      },
+    );
+    // Bounded: the read stops after the reviewed budget, and the unrelated
+    // `.env file not found` line in Wrangler's stdout is never mistaken for a
+    // missing object, which would have let the publish upload over it.
+    assert.equal(
+      objectPathCallCount(runner, "get", artifactObjectPath),
+      WRANGLER_ATTEMPT_BOUND,
+    );
+    assert.equal(delays.length, WRANGLER_ATTEMPT_BOUND - 1);
+    assert.ok(delays[1] > delays[0]);
+    assert.equal(runner.calls.some((call) => call[2] === "put"), false);
+  } finally {
+    await fixture.cleanup();
+  }
+});
+
+test("retries a transient Wrangler upload failure and publishes", async () => {
+  const fixture = await createReleaseFixture();
+  const digest = sha256(fixture.dmgBytes);
+  const manifestObjectPath = `${APPROVED_R2_BUCKET}/releases/1/${digest}/release-manifest.json`;
+  const runner = statefulRemoteObjectRunner({
+    failures: new Map([[manifestObjectPath, 1]]),
+  });
+  const publicReadback = publicReadbackFixture(fixture);
+  try {
+    const publication = await publishSparkleUpdate({
+      appcastPath: fixture.appcastPath,
+      bucket: APPROVED_R2_BUCKET,
+      channel: "stable",
+      dmgPath: fixture.dmgPath,
+      publish: true,
+      releaseManifestPath: fixture.releaseManifestPath,
+      sparklePublicEdKey: TEST_PUBLIC_ED_KEY,
+      runWrangler: runner.run,
+      fetchPublic: publicReadback.fetch,
+      validateDMG: async () => {},
+    });
+    assert.equal(publication.published, true);
+    assert.equal(objectPathCallCount(runner, "put", manifestObjectPath), 2);
+    assert.deepEqual(
+      runner.objects.get(manifestObjectPath),
+      await readFile(fixture.releaseManifestPath),
+    );
+  } finally {
+    await fixture.cleanup();
+  }
+});
+
+test("never quotes the owner guard secret in a Wrangler diagnostic", async () => {
+  const fixture = await createReleaseFixture();
+  const secret = "o".repeat(48);
+  const runner = statefulRemoteObjectRunner();
+  const leakingRunner = async (arguments_) => {
+    runner.calls.push(arguments_);
+    return {
+      status: 1,
+      stdout: "",
+      stderr: `wrangler echoed ${process.env[APPCAST_ATOMIC_GUARD_TOKEN_ENV]}`,
+    };
+  };
+  leakingRunner.atomicAppcastGuard = runner.run.atomicAppcastGuard;
+  const restore = process.env[APPCAST_ATOMIC_GUARD_TOKEN_ENV];
+  process.env[APPCAST_ATOMIC_GUARD_TOKEN_ENV] = secret;
+  try {
+    await assert.rejects(
+      publishSparkleUpdate({
+        appcastPath: fixture.appcastPath,
+        bucket: APPROVED_R2_BUCKET,
+        channel: "stable",
+        dmgPath: fixture.dmgPath,
+        publish: true,
+        releaseManifestPath: fixture.releaseManifestPath,
+        sparklePublicEdKey: TEST_PUBLIC_ED_KEY,
+        runWrangler: leakingRunner,
+        validateDMG: async () => {},
+      }),
+      (error) => {
+        assert.equal(error.code, "SPARKLE_UPDATE_WRANGLER_FAILED");
+        assert.equal(error.message.includes(secret), false);
+        assert.match(error.message, /\[redacted\]/u);
+        return true;
+      },
+    );
+  } finally {
+    if (restore === undefined) {
+      delete process.env[APPCAST_ATOMIC_GUARD_TOKEN_ENV];
+    } else {
+      process.env[APPCAST_ATOMIC_GUARD_TOKEN_ENV] = restore;
+    }
+    await fixture.cleanup();
+  }
+});
+
 test("retries after an artifact-only partial publication and resumes missing work", async () => {
   const fixture = await createReleaseFixture();
   const digest = sha256(fixture.dmgBytes);
   const artifactObjectPath = `${APPROVED_R2_BUCKET}/releases/1/${digest}/${RELEASE_MANIFEST.macOS.arm64DmgFileName}`;
   const manifestObjectPath = `${APPROVED_R2_BUCKET}/releases/1/${digest}/release-manifest.json`;
   const appcastObjectPath = `${APPROVED_R2_BUCKET}/appcast.xml`;
+  // The upload must fail on every attempt of the bounded Wrangler retry, or
+  // the publish would recover instead of stranding the partial publication
+  // this spec resumes from.
   const runner = statefulRemoteObjectRunner({
-    failures: new Map([[manifestObjectPath, 1]]),
+    failures: new Map([[manifestObjectPath, WRANGLER_ATTEMPT_BOUND]]),
   });
   const publicReadback = publicReadbackFixture(fixture);
   const options = {
@@ -1076,7 +1351,15 @@ test("retries after an artifact-only partial publication and resumes missing wor
     assert.equal(publication.status, "published");
     assert.deepEqual(
       runner.calls.filter((call) => call[2] === "put").map((call) => call[3]),
-      [artifactObjectPath, manifestObjectPath, manifestObjectPath, appcastObjectPath],
+      [
+        artifactObjectPath,
+        ...Array.from(
+          { length: WRANGLER_ATTEMPT_BOUND },
+          () => manifestObjectPath,
+        ),
+        manifestObjectPath,
+        appcastObjectPath,
+      ],
     );
   } finally {
     await fixture.cleanup();

--- a/test/publish-sparkle-update.test.js
+++ b/test/publish-sparkle-update.test.js
@@ -313,12 +313,44 @@ const WRANGLER_EXPIRED_TOKEN_STDOUT =
   ".env file not found at \"/repo/.env\". Continuing...\n"
   + " wrangler 4.114.0\nDownloading \"object\" from \"bucket\".\n";
 
-function wranglerExpiredTokenStderr(objectPath) {
+function wranglerExpiredTokenStderr(objectPath, accountId = "account") {
   return "\u001B[31m✘ \u001B[41;31m[\u001B[41;97mERROR\u001B[41;31m]\u001B[0m"
-    + ` \u001B[1mFailed to fetch /accounts/account/r2/buckets/${objectPath}`
+    + ` \u001B[1mFailed to fetch /accounts/${accountId}/r2/buckets/${objectPath}`
     + " - 401: Unauthorized;\u001B[0m\n\n"
     + "  {\"result\":null,\"success\":false,\"errors\":"
     + "[{\"code\":10000,\"message\":\"Authentication error\"}],\"messages\":[]}\n";
+}
+
+// Stand-ins for the owner identifiers the reproduced failure actually printed,
+// which are deliberately not committed: a Cloudflare account id is 32
+// hexadecimal characters, and the default account name is derived from the
+// account email.
+const FIXTURE_ACCOUNT_ID = "0123456789abcdef0123456789abcdef";
+const FIXTURE_ACCOUNT_EMAIL = "owner@example.com";
+
+/**
+ * The stdout of the reproduced cold 401, line for line minus the SGR escapes
+ * its siblings above already pin: Wrangler reacts to the authentication
+ * failure by printing its whoami block, so the account email, the account id,
+ * the account-name/id table and the token scope list all land in the publish
+ * log behind the object key.
+ */
+function wranglerColdAuthFailureStdout(objectPath) {
+  return "\n ⛅️ wrangler 4.114.0\n────────────────────\n"
+    + "Resource location: remote \n\n"
+    + `Downloading "${objectPath}" from "tibotattle-dogfood-updates".\n\n`
+    + "Getting User settings...\n"
+    + "👋 You are logged in with an OAuth Token, associated with the email"
+    + ` ${FIXTURE_ACCOUNT_EMAIL}.\n`
+    + "🔐 Credentials are stored in:"
+    + " /Users/owner/Library/Preferences/.wrangler/config/default.toml\n"
+    + "┌──────────────┬──────────────┐\n"
+    + "│ Account Name │ Account ID   │\n"
+    + "├──────────────┼──────────────┤\n"
+    + `│ ${FIXTURE_ACCOUNT_EMAIL}'s Account │ ${FIXTURE_ACCOUNT_ID} │\n`
+    + "└──────────────┴──────────────┘\n"
+    + "🔓 Token Permissions:\nScope (Access)\n- account (read)\n- user (read)\n"
+    + "- workers (write)\n- offline_access \n";
 }
 
 /**
@@ -1262,6 +1294,69 @@ test("retries a transient Wrangler upload failure and publishes", async () => {
     assert.deepEqual(
       runner.objects.get(manifestObjectPath),
       await readFile(fixture.releaseManifestPath),
+    );
+  } finally {
+    await fixture.cleanup();
+  }
+});
+
+test("quotes the cold 401 without the account identity Wrangler prints with it", async () => {
+  const fixture = await createReleaseFixture();
+  const digest = sha256(fixture.dmgBytes);
+  const artifactObjectPath = `${APPROVED_R2_BUCKET}/releases/1/${digest}/${RELEASE_MANIFEST.macOS.arm64DmgFileName}`;
+  const runner = statefulRemoteObjectRunner();
+  const coldAuthFailure = async (arguments_) => {
+    runner.calls.push(arguments_);
+    return {
+      status: 1,
+      stdout: wranglerColdAuthFailureStdout(arguments_.at(3)),
+      stderr: wranglerExpiredTokenStderr(arguments_.at(3), FIXTURE_ACCOUNT_ID),
+    };
+  };
+  coldAuthFailure.atomicAppcastGuard = runner.run.atomicAppcastGuard;
+  try {
+    await assert.rejects(
+      publishSparkleUpdate({
+        appcastPath: fixture.appcastPath,
+        bucket: APPROVED_R2_BUCKET,
+        channel: "stable",
+        dmgPath: fixture.dmgPath,
+        publish: true,
+        releaseManifestPath: fixture.releaseManifestPath,
+        sparklePublicEdKey: TEST_PUBLIC_ED_KEY,
+        runWrangler: coldAuthFailure,
+        validateDMG: async () => {},
+      }),
+      (error) => {
+        // Everything that diagnoses the failure survives.
+        assert.equal(error.code, "SPARKLE_UPDATE_WRANGLER_FAILED");
+        assert.match(error.message, /status 1/u);
+        assert.match(error.message, /Failed to fetch/u);
+        assert.match(error.message, /401: Unauthorized/u);
+        assert.match(
+          error.message,
+          /\{"code":10000,"message":"Authentication error"\}/u,
+        );
+        // The object key, including its content-addressed SHA-256, is not
+        // mistaken for an account id and survives whole.
+        assert.ok(error.message.includes(artifactObjectPath));
+        assert.ok(error.message.includes(digest));
+        // Nothing that identifies the owner or the account does. A publish log
+        // is pasted into issues; the whoami block Wrangler prints alongside an
+        // auth failure diagnoses nothing here.
+        assert.equal(error.message.includes(FIXTURE_ACCOUNT_EMAIL), false);
+        assert.equal(error.message.includes(FIXTURE_ACCOUNT_ID), false);
+        assert.equal(error.message.includes("Token Permissions"), false);
+        assert.equal(error.message.includes("Account Name"), false);
+        assert.equal(error.message.includes("/Users/owner"), false);
+        // Redacted, not silently truncated.
+        assert.match(error.message, /\[redacted-account-id\]/u);
+        assert.match(
+          error.message,
+          /\[redacted: Wrangler account identity block\]/u,
+        );
+        return true;
+      },
     );
   } finally {
     await fixture.cleanup();


### PR DESCRIPTION
The publisher hard-failed its first publish attempt on four consecutive dogfood builds (1016, 1018, 1019, 1020) with 'Unable to read R2 object', succeeding on an immediate retry.

Root cause, reproduced deterministically rather than inferred: the pinned Wrangler's OAuth access token carries an expiration, and the first invocation after it lapses issues the R2 request with the STALE token, receives 401 Unauthorized, refreshes in the background and persists the new token — which is exactly why the rerun always worked. Confirmed by timing a probe to the token's literal expiry second and observing the config's expiration_time advance during the cold run. Cold stderr carries '401: Unauthorized' with an 'Authentication error' body; warm stderr carries 'The specified key does not exist.' Since a 401 contains no not-found wording, resultWasNotFound returned false and a routine cold read was hard-failed.

Three changes. Every Wrangler call now runs through a bounded retry (3 attempts, linear backoff, each retry announced on stderr so stdout stays reserved for the receipt), applied to uploads as well as reads — re-putting is safe because every key putObject writes is content-addressed by the SHA-256 of the bytes being sent, and the appcast write goes through the HTTPS atomic guard rather than Wrangler. Hard failures now quote status, stdout and stderr, because a failure that says nothing is why this survived four occurrences. And not-found classification is TIGHTENED, not broadened, to Wrangler's actual sentence: the old loose substring match also matched Wrangler's debug-level '.env file not found at …' notice, which under WRANGLER_LOG would have read a 401 as an ABSENT OBJECT and skipped retained-object verification.

Because the 401 path makes Wrangler print its whoami dump, the quoted output is scrubbed: the identity block is dropped structurally from its own marker, and email and 32-hex account id are redacted by pattern with visible markers. The account-id pattern is guarded on both sides so it can never eat the 64-hex content digest inside the object key it is quoting — the failure message keeps the error line, status, API error body, object key and digest.

Six specs following the injected-runWrangler idiom, with fixtures speaking Wrangler's literal captured output: transient-401-then-succeeds, immediate no-retry not-found, persistent failure failing closed with the output attached and exactly 3 attempts, transient upload retry, guard-secret scrubbing, and the identity scrub asserting the diagnostics survive while the identifiers do not. Both guards mutation-tested.

64 tests across publisher, stable-feed and channel-policy suites: 63 pass, 1 pre-existing skip. R7 evidence 2/2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)