### PR TITLE
fix(dashboard): keep the usage figures a quick reload cannot rebuild

### DIFF
--- a/src/local-companion-data.js
+++ b/src/local-companion-data.js
@@ -3331,12 +3331,22 @@ export async function buildLocalCompanionSnapshot({
 // cannot disagree about which reloads arrive without their heavy datasets.
 const DEFERRED_PROJECTION_PURPOSES = new Set(["startup", "quick"]);
 
-// The projection-derived surfaces. A deferred build returns these as empty
-// arrays rather than omitting them, which is why replacing a full snapshot
-// with a quick one blanks the dashboard instead of leaving it alone.
-const PROJECTION_SURFACES = Object.freeze(["gradient", "weekly"]);
-
-function projectionRowCount(surface) {
+// How much evidence a surface is actually carrying. Zero means "a deferred
+// build could not rebuild this", which is the only condition under which the
+// previous value is carried forward.
+//
+// Three shapes, because the builder empties these surfaces three different
+// ways and a single row count silently misses two of them:
+//
+//   datasetRows      gradient/weekly, whose rows sit under `.datasets`
+//   arrayRows        the timelines, which come back as bare empty arrays
+//   usagePeriodRows  the usage periods, which come back FULLY POPULATED with
+//                    four zeroed placeholders from insufficientEvidenceUsagePeriods()
+//
+// That last one is why 0.1.14 fixed the charts but not the usage figures: the
+// placeholder periods have a positive length, so a length check reads them as
+// present and lets them overwrite real totals with zeroes.
+function datasetRows(surface) {
   const datasets = surface?.datasets;
   if (!datasets || typeof datasets !== "object") return 0;
   let rows = 0;
@@ -3345,6 +3355,55 @@ function projectionRowCount(surface) {
   }
   return rows;
 }
+
+function arrayRows(surface) {
+  return Array.isArray(surface) ? surface.length : 0;
+}
+
+function usagePeriodRows(surface) {
+  if (!Array.isArray(surface)) return 0;
+  let events = 0;
+  for (const period of surface) {
+    const value = period?.events;
+    if (typeof value === "number" && Number.isFinite(value)) events += value;
+  }
+  return events;
+}
+
+// Every surface a deferred projection cannot rebuild, as a path into the
+// published snapshot. Registered centrally so the retention and the guard test
+// read the same list: test/local-companion-data.test.js drives the real builder
+// in both modes and fails if any surface loses evidence without appearing here,
+// so a newly added projection surface cannot reintroduce this class silently.
+const PROJECTION_SURFACES = Object.freeze([
+  { path: Object.freeze(["gradient"]), rows: datasetRows },
+  { path: Object.freeze(["weekly"]), rows: datasetRows },
+  { path: Object.freeze(["overview", "usage"]), rows: usagePeriodRows },
+  { path: Object.freeze(["overview", "timeline", "usage"]), rows: arrayRows },
+  { path: Object.freeze(["overview", "timeline", "sparkUsage"]), rows: arrayRows },
+  {
+    path: Object.freeze(["overview", "timeline", "calibrationUsage"]),
+    rows: arrayRows,
+  },
+]);
+
+// Resolve a registered path, or null if any segment is absent. Absence is not
+// emptiness: `calibrationUsage` exists only under the opt-in side-chat estimate
+// flag, and a surface the build deliberately omits must stay omitted rather
+// than being conjured back from the previous snapshot.
+function surfaceParent(snapshot, path) {
+  let node = snapshot;
+  for (const key of path.slice(0, -1)) {
+    if (node === null || typeof node !== "object" || !(key in node)) return null;
+    node = node[key];
+  }
+  if (node === null || typeof node !== "object") return null;
+  return Object.hasOwn(node, path[path.length - 1]) ? node : null;
+}
+
+export const RETAINED_PROJECTION_SURFACE_PATHS = Object.freeze(
+  PROJECTION_SURFACES.map((surface) => surface.path.join(".")),
+);
 
 export class LocalCompanionDataStore {
   #builder;
@@ -3382,24 +3441,33 @@ export class LocalCompanionDataStore {
   //
   // The refresh caller already treats a FAILED quick reload as "keep the
   // previous good dashboard". A successful one should not be more destructive
-  // than a failure. So the fresh overview is taken as-is, and the two
-  // projection-derived surfaces are carried forward whenever the deferred
-  // build has nothing to put in their place.
+  // than a failure, so every projection-derived surface is carried forward
+  // whenever the deferred build has nothing to put in its place.
+  //
+  // 0.1.14 scoped this to the two TOP-LEVEL surfaces and took the fresh
+  // overview as-is. That left the same defect live in the usage figures and
+  // both usage timelines, which live inside `overview` and are emptied
+  // separately by `unifiedAccountingWithheld` — the charts stopped blanking
+  // and the usage kept flickering. Surfaces are registered by path now, so
+  // nesting is not what decides whether a surface is protected.
   //
   // Scoped deliberately: only for the purposes that request a deferred
-  // projection, and only when the incoming surface is genuinely empty while
-  // the retained one is not. A full reload always replaces both, so a real
-  // transition to empty still lands on the next complete refresh and this can
-  // never pin stale figures beyond it.
+  // projection, and only when the incoming surface carries no evidence while
+  // the retained one does. A full reload always replaces every surface, so a
+  // real transition to empty still lands on the next complete refresh and this
+  // can never pin stale figures beyond it.
   #withRetainedProjection(next, options) {
     const purpose = options?.purpose ?? "full";
     if (!DEFERRED_PROJECTION_PURPOSES.has(purpose)) return next;
     const retained = this.#snapshot;
     if (retained === null) return next;
-    for (const surface of PROJECTION_SURFACES) {
-      if (projectionRowCount(next[surface]) === 0
-          && projectionRowCount(retained[surface]) > 0) {
-        next[surface] = structuredClone(retained[surface]);
+    for (const { path, rows } of PROJECTION_SURFACES) {
+      const key = path[path.length - 1];
+      const nextParent = surfaceParent(next, path);
+      const retainedParent = surfaceParent(retained, path);
+      if (nextParent === null || retainedParent === null) continue;
+      if (rows(nextParent[key]) === 0 && rows(retainedParent[key]) > 0) {
+        nextParent[key] = structuredClone(retainedParent[key]);
       }
     }
     return next;

--- a/test/local-companion-data.test.js
+++ b/test/local-companion-data.test.js
@@ -4,6 +4,7 @@ import { renameSync } from "node:fs";
 import {
   mkdir,
   mkdtemp,
+  readFile,
   rm,
   stat,
   writeFile,
@@ -13,6 +14,7 @@ import { join } from "node:path";
 import {
   LOCAL_COMPANION_SCHEMA_VERSION,
   LocalCompanionDataStore,
+  RETAINED_PROJECTION_SURFACE_PATHS,
   buildLocalCompanionSnapshot,
 } from "../src/local-companion-data.js";
 import {
@@ -2256,4 +2258,133 @@ test("unified mode with no valid generation withholds the provisional collector 
   } finally {
     await rm(root, { recursive: true });
   }
+});
+
+test("a deferred quick reload keeps the usage figures and both usage timelines", () => {
+  // 0.1.14 protected gradient/weekly and left these three live, because they
+  // sit inside `overview` rather than at the top level. Reported against the
+  // shipped 0.1.14 build as usage still appearing and disappearing while the
+  // charts held still.
+  //
+  // The usage PERIODS matter most here: a deferred build does not empty them,
+  // it replaces them with four fully-formed zeroed placeholders, so any check
+  // based on array length reads them as present and lets zeroes overwrite real
+  // totals.
+  const period = (events) => ({ id: "7d", label: "Last 7 days", events });
+  const snapshotFor = (purpose) => {
+    const deferred = ["startup", "quick"].includes(purpose);
+    return {
+      schemaVersion: LOCAL_COMPANION_SCHEMA_VERSION,
+      mode: "real_local_evidence",
+      generatedAt: "2026-08-20T21:00:00.000Z",
+      overview: {
+        marker: purpose,
+        quota: { windows: [{ remainingPercent: purpose === "quick" ? 41 : 77 }] },
+        usage: deferred ? [period(0)] : [period(12)],
+        timeline: {
+          usage: deferred ? [] : [{ at: 1 }, { at: 2 }],
+          sparkUsage: deferred ? [] : [{ at: 1 }],
+          calibrationUsage: deferred ? [] : [{ at: 1 }],
+          quota: [{ at: 9 }],
+        },
+      },
+      gradient: { datasets: deferred ? { rolling: [] } : { rolling: [{ at: 1 }] } },
+      weekly: { datasets: deferred ? { weekly_values: [] } : { weekly_values: [{ sequence: 1 }] } },
+      quality: {},
+      reports: [],
+    };
+  };
+  const store = new LocalCompanionDataStore({
+    builder: async ({ purpose = "full" } = {}) => snapshotFor(purpose),
+  });
+
+  return (async () => {
+    await store.reload({ purpose: "full" });
+    await store.reload({ purpose: "quick" });
+    const overview = store.getOverview();
+
+    // Retained: the surfaces a deferred build could not rebuild.
+    assert.equal(overview.usage[0].events, 12, "usage totals must not drop to zero");
+    assert.equal(overview.timeline.usage.length, 2);
+    assert.equal(overview.timeline.sparkUsage.length, 1);
+    assert.equal(overview.timeline.calibrationUsage.length, 1);
+    assert.equal(store.getGradient().datasets.rolling.length, 1);
+    assert.equal(store.getWeekly().datasets.weekly_values.length, 1);
+
+    // Still fresh: the fast-moving figures the quick pass exists to deliver.
+    assert.equal(overview.marker, "quick");
+    assert.equal(overview.quota.windows[0].remainingPercent, 41);
+
+    // A surface the build omits entirely stays omitted rather than being
+    // conjured back: absence is a configuration choice, not emptiness.
+    const withoutCalibration = new LocalCompanionDataStore({
+      builder: async ({ purpose = "full" } = {}) => {
+        const next = snapshotFor(purpose);
+        if (["startup", "quick"].includes(purpose)) delete next.overview.timeline.calibrationUsage;
+        return next;
+      },
+    });
+    await withoutCalibration.reload({ purpose: "full" });
+    await withoutCalibration.reload({ purpose: "quick" });
+    assert.equal(
+      Object.hasOwn(withoutCalibration.getOverview().timeline, "calibrationUsage"),
+      false,
+    );
+
+    // A FULL reload stays authoritative in both directions, so a genuine
+    // transition to empty still lands and this can never pin stale figures.
+    const emptying = new LocalCompanionDataStore({
+      builder: async () => {
+        const next = snapshotFor("full");
+        next.overview.usage = [period(0)];
+        next.overview.timeline.usage = [];
+        return next;
+      },
+    });
+    await emptying.reload({ purpose: "full" });
+    await emptying.reload({ purpose: "full" });
+    assert.equal(emptying.getOverview().usage[0].events, 0);
+    assert.equal(emptying.getOverview().timeline.usage.length, 0);
+  })();
+});
+
+test("every surface a withheld projection empties is registered for retention", async () => {
+  // The completeness gate for this defect class. `unifiedAccountingWithheld`
+  // is the single condition under which the builder substitutes evidence-free
+  // values, so enumerating its substitution sites enumerates the class.
+  //
+  // Two of the eight sites yield real data surfaces as bare empty arrays and
+  // one yields the zeroed placeholder periods; the remaining five yield a
+  // coverage window or a source LABEL, which carry no rows and are meant to
+  // change on a deferred pass. If a new evidence-bearing substitution appears,
+  // this fails until it is registered in PROJECTION_SURFACES — which is the
+  // point, because reviewing the retention list is not something anyone
+  // remembers to do when adding a surface.
+  const source = await readFile(
+    new URL("../src/local-companion-data.js", import.meta.url),
+    "utf8",
+  );
+  const emptyArraySites = source.match(/unifiedAccountingWithheld\s+\?\s+\[\]/gu) ?? [];
+  const placeholderPeriodSites =
+    source.match(/unifiedAccountingWithheld\s+\?\s+insufficientEvidenceUsagePeriods\(\)/gu) ?? [];
+
+  assert.equal(
+    emptyArraySites.length,
+    2,
+    "new `unifiedAccountingWithheld ? []` surface — register it in PROJECTION_SURFACES",
+  );
+  assert.equal(
+    placeholderPeriodSites.length,
+    1,
+    "new placeholder-period substitution — register it in PROJECTION_SURFACES",
+  );
+
+  assert.deepEqual(RETAINED_PROJECTION_SURFACE_PATHS, [
+    "gradient",
+    "weekly",
+    "overview.usage",
+    "overview.timeline.usage",
+    "overview.timeline.sparkUsage",
+    "overview.timeline.calibrationUsage",
+  ]);
 });


### PR DESCRIPTION
Reported against the shipped 0.1.14 build: the charts stopped blanking, but the usage figures still appear and disappear.

### Why 0.1.14 missed it

Its retention covered the two **top-level** projection surfaces (`gradient`, `weekly`) and explicitly took the fresh overview as-is. The usage periods and both usage timelines live *inside* `overview`, so they were never protected. Surfaces are registered by path now — nesting no longer decides whether a surface is retained.

### The part that made it easy to miss

The three surfaces don't empty the same way:

| Surface | How a deferred build empties it |
| --- | --- |
| `overview.timeline.usage`, `…sparkUsage` | bare `[]` |
| `overview.usage` | four **fully-formed zeroed** placeholder periods |

The placeholders have a positive length, so any length-based emptiness check reads them as present and lets zeroes overwrite real totals. Evidence is now counted per surface shape: dataset rows, array rows, or summed period events.

### Completeness, not one more patch

`unifiedAccountingWithheld` is the only condition under which the builder substitutes evidence-free values, so its substitution sites enumerate the class. There are eight — three empty real data (all now registered), and five yield a coverage window or a source label, which carry no rows and are supposed to change on a deferred pass.

A test counts those sites and fails if a new evidence-bearing one appears without being registered. An audit done once doesn't stop the fourth instance; a gate does.

### Preserved and pinned

- The quick pass still publishes quota and pace immediately — its entire purpose.
- A **full** reload still lands a genuine transition to empty, so this cannot pin stale figures.
- A surface the build omits entirely stays omitted rather than being restored (`calibrationUsage` is opt-in; absence is configuration, not emptiness).

### Tests

2777 passing. The only failures are the two `r7-generated-release-evidence` tests on `workloadCodeSha256` — `src/local-companion-data.js` is R7 workload source, so the receipts need regenerating before a release. Expected and unrelated to this logic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)