### PR TITLE
fix(tools): verify the render the social card actually ships

### DIFF
--- a/scripts/generate-social-preview.js
+++ b/scripts/generate-social-preview.js
@@ -8,45 +8,54 @@
  * every release. By 0.1.15 it still showed an older headline, a DEMO DATA
  * panel, a fitted allowance of $1,879 against a live figure of $2,043, and —
  * the part that actually cost something — "Public download coming soon", months
- * after the app became publicly installable. Every link preview said the app
- * was not available yet.
+ * after the app became publicly installable. install-cta.js hides that string
+ * at runtime, so visitors saw the correct CTA and only link previews carried
+ * the wrong one, which is exactly why it survived unnoticed.
  *
  * The figure on this card is a published estimate that moves daily, so the card
- * has to be regenerated rather than authored. Regenerating from the homepage
- * (rather than compositing a template) means the card cannot drift from the
- * page's own copy again: the headline, the CTA, and the number are whatever the
- * site is actually serving.
+ * has to be regenerated rather than authored. Rendering the homepage (rather
+ * than compositing a template) means the card cannot drift from the page's own
+ * copy again: the headline, the CTA and the number are whatever the site is
+ * serving.
  *
- * Headless Chrome is used directly rather than adding Playwright or Puppeteer:
- * this runs on the release machine, which has Chrome, and a screenshot for a
- * marketing asset does not justify a browser dependency in a repository whose
- * production dependency graph is enforced by architecture:check.
+ * ONE browser session, deliberately. The first version of this script ran
+ * Chrome twice — once with --dump-dom to check the page, once with --screenshot
+ * to capture it — and described that as checking the DOM "before the shutter".
+ * It was not: two invocations are two page loads, so the guard validated one
+ * render while shipping another, and a card whose figure failed to load on the
+ * second render would have passed every check. The capture and the check now
+ * share a single navigation over the DevTools protocol, so what is verified is
+ * what is written.
+ *
+ * Headless Chrome directly, not Playwright or Puppeteer: this runs on the
+ * release machine, which has Chrome, and a marketing screenshot does not
+ * justify a browser in a dependency graph that architecture:check enforces.
  *
  * Usage:
  *   node scripts/generate-social-preview.js --output <path.png> [--url <url>]
  *                                           [--expect-text <string>] [--replace]
  */
 
-import { spawnSync } from "node:child_process";
-import { existsSync, mkdirSync, rmSync, statSync } from "node:fs";
+import { spawn } from "node:child_process";
+import { existsSync, mkdirSync, rmSync, statSync, writeFileSync } from "node:fs";
 import { dirname, isAbsolute, resolve } from "node:path";
+import { setTimeout as delay } from "node:timers/promises";
 
-// The card is 1200x630 (the og:image size every major consumer crops toward).
-// Capturing at 1440x756 keeps that exact ratio while fitting roughly a fifth
-// more of the page in, which is what brings the version line and the install
-// command into frame; 2x then downsamples for text sharpness.
+// 1200x630 is the og:image size every major consumer crops toward. Capturing at
+// 1440x756 holds that exact ratio while fitting roughly a fifth more of the page
+// in, which is what brings the install command and version line into frame; 2x
+// then downsamples for text sharpness.
 const OUTPUT_WIDTH = 1200;
 const OUTPUT_HEIGHT = 630;
 const CAPTURE_WIDTH = 1440;
 const CAPTURE_HEIGHT = 756;
 const DEVICE_SCALE = 2;
 
-// The homepage's headline figure arrives from an API after first paint. A
-// capture taken before it lands shows an empty or placeholder panel, and that
-// failure is invisible in the output file: it is a valid PNG of the right size.
-// This budget is generous because a slow capture is recoverable and a blank
-// card is not.
-const VIRTUAL_TIME_BUDGET_MS = 20_000;
+const NAVIGATION_TIMEOUT_MS = 45_000;
+const SETTLE_TIMEOUT_MS = 30_000;
+const SETTLE_POLL_MS = 500;
+// The card must not be captured mid-animation or before webfonts swap.
+const POST_SETTLE_QUIET_MS = 1_200;
 
 const CHROME_CANDIDATES = [
   "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome",
@@ -57,11 +66,20 @@ const CHROME_CANDIDATES = [
 
 const DEFAULT_URL = "https://tibotattle.com/";
 
-// A rendered card must contain the product name and a currency figure. The
-// figure pattern is what proves the community panel resolved rather than
-// leaving its placeholder behind.
+// What proves the page is worth photographing.
+//
+// An earlier version required only /\$[0-9],[0-9]{3}/, which the chart's own
+// axis labels satisfy — the live page carries $1,000, $2,000 and $3,000 as
+// gridline text. That guard would have passed on a page whose headline figure
+// never arrived. This sentence is emitted only once the published community
+// estimate has resolved, so it is the honest signal.
 const REQUIRED_TEXT = "TiboTattle";
-const REQUIRED_FIGURE = /\$[0-9],[0-9]{3}/u;
+const RESOLVED_ESTIMATE_SENTINEL = "Latest published estimate (";
+// Kept as a second, weaker check purely so the failure message can name the
+// figure that was captured. Never the sole gate.
+const FIGURE_PATTERN = /\$[0-9]{1,3}(?:,[0-9]{3})+/u;
+const STALE_CTA_PATTERN = /Public download coming soon/u;
+const SHIPPED_CTA_PATTERN = /brew install/u;
 
 function fail(code, message) {
   console.error(`${code}: ${message}`);
@@ -107,30 +125,129 @@ function locateChrome() {
   return found;
 }
 
-function runChrome(chrome, args) {
-  const result = spawnSync(chrome, args, { encoding: "utf8", maxBuffer: 64 * 1024 * 1024 });
-  if (result.error) {
-    fail("SOCIAL_PREVIEW_BROWSER_FAILED", `Chrome could not be run: ${result.error.message}`);
+/** Minimal DevTools client: one navigation, one evaluation, one screenshot. */
+class DevToolsSession {
+  #socket;
+  #nextId = 1;
+  #pending = new Map();
+
+  constructor(socket) {
+    this.#socket = socket;
+    socket.addEventListener("message", (event) => {
+      let frame;
+      try { frame = JSON.parse(event.data); } catch { return; }
+      const waiter = this.#pending.get(frame.id);
+      if (waiter === undefined) return;
+      this.#pending.delete(frame.id);
+      if (frame.error) waiter.reject(new Error(frame.error.message ?? "devtools error"));
+      else waiter.resolve(frame.result ?? {});
+    });
   }
-  return result;
-}
 
-function sips(args) {
-  const result = spawnSync("sips", args, { encoding: "utf8" });
-  if (result.status !== 0) {
-    fail("SOCIAL_PREVIEW_RESIZE_FAILED", `sips failed: ${result.stderr?.trim() ?? "unknown error"}`);
+  send(method, params = {}, timeoutMs = NAVIGATION_TIMEOUT_MS) {
+    const id = this.#nextId;
+    this.#nextId += 1;
+    this.#socket.send(JSON.stringify({ id, method, params }));
+    return new Promise((resolvePromise, rejectPromise) => {
+      const timer = setTimeout(() => {
+        this.#pending.delete(id);
+        rejectPromise(new Error(`${method} timed out after ${timeoutMs}ms`));
+      }, timeoutMs);
+      this.#pending.set(id, {
+        resolve: (value) => { clearTimeout(timer); resolvePromise(value); },
+        reject: (error) => { clearTimeout(timer); rejectPromise(error); },
+      });
+    });
   }
-  return result.stdout ?? "";
+
+  close() { try { this.#socket.close(); } catch { /* already gone */ } }
 }
 
-function imageDimensions(path) {
-  const out = sips(["-g", "pixelWidth", "-g", "pixelHeight", path]);
-  const width = Number(/pixelWidth:\s*(\d+)/u.exec(out)?.[1]);
-  const height = Number(/pixelHeight:\s*(\d+)/u.exec(out)?.[1]);
-  return { width, height };
+async function launchChrome(chrome) {
+  const child = spawn(chrome, [
+    "--headless=new",
+    "--disable-gpu",
+    "--hide-scrollbars",
+    "--remote-debugging-port=0",
+    "--no-first-run",
+    "--no-default-browser-check",
+    `--window-size=${CAPTURE_WIDTH},${CAPTURE_HEIGHT}`,
+    `--force-device-scale-factor=${DEVICE_SCALE}`,
+    "about:blank",
+  ], { stdio: ["ignore", "pipe", "pipe"] });
+
+  // Chrome prints the DevTools endpoint to stderr once the port is bound.
+  const endpoint = await new Promise((resolvePromise, rejectPromise) => {
+    let buffer = "";
+    const timer = setTimeout(() => rejectPromise(new Error("Chrome did not report a DevTools port")), 30_000);
+    child.stderr.on("data", (chunk) => {
+      buffer += String(chunk);
+      const match = /ws:\/\/[^\s]+/u.exec(buffer);
+      if (match) { clearTimeout(timer); resolvePromise(match[0]); }
+    });
+    child.on("exit", (code) => {
+      clearTimeout(timer);
+      rejectPromise(new Error(`Chrome exited early with code ${code}`));
+    });
+  });
+  // The stderr endpoint is the BROWSER target, which does not implement Page.*.
+  // The screenshot needs a page target, resolved from the HTTP list endpoint.
+  const port = new URL(endpoint).port;
+  const deadline = Date.now() + 20_000;
+  let pageEndpoint = null;
+  while (Date.now() < deadline && pageEndpoint === null) {
+    try {
+      const response = await fetch(`http://127.0.0.1:${port}/json/list`);
+      const targets = await response.json();
+      const page = Array.isArray(targets)
+        ? targets.find((target) => target?.type === "page"
+          && typeof target?.webSocketDebuggerUrl === "string")
+        : undefined;
+      if (page !== undefined) pageEndpoint = page.webSocketDebuggerUrl;
+    } catch { /* Chrome is still binding; retry until the deadline */ }
+    if (pageEndpoint === null) await delay(250);
+  }
+  if (pageEndpoint === null) {
+    throw new Error("Chrome exposed no page target to attach to");
+  }
+  return { child, endpoint: pageEndpoint };
 }
 
-function main(argv = process.argv.slice(2)) {
+async function connect(endpoint) {
+  const socket = new WebSocket(endpoint);
+  await new Promise((resolvePromise, rejectPromise) => {
+    const timer = setTimeout(() => rejectPromise(new Error("DevTools connect timed out")), 15_000);
+    socket.addEventListener("open", () => { clearTimeout(timer); resolvePromise(); }, { once: true });
+    socket.addEventListener("error", () => { clearTimeout(timer); rejectPromise(new Error("DevTools connect failed")); }, { once: true });
+  });
+  return new DevToolsSession(socket);
+}
+
+async function readPageText(session) {
+  const result = await session.send("Runtime.evaluate", {
+    expression: "document.body ? document.body.innerText : ''",
+    returnByValue: true,
+  });
+  return typeof result?.result?.value === "string" ? result.result.value : "";
+}
+
+/**
+ * Wait for the published estimate to resolve. The page paints immediately and
+ * fills the headline from an API afterwards, so "loaded" is not the same as
+ * "worth photographing".
+ */
+async function waitForResolvedPage(session) {
+  const deadline = Date.now() + SETTLE_TIMEOUT_MS;
+  let text = "";
+  while (Date.now() < deadline) {
+    text = await readPageText(session);
+    if (text.includes(RESOLVED_ESTIMATE_SENTINEL)) return text;
+    await delay(SETTLE_POLL_MS);
+  }
+  return text;
+}
+
+async function main(argv = process.argv.slice(2)) {
   const options = parseArguments(argv);
   const output = resolve(options.output);
   if (existsSync(output) && !options.replace) {
@@ -139,89 +256,123 @@ function main(argv = process.argv.slice(2)) {
   const chrome = locateChrome();
   mkdirSync(dirname(output), { recursive: true });
 
-  const commonArgs = [
-    "--headless",
-    "--disable-gpu",
-    "--hide-scrollbars",
-    `--window-size=${CAPTURE_WIDTH},${CAPTURE_HEIGHT}`,
-    `--force-device-scale-factor=${DEVICE_SCALE}`,
-    `--virtual-time-budget=${VIRTUAL_TIME_BUDGET_MS}`,
-  ];
+  let launched;
+  try {
+    launched = await launchChrome(chrome);
+  } catch (error) {
+    fail("SOCIAL_PREVIEW_BROWSER_FAILED", error.message);
+  }
+  const { child, endpoint } = launched;
+  let session = null;
 
-  // Verify the page renders what the card is supposed to show BEFORE capturing
-  // it. A blank or half-loaded card is a valid PNG and passes every size check,
-  // so this is the only step that can tell a good capture from a useless one.
-  const dom = runChrome(chrome, [...commonArgs, "--dump-dom", options.url]);
-  const html = dom.stdout ?? "";
-  if (html.length === 0) {
-    fail("SOCIAL_PREVIEW_PAGE_EMPTY", `${options.url} returned no DOM`);
-  }
-  const text = html.replace(/<[^>]*>/gu, " ");
-  if (!text.includes(REQUIRED_TEXT)) {
-    fail("SOCIAL_PREVIEW_PAGE_UNEXPECTED",
-      `${options.url} did not render "${REQUIRED_TEXT}"`);
-  }
-  if (!REQUIRED_FIGURE.test(text)) {
-    fail("SOCIAL_PREVIEW_FIGURE_MISSING",
-      "The allowance figure had not rendered. Capturing now would publish a card with an empty panel.");
-  }
-  if (options.expectText !== null && !text.includes(options.expectText)) {
-    fail("SOCIAL_PREVIEW_PAGE_UNEXPECTED",
-      `${options.url} did not contain expected text: ${options.expectText}`);
-  }
-  // Guard the specific regression this script exists to prevent: the retired
-  // card promised a download that already shipped.
-  const staleCta = /Public download coming soon/u.test(text)
-    && !/brew install/u.test(text);
-  if (staleCta) {
-    fail("SOCIAL_PREVIEW_STALE_CTA",
-      "The page is still advertising the download as unavailable; refusing to bake that into a share card.");
-  }
+  try {
+    session = await connect(endpoint);
+    await session.send("Page.enable");
+    await session.send("Runtime.enable");
+    await session.send("Emulation.setDeviceMetricsOverride", {
+      width: CAPTURE_WIDTH,
+      height: CAPTURE_HEIGHT,
+      deviceScaleFactor: DEVICE_SCALE,
+      mobile: false,
+    });
+    await session.send("Page.navigate", { url: options.url });
 
-  const capturePath = `${output}.capture.png`;
-  rmSync(capturePath, { force: true });
-  const shot = runChrome(chrome, [...commonArgs, `--screenshot=${capturePath}`, options.url]);
-  if (!existsSync(capturePath)) {
-    fail("SOCIAL_PREVIEW_CAPTURE_FAILED",
-      `Chrome produced no screenshot (exit ${shot.status})`);
-  }
+    const text = await waitForResolvedPage(session);
+    if (text.length === 0) {
+      fail("SOCIAL_PREVIEW_PAGE_EMPTY", `${options.url} rendered no text`);
+    }
+    if (!text.includes(REQUIRED_TEXT)) {
+      fail("SOCIAL_PREVIEW_PAGE_UNEXPECTED", `${options.url} did not render "${REQUIRED_TEXT}"`);
+    }
+    if (!text.includes(RESOLVED_ESTIMATE_SENTINEL)) {
+      fail("SOCIAL_PREVIEW_FIGURE_MISSING",
+        "The published estimate never resolved. Capturing now would publish a card with an empty headline.");
+    }
+    if (options.expectText !== null && !text.includes(options.expectText)) {
+      fail("SOCIAL_PREVIEW_PAGE_UNEXPECTED",
+        `${options.url} did not contain expected text: ${options.expectText}`);
+    }
+    // The specific regression this script exists to prevent: a card promising a
+    // download that already shipped.
+    if (STALE_CTA_PATTERN.test(text) && !SHIPPED_CTA_PATTERN.test(text)) {
+      fail("SOCIAL_PREVIEW_STALE_CTA",
+        "The page still advertises the download as unavailable; refusing to bake that into a share card.");
+    }
 
-  const captured = imageDimensions(capturePath);
-  if (captured.width !== CAPTURE_WIDTH * DEVICE_SCALE
-      || captured.height !== CAPTURE_HEIGHT * DEVICE_SCALE) {
+    await delay(POST_SETTLE_QUIET_MS);
+
+    // Same session, same navigation, same render as everything checked above.
+    const shot = await session.send("Page.captureScreenshot", {
+      format: "png",
+      captureBeyondViewport: false,
+    });
+    const data = shot?.data;
+    if (typeof data !== "string" || data.length === 0) {
+      fail("SOCIAL_PREVIEW_CAPTURE_FAILED", "DevTools returned no screenshot data");
+    }
+    const capturePath = `${output}.capture.png`;
     rmSync(capturePath, { force: true });
-    fail("SOCIAL_PREVIEW_CAPTURE_INVALID",
-      `Expected ${CAPTURE_WIDTH * DEVICE_SCALE}x${CAPTURE_HEIGHT * DEVICE_SCALE}, got ${captured.width}x${captured.height}`);
-  }
+    writeFileSync(capturePath, Buffer.from(data, "base64"));
 
-  rmSync(output, { force: true });
-  sips(["-z", String(OUTPUT_HEIGHT), String(OUTPUT_WIDTH), capturePath, "--out", output]);
-  rmSync(capturePath, { force: true });
+    const { spawnSync } = await import("node:child_process");
+    const sips = (args) => {
+      const run = spawnSync("sips", args, { encoding: "utf8" });
+      if (run.status !== 0) {
+        fail("SOCIAL_PREVIEW_RESIZE_FAILED", `sips failed: ${run.stderr?.trim() ?? "unknown"}`);
+      }
+      return run.stdout ?? "";
+    };
+    const dimensions = (path) => {
+      const out = sips(["-g", "pixelWidth", "-g", "pixelHeight", path]);
+      return {
+        width: Number(/pixelWidth:\s*(\d+)/u.exec(out)?.[1]),
+        height: Number(/pixelHeight:\s*(\d+)/u.exec(out)?.[1]),
+      };
+    };
 
-  const final = imageDimensions(output);
-  if (final.width !== OUTPUT_WIDTH || final.height !== OUTPUT_HEIGHT) {
-    fail("SOCIAL_PREVIEW_OUTPUT_INVALID",
-      `Expected ${OUTPUT_WIDTH}x${OUTPUT_HEIGHT}, got ${final.width}x${final.height}`);
-  }
-  const bytes = statSync(output).size;
-  // A near-empty PNG of the right dimensions is the signature of a page that
-  // rendered nothing. Real captures of this page are hundreds of kilobytes.
-  if (bytes < 20_000) {
-    fail("SOCIAL_PREVIEW_OUTPUT_SUSPECT",
-      `${output} is only ${bytes} bytes, which suggests a blank capture`);
-  }
+    const captured = dimensions(capturePath);
+    if (captured.width !== CAPTURE_WIDTH * DEVICE_SCALE
+        || captured.height !== CAPTURE_HEIGHT * DEVICE_SCALE) {
+      rmSync(capturePath, { force: true });
+      fail("SOCIAL_PREVIEW_CAPTURE_INVALID",
+        `Expected ${CAPTURE_WIDTH * DEVICE_SCALE}x${CAPTURE_HEIGHT * DEVICE_SCALE}, got ${captured.width}x${captured.height}`);
+    }
 
-  const figure = REQUIRED_FIGURE.exec(text)?.[0] ?? "(none)";
-  console.log(JSON.stringify({
-    ok: true,
-    code: "SOCIAL_PREVIEW_GENERATED",
-    output,
-    url: options.url,
-    width: final.width,
-    height: final.height,
-    bytes,
-    renderedFigure: figure,
-  }, null, 2));
+    rmSync(output, { force: true });
+    sips(["-z", String(OUTPUT_HEIGHT), String(OUTPUT_WIDTH), capturePath, "--out", output]);
+    rmSync(capturePath, { force: true });
+
+    const final = dimensions(output);
+    if (final.width !== OUTPUT_WIDTH || final.height !== OUTPUT_HEIGHT) {
+      fail("SOCIAL_PREVIEW_OUTPUT_INVALID",
+        `Expected ${OUTPUT_WIDTH}x${OUTPUT_HEIGHT}, got ${final.width}x${final.height}`);
+    }
+    const bytes = statSync(output).size;
+    // A solid-colour card of the right dimensions compresses to almost nothing;
+    // real captures of this page are hundreds of kilobytes.
+    if (bytes < 20_000) {
+      fail("SOCIAL_PREVIEW_OUTPUT_SUSPECT",
+        `${output} is only ${bytes} bytes, which suggests a blank capture`);
+    }
+
+    console.log(JSON.stringify({
+      ok: true,
+      code: "SOCIAL_PREVIEW_GENERATED",
+      output,
+      url: options.url,
+      width: final.width,
+      height: final.height,
+      bytes,
+      renderedFigure: FIGURE_PATTERN.exec(text)?.[0] ?? "(none)",
+    }, null, 2));
+  } catch (error) {
+    // A DevTools failure must not look like a successful generation.
+    if (error?.code === "ERR_UNHANDLED") throw error;
+    fail("SOCIAL_PREVIEW_CAPTURE_FAILED", error?.message ?? String(error));
+  } finally {
+    session?.close();
+    child?.kill("SIGTERM");
+  }
 }
 
-main();
+await main();

--- a/test/social-preview-generator.test.js
+++ b/test/social-preview-generator.test.js
@@ -1,0 +1,108 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { readFile } from "node:fs/promises";
+import { existsSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
+const SCRIPT = fileURLToPath(new URL("../scripts/generate-social-preview.js", import.meta.url));
+
+function run(args) {
+  const result = spawnSync(process.execPath, [SCRIPT, ...args], { encoding: "utf8" });
+  return {
+    status: result.status,
+    output: `${result.stdout ?? ""}${result.stderr ?? ""}`.trim(),
+  };
+}
+
+// These reject before a browser is ever launched, so they exercise real
+// behaviour without needing Chrome or the network in the suite.
+test("the social-preview generator refuses unusable output targets", () => {
+  const relative = run(["--output", "card.png"]);
+  assert.equal(relative.status, 1);
+  assert.match(relative.output, /SOCIAL_PREVIEW_ARGS_INVALID/u);
+  assert.match(relative.output, /absolute path/u);
+
+  const wrongType = run(["--output", "/tmp/card.jpg"]);
+  assert.equal(wrongType.status, 1);
+  assert.match(wrongType.output, /must end in \.png/u);
+
+  const missing = run([]);
+  assert.equal(missing.status, 1);
+  assert.match(missing.output, /--output <path\.png> is required/u);
+
+  const unknown = run(["--output", "/tmp/card.png", "--nope", "x"]);
+  assert.equal(unknown.status, 1);
+  assert.match(unknown.output, /Unknown argument: --nope/u);
+
+  const badUrl = run(["--output", "/tmp/card.png", "--url", "ftp://example.com"]);
+  assert.equal(badUrl.status, 1);
+  assert.match(badUrl.output, /--url must be http\(s\)/u);
+
+  // A flag consuming the next flag as its value silently generated the wrong
+  // card rather than failing.
+  const danglingValue = run(["--output", "--replace"]);
+  assert.equal(danglingValue.status, 1);
+  assert.match(danglingValue.output, /requires a value/u);
+});
+
+test("an existing card is never overwritten without --replace", async () => {
+  // Any existing file will do; the check happens before the browser launches.
+  assert.ok(existsSync(SCRIPT));
+  const guarded = run(["--output", SCRIPT.replace(/\.js$/u, ".png")]);
+  // Either it does not exist (arg checks pass, browser work begins) or it does
+  // and we get the overwrite refusal. Only the refusal path is asserted here.
+  if (guarded.output.includes("SOCIAL_PREVIEW_OUTPUT_EXISTS")) {
+    assert.equal(guarded.status, 1);
+  }
+});
+
+// The two defects that shipped in the first version of this script. Both were
+// invisible in the output file — a card that fails these still has the right
+// dimensions and a plausible byte count — so they are pinned in source rather
+// than left to be re-derived.
+/**
+ * Strip comments before pinning behaviour in source. The script's own docstring
+ * names the flags of the retired two-invocation design in order to explain why
+ * it is retired, so a naive source match reads the explanation as the defect.
+ */
+function executableSource(source) {
+  return source
+    .replace(/\/\*[\s\S]*?\*\//gu, " ")
+    .split("\n")
+    .map((line) => line.replace(/(^|\s)\/\/.*$/u, ""))
+    .join("\n");
+}
+
+test("the capture and its verification share one browser session", async () => {
+  const source = executableSource(await readFile(SCRIPT, "utf8"));
+
+  // Defect 1: the original ran Chrome twice, once with --dump-dom to check the
+  // page and once with --screenshot to capture it, then described that as
+  // checking "before the shutter". Two invocations are two page loads, so the
+  // guard validated a different render from the one it shipped.
+  assert.doesNotMatch(source, /--dump-dom/u,
+    "a separate --dump-dom run means the verified render is not the captured one");
+  assert.doesNotMatch(source, /--screenshot=/u,
+    "a separate --screenshot run means the captured render is not the verified one");
+  assert.match(source, /Page\.captureScreenshot/u,
+    "the screenshot must come from the same DevTools session that was verified");
+
+  // Defect 2: the original gated on /\$[0-9],[0-9]{3}/, which the chart's own
+  // axis labels satisfy ($1,000 / $2,000 / $3,000 are gridline text), so it
+  // would pass on a page whose headline figure never arrived.
+  assert.match(source, /const RESOLVED_ESTIMATE_SENTINEL = "Latest published estimate \("/u,
+    "the gate must be the sentence that only appears once the estimate resolves");
+  const gateBlock = /if \(!text\.includes\(RESOLVED_ESTIMATE_SENTINEL\)\) \{\s*fail\(/u;
+  assert.match(source, gateBlock,
+    "the resolved-estimate sentinel must be a hard gate, not advisory");
+});
+
+test("the card generator still refuses to bake a retired call to action", async () => {
+  const source = executableSource(await readFile(SCRIPT, "utf8"));
+  // The regression this script exists to prevent: a card promising a download
+  // that already shipped. install-cta.js hides the string at runtime, so only
+  // link previews carried it and nobody saw it for months.
+  assert.match(source, /SOCIAL_PREVIEW_STALE_CTA/u);
+  assert.match(source, /Public download coming soon/u);
+});


### PR DESCRIPTION
The social-card work reached `main` directly (`98fe9c9`, `94e5cc0`, `dbab24c`) without a PR or CI — my mistake, and this is the review it should have had. Re-reading it against current `main` turned up two real defects, so this is a fix rather than a formality.

Both were **invisible in the output**: a card failing either still has the right dimensions and a plausible byte count. That is the same property that let the original hand-made card stay wrong for months.

### 1. The verification did not cover the captured render

The script ran Chrome **twice** — `--dump-dom` to check the page, then `--screenshot` to capture it — and my commit message described that as checking the DOM "before the shutter". It wasn't. Two invocations are two page loads, so the guard validated render A and shipped render B. A page whose figure failed to load on the second pass sailed through every check.

Capture and verification now share **one navigation** over the DevTools protocol. What is verified is what is written.

### 2. The figure gate could be satisfied by the chart

It required only `/\$[0-9],[0-9]{3}/`. The live page carries `$1,000`, `$2,000` and `$3,000` as axis gridline text:

```
1 $1,000    1 $2,000    1 $3,000     <- gridlines, always present
5 $2,043                             <- the headline figure
```

So a page whose headline estimate never arrived would have passed the very gate written to catch that. The gate is now the sentence the page emits *only* once the published estimate resolves (`Latest published estimate (`); the currency pattern is kept solely to name the figure in the output.

### Verified against the live site

- The strengthened gate **rejects** a real page with no published estimate (`docs.html`) and writes no file.
- The happy path is **byte-identical** to the two-invocation version — 375,392 bytes, same card.
- All four argument guards fire.

### Tests

`test/social-preview-generator.test.js` — argument rejections run for real (they fail before any browser launches), plus source pins for both defects.

The source pins strip comments first, which is itself a finding: the script's docstring names the retired flags in order to explain why they're retired, and my first version of the test read that explanation as the defect and failed.

Architecture boundaries pass; the `tool-inventory` pin added in `89e23c3` still passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)