### PR TITLE
fix(macos): disable unused window tabbing

### DIFF
--- a/apps/macos/UsageMonitorApp.swift
+++ b/apps/macos/UsageMonitorApp.swift
@@ -8777,6 +8777,10 @@ private enum NativeDashboardChromeLayoutSmokeTest {
 @main
 private struct UsageMonitorMain {
     static func main() {
+        // TiboTattle has no document-style multi-window workflow. Opt out
+        // before AppKit creates the application or any windows so it does not
+        // expose a browser-style tab bar with no product meaning.
+        NSWindow.allowsAutomaticWindowTabbing = false
         let arguments = Array(CommandLine.arguments.dropFirst())
         // This isolated seam smoke intentionally runs before bundle branding
         // is resolved, so it can execute as a plain launcher binary without

--- a/test/macos-app-bundle.test.js
+++ b/test/macos-app-bundle.test.js
@@ -1599,6 +1599,26 @@ test("native dashboard launch gates its first refresh on the rendered page", asy
   assert.match(companionExit, /startupAutomaticRefreshPending = false/u);
 });
 
+test("native app disables AppKit window tabbing before startup", async () => {
+  const source = await readFile(SWIFT_SOURCE, "utf8");
+  const mainStart = source.indexOf("static func main() {");
+  const tabbingOptOut = source.indexOf(
+    "NSWindow.allowsAutomaticWindowTabbing = false",
+    mainStart,
+  );
+  const argumentParsing = source.indexOf(
+    "let arguments = Array(CommandLine.arguments.dropFirst())",
+    mainStart,
+  );
+
+  assert.ok(mainStart >= 0, "the native app entry point is present");
+  assert.ok(tabbingOptOut > mainStart, "AppKit window tabbing is disabled");
+  assert.ok(
+    argumentParsing > tabbingOptOut,
+    "window tabbing is disabled before any startup or smoke-test path",
+  );
+});
+
 test("unified toolbar preserves the rich loopback report and single authority", async () => {
   const source = await readFile(SWIFT_SOURCE, "utf8");
   assert.match(


### PR DESCRIPTION
## Summary
- opt the native macOS app out of AppKit automatic window tabbing before startup
- prevent the system-supplied Show Tab Bar affordance from appearing in this single-window app
- add a regression test that pins the opt-out before any startup path

## Validation
- node --test --test-name-pattern="native app disables AppKit window tabbing before startup" test/macos-app-bundle.test.js
- npm run product:macos:test (59/59 passed)
- disposable development-build QA: View and toolbar context menus contain no Show Tab Bar command