### PR TITLE
fix(accounting): give the resident archive projection its own memory ceiling

### DIFF
--- a/src/replay-safe-accounting-cache.js
+++ b/src/replay-safe-accounting-cache.js
@@ -196,6 +196,12 @@ const MAX_RETAINED_TRANSITION_BYTES = 320 * 1024 * 1024;
 // delta alone can never pass the absolute. Change them as a PAIR, and read
 // ACCOUNTING_REBUILD_CHILD_OLD_SPACE_MIB before changing either — the derived
 // cap is what keeps a miss an honest deferral rather than a SIGABRT.
+//
+// All three describe the REBUILD, which since #38 runs in a short-lived child.
+// The resident companion's archive projection is a separate process situation
+// and has a separate pair, MAX_ARCHIVE_ACCOUNTING_RSS_BYTES and
+// ARCHIVE_ACCOUNTING_RSS_DELTA_BUDGET_BYTES, further down. Nothing here is a
+// default for anything there; that inheritance is the bug they exist to close.
 // ---------------------------------------------------------------------------
 // Absolute whole-process RSS TARGET for one accounting rebuild. It is a
 // TARGET, not a hard blocker: a miss degrades to a retained-cache soft-fail
@@ -249,11 +255,14 @@ const MAX_RETAINED_TRANSITION_BYTES = 320 * 1024 * 1024;
 //     derived. That derivation is what keeps the RSS guard reading before V8
 //     aborts, so a miss arrives as a typed deferral instead of a SIGABRT the
 //     parent can only report as accounting_rebuild_subprocess_failed.
-//   - it is also the default ceiling for buildReplaySafeAccountingPeriod, so
-//     the archive projection that the resident companion runs (see
-//     src/local-archive-accounting-index.js) is loosened by the same amount.
-//     That path is bounded first by its own read budgets and chunking; this
-//     ceiling is its backstop, not its budget.
+//   - its reach STOPS at the rebuild. Until 2026-08-20 it was also the
+//     default ceiling for buildReplaySafeAccountingPeriod, so raising it
+//     here silently loosened the archive projection the RESIDENT companion
+//     runs by the same 4 GiB — the opposite of what #38 moved the rebuild
+//     into a child to achieve. That path now resolves its own ceiling from
+//     MAX_ARCHIVE_ACCOUNTING_RSS_BYTES below, and a regression pins that it
+//     does not follow this constant. Headroom is free in a process that
+//     exits; it is not free in one that stays.
 const MAX_ACCOUNTING_RSS_BYTES = Math.floor(6 * 1024 * 1024 * 1024);
 // What one accounting rebuild may itself ADD to process RSS over the baseline
 // captured at build start. The effective ceiling is
@@ -369,6 +378,70 @@ const ACCOUNTING_REBUILD_CHILD_ENTRY = fileURLToPath(
 const ACCOUNTING_REBUILD_CHILD_OLD_SPACE_MIB = Math.ceil(
   MAX_ACCOUNTING_RSS_BYTES / (1024 * 1024),
 );
+// ---------------------------------------------------------------------------
+// The ARCHIVE projection's own ceiling, deliberately NOT the rebuild's.
+//
+// buildReplaySafeAccountingPeriod has two callers with opposite memory
+// situations, and until 2026-08-20 they shared one number by inheritance
+// rather than by decision:
+//   - the rebuild calls it as a sub-build and NAMES its own ceiling (the
+//     effective target it already computed), so it is unaffected by anything
+//     here and must stay that way;
+//   - refreshLocalArchiveAccountingIndex (src/local-archive-accounting-index.js)
+//     names nothing, and runs inside the RESIDENT menu-bar companion.
+// A ceiling sized for a short-lived child that hands every page back to the OS
+// on exit is the wrong ceiling for a process the user leaves running all day.
+// The 2 -> 6 GiB rebuild raise reached this path only because the default was
+// never chosen; that is the defect these two constants close.
+//
+// The shape is baseline + delta rather than a bare absolute, and that is the
+// substance of the fix rather than a stylistic echo of the rebuild policy. A
+// whole-process absolute cannot work in the companion, because it charges the
+// pass for memory the pass did not allocate and cannot free. Measured on the
+// owner's own machine (dogfood 0.1.13 build 1020, 4,886 sources / 128.5 GB
+// indexed), the resident companion oscillates between 1,312 and 2,089 MiB
+// across a twenty-second window — it crosses 2 GiB on GC timing alone. Under
+// the pre-raise 2 GiB absolute this projection would therefore have deferred
+// or not deferred depending on when V8 last collected, which is the worst of
+// the available failure modes: not a bound, a coin flip. A delta measured off
+// THIS pass's own baseline is the only arm that attributes growth to the pass
+// that caused it.
+//
+// 512 MiB of delta is set against a measured need, not a guess. Streaming a
+// corpus the size of the owner's real one (572,089 events over two years,
+// with production dimension cardinality across model, speed, service tier,
+// surface, agent scope and lineage) through this builder peaks at 98.6 MiB of
+// RSS growth. Doubling and quadrupling that stream — 1.14M and 2.29M events —
+// peaks at 119.8 MiB and 113.9 MiB, i.e. FLAT. That is the constant-memory
+// contract in the builder's own doc comment holding up under measurement: the
+// aggregate is fixed-shape and retains no raw inputs, so its residency tracks
+// dimension cardinality and not corpus size. 512 MiB is roughly 4x the peak
+// at 4x the owner's corpus, which is headroom for cardinality drift and lazy
+// GC without being room for a regression to hide in. Note what this delta is
+// NOT: it is not the 512 MiB that made the 2026-08-11 incident inevitable.
+// That number was applied to the REBUILD, whose transition mining genuinely
+// needs gigabytes; applying it to a pass measured flat at ~100 MiB is a
+// different claim with different evidence behind it.
+const ARCHIVE_ACCOUNTING_RSS_DELTA_BUDGET_BYTES = Math.floor(
+  512 * 1024 * 1024,
+);
+// The absolute backstop over the delta, and the arm that stops the companion
+// being driven into swap by a projection off an already-enormous baseline.
+// 3 GiB is picked so that on real hardware the DELTA is what binds: at the
+// companion's observed 2,089 MiB peak the effective ceiling is
+// min(3 GiB, ~2.54 GiB) = ~2.54 GiB, leaving the pass its full 512 MiB
+// against a measured need near 100 MiB. The absolute takes over only above a
+// ~2.5 GiB baseline — a companion half again the size of the fattest yet
+// observed — and above that line refusing to add another half gigabyte is the
+// correct answer rather than a regrettable one. This is a real cliff and is
+// meant to be, and it is survivable in the exact way that matters: the trip
+// is caught and reported as archive_projection_unavailable, never a failed
+// refresh and never a lost index — the indexing pass has already committed by
+// the time the projection runs. The prior projection is left on disk and goes
+// on being served until the index advances past its coverage fingerprint,
+// after which the surface reads unavailable rather than stale. Past this line
+// the companion's size is the bug to fix, not the ceiling.
+const MAX_ARCHIVE_ACCOUNTING_RSS_BYTES = Math.floor(3 * 1024 * 1024 * 1024);
 // The memory policy as the tests and any future caller should read it: derived
 // from the constants above rather than mirrored, so a regression can pin the
 // RELATIONSHIPS (cap >= absolute >= effective ceiling) without going stale the
@@ -377,6 +450,12 @@ export const REPLAY_SAFE_ACCOUNTING_MEMORY_POLICY = Object.freeze({
   maximumRssBytes: MAX_ACCOUNTING_RSS_BYTES,
   rssDeltaBudgetBytes: ACCOUNTING_RSS_DELTA_BUDGET_BYTES,
   rebuildChildOldSpaceMib: ACCOUNTING_REBUILD_CHILD_OLD_SPACE_MIB,
+  // The resident archive projection's ceiling, carried here so a regression
+  // can pin that it is SEPARATE from the rebuild's rather than trusting the
+  // two to stay apart by accident. Every field above describes a process that
+  // exits after one pass; these two describe one that does not.
+  archiveMaximumRssBytes: MAX_ARCHIVE_ACCOUNTING_RSS_BYTES,
+  archiveRssDeltaBudgetBytes: ARCHIVE_ACCOUNTING_RSS_DELTA_BUDGET_BYTES,
 });
 // SIGTERM asks the child to unwind through its own abort checks (typed abort
 // envelope); a child that cannot unwind inside this grace is killed hard. The
@@ -2069,7 +2148,11 @@ export async function buildReplaySafeAccountingPeriod({
   signal = null,
   declaredSpeedBaselines = [],
   rss = () => process.memoryUsage().rss,
-  maximumRssBytes = MAX_ACCOUNTING_RSS_BYTES,
+  // null is "the caller does not name a ceiling", which is the ARCHIVE case:
+  // resolve one off this pass's own baseline from the archive policy. The
+  // rebuild names its own and is unaffected. Inheriting the rebuild's number
+  // here is exactly the defect MAX_ARCHIVE_ACCOUNTING_RSS_BYTES documents.
+  maximumRssBytes = null,
 } = {}) {
   const canonicalStart = canonicalInstant(startAt);
   const canonicalEnd = canonicalInstant(endAt);
@@ -2084,8 +2167,8 @@ export async function buildReplaySafeAccountingPeriod({
       || typeof scan !== "function"
       || !validAbortSignal(signal)
       || typeof rss !== "function"
-      || !Number.isSafeInteger(maximumRssBytes)
-      || maximumRssBytes < 1) {
+      || (maximumRssBytes !== null
+        && (!Number.isSafeInteger(maximumRssBytes) || maximumRssBytes < 1))) {
     throw new TypeError("Replay-safe accounting period options are invalid");
   }
   const baselines = Array.isArray(declaredSpeedBaselines)
@@ -2096,12 +2179,26 @@ export async function buildReplaySafeAccountingPeriod({
   const period = newPeriod(id, label);
   const price = createAccountingPricer();
   let acceptedEvents = 0;
+  // A named ceiling is taken verbatim and costs no extra reading, so the
+  // rebuild's sub-build samples rss() exactly as often as it always has.
+  // Only the unnamed archive case measures a baseline and derives from it.
+  let effectiveMaximumRssBytes = maximumRssBytes;
+  if (effectiveMaximumRssBytes === null) {
+    const baselineRss = rss();
+    if (!Number.isSafeInteger(baselineRss) || baselineRss < 0) {
+      throw fixedError("accounting_archive_rss_measurement_invalid");
+    }
+    effectiveMaximumRssBytes = Math.min(
+      MAX_ARCHIVE_ACCOUNTING_RSS_BYTES,
+      baselineRss + ARCHIVE_ACCOUNTING_RSS_DELTA_BUDGET_BYTES,
+    );
+  }
   const checkRuntimeMemory = () => {
     const currentRss = rss();
     if (!Number.isSafeInteger(currentRss) || currentRss < 0) {
       throw fixedError("accounting_archive_rss_measurement_invalid");
     }
-    if (currentRss > maximumRssBytes) {
+    if (currentRss > effectiveMaximumRssBytes) {
       throw fixedError("accounting_archive_rss_limit_exceeded");
     }
   };

--- a/test/local-archive-accounting-index.test.js
+++ b/test/local-archive-accounting-index.test.js
@@ -21,6 +21,10 @@ import {
   readLocalArchiveAccountingPeriod,
   refreshLocalArchiveAccountingIndex,
 } from "../src/local-archive-accounting-index.js";
+import {
+  REPLAY_SAFE_ACCOUNTING_MEMORY_POLICY,
+  buildReplaySafeAccountingPeriod,
+} from "../src/replay-safe-accounting-cache.js";
 
 const CHUNK_BYTES = 4 * 1024 * 1024;
 const PRIVATE_CANARY = "PRIVATE_ARCHIVE_INDEX_CANARY";
@@ -96,6 +100,59 @@ async function fixture({
   }
   return { root, codexHome };
 }
+
+test("the resident archive projection reads its own ceiling, not the rebuild's", async () => {
+  // This refresh runs INSIDE the menu-bar companion. Until 2026-08-20 it named
+  // no ceiling and so inherited buildReplaySafeAccountingPeriod's default,
+  // which was the rebuild's absolute target — a number sized for a short-lived
+  // child that hands every page back on exit. Raising that constant to 6 GiB
+  // for the child therefore loosened the resident process by the same 4 GiB,
+  // against the whole point of moving the rebuild out of process (#38).
+  const { archiveMaximumRssBytes, maximumRssBytes } =
+    REPLAY_SAFE_ACCOUNTING_MEMORY_POLICY;
+  // Residency chosen to sit strictly BETWEEN the two policies: over the
+  // archive ceiling, comfortably under the rebuild's. Under the old inherited
+  // default this projection completed; under the archive policy it must not.
+  const betweenPolicies = archiveMaximumRssBytes + 64 * 1024 * 1024;
+  assert.ok(betweenPolicies > archiveMaximumRssBytes);
+  assert.ok(betweenPolicies < maximumRssBytes);
+
+  const { root, codexHome } = await fixture({ includeUsage: true });
+  const indexFile = join(root, "local-archive-accounting-index-v1.sqlite");
+  const secretFile = join(root, "local-archive-accounting-index-secret-v1");
+  const observedOptions = [];
+  try {
+    const refreshed = await refreshLocalArchiveAccountingIndex({
+      indexFile,
+      secretFile,
+      codexHome,
+      now: () => Date.parse("2026-07-25T12:00:00.000Z"),
+      workerCount: 1,
+      chunkBytes: CHUNK_BYTES,
+      buildAccountingPeriod: (options) => {
+        observedOptions.push(options);
+        return buildReplaySafeAccountingPeriod({
+          ...options,
+          rss: () => betweenPolicies,
+        });
+      },
+    });
+
+    // The indexing pass itself is untouched — only the projection is refused,
+    // and refused as a reported outcome rather than a failed refresh.
+    assert.equal(refreshed.refreshStatus, "built");
+    assert.equal(refreshed.projectionStatus, "unavailable");
+    assert.equal(refreshed.projectionErrorCode, "archive_projection_unavailable");
+
+    // And the call site still names no ceiling, which is what makes the
+    // default the thing under test. If a future edit starts passing one, this
+    // fails loudly rather than quietly moving the property somewhere else.
+    assert.equal(observedOptions.length, 1);
+    assert.equal(observedOptions[0].maximumRssBytes, undefined);
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
 
 test("archive read budgets remain strict for short non-aligned passes", async () => {
   const { root, codexHome } = await fixture({ includeSecondSource: true });

--- a/test/replay-safe-accounting-cache.test.js
+++ b/test/replay-safe-accounting-cache.test.js
@@ -2937,6 +2937,8 @@ test("the shipped accounting memory policy is the owner-set pair and a derived c
     maximumRssBytes: 6 * 1024 * 1024 * 1024,
     rssDeltaBudgetBytes: Math.floor(5.25 * 1024 * 1024 * 1024),
     rebuildChildOldSpaceMib: 6_144,
+    archiveMaximumRssBytes: 3 * 1024 * 1024 * 1024,
+    archiveRssDeltaBudgetBytes: 512 * 1024 * 1024,
   });
   // DERIVED, not coincident: the child's V8 old-space cap is the absolute
   // target expressed in MiB. Because the effective ceiling is at most the
@@ -2975,6 +2977,143 @@ test("the shipped accounting memory policy is the owner-set pair and a derived c
       + "than by the accounting delta; if that stops holding, the scan-guard "
       + "regression below is asserting the wrong regime",
   );
+});
+
+// The resident companion's OBSERVED whole-process residency (dogfood 0.1.13
+// build 1020, 4,886 sources / 128.5 GB indexed), sampled every two seconds
+// over twenty seconds: 1,312-2,089 MiB. Both ends matter. The high end is why
+// the archive projection cannot be policed by a 2 GiB absolute — the companion
+// crosses that line on GC timing alone, so the guard would fire or not fire at
+// random. The spread is why the ceiling is resolved off a per-pass baseline
+// rather than fixed.
+const OBSERVED_COMPANION_RSS_FLOOR = 1_312 * 1024 * 1024;
+const OBSERVED_COMPANION_RSS_PEAK = 2_089 * 1024 * 1024;
+const ARCHIVE_RSS_ABSOLUTE =
+  REPLAY_SAFE_ACCOUNTING_MEMORY_POLICY.archiveMaximumRssBytes;
+const ARCHIVE_RSS_DELTA =
+  REPLAY_SAFE_ACCOUNTING_MEMORY_POLICY.archiveRssDeltaBudgetBytes;
+
+test("the resident archive projection is bounded by its own policy, never the rebuild's", () => {
+  // THE SEPARATION. buildReplaySafeAccountingPeriod once defaulted to the
+  // rebuild's ceiling, so the 2026-08-20 raise of a constant that exists to
+  // size a SHORT-LIVED CHILD silently handed the resident menu-bar companion
+  // a 6 GiB backstop — undoing, for this path, what #38 moved the rebuild out
+  // of process to achieve. Free headroom in a process that exits is not free
+  // in one the user leaves running all day.
+  assert.ok(
+    ARCHIVE_RSS_ABSOLUTE < ACCOUNTING_RSS_ABSOLUTE,
+    "the resident archive ceiling must stay strictly below the rebuild's; "
+      + "equality would mean the default had drifted back into inheritance",
+  );
+  assert.ok(
+    ARCHIVE_RSS_DELTA < ACCOUNTING_RSS_DELTA,
+    "the resident archive delta must stay strictly below the rebuild's",
+  );
+
+  // Which arm binds, at the residency actually measured on the owner's
+  // machine. The DELTA has to be the binding arm across the whole observed
+  // band, because the absolute arm charges the projection for memory the
+  // companion allocated for unrelated reasons and cannot hand back.
+  for (const baseline of [
+    OBSERVED_COMPANION_RSS_FLOOR,
+    OBSERVED_COMPANION_RSS_PEAK,
+  ]) {
+    assert.ok(
+      baseline + ARCHIVE_RSS_DELTA < ARCHIVE_RSS_ABSOLUTE,
+      "across the observed companion band the delta must bind, so the pass "
+        + "gets its full budget rather than whatever the absolute leaves over",
+    );
+  }
+
+  // And the reason a bare absolute was rejected rather than merely retuned: at
+  // the pre-raise 2 GiB the observed band STRADDLES the ceiling, so the same
+  // projection on the same corpus would defer or not defer on GC timing.
+  const PRE_RAISE_ABSOLUTE = 2 * 1024 * 1024 * 1024;
+  assert.ok(
+    OBSERVED_COMPANION_RSS_FLOOR < PRE_RAISE_ABSOLUTE
+      && OBSERVED_COMPANION_RSS_PEAK > PRE_RAISE_ABSOLUTE,
+    "restoring the pre-raise absolute would have made the guard a coin flip "
+      + "on this machine; that is what the baseline + delta shape avoids",
+  );
+});
+
+test("an archive projection past its own delta defers while still far under the rebuild ceiling", async () => {
+  // The discriminating case, and the one that fails if the default ever goes
+  // back to inheriting: residency here is well inside the rebuild's effective
+  // ceiling, so a period build reading that policy would sail through.
+  const baseline = OBSERVED_COMPANION_RSS_PEAK;
+  const overArchiveUnderRebuild = baseline + ARCHIVE_RSS_DELTA + 1;
+  assert.ok(
+    overArchiveUnderRebuild < ACCOUNTING_RSS_ABSOLUTE
+      && overArchiveUnderRebuild < baseline + ACCOUNTING_RSS_DELTA,
+    "the fixture must sit under BOTH arms of the rebuild policy, or it is "
+      + "not evidence about which policy the archive path read",
+  );
+
+  let sampled = 0;
+  await assert.rejects(
+    buildReplaySafeAccountingPeriod({
+      startAt: "1970-01-01T00:00:00.000Z",
+      endAt: "2026-08-20T12:00:00.000Z",
+      // Baseline first, then the pass grows one byte past its delta.
+      rss: () => {
+        sampled += 1;
+        return sampled === 1 ? baseline : overArchiveUnderRebuild;
+      },
+      scan: scanner([
+        usageEvent({
+          timestamp: "2026-07-27T11:55:00.000Z",
+          components: { input_uncached_tokens: 1 },
+        }),
+      ]),
+    }),
+    (error) => error?.code === "accounting_archive_rss_limit_exceeded",
+  );
+
+  // The absolute arm is a real backstop too: a companion already past it gets
+  // no projection at all, however little the pass itself would have grown.
+  await assert.rejects(
+    buildReplaySafeAccountingPeriod({
+      startAt: "1970-01-01T00:00:00.000Z",
+      endAt: "2026-08-20T12:00:00.000Z",
+      rss: () => ARCHIVE_RSS_ABSOLUTE + 1,
+      scan: scanner([]),
+    }),
+    (error) => error?.code === "accounting_archive_rss_limit_exceeded",
+  );
+});
+
+test("a caller that names its own ceiling keeps it, which is how the rebuild sub-build stays unchanged", async () => {
+  // buildReplaySafeAccountingCache passes the effective ceiling it already
+  // computed off the CHILD's baseline. That seam has to keep taking the named
+  // number verbatim — the archive policy must not tighten a rebuild that is
+  // already fighting for room, and must not sample rss() an extra time.
+  const named = 4 * 1024 * 1024 * 1024;
+  assert.ok(
+    named > ARCHIVE_RSS_ABSOLUTE,
+    "the named ceiling must exceed the archive absolute, or this proves "
+      + "nothing about which one was applied",
+  );
+  const samples = [];
+  const result = await buildReplaySafeAccountingPeriod({
+    startAt: "1970-01-01T00:00:00.000Z",
+    endAt: "2026-08-20T12:00:00.000Z",
+    maximumRssBytes: named,
+    rss: () => {
+      samples.push(ARCHIVE_RSS_ABSOLUTE + 1);
+      return ARCHIVE_RSS_ABSOLUTE + 1;
+    },
+    scan: scanner([
+      usageEvent({
+        timestamp: "2026-07-27T11:55:00.000Z",
+        components: { input_uncached_tokens: 1 },
+      }),
+    ]),
+  });
+  assert.equal(result.period.events, 1);
+  // Two readings: the pre-flight check and the post-scan check. A third would
+  // mean the named path had started deriving a baseline it was told not to.
+  assert.equal(samples.length, 2);
 });
 
 test("an RSS ceiling miss during accounting is a soft target: the prior cache is retained and served", async () => {


### PR DESCRIPTION
## What

`buildReplaySafeAccountingPeriod` defaulted `maximumRssBytes` to `MAX_ACCOUNTING_RSS_BYTES` — by inheritance, from the day it was written, never by decision.

That constant sizes **one accounting rebuild**, which since #38 runs in a short-lived child that hands every page back to the OS on exit. So the 2 → 6 GiB raise in #48 was free there. It was not free here: the same default is what `src/local-archive-accounting-index.js` reads, and `refreshLocalArchiveAccountingIndex` runs inside the **resident menu-bar companion**. The raise moved that process's whole-process RSS backstop from 2 GiB to 6 GiB — the opposite of what moving the rebuild out of process was for. #48 recorded the coupling in a comment as a known consequence; this closes it.

## Scope, stated plainly

The archive refresh is wired only when `accountingSourceMode === "legacy"` (`apps/local/server.js`), and production defaults to `"unified"`. So this was a **latent** exposure, not a live one — plus whatever future caller omits the ceiling. Worth closing precisely because a legacy rollback gets selected when something is already wrong.

## Why a new shape, not a new number

Restoring the pre-raise 2 GiB would have been worse than leaving it alone.

Sampled every two seconds across twenty seconds, the owner's live companion (dogfood 0.1.13 build 1020, 4,886 sources / 128.5 GB indexed) sits between **1,312 and 2,089 MiB** — it crosses 2 GiB on GC timing alone. A whole-process *absolute* cannot police a resident process: it charges the pass for memory the pass never allocated and cannot free, so the same projection over the same corpus would defer or not defer depending on when V8 last collected. Not a bound, a coin flip.

The archive path therefore takes the `min(absolute, baseline + delta)` shape the rebuild already uses, with its own pair:

| constant | value |
|---|---|
| `ARCHIVE_ACCOUNTING_RSS_DELTA_BUDGET_BYTES` | 512 MiB |
| `MAX_ARCHIVE_ACCOUNTING_RSS_BYTES` | 3 GiB |

**The delta is measured, not guessed.** Streaming a corpus the size of the owner's real one (572,089 events over two years, production dimension cardinality across model, speed, service tier, surface, agent scope and lineage) through this builder peaks at **98.6 MiB** of RSS growth. Doubling and quadrupling that stream peaks at **119.8** and **113.9 MiB** — flat. The constant-memory contract in the builder's own doc comment holds up under measurement, so 512 MiB is ~4x the peak at 4x the owner's corpus: headroom for cardinality drift and lazy GC, not room for a regression to hide in.

It is *not* a repeat of the 512 MiB that made the 2026-08-11 incident inevitable — that number bounded the **rebuild**, whose transition mining genuinely needs gigabytes. 3 GiB is then chosen so the **delta** is the binding arm across the whole observed companion band, leaving the absolute as the swap backstop it ought to be.

## The rebuild path is untouched

`maximumRssBytes` now defaults to `null`, meaning "the caller named none". A named ceiling is taken verbatim **and samples `rss()` no extra times**, so `buildReplaySafeAccountingCache`'s history sub-build — which passes the effective ceiling it already computed off the child's baseline — is unchanged byte for byte. Tightening a rebuild that is already fighting for room was the one outcome this fix had to avoid.

## Regressions

They discriminate: re-pointing the archive resolution back at the rebuild constants fails exactly the two behavioural ones, and both pass with the fix.

- the separation itself, which arm binds at the residency actually measured, and why a bare absolute was rejected rather than retuned;
- a projection past its own delta defers **while sitting under both arms of the rebuild policy**, so it is evidence about which policy was read;
- a named ceiling still wins, asserted down to the `rss()` sample count;
- end to end through `refreshLocalArchiveAccountingIndex` at residency between the two policies: the index still commits, only the projection is refused, and the call site is pinned to name no ceiling.

The value tripwire carries the archive pair, so a policy move still has to come through one deliberate place.

## Testing

275/275 across the ten affected suites, re-run after rebasing onto #48.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
