### PR TITLE
fix(macos): keep live allowance visible during refresh

### DIFF
--- a/apps/macos/Sources/MenuBarStatus.swift
+++ b/apps/macos/Sources/MenuBarStatus.swift
@@ -273,15 +273,22 @@ struct MenuBarStatusSnapshot: Equatable {
         phase == .ready || phase == .analyzing
     }
 
-    /// The compact menu-bar title. A number appears only for live evidence.
-    /// `…` means "an explicit pass is running", `–` means "no number can be
-    /// shown honestly right now" and the menu says which case applies.
+    /// The compact menu-bar title. A fresh verified number remains useful while
+    /// an explicit pass checks for newer evidence, so analysis state does not
+    /// replace it. `…` means "a pass is running without a live number"; `–`
+    /// means "no number can be shown honestly right now" and the menu explains
+    /// which case applies.
     var title: String {
-        if phase == .analyzing { return analyzingPlaceholder }
-        guard phase == .ready, evidence == .live, let lane = primaryLane else {
-            return unknownPlaceholder
+        if companionReachable,
+           evidence == .live,
+           let lane = primaryLane {
+            return TiboTattleLocalization.percentString(
+                lane.roundedRemainingPercent
+            )
         }
-        return TiboTattleLocalization.percentString(lane.roundedRemainingPercent)
+        return phase == .analyzing
+            ? analyzingPlaceholder
+            : unknownPlaceholder
     }
 
     /// Spoken by VoiceOver in place of the glyph and the terse title. The

--- a/apps/macos/UsageMonitorApp.swift
+++ b/apps/macos/UsageMonitorApp.swift
@@ -7696,7 +7696,14 @@ private enum MenuBarContractSmokeTest {
             weeklyLane,
             now: observedAt
         )
+        var analyzingLiveSnapshot = liveSnapshot
+        analyzingLiveSnapshot.phase = .analyzing
+        var analyzingWithoutLiveEvidence = MenuBarStatusSnapshot()
+        analyzingWithoutLiveEvidence.phase = .analyzing
+        var unavailableLiveSnapshot = liveSnapshot
+        unavailableLiveSnapshot.phase = .unavailable
         let reset = resetCountdown(resetAt, now: observedAt)
+        let expectedLiveTitle = TiboTattleLocalization.percentString(71)
         let expectedLiveSummary = reset.map {
             TiboTattleLocalization.format(
                 .menuBarQuotaWeeklyPositionResets,
@@ -7740,6 +7747,11 @@ private enum MenuBarContractSmokeTest {
                   elapsedPercent: 24,
                   usedPercent: 29
               ),
+              liveSnapshot.title == expectedLiveTitle,
+              analyzingLiveSnapshot.title == expectedLiveTitle,
+              analyzingWithoutLiveEvidence.title == "…",
+              staleSnapshot.title == "–",
+              unavailableLiveSnapshot.title == "–",
               liveSummary == expectedLiveSummary,
               staleSummary == expectedStaleSummary
         else {
@@ -7753,7 +7765,8 @@ private enum MenuBarContractSmokeTest {
                 + "native_rows=true titles=true states=starting,unavailable "
                 + "shortcuts=cmd-r,cmd-comma,cmd-q "
                 + "dismissal=native,escape,same-app,deactivation "
-                + "weekly_position=fresh-only"
+                + "weekly_position=fresh-only "
+                + "analysis_title=live-fallback"
         )
         return 0
     }

--- a/test/macos-app-bundle.test.js
+++ b/test/macos-app-bundle.test.js
@@ -2002,13 +2002,21 @@ test("menu-bar status item degrades honestly and never invents allowance evidenc
   assert.match(source, /configure\(\s*aboutItem,/u);
   assert.match(source, /#selector\(showAbout\)/u);
 
-  // The compact title shows a number only for live evidence; stale, absent,
-  // starting, failed, and analyzing states all collapse to a placeholder.
+  // The compact title keeps a verified live number visible while a refresh is
+  // running. Analysis gets its own placeholder only when no live number is
+  // available; stale, absent, starting, and failed states remain non-numeric.
   assert.match(
     source,
-    /guard phase == \.ready, evidence == \.live, let lane = primaryLane else \{\s*return unknownPlaceholder/u,
+    /if companionReachable,\s*evidence == \.live,\s*let lane = primaryLane \{\s*return TiboTattleLocalization\.percentString\(\s*lane\.roundedRemainingPercent\s*\)/u,
   );
-  assert.match(source, /if phase == \.analyzing \{ return analyzingPlaceholder \}/u);
+  assert.match(
+    source,
+    /return phase == \.analyzing\s*\? analyzingPlaceholder\s*:\s*unknownPlaceholder/u,
+  );
+  assert.doesNotMatch(
+    source,
+    /if phase == \.analyzing \{ return analyzingPlaceholder \}/u,
+  );
   assert.match(source, /private let analyzingPlaceholder = "…"/u);
   assert.match(source, /private let unknownPlaceholder = "–"/u);
   assert.match(
@@ -5930,7 +5938,7 @@ macOSArtifactTest("reproducible ad-hoc-signed app passes orderly and launcher-SI
     );
     assert.match(
       menuBarSmoke.stdout,
-      /^USAGE_MONITOR_MACOS_MENU_BAR_CONTRACT native_rows=true titles=true states=starting,unavailable shortcuts=cmd-r,cmd-comma,cmd-q dismissal=native,escape,same-app,deactivation weekly_position=fresh-only$/mu,
+      /^USAGE_MONITOR_MACOS_MENU_BAR_CONTRACT native_rows=true titles=true states=starting,unavailable shortcuts=cmd-r,cmd-comma,cmd-q dismissal=native,escape,same-app,deactivation weekly_position=fresh-only analysis_title=live-fallback$/mu,
     );
     const quotaNotificationSmoke = spawnSync(
       join(outputA, "Contents", "MacOS", "TiboTattle"),


### PR DESCRIPTION
## Summary
- keep the latest fresh, verified allowance percentage visible while local analysis refreshes it
- reserve the ellipsis for analysis when no live allowance value is available
- add source assertions and packaged AppKit state-matrix coverage for the fallback

## Testing
- `USAGE_MONITOR_TEST_LANES=1 USAGE_MONITOR_MACOS_TEST_SCOPE=source node --test --test-concurrency=1 test/macos-app-bundle.test.js` (47 passed, 3 artifact exclusions)
- `node --test --test-concurrency=1 test/macos-localization.test.js` (2 passed)
- release-profile app build plus `--menu-bar-contract-smoke-test` (`analysis_title=live-fallback`)
- focused reproducibility/watchdog artifact test passed on retry after an unrelated mounted-DMG Login Item timeout