### PR TITLE
Fix misleading offline update-check message

### DIFF
--- a/apps/macos/Resources/en.lproj/Localizable.strings
+++ b/apps/macos/Resources/en.lproj/Localizable.strings
@@ -272,6 +272,8 @@
 "menuBar.failureRecovery" = "Not running: %@. Open the window for the recovery step.";
 "settings.codexFolderCustomSelectedPath" = "Custom folder: %@";
 "settings.codexFolderDefaultLocation" = "Default location (~/.codex)";
+"settings.updateCheckUnavailableMessage" = "TiboTattle couldn't complete the update check. Check your internet connection and try again.";
+"settings.updateCheckUnavailableTitle" = "Couldn't check for updates";
 "settings.updateDisclosureAutomaticOff" = "Signed app updates are available from About → Check for Updates. Automatic downloads are currently off; you can turn them on in Settings → About when available.";
 "settings.updateDisclosureAutomaticOn" = "Signed app updates are checked automatically. By default, a verified update downloads in the background and installs when you quit; you can turn that off in Settings → About.";
 "settings.updateDisclosureDevelopment" = "This development build does not include update checks. Signed releases installed in Applications can check for updates from About.";

--- a/apps/macos/Resources/es.lproj/Localizable.strings
+++ b/apps/macos/Resources/es.lproj/Localizable.strings
@@ -206,6 +206,8 @@
 "menuBar.failureRecovery" = "No está en ejecución: %@. Abre la ventana para ver el paso de recuperación.";
 "settings.codexFolderCustomSelectedPath" = "Carpeta personalizada: %@";
 "settings.codexFolderDefaultLocation" = "Ubicación predeterminada (~/.codex)";
+"settings.updateCheckUnavailableMessage" = "TiboTattle no pudo completar la búsqueda de actualizaciones. Comprueba tu conexión a Internet e inténtalo de nuevo.";
+"settings.updateCheckUnavailableTitle" = "No se pudo buscar actualizaciones";
 "settings.updateDisclosureAutomaticOff" = "Las actualizaciones de la app firmada están disponibles en Acerca de → Buscar actualizaciones. Las descargas automáticas están desactivadas; puedes activarlas en Configuración → Acerca de cuando estén disponibles.";
 "settings.updateDisclosureAutomaticOn" = "Las actualizaciones de la app firmada se comprueban automáticamente. De forma predeterminada, una actualización verificada se descarga en segundo plano y se instala al salir; puedes desactivarlo en Configuración → Acerca de.";
 "settings.updateDisclosureDevelopment" = "Esta compilación de desarrollo no incluye comprobaciones de actualización. Las versiones firmadas instaladas en Aplicaciones pueden buscar actualizaciones desde Acerca de.";

--- a/apps/macos/Resources/zh-Hans.lproj/Localizable.strings
+++ b/apps/macos/Resources/zh-Hans.lproj/Localizable.strings
@@ -206,6 +206,8 @@
 "menuBar.failureRecovery" = "未在运行：%@。请打开窗口查看恢复步骤。";
 "settings.codexFolderCustomSelectedPath" = "自定义文件夹：%@";
 "settings.codexFolderDefaultLocation" = "默认位置（~/.codex）";
+"settings.updateCheckUnavailableMessage" = "TiboTattle 无法完成更新检查。请检查互联网连接后重试。";
+"settings.updateCheckUnavailableTitle" = "无法检查更新";
 "settings.updateDisclosureAutomaticOff" = "已签名应用更新可在“关于”→“检查更新”中获取。自动下载目前已关闭；可在“设置”→“关于”中开启（如可用）。";
 "settings.updateDisclosureAutomaticOn" = "会自动检查已签名应用更新。默认情况下，已验证的更新会在后台下载并在退出时安装；可在“设置”→“关于”中关闭此项。";
 "settings.updateDisclosureDevelopment" = "此开发构建不包含更新检查。安装在“应用程序”中的已签名版本可从“关于”中检查更新。";

--- a/apps/macos/Sources/Localization.swift
+++ b/apps/macos/Sources/Localization.swift
@@ -330,6 +330,8 @@ enum TiboTattleLocalization {
         case settingsRefreshIntervalFifteenMinutes = "settings.refreshIntervalFifteenMinutes"
         case settingsRefreshIntervalThirtyMinutes = "settings.refreshIntervalThirtyMinutes"
         case settingsUseDefault = "settings.useDefault"
+        case settingsUpdateCheckUnavailableMessage = "settings.updateCheckUnavailableMessage"
+        case settingsUpdateCheckUnavailableTitle = "settings.updateCheckUnavailableTitle"
         case settingsUpdateDisclosureAutomaticOff = "settings.updateDisclosureAutomaticOff"
         case settingsUpdateDisclosureAutomaticOn = "settings.updateDisclosureAutomaticOn"
         case settingsUpdateDisclosureDevelopment = "settings.updateDisclosureDevelopment"
@@ -865,6 +867,10 @@ enum TiboTattleLocalization {
                 "Every 30 minutes"
             case .settingsUseDefault:
                 "Use Default"
+            case .settingsUpdateCheckUnavailableMessage:
+                "TiboTattle couldn't complete the update check. Check your internet connection and try again."
+            case .settingsUpdateCheckUnavailableTitle:
+                "Couldn't check for updates"
             case .settingsUpdateDisclosureAutomaticOff:
                 "Signed app updates are available from About → Check for Updates. Automatic downloads are currently off; you can turn them on in Settings → General when available."
             case .settingsUpdateDisclosureAutomaticOn:

--- a/apps/macos/UsageMonitorApp.swift
+++ b/apps/macos/UsageMonitorApp.swift
@@ -556,7 +556,10 @@ private final class AppUpdater: NSObject {
             feedIsReachable = false
             setState(.failed)
             if userInitiated {
-                showFeedFailureAlert()
+                showUpdateFailureAlert(
+                    messageKey: .launcherUpdateUnavailable,
+                    informativeTextKey: .settingsAutomaticUpdatesUnavailable
+                )
             }
             return
         }
@@ -580,7 +583,10 @@ private final class AppUpdater: NSObject {
                     self.feedIsReachable = false
                     self.setState(.failed)
                     if userInitiated {
-                        self.showFeedFailureAlert()
+                        self.showUpdateFailureAlert(
+                            messageKey: .settingsUpdateCheckUnavailableTitle,
+                            informativeTextKey: .settingsUpdateCheckUnavailableMessage
+                        )
                     }
                     return
                 }
@@ -590,15 +596,14 @@ private final class AppUpdater: NSObject {
         }.resume()
     }
 
-    private func showFeedFailureAlert() {
+    private func showUpdateFailureAlert(
+        messageKey: TiboTattleLocalization.Key,
+        informativeTextKey: TiboTattleLocalization.Key
+    ) {
         let alert = NSAlert()
         alert.alertStyle = .warning
-        alert.messageText = TiboTattleLocalization.string(
-            .launcherUpdateUnavailable
-        )
-        alert.informativeText = TiboTattleLocalization.string(
-            .settingsAutomaticUpdatesUnavailable
-        )
+        alert.messageText = TiboTattleLocalization.string(messageKey)
+        alert.informativeText = TiboTattleLocalization.string(informativeTextKey)
         alert.addButton(withTitle: TiboTattleLocalization.string(.launcherRetry))
         alert.addButton(withTitle: TiboTattleLocalization.string(.commonCancel))
         if alert.runModal() == .alertFirstButtonReturn {

--- a/test/macos-app-bundle.test.js
+++ b/test/macos-app-bundle.test.js
@@ -858,7 +858,15 @@ test("native launcher keeps the requested foreground-only lifecycle", async () =
   );
   assert.match(
     source,
-    /guard Self\.feedResponseIsReachable\([\s\S]*showFeedFailureAlert/u,
+    /guard Self\.feedResponseIsReachable\([\s\S]*showUpdateFailureAlert\(\s*messageKey:\s*\.settingsUpdateCheckUnavailableTitle,\s*informativeTextKey:\s*\.settingsUpdateCheckUnavailableMessage/u,
+  );
+  assert.match(
+    source,
+    /guard let appcastURL = Self\.appcastURL else \{[\s\S]*showUpdateFailureAlert\(\s*messageKey:\s*\.launcherUpdateUnavailable,\s*informativeTextKey:\s*\.settingsAutomaticUpdatesUnavailable/u,
+  );
+  assert.match(
+    source,
+    /private func showUpdateFailureAlert\([\s\S]*?alert\.messageText = TiboTattleLocalization\.string\(messageKey\)[\s\S]*?alert\.informativeText = TiboTattleLocalization\.string\(informativeTextKey\)/u,
   );
   assert.match(source, /alert\.addButton\(withTitle: TiboTattleLocalization\.string\(\.launcherRetry\)\)/u);
   assert.match(source, /alert\.addButton\(withTitle: TiboTattleLocalization\.string\(\.commonCancel\)\)/u);

--- a/test/macos-localization.test.js
+++ b/test/macos-localization.test.js
@@ -110,6 +110,14 @@ test("native catalogs have complete language parity and preserve placeholders", 
     english.get("settings.languageSummary"),
     "Uses your Mac language by default.",
   );
+  assert.equal(
+    english.get("settings.updateCheckUnavailableTitle"),
+    "Couldn't check for updates",
+  );
+  assert.equal(
+    english.get("settings.updateCheckUnavailableMessage"),
+    "TiboTattle couldn't complete the update check. Check your internet connection and try again.",
+  );
   assert.match(swiftSource, /LanguagePreference: String, CaseIterable/u);
   assert.match(swiftSource, /UserDefaults\.standard\.set/u);
   assert.match(swiftSource, /Locale\.preferredLanguages/u);


### PR DESCRIPTION
## Summary
- distinguish updater-disabled builds from a failed manual update preflight
- explain connectivity failures and retain the retry action
- add localized copy and regression coverage

## Validation
- node --test test/macos-localization.test.js
- node --test --test-name-pattern=native launcher keeps the requested foreground-only lifecycle test/macos-app-bundle.test.js
- plutil lint for all three native localization catalogs
- swiftc typecheck for native sources

## Limitation
- npm run product:macos:test did not complete because the pinned Sparkle framework download timed out twice before tests started.