### PR TITLE
fix(accounting): raise the rebuild ceiling to 6 GiB for real owner-scale corpora

### DIFF
--- a/src/replay-safe-accounting-cache.js
+++ b/src/replay-safe-accounting-cache.js
@@ -180,35 +180,81 @@ const PACE_STATUSES = new Set([
 const ACCOUNT_SCOPE_ID_PATTERN = /^openai-account:v1:[A-Za-z0-9_-]{43}$/u;
 const ACCOUNT_TRACK_ID_PATTERN = /^account-track:v1:[a-f0-9]{64}$/u;
 const MAX_RETAINED_TRANSITION_BYTES = 320 * 1024 * 1024;
-// Absolute whole-process RSS TARGET for one accounting rebuild. Raised
-// 1.5 -> 2 GiB on owner directive (2026-08-11) after a live 0.1.6 incident:
-// the transition-mining pass tripped at ~1.6 GB whole-process RSS on a
-// companion whose baseline idles near ~800 MB, and the throw hard-failed the
-// entire refresh — blanking the dashboard and flip-flopping every 5 minutes
-// as the scheduler re-ran the doomed pass. This ceiling is a TARGET, not a
-// hard blocker: a miss degrades to a retained-cache soft-fail rather than
-// failing the refresh (see refreshReplaySafeAccountingCache and
-// ACCOUNTING_BUDGET_MISS_CODES). It remains the backstop that stops the pass
-// before it can OOM the process.
+// ---------------------------------------------------------------------------
+// The accounting rebuild's memory policy. Three numbers, only two of them set
+// by hand:
 //
-// HELD at 2 GiB on 2026-08-20, against a proposal to raise it to 6 GiB. The
-// evidence for that raise — 26 consecutive
-// accounting_transition_rss_limit_exceeded deferrals from 2026-08-18T19:28 on
-// a 572,089-event / 128.5 GB / 4,880-source corpus — predates the rebuild's
-// move into a short-lived child, and every one of those deferrals was the
-// COMPANION's own ~1.9 GiB post-indexing baseline eating the budget before the
-// pass began, not the pass outgrowing it. Isolation is what cures that (see
-// ACCOUNTING_REBUILD_ISOLATION_MODES); the ceiling was never the binding
-// constraint. Re-measured in the child against an owner-shaped corpus
-// (572,000 events / 25,870 transitions / 130 weekly windows), the rebuild
-// peaks at 485 MiB of RSS GROWTH over a clean baseline even with an
-// effectively unbounded heap, so the effective child ceiling
-// (min(this, baseline + ACCOUNTING_RSS_DELTA_BUDGET_BYTES) ~ 1.3 GiB) already
-// carries ~2.7x the measured need. Raising it further would only lift the
-// ceiling above the child's own V8 heap cap, which is exactly what converts an
-// honest deferral into a crash — see ACCOUNTING_REBUILD_CHILD_OLD_SPACE_MIB,
-// which is derived from this constant so the two cannot drift apart.
-const MAX_ACCOUNTING_RSS_BYTES = Math.floor(2 * 1024 * 1024 * 1024);
+//   MAX_ACCOUNTING_RSS_BYTES                absolute whole-process RSS target
+//   ACCOUNTING_RSS_DELTA_BUDGET_BYTES       what one pass may ADD over its
+//                                           own start-of-build baseline
+//   ACCOUNTING_REBUILD_CHILD_OLD_SPACE_MIB  DERIVED from the first
+//
+// A pass runs under min(MAX_ACCOUNTING_RSS_BYTES,
+// baselineRss + ACCOUNTING_RSS_DELTA_BUDGET_BYTES), so the two hand-set
+// numbers only mean anything together: raising the absolute while leaving the
+// delta behind moves nothing at all off a clean baseline, and raising the
+// delta alone can never pass the absolute. Change them as a PAIR, and read
+// ACCOUNTING_REBUILD_CHILD_OLD_SPACE_MIB before changing either — the derived
+// cap is what keeps a miss an honest deferral rather than a SIGABRT.
+// ---------------------------------------------------------------------------
+// Absolute whole-process RSS TARGET for one accounting rebuild. It is a
+// TARGET, not a hard blocker: a miss degrades to a retained-cache soft-fail
+// rather than failing the refresh (see refreshReplaySafeAccountingCache and
+// ACCOUNTING_BUDGET_MISS_CODES). It remains the backstop that stops a runaway
+// pass before it can OOM the process.
+//
+// The number has moved twice, and both moves are worth keeping:
+//
+//   1.5 -> 2 GiB (2026-08-11), after a live 0.1.6 incident: the
+//     transition-mining pass tripped at ~1.6 GB whole-process RSS on a
+//     companion idling near ~800 MB, and the throw hard-failed the entire
+//     refresh — blanking the dashboard and flip-flopping every 5 minutes as
+//     the scheduler re-ran the doomed pass. That incident is why a miss is
+//     soft today.
+//   2 -> 6 GiB (2026-08-20, owner directive), recorded below.
+//
+// What 6 GiB rests on is the owner's REAL corpus rather than a model of it,
+// and the distinction is the whole point. The pair this replaces (2 GiB
+// absolute / 1.25 GiB delta) was held earlier the same day on the strength of
+// a SYNTHETIC 572,000-event corpus that peaked at 485 MiB of RSS growth in the
+// child — a measurement which argued the ceiling already carried ~2.7x the
+// need and therefore could not be what was failing. The real corpus is 4,886
+// sources, 128.5 GB indexed, 572,089 all-time events, and it does not behave
+// like that model. Dogfood build 1020 — which already carries BOTH the
+// rebuild's move into an isolated child (#38) and the child heap cap derived
+// from this constant (#45) — still deferred at 2026-08-20T15:02Z: refresh
+// status "succeeded", accountingRebuildDeferred {status: "deferred", reason:
+// "accounting_transition_rss_limit_exceeded", retained: true, consecutive: 1},
+// and accounting.historyCoverage stuck at "partial" /
+// "cache_generation_mismatch" against an index that was itself fully complete
+// (4,886/4,886 sources, 0 pending). Isolation was supposed to have retired
+// that class of deferral. On real data it did not, so the ceiling does bind
+// here and the synthetic peak is not evidence about this corpus.
+//
+// No measured child peak on the real corpus stands behind 6 GiB either: the
+// one live sampling attempt landed inside the post-deferral backoff, so no
+// rebuild ran during it and it measured nothing. The number is therefore set
+// for HEADROOM rather than fitted to a peak — deliberately, because that is
+// the cheaper error in both directions. The rebuild child is short-lived and
+// returns every byte to the OS when it exits, so ceiling headroom that goes
+// unused costs literally nothing; a ceiling trimmed to a measured peak buys a
+// fresh diagnosis cycle the first time the corpus grows past it, and this
+// corpus grows every day. The guard is not being removed — a runaway still
+// climbs into it and still stops — it is being moved off the path of an
+// ordinary large install, so that what fires is a defect and not a big
+// history.
+//
+// Two consequences to know before touching this number:
+//   - ACCOUNTING_REBUILD_CHILD_OLD_SPACE_MIB is DERIVED from it and must stay
+//     derived. That derivation is what keeps the RSS guard reading before V8
+//     aborts, so a miss arrives as a typed deferral instead of a SIGABRT the
+//     parent can only report as accounting_rebuild_subprocess_failed.
+//   - it is also the default ceiling for buildReplaySafeAccountingPeriod, so
+//     the archive projection that the resident companion runs (see
+//     src/local-archive-accounting-index.js) is loosened by the same amount.
+//     That path is bounded first by its own read budgets and chunking; this
+//     ceiling is its backstop, not its budget.
+const MAX_ACCOUNTING_RSS_BYTES = Math.floor(6 * 1024 * 1024 * 1024);
 // What one accounting rebuild may itself ADD to process RSS over the baseline
 // captured at build start. The effective ceiling is
 // min(MAX_ACCOUNTING_RSS_BYTES, baselineRss + this delta), so the delta must
@@ -216,19 +262,23 @@ const MAX_ACCOUNTING_RSS_BYTES = Math.floor(2 * 1024 * 1024 * 1024);
 // than capping the pass below it. The old 512 MiB delta is exactly what made
 // the 2026-08-11 incident inevitable: with the ~800 MB live baseline it capped
 // the build at ~1.3 GB — BELOW the 1.6 GB the pass actually needed — so the
-// miss was structural, not a real leak. Raised to 1.25 GiB so a typical
-// baseline lands on the absolute target (min(2 GiB, 800 MB + 1.25 GiB =
-// 2.05 GiB) = 2 GiB), while MAX_ACCOUNTING_RSS_BYTES stays the absolute
-// backstop against a leaking baseline.
+// miss was structural, not a real leak.
 //
-// HELD at 1.25 GiB on 2026-08-20 alongside the absolute target. Since the
-// rebuild moved into a child this delta is what actually BINDS: off the
-// child's clean baseline the effective ceiling is baseline + 1.25 GiB ~
-// 1.3 GiB, below the 2 GiB absolute. Measured need in that child is 485 MiB of
-// growth at owner scale, so the delta is ~2.6x the measured climb — enough
-// that a real corpus never trips it, tight enough that a regression back to
-// O(corpus) residency still does.
-const ACCOUNTING_RSS_DELTA_BUDGET_BYTES = Math.floor(1.25 * 1024 * 1024 * 1024);
+// 5.25 GiB (2026-08-20, owner directive), moved in lockstep with the absolute
+// target above because since the rebuild became a child THIS is the number
+// that actually binds. Off the child's clean ~60 MB baseline the effective
+// ceiling is baseline + delta and never the absolute, so the previous 1.25 GiB
+// delta pinned every child at ~1.31 GiB however high the absolute went —
+// which is precisely why build 1020 kept deferring under a 2 GiB absolute that
+// looked like ample room. At 5.25 GiB the child's effective ceiling is
+// ~5.31 GiB, and MAX_ACCOUNTING_RSS_BYTES becomes what binds only above a
+// ~768 MiB baseline (6 - 5.25 GiB), i.e. for an in-process build off a fat
+// companion — which is the arm it was always meant to police.
+//
+// This is still a backstop and not an absence: a regression back to O(corpus)
+// residency on a corpus this size climbs into 5.31 GiB and stops the pass, as
+// a metered deferral with the prior cache retained and served.
+const ACCOUNTING_RSS_DELTA_BUDGET_BYTES = Math.floor(5.25 * 1024 * 1024 * 1024);
 // A memory-budget miss — whole-process RSS over the effective ceiling, the
 // scan guard's own RSS trip, or the per-row retained-byte meter over budget —
 // is a soft TARGET miss, not a hard failure. refreshReplaySafeAccountingCache
@@ -266,15 +316,17 @@ const ACCOUNTING_RSS_CHECK_INTERVAL = 2_048;
 // still starved the in-process rebuild at real scale: the derived transition
 // series legitimately accumulates across batches (~100-200 MB over multi-year
 // history), and the RSS guard measures the WHOLE process — a companion that
-// idles near 1.9 GiB after indexing an ~80 GB corpus reaches the 2 GiB
-// absolute target with no headroom for ANY rebuild growth, so every attempt
-// deferred and the cost surface stayed empty (dogfood 0.1.13, 2026-08-19:
-// accounting_rebuild_deferred at 23:21:26Z and 23:39:15Z on the streamed
-// code). A child starts from a clean ~60 MB baseline, the same guard polices
-// the CHILD's own RSS — which is the guard's actual purpose, keeping the
-// resident menu-bar app sane, now served even better because the parent never
-// grows at all — and exit returns every rebuild byte to the OS instead of
-// fossilizing the next attempt's baseline.
+// idles near 1.9 GiB after indexing an ~80 GB corpus reached the then-current
+// 2 GiB absolute target with no headroom for ANY rebuild growth, so every
+// attempt deferred and the cost surface stayed empty (dogfood 0.1.13,
+// 2026-08-19: accounting_rebuild_deferred at 23:21:26Z and 23:39:15Z on the
+// streamed code). Isolation was necessary but, as build 1020 later showed, not
+// on its own sufficient — see MAX_ACCOUNTING_RSS_BYTES for the 2026-08-20
+// raise it did not remove the need for. A child starts from a clean ~60 MB
+// baseline, the same guard polices the CHILD's own RSS — which is the guard's
+// actual purpose, keeping the resident menu-bar app sane, now served even
+// better because the parent never grows at all — and exit returns every
+// rebuild byte to the OS instead of fossilizing the next attempt's baseline.
 const ACCOUNTING_REBUILD_ISOLATION_MODES = Object.freeze([
   "auto",
   "subprocess",
@@ -302,18 +354,30 @@ const ACCOUNTING_REBUILD_CHILD_ENTRY = fileURLToPath(
 // effective ceiling and had exactly that inversion latent in it.
 //
 // This is a ceiling, not a reservation: V8 grows old space on demand, so a
-// larger cap costs nothing until the pass actually needs it. Measured at owner
-// scale (572,000 events / 25,870 transitions / 130 weekly windows), peak RSS
-// growth over a clean baseline is 362 MiB under a 512 MiB cap and 485 MiB with
-// the cap effectively unbounded — a ~123 MiB lazy-GC swing, consistent with
-// the 147-354 MiB swing measured in #33, and in both cases far below the
-// ~1.3 GiB effective ceiling. Prompt collection therefore does not depend on
-// pinning the cap under that ceiling, and a regression back to O(corpus)
-// residency still stops the pass — now as a metered deferral rather than an
-// out-of-memory abort.
+// larger cap costs nothing until the pass actually needs it, and the child
+// exits within one rebuild and hands every page back to the OS. That is what
+// makes the derivation free to follow MAX_ACCOUNTING_RSS_BYTES up to 6 GiB
+// (2026-08-20) without asking anything of a machine that never needs it: a
+// child that peaks at a few hundred MiB is charged for a few hundred MiB,
+// exactly as it was under the previous 2 GiB derivation. What the raise buys
+// is that the guard, not V8, is still the thing that stops a pass which does
+// climb — synthetic runs at 572,000 events showed a ~123 MiB lazy-GC swing
+// between a 512 MiB cap and an unbounded one (consistent with the
+// 147-354 MiB swing measured in #33), so collection behaviour does not depend
+// on pinning the cap low, while a cap below the ceiling would silently convert
+// every real overflow into an abort the parent cannot explain.
 const ACCOUNTING_REBUILD_CHILD_OLD_SPACE_MIB = Math.ceil(
   MAX_ACCOUNTING_RSS_BYTES / (1024 * 1024),
 );
+// The memory policy as the tests and any future caller should read it: derived
+// from the constants above rather than mirrored, so a regression can pin the
+// RELATIONSHIPS (cap >= absolute >= effective ceiling) without going stale the
+// next time the numbers move, and one deliberate tripwire can pin the VALUES.
+export const REPLAY_SAFE_ACCOUNTING_MEMORY_POLICY = Object.freeze({
+  maximumRssBytes: MAX_ACCOUNTING_RSS_BYTES,
+  rssDeltaBudgetBytes: ACCOUNTING_RSS_DELTA_BUDGET_BYTES,
+  rebuildChildOldSpaceMib: ACCOUNTING_REBUILD_CHILD_OLD_SPACE_MIB,
+});
 // SIGTERM asks the child to unwind through its own abort checks (typed abort
 // envelope); a child that cannot unwind inside this grace is killed hard. The
 // value only bounds teardown after an abort — never the build itself.
@@ -3245,14 +3309,18 @@ export async function buildReplaySafeAccountingCache({
   // accounting build's authoritative ceiling is the effective target computed
   // above (checkRuntimeMemory), so pass the guard the LOWER of the two: it can
   // only tighten the transition-path target, never contradict it. Which side
-  // wins depends on the baseline and is deliberately not assumed: off the
-  // rebuild child's clean baseline the accounting effective ceiling (~1.3 GiB)
-  // is the lower one, while a fat in-process baseline pushes it up against the
-  // export policy's 1.5 GiB. In practice the heavy growth is the post-scan
-  // transition mining that checkRuntimeMemory polices at the full effective
-  // target, while the scan phase stays within either bound. A scan-phase RSS
-  // trip is likewise a soft budget miss (accounting_scan_rss_limit_exceeded),
-  // not a hard refresh failure.
+  // wins depends on the baseline and is deliberately not assumed. Since the
+  // 2026-08-20 raise the export policy's 1.5 GiB is the lower one for every
+  // baseline under 1.5 GiB — the rebuild child's clean baseline included — so
+  // the scan phase is now clamped by the export policy while the transition
+  // path runs at the full ~5.31 GiB effective ceiling. That asymmetry is
+  // intentional rather than overlooked: every observed deferral, build 1020's
+  // included, was on the transition path, and a scan-phase trip is likewise a
+  // soft budget miss (accounting_scan_rss_limit_exceeded) that retains and
+  // serves the prior cache rather than failing the refresh. In practice the
+  // heavy growth is the post-scan transition mining that checkRuntimeMemory
+  // polices at the full effective target, while the scan phase stays within
+  // either bound.
   const scanResourceGuardMaximumRssBytes = Math.min(
     effectiveMaximumRssBytes,
     DEFAULT_EXPORT_RESOURCE_LIMITS.maximumRssBytes,

--- a/src/replay-safe-accounting-rebuild-child.js
+++ b/src/replay-safe-accounting-rebuild-child.js
@@ -17,13 +17,18 @@ import { stableJson } from "./export/canonical-json.js";
 // process that starts from a clean baseline and returns every byte to the OS
 // on exit. Running the build inside the resident menu-bar companion could not
 // achieve either: after real indexing on a large corpus the companion
-// legitimately idles near the 2 GiB absolute accounting target, so the
-// budget-relative guard had no headroom left for ANY rebuild growth, and the
-// rebuild deferred forever (live 0.1.13 incident, 2026-08-19: a 4,852-source /
-// ~80 GB companion sat at 1.88 GiB whole-process RSS after indexing and logged
+// legitimately idles at a residency comparable to the accounting target
+// itself, so the budget-relative guard had no headroom left for ANY rebuild
+// growth, and the rebuild deferred forever (live 0.1.13 incident, 2026-08-19:
+// a 4,852-source / ~80 GB companion sat at 1.88 GiB whole-process RSS after
+// indexing, against a 2 GiB target at the time, and logged
 // accounting_rebuild_deferred / accounting_transition_rss_limit_exceeded on
 // every attempt even after the streaming-corpus fix bounded per-batch
-// residency).
+// residency). The 2026-08-20 raise leaves that headroom argument less tight at
+// today's numbers, but the other two reasons are structural and do not depend
+// on the ceiling at all: growth here never enlarges the resident process, and
+// exit returns every rebuild byte to the OS instead of fossilizing the next
+// attempt's baseline.
 //
 // Contract (see buildReplaySafeAccountingCacheInSubprocess, the only caller):
 // argv carries exactly two file paths — a request file the parent wrote and a

--- a/test/replay-safe-accounting-cache.test.js
+++ b/test/replay-safe-accounting-cache.test.js
@@ -4,6 +4,7 @@ import { mkdtemp, rm, stat } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
+  REPLAY_SAFE_ACCOUNTING_MEMORY_POLICY,
   REPLAY_SAFE_ACCOUNTING_SCHEMA_VERSION,
   assertReplaySafeAccountingCache,
   buildReplaySafeAccountingCache,
@@ -2909,13 +2910,72 @@ test("compact transition input ceilings fail closed without truncating or replac
   assert.equal((await stat(cacheFile)).mode & 0o777, 0o600);
 });
 
-// Effective-ceiling arithmetic mirrored from the module: absolute 2 GiB target,
-// 1.25 GiB self-growth delta, effective = min(absolute, baseline + delta).
-const ACCOUNTING_RSS_ABSOLUTE = 2 * 1024 * 1024 * 1024;
-const ACCOUNTING_RSS_DELTA = Math.floor(1.25 * 1024 * 1024 * 1024);
+// Effective-ceiling arithmetic READ FROM the module rather than mirrored:
+// effective = min(absolute, baseline + delta). The tests below pin that
+// RELATIONSHIP, so they keep testing the same property when the policy moves;
+// the shipped VALUES are pinned once, deliberately, by the tripwire directly
+// below. Mirrored literals here would have meant every ceiling test silently
+// encoding one particular number, which is how the 2026-08-20 raise found
+// three regressions asserting a ceiling the product no longer had.
+const ACCOUNTING_RSS_ABSOLUTE =
+  REPLAY_SAFE_ACCOUNTING_MEMORY_POLICY.maximumRssBytes;
+const ACCOUNTING_RSS_DELTA =
+  REPLAY_SAFE_ACCOUNTING_MEMORY_POLICY.rssDeltaBudgetBytes;
 // Mirrored from src/export/resource-policy.js: the shared export policy's own
 // RSS bound, which clamps the deep-scan guard independently of the above.
 const EXPORT_POLICY_MAX_RSS_BYTES = Math.floor(1.5 * 1024 * 1024 * 1024);
+// A realistic resting companion RSS after indexing a large history — the
+// baseline the in-process arm of the guard is actually shaped for.
+const REALISTIC_COMPANION_BASELINE = 800 * 1024 * 1024;
+
+test("the shipped accounting memory policy is the owner-set pair and a derived child cap", () => {
+  // THE TRIPWIRE, and the only place a literal ceiling lives. Everything else
+  // derives, so this is what a policy change has to come through — and the
+  // rationale for these numbers is in the constants themselves, not in a pull
+  // request that will not be read again.
+  assert.deepEqual(REPLAY_SAFE_ACCOUNTING_MEMORY_POLICY, {
+    maximumRssBytes: 6 * 1024 * 1024 * 1024,
+    rssDeltaBudgetBytes: Math.floor(5.25 * 1024 * 1024 * 1024),
+    rebuildChildOldSpaceMib: 6_144,
+  });
+  // DERIVED, not coincident: the child's V8 old-space cap is the absolute
+  // target expressed in MiB. Because the effective ceiling is at most the
+  // absolute for every baseline, and whole-process RSS always exceeds the JS
+  // heap, this ordering is what guarantees the RSS guard reads before V8
+  // aborts — a typed accounting_transition_rss_limit_exceeded deferral rather
+  // than a SIGABRT the parent can only report as
+  // accounting_rebuild_subprocess_failed.
+  assert.equal(
+    REPLAY_SAFE_ACCOUNTING_MEMORY_POLICY.rebuildChildOldSpaceMib * 1024 * 1024,
+    REPLAY_SAFE_ACCOUNTING_MEMORY_POLICY.maximumRssBytes,
+  );
+  // Which arm binds where. Off the rebuild child's clean baseline the DELTA is
+  // the effective ceiling, so raising the absolute alone would have been inert
+  // there; the absolute only takes over above a fat in-process baseline. Both
+  // regimes are exercised by the two ceiling tests below, and pinning them
+  // here is what stops a future edit from moving a number until one of those
+  // tests is quietly testing the same arm twice.
+  const cleanChildBaseline = 60 * 1024 * 1024;
+  assert.ok(
+    cleanChildBaseline + ACCOUNTING_RSS_DELTA < ACCOUNTING_RSS_ABSOLUTE,
+    "off a clean child baseline the delta must be the binding ceiling",
+  );
+  assert.ok(
+    REALISTIC_COMPANION_BASELINE + ACCOUNTING_RSS_DELTA >= ACCOUNTING_RSS_ABSOLUTE,
+    "off a realistic companion baseline the absolute target must be the "
+      + "binding ceiling",
+  );
+  // The deep-scan phase is clamped by the shared export policy at any baseline
+  // below 1.5 GiB, the child's included. Asserted so the asymmetry stays a
+  // recorded decision (the observed deferrals were all on the transition path)
+  // rather than a surprise found in a later incident.
+  assert.ok(
+    EXPORT_POLICY_MAX_RSS_BYTES < cleanChildBaseline + ACCOUNTING_RSS_DELTA,
+    "the scan phase is expected to be clamped by the export policy rather "
+      + "than by the accounting delta; if that stops holding, the scan-guard "
+      + "regression below is asserting the wrong regime",
+  );
+});
 
 test("an RSS ceiling miss during accounting is a soft target: the prior cache is retained and served", async () => {
   const directory = await mkdtemp(join(tmpdir(), "usage-monitor-rss-bound-"));
@@ -2987,9 +3047,17 @@ test("the RSS guard is budget-relative: a pass past the delta budget soft-fails 
   const before = await readTestCache(cacheFile);
   const baseline = 200 * 1024 * 1024;
   // Baseline capture and the start check see the companion's resting RSS; the
-  // post-scan check sees the pass one byte past its 1.25 GiB delta budget while
-  // still far UNDER the 2 GiB absolute ceiling — the delta arm binds, and it is
-  // a soft target: the prior cache is retained, the refresh does not fail.
+  // post-scan check sees the pass one byte past its delta budget while still
+  // UNDER the absolute ceiling — the delta arm binds, and it is a soft target:
+  // the prior cache is retained, the refresh does not fail. The premise is
+  // asserted rather than assumed, so a policy change that made the absolute
+  // the binding arm at this baseline fails here instead of leaving this test
+  // silently exercising the other arm.
+  assert.ok(
+    baseline + ACCOUNTING_RSS_DELTA < ACCOUNTING_RSS_ABSOLUTE,
+    "this test only exercises the delta arm while baseline + delta stays "
+      + "below the absolute ceiling",
+  );
   const samples = [baseline, baseline, baseline + ACCOUNTING_RSS_DELTA + 1];
 
   const outcome = await refreshReplaySafeAccountingCache({
@@ -3085,14 +3153,21 @@ test("a memory-budget miss with no prior cache degrades honestly without throwin
   assert.equal(served.cache, null);
 });
 
-test("a rebuild within the raised 2 GiB budget completes normally", async () => {
+test("the 2026-08-11 incident's own reading is in budget and rebuilds normally", async () => {
   const directory = await mkdtemp(join(tmpdir(), "usage-monitor-rss-in-budget-"));
   const cacheFile = join(directory, "accounting.json");
-  const baseline = 800 * 1024 * 1024;
+  const baseline = REALISTIC_COMPANION_BASELINE;
   // The live-failure reading: ~800 MB baseline, the pass climbs to ~1.6 GB.
-  // Under the old 1.5 GiB ceiling / 512 MiB delta that hard-failed; under the
-  // raised 2 GiB target it is comfortably in budget and the cache builds.
+  // Under the then-current 1.5 GiB ceiling / 512 MiB delta that hard-failed
+  // and blanked the dashboard; every policy shipped since keeps it in budget,
+  // so the cache builds. Asserted against the live policy rather than a
+  // remembered ceiling, so this stays the incident's regression rather than a
+  // test of one particular number.
   const climbed = 1_600 * 1024 * 1024;
+  assert.ok(
+    climbed <= Math.min(ACCOUNTING_RSS_ABSOLUTE, baseline + ACCOUNTING_RSS_DELTA),
+    "the reading that caused the 2026-08-11 incident must stay in budget",
+  );
   let calls = 0;
   const cache = await refreshReplaySafeAccountingCache({
     cacheFile,
@@ -3113,8 +3188,8 @@ test("a rebuild within the raised 2 GiB budget completes normally", async () => 
   assert.equal(period(cache, "7d").events, 1);
 });
 
-test("the effective transition ceiling is the 2 GiB target for a realistic ~800 MB baseline", async () => {
-  const directory = await mkdtemp(join(tmpdir(), "usage-monitor-rss-2gib-"));
+test("the absolute target is the effective transition ceiling for a realistic companion baseline", async () => {
+  const directory = await mkdtemp(join(tmpdir(), "usage-monitor-rss-absolute-"));
   const cacheFile = join(directory, "accounting.json");
   await refreshReplaySafeAccountingCache({
     cacheFile,
@@ -3122,13 +3197,19 @@ test("the effective transition ceiling is the 2 GiB target for a realistic ~800 
     scan: scanner([]),
   });
   const before = await readTestCache(cacheFile);
-  const baseline = 800 * 1024 * 1024;
-  // Baseline capture + start check see the ~800 MB resting RSS; the post-scan
-  // transition-path check sees the pass one byte past the 2 GiB absolute
-  // target. min(2 GiB, 800 MB + 1.25 GiB = 2.05 GiB) = 2 GiB, so this is the
-  // exact boundary: paired with the "1.6 GB completes" test above it brackets
-  // the effective ceiling at ~2 GiB (the 1.6 GB the incident tripped at is now
-  // comfortably under budget), and crossing it is a soft target miss.
+  const baseline = REALISTIC_COMPANION_BASELINE;
+  // The other arm of the min(). Baseline capture + start check see the ~800 MB
+  // resting RSS; the post-scan transition-path check sees the pass one byte
+  // past the ABSOLUTE target, which at this baseline is the lower of the two
+  // and therefore the exact boundary. Paired with the "1.6 GB completes" test
+  // above this brackets the in-process effective ceiling (the 1.6 GB the
+  // 2026-08-11 incident tripped at is comfortably under budget at any shipped
+  // policy since), and crossing it is a soft target miss.
+  assert.ok(
+    baseline + ACCOUNTING_RSS_DELTA >= ACCOUNTING_RSS_ABSOLUTE,
+    "this test only exercises the absolute arm while a realistic baseline "
+      + "plus the delta reaches the absolute ceiling",
+  );
   const samples = [baseline, baseline, ACCOUNTING_RSS_ABSOLUTE + 1];
 
   const outcome = await refreshReplaySafeAccountingCache({
@@ -3197,10 +3278,16 @@ test("the scan resource guard inherits the budget-relative RSS ceiling", async (
     Math.min(baseline + ACCOUNTING_RSS_DELTA, EXPORT_POLICY_MAX_RSS_BYTES),
   );
   // At this modest baseline — the shape the rebuild child actually runs at —
-  // the budget-relative ceiling is the lower of the two, so the guard inherits
-  // it rather than the export policy's flat bound.
-  assert.equal(observedGuard?.limits.maximumRssBytes, baseline + ACCOUNTING_RSS_DELTA);
-  assert.ok(baseline + ACCOUNTING_RSS_DELTA < EXPORT_POLICY_MAX_RSS_BYTES);
+  // the export policy's flat bound is the lower of the two since the
+  // 2026-08-20 delta raise, so the scan phase is clamped by the export policy
+  // while the transition path runs at the full budget-relative ceiling. Pinned
+  // explicitly, because that split is a decision (the observed deferrals were
+  // all on the transition path) and not an accident of arithmetic.
+  assert.equal(
+    observedGuard?.limits.maximumRssBytes,
+    EXPORT_POLICY_MAX_RSS_BYTES,
+  );
+  assert.ok(EXPORT_POLICY_MAX_RSS_BYTES < baseline + ACCOUNTING_RSS_DELTA);
 });
 
 test("deep log scanning receives hard resource bounds and preserves the last cache when they trip", async () => {

--- a/test/replay-safe-accounting-corpus-stream.test.js
+++ b/test/replay-safe-accounting-corpus-stream.test.js
@@ -8,6 +8,7 @@ import {
   buildReplaySafeAccountingCache,
   refreshReplaySafeAccountingCache,
   readReplaySafeAccountingCache,
+  REPLAY_SAFE_ACCOUNTING_MEMORY_POLICY,
   REPLAY_SAFE_ACCOUNTING_SCHEMA_VERSION,
 } from "../src/replay-safe-accounting-cache.js";
 import {
@@ -476,13 +477,14 @@ test("a corpus far larger than one derivation batch completes in ONE pass under 
 // was necessary but insufficient at owner scale: the derived transition series
 // still accumulates across batches, and the RSS guard measures the WHOLE
 // process — a companion that legitimately idles near 1.9 GiB after indexing an
-// ~80 GB corpus reaches the 2 GiB absolute target with no headroom for ANY
-// rebuild growth, so the streamed rebuild kept deferring (dogfood 0.1.13,
-// 2026-08-19, 23:21:26Z and 23:39:15Z). Production rebuilds therefore run in a
-// short-lived child with a clean baseline. These tests pin the boundary:
+// ~80 GB corpus reached the then-current 2 GiB absolute target with no headroom
+// for ANY rebuild growth, so the streamed rebuild kept deferring (dogfood
+// 0.1.13, 2026-08-19, 23:21:26Z and 23:39:15Z). Production rebuilds therefore
+// run in a short-lived child with a clean baseline. These tests pin the
+// boundary:
 //  1. the child's artifact is BYTE-identical to the in-process build;
-//  2. a rebuild completes while the parent sits past the absolute backstop —
-//     the exact state that deferred forever in-process;
+//  2. a rebuild completes while the parent sits past the ceiling both arms are
+//     handed — the exact state that deferred forever in-process;
 //  3. a child that dies fails closed to the deferral (never a crash loop,
 //     never a clobbered prior cache);
 //  4. the caller's abort is an abort, not a deferral.
@@ -912,14 +914,38 @@ test("isolation options validate closed", async () => {
 });
 
 // The decisive owner-scale regression. The parent process is inflated past the
-// 2 GiB absolute accounting backstop and RETAINS that ballast — the state a
-// large-history companion legitimately reaches after indexing — then runs the
-// same rebuild both ways. In-process the guard's very first check must defer
-// (that IS the 0.1.13 livelock: baseline past the target, zero headroom, every
-// attempt deferred). The default isolated rebuild must COMPLETE against the
-// same corpus while the parent stays inflated, because the guard now measures
-// the child's own clean-baseline RSS. Runs in a spawned parent so the 2 GiB
-// ballast never lives in the shared test-runner process.
+// RSS ceiling BOTH arms are handed, and RETAINS that ballast across the whole
+// run — the state a large-history companion legitimately reaches after
+// indexing — then runs the same rebuild both ways. In-process the guard's very
+// first check must defer (that IS the 0.1.13 livelock: baseline past the
+// ceiling, zero headroom, every attempt deferred). The default isolated
+// rebuild must COMPLETE against the same corpus while the parent stays
+// inflated, because the guard now measures the child's own clean-baseline RSS.
+// Runs in a spawned parent so the ballast never lives in the shared
+// test-runner process.
+//
+// The ceiling is PARAMETERISED rather than left at the shipped absolute, and
+// that is the substance of the 2026-08-20 rework. This test used to allocate
+// 2 GiB + 64 MiB of touched ballast to clear the then-shipped 2 GiB absolute;
+// against the raised 6 GiB absolute the same device would need more than 6 GiB
+// resident inside a test process, which is impractical and openly hostile on a
+// developer machine. What is under test is a RELATIONSHIP — a parent past the
+// ceiling, a child starting clean beneath it — and a relationship is
+// scale-free, so both arms are handed one small explicit ceiling instead. The
+// SHIPPED numbers, and the fact that the real spawn carries them, are pinned
+// separately: by the invariant test below, which reads the production child's
+// own execArgv and request, and by the policy tripwire in
+// test/replay-safe-accounting-cache.test.js.
+//
+// Both numbers below are measured rather than chosen. The real production
+// child completes this fixture under a 160 MiB whole-process ceiling and
+// defers under 128 MiB, so 384 MiB carries ~2.4x its measured need and the
+// isolated arm cannot flake; 768 MiB of touched ballast leaves the parent
+// near ~880 MiB, ~2.3x the same ceiling, so the in-process arm cannot flake
+// either. The ballast is roughly a third of what this test used to allocate,
+// and a ninth of what clearing the shipped absolute would now demand.
+const INFLATED_PARENT_CEILING_BYTES = 384 * 1024 * 1024;
+const INFLATED_PARENT_BALLAST_BYTES = 768 * 1024 * 1024;
 const INFLATED_PARENT = String.raw`
 const { refreshReplaySafeAccountingCache } = await import(
   process.env.REBUILD_PARENT_MODULE
@@ -941,14 +967,22 @@ const shared = {
   unifiedIndexFile: process.env.REBUILD_PARENT_INDEX_FILE,
   now: () => nowMs,
   declaredSpeedBaselines: JSON.parse(process.env.REBUILD_PARENT_BASELINES),
+  // ONE ceiling, handed identically to both arms, so the only thing that
+  // differs between them is which process the guard measures.
+  maximumRssBytes: Number(process.env.REBUILD_PARENT_CEILING_BYTES),
 };
 const inProcess = await refreshReplaySafeAccountingCache({
   ...shared,
   rebuildIsolation: "in_process",
 });
 const isolated = await refreshReplaySafeAccountingCache({ ...shared });
+// Sampled AFTER both rebuilds: proves the parent was still over the ceiling
+// while the isolated arm ran, rather than having quietly shed the ballast
+// somewhere between the two calls.
+const parentRssAfterBytes = process.memoryUsage().rss;
 process.stdout.write(JSON.stringify({
   parentRssBytes,
+  parentRssAfterBytes,
   // Reading the ballast after both rebuilds keeps it retained throughout.
   ballastByte: ballast[ballast.length - 1],
   inProcess: {
@@ -969,16 +1003,24 @@ process.stdout.write(JSON.stringify({
 }) + "\n");
 `;
 
-test("a rebuild completes in the child while the parent sits past the absolute RSS backstop", { timeout: 240_000 }, async (t) => {
+test("a rebuild completes in the child while the parent sits past the RSS ceiling both arms are handed", { timeout: 240_000 }, async (t) => {
   const directory = await mkdtemp(join(tmpdir(), "usage-monitor-rebuild-inflated-parent-"));
   try {
     const fixture = await writeCompleteGenerationIndex(
       join(directory, "local-unified-index-v1.sqlite"),
       SUBPROCESS_FIXTURE_SHAPE,
     );
-    // 2 GiB absolute target + 64 MiB: past the backstop, the way the owner's
-    // companion idles at 1.88 GiB and crosses during any in-process attempt.
-    const ballastBytes = (2 * 1024 + 64) * 1024 * 1024;
+    // The scaled model of the shipped absolute: a parent resident twice its
+    // own ceiling, the way the owner's companion idles past the accounting
+    // target and crosses it during any in-process attempt. Asserted to BE a
+    // scaled model, so nobody later reads this ceiling as the product's.
+    assert.ok(
+      INFLATED_PARENT_CEILING_BYTES
+        < REPLAY_SAFE_ACCOUNTING_MEMORY_POLICY.maximumRssBytes,
+      "the parameterised ceiling stands in for the shipped absolute and must "
+        + "stay below it; the shipped value is pinned by the policy tripwire",
+    );
+    const ballastBytes = INFLATED_PARENT_BALLAST_BYTES;
     const child = spawnSync(process.execPath, [
       "--input-type=module",
       "--eval",
@@ -999,21 +1041,33 @@ test("a rebuild completes in the child while the parent sits past the absolute R
         REBUILD_PARENT_NOW_MS: String(NOW),
         REBUILD_PARENT_BASELINES: JSON.stringify(DECLARED_SPEED_BASELINES),
         REBUILD_PARENT_BALLAST_BYTES: String(ballastBytes),
+        REBUILD_PARENT_CEILING_BYTES: String(INFLATED_PARENT_CEILING_BYTES),
       },
     });
     assert.equal(child.error, undefined, child.error?.message);
     assert.equal(child.signal, null, child.stderr);
     assert.equal(child.status, 0, child.stderr);
     const outcome = JSON.parse(child.stdout);
+    const asMiB = (bytes) => (bytes / 1024 / 1024).toFixed(0);
     t.diagnostic(
-      `parent RSS ${(outcome.parentRssBytes / 1024 / 1024).toFixed(0)} MiB; `
-        + "in-process deferred, isolated child completed",
+      `parent RSS ${asMiB(outcome.parentRssBytes)} MiB before and `
+        + `${asMiB(outcome.parentRssAfterBytes)} MiB after, against a `
+        + `${asMiB(INFLATED_PARENT_CEILING_BYTES)} MiB ceiling; in-process `
+        + "deferred, isolated child completed",
     );
     assert.equal(outcome.ballastByte, 0xa5);
-    // The parent genuinely sat past the 2 GiB absolute accounting target.
+    // The parent genuinely sat past the ceiling it handed both arms — before
+    // the first rebuild and still after the second, so the isolated arm did
+    // not succeed by the parent quietly shedding its residency in between.
     assert.ok(
-      outcome.parentRssBytes > 2 * 1024 * 1024 * 1024,
-      `parent RSS ${outcome.parentRssBytes} must exceed the absolute backstop`,
+      outcome.parentRssBytes > INFLATED_PARENT_CEILING_BYTES,
+      `parent RSS ${outcome.parentRssBytes} must exceed the ceiling `
+        + `${INFLATED_PARENT_CEILING_BYTES} before either rebuild`,
+    );
+    assert.ok(
+      outcome.parentRssAfterBytes > INFLATED_PARENT_CEILING_BYTES,
+      `parent RSS ${outcome.parentRssAfterBytes} must still exceed the ceiling `
+        + `${INFLATED_PARENT_CEILING_BYTES} after the isolated rebuild landed`,
     );
     // In-process: the incident, reproduced — the guard's first check defers
     // and no attempt could ever land (retained:false, nothing on disk yet).
@@ -1051,9 +1105,13 @@ test("a rebuild completes in the child while the parent sits past the absolute R
 //     reported as the opaque accounting_rebuild_subprocess_failed.
 //
 // Both paths end in a deferral, so from outside the difference is invisible —
-// which is precisely how a proposed 6 GiB RSS target came to be paired with a
-// 1 GiB child heap, leaving a guard that could never fire. These tests pin the
-// order itself: once at production values, once causally.
+// which is precisely how the first attempt at a 6 GiB RSS target came to be
+// paired with a 1 GiB child heap, leaving a guard that could never fire. That
+// target is now shipped, and deriving the cap from it is what makes the
+// pairing unrepresentable rather than merely discouraged. These tests pin the
+// order itself: once at production values, once causally. The causal pair runs
+// at its own small pressure point by design — the mechanism is scale-free, and
+// the SHIPPED numbers are the invariant test's job, not this one's.
 // ---------------------------------------------------------------------------
 
 test("the rebuild child is spawned with a heap cap at or above the RSS ceiling it is handed", async () => {
@@ -1124,6 +1182,21 @@ test("the rebuild child is spawned with a heap cap at or above the RSS ceiling i
         + `ceiling it is handed (${probe.requestMaximumRssBytes} bytes); below it, `
         + "V8 aborts the child before the guard can defer and the honest budget "
         + "reason is replaced by accounting_rebuild_subprocess_failed",
+    );
+    // ...and both sides of that inequality are the SHIPPED policy, not two
+    // small numbers that happen to be ordered. Without this pair the invariant
+    // above would hold just as well for a child launched with a toy ceiling
+    // and a toy cap, which is exactly the state a partial edit leaves behind.
+    assert.equal(
+      probe.requestMaximumRssBytes,
+      REPLAY_SAFE_ACCOUNTING_MEMORY_POLICY.maximumRssBytes,
+      "the production spawn must hand the child the shipped absolute target",
+    );
+    assert.equal(
+      capBytes,
+      REPLAY_SAFE_ACCOUNTING_MEMORY_POLICY.rebuildChildOldSpaceMib
+        * 1024 * 1024,
+      "the production spawn must carry the cap derived from that target",
     );
   } finally {
     await rm(directory, { recursive: true, force: true });
@@ -1242,6 +1315,17 @@ const CAP_ORDER_PRESSURE_MIB = 64;
 // (cap >= ceiling) without needing the shipped corpus to reach it.
 const CAP_ORDER_ROOMY_CAP_MIB = 512;
 const CAP_ORDER_UNREACHABLE_BUDGET_MIB = 8_192;
+// What arm 2's ceiling ACTUALLY resolves to. The build's effective ceiling is
+// min(the maximumRssBytes it is handed, baseline + the module's self-growth
+// delta), so asking for 8 GiB does not by itself put the ceiling out of reach —
+// the shipped delta is the other term and may well be the smaller one. Both
+// terms have to stay far above the pressure point, or "unreachable" quietly
+// becomes reachable, the guard fires in arm 2 as well, and the pair stops
+// isolating the cap as the only difference between the arms.
+const CAP_ORDER_ARM_TWO_EFFECTIVE_BUDGET_BYTES = Math.min(
+  CAP_ORDER_UNREACHABLE_BUDGET_MIB * 1024 * 1024,
+  REPLAY_SAFE_ACCOUNTING_MEMORY_POLICY.rssDeltaBudgetBytes,
+);
 
 function runCapOrderArm({ oldSpaceMiB, budgetMiB, indexFile }) {
   return spawnSync(process.execPath, [
@@ -1303,6 +1387,13 @@ test("the same overflow is a typed budget miss above the cap and an untyped deat
     // reach so ONLY the cap can bite, and the same corpus at the same pressure
     // now kills the process outright: no code, no envelope, nothing for the
     // parent to classify beyond "the child died".
+    assert.ok(
+      CAP_ORDER_ARM_TWO_EFFECTIVE_BUDGET_BYTES
+        > 8 * CAP_ORDER_PRESSURE_MIB * 1024 * 1024,
+      "arm 2's ceiling must stay far out of reach of the pressure point, or "
+        + "the RSS guard fires here too and the arms stop differing only in "
+        + "the cap",
+    );
     const starved = runCapOrderArm({
       oldSpaceMiB: CAP_ORDER_PRESSURE_MIB,
       budgetMiB: CAP_ORDER_UNREACHABLE_BUDGET_MIB,


### PR DESCRIPTION
Owner-directed. On dogfood 1020 — which already contains #38's subprocess isolation and #45's derived child cap — the rebuild still deferred at owner scale with accounting_transition_rss_limit_exceeded, leaving accounting.historyCoverage pinned at partial/cache_generation_mismatch with the index itself fully complete (4,886 of 4,886 sources, 128.5 GB, 0 pending).

MAX_ACCOUNTING_RSS_BYTES 2 → 6 GiB and ACCOUNTING_RSS_DELTA_BUDGET_BYTES 1.25 → 5.25 GiB; the child's old-space cap stays DERIVED from MAX per #45, so it follows to 6144 automatically and the guard still provably trips before V8 (honest deferral rather than SIGABRT). The companion's own --max-old-space-size stays removed — since #38 the resident process does not run the rebuild.

Why the delta had to move too: the effective child ceiling was min(2 GiB, cleanBaseline + 1.25 GiB) ≈ 1.31 GiB, so raising only the absolute would have been completely inert. The real corpus therefore needs ~2.6x what #45's synthetic 572k-event model measured (485 MiB) — which is why that model was the wrong basis. The rationale now lives in the constants rather than a PR description, including why a measured-tight ceiling was rejected in favour of headroom: the rebuild child is short-lived and returns every byte on exit, so unused headroom costs nothing, while a tight ceiling costs a fresh diagnosis cycle each time a corpus grows past it.

The ballast regression is reworked to be scale-free rather than deleted: the ceiling is parameterised and handed identically to both arms, with 768 MiB of touched parent ballast against a 384 MiB ceiling — in-process defers on its first check, the isolated child completes because it starts clean. Both figures are measured (the production child completes that fixture at 160 MiB and defers at 128 MiB), and the test is now strictly stronger than the original: parent residency is sampled after both rebuilds, closing a gap where the isolated arm could have passed because the parent quietly shed ballast in between. Runs in 758 ms instead of allocating multiple GiB.

Gates: the three named suites 144/144, macos-source 46 pass, UI 324/324, architecture clean, causal pair and derived-cap invariant both still meaningful at the new values.

Two documented consequences, neither blocking: the deep-scan phase is now clamped by the shared export policy's 1.5 GiB rather than this pair (a loosening from ~1.31 GiB, and every observed deferral was on the transition path — the regime is pinned in tests so a future scan-phase deferral is unmistakable), and MAX_ACCOUNTING_RSS_BYTES is shared with buildReplaySafeAccountingPeriod on the legacy archive path, which is gated off in the shipped build (accountingSourceMode === legacy) and has a follow-up to get its own ceiling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)