### PR TITLE
fix(macos): always leave a way to reopen a collapsed sidebar

### DIFF
--- a/apps/macos/Resources/en.lproj/Localizable.strings
+++ b/apps/macos/Resources/en.lproj/Localizable.strings
@@ -118,6 +118,7 @@
 "nativeDashboard.community" = "Community";
 "nativeDashboard.dataPrivacy" = "Data & Privacy";
 "nativeDashboard.fresh" = "Fresh";
+"nativeDashboard.hideSidebar" = "Hide Sidebar";
 "nativeDashboard.howItWorks" = "Usage and costs";
 "nativeDashboard.needsRefresh" = "Stale";
 "nativeDashboard.localOnly" = "Local only";
@@ -126,6 +127,7 @@
 "nativeDashboard.refreshUsage" = "Refresh";
 "nativeDashboard.refreshUsageTooltip" = "Update local usage now. This reads only the selected Codex folders on this Mac.";
 "nativeDashboard.share" = "Share";
+"nativeDashboard.showSidebar" = "Show Sidebar";
 "nativeDashboard.shareTooltip" = "Open the local share card.";
 "nativeDashboard.starting" = "Starting…";
 "nativeDashboard.status" = "Status";

--- a/apps/macos/Resources/es.lproj/Localizable.strings
+++ b/apps/macos/Resources/es.lproj/Localizable.strings
@@ -12,6 +12,7 @@
 "nativeDashboard.community" = "Comunidad";
 "nativeDashboard.dataPrivacy" = "Datos y privacidad";
 "nativeDashboard.fresh" = "Actualizado";
+"nativeDashboard.hideSidebar" = "Ocultar barra lateral";
 "nativeDashboard.howItWorks" = "Uso y costes";
 "nativeDashboard.needsRefresh" = "Desactualizado";
 "nativeDashboard.localOnly" = "Solo local";
@@ -20,6 +21,7 @@
 "nativeDashboard.refreshUsage" = "Actualizar";
 "nativeDashboard.refreshUsageTooltip" = "Actualiza ahora el uso local. Solo lee las carpetas de Codex seleccionadas en este Mac.";
 "nativeDashboard.share" = "Compartir";
+"nativeDashboard.showSidebar" = "Mostrar barra lateral";
 "nativeDashboard.shareTooltip" = "Abrir la tarjeta local para compartir.";
 "nativeDashboard.starting" = "Iniciando…";
 "nativeDashboard.status" = "Estado";

--- a/apps/macos/Resources/zh-Hans.lproj/Localizable.strings
+++ b/apps/macos/Resources/zh-Hans.lproj/Localizable.strings
@@ -12,6 +12,7 @@
 "nativeDashboard.community" = "社区";
 "nativeDashboard.dataPrivacy" = "数据与隐私";
 "nativeDashboard.fresh" = "最新";
+"nativeDashboard.hideSidebar" = "隐藏边栏";
 "nativeDashboard.howItWorks" = "用量与成本";
 "nativeDashboard.needsRefresh" = "已过期";
 "nativeDashboard.localOnly" = "仅限本机";
@@ -20,6 +21,7 @@
 "nativeDashboard.refreshUsage" = "刷新";
 "nativeDashboard.refreshUsageTooltip" = "立即更新本地使用情况。只会读取这台 Mac 上选定的 Codex 文件夹。";
 "nativeDashboard.share" = "分享";
+"nativeDashboard.showSidebar" = "显示边栏";
 "nativeDashboard.shareTooltip" = "打开本地分享卡片。";
 "nativeDashboard.starting" = "正在启动…";
 "nativeDashboard.status" = "状态";

--- a/apps/macos/Sources/Localization.swift
+++ b/apps/macos/Sources/Localization.swift
@@ -190,6 +190,8 @@ enum TiboTattleLocalization {
         case nativeDashboardStatus = "nativeDashboard.status"
         case nativeDashboardTrends = "nativeDashboard.trends"
         case nativeDashboardUpdating = "nativeDashboard.updating"
+        case nativeDashboardHideSidebar = "nativeDashboard.hideSidebar"
+        case nativeDashboardShowSidebar = "nativeDashboard.showSidebar"
         case menuAboutProduct = "menu.aboutProduct"
         case menuCopy = "menu.copy"
         case menuEdit = "menu.edit"
@@ -587,6 +589,10 @@ enum TiboTattleLocalization {
                 "Trends"
             case .nativeDashboardUpdating:
                 "Running…"
+            case .nativeDashboardHideSidebar:
+                "Hide Sidebar"
+            case .nativeDashboardShowSidebar:
+                "Show Sidebar"
             case .menuAboutProduct:
                 "About %@"
             case .menuCopy:

--- a/apps/macos/UsageMonitorApp.swift
+++ b/apps/macos/UsageMonitorApp.swift
@@ -2968,11 +2968,15 @@ private final class NativeDashboardChrome: NSSplitViewController {
     /// and above the report item's default 250 so a window resize stretches
     /// the report rather than the sidebar.
     private static let sidebarHoldingPriority = NSLayoutConstraint.Priority(260)
-    private static let splitAutosaveName = "com.usagemonitor.local.dashboard-split.v1"
+    static let splitAutosaveName = "com.usagemonitor.local.dashboard-split.v1"
     /// One-time marker that the resting width has been seeded. After this,
     /// the autosaved divider position is the user's own and is never fought.
     private static let splitSeededDefaultsKey =
         "tibotattle.dashboard-split-seeded.v1"
+    /// One-time marker that a sidebar stranded by an older build has been
+    /// reopened. See `rescueStrandedSidebar(_:)`.
+    static let sidebarRescuedDefaultsKey =
+        "tibotattle.dashboard-sidebar-rescued.v1"
 
     private let sidebar = NSVisualEffectView()
     private let sidebarWash = NativeSidebarBrandWash()
@@ -3096,6 +3100,46 @@ private final class NativeDashboardChrome: NSSplitViewController {
         nil
     }
 
+    /// The sidebar pane's split item. The sidebar is added first, so it is the
+    /// leading item; reading it back through `splitViewItems` keeps a single
+    /// source of truth rather than a second stored reference that could drift.
+    private var sidebarItem: NSSplitViewItem? { splitViewItems.first }
+
+    /// Whether the sidebar is currently collapsed. The navigation rows live
+    /// only here — the web report hides its own sidebar in native mode — so a
+    /// collapsed sidebar is a window with no way to change page.
+    var sidebarIsCollapsed: Bool { sidebarItem?.isCollapsed ?? false }
+
+    /// Reopen the sidebar. Returns true when it actually reopened one, so a
+    /// caller (and the smoke test) can tell a rescue from a no-op.
+    @discardableResult
+    func revealSidebar() -> Bool {
+        guard let item = sidebarItem, item.isCollapsed else { return false }
+        item.isCollapsed = false
+        return true
+    }
+
+    /// Reopen a sidebar that an older build could strand shut.
+    ///
+    /// Dragging the divider to the leading edge collapses the sidebar, and the
+    /// split view's autosave persists that across relaunches — but builds
+    /// through 0.1.16 shipped no toolbar item, menu command, or key equivalent
+    /// that could reopen it, and a collapsed pane has no divider left to drag.
+    /// The result was a window with no navigation at all, permanently
+    /// (owner-reported, 2026-08-22).
+    ///
+    /// This build adds those affordances, so a collapse is now the user's
+    /// reversible choice and must be respected. The one exception is the
+    /// stranded state itself: reopen it exactly once, on the first launch that
+    /// can undo it, then record the marker and never reopen again.
+    private func rescueStrandedSidebar(_ defaults: UserDefaults) {
+        guard !defaults.bool(forKey: Self.sidebarRescuedDefaultsKey) else {
+            return
+        }
+        defaults.set(true, forKey: Self.sidebarRescuedDefaultsKey)
+        revealSidebar()
+    }
+
     /// The very first launch has no autosaved divider to restore, and plain
     /// constraint solving would rest the sidebar at its 180pt minimum. Seed
     /// the designed 216pt opening width exactly once; every later launch
@@ -3105,12 +3149,35 @@ private final class NativeDashboardChrome: NSSplitViewController {
         guard !restingWidthSeeded else { return }
         restingWidthSeeded = true
         let defaults = UserDefaults.standard
+        // Before the seeding gate below: every already-installed user has the
+        // seeded marker set, and a stranded sidebar is exactly the state those
+        // users are in, so a rescue behind that early return would never run.
+        rescueStrandedSidebar(defaults)
         guard !defaults.bool(forKey: Self.splitSeededDefaultsKey) else {
             return
         }
         defaults.set(true, forKey: Self.splitSeededDefaultsKey)
         view.layoutSubtreeIfNeeded()
         splitView.setPosition(Self.sidebarRestingThickness, ofDividerAt: 0)
+    }
+
+    /// Keep the sidebar command readable in the View menu: AppKit flips the
+    /// toolbar item's own label, but a menu item keeps whatever title it was
+    /// built with unless validation rewrites it.
+    override func validateUserInterfaceItem(
+        _ item: NSValidatedUserInterfaceItem
+    ) -> Bool {
+        if item.action == #selector(NSSplitViewController.toggleSidebar(_:)) {
+            if let menuItem = item as? NSMenuItem {
+                menuItem.title = TiboTattleLocalization.string(
+                    sidebarIsCollapsed
+                        ? .nativeDashboardShowSidebar
+                        : .nativeDashboardHideSidebar
+                )
+            }
+            return true
+        }
+        return super.validateUserInterfaceItem(item)
     }
 
     func select(_ destination: NativeDashboardDestination) {
@@ -3845,6 +3912,7 @@ private final class AppDelegate: NSObject, NSApplicationDelegate,
         _ toolbar: NSToolbar
     ) -> [NSToolbarItem.Identifier] {
         [
+            .toggleSidebar,
             .flexibleSpace,
             Self.toolbarStatusRefreshIdentifier,
             Self.toolbarShareIdentifier,
@@ -3856,6 +3924,13 @@ private final class AppDelegate: NSObject, NSApplicationDelegate,
         _ toolbar: NSToolbar
     ) -> [NSToolbarItem.Identifier] {
         [
+            // The system sidebar toggle, first and always present. The sidebar
+            // can be collapsed by dragging its divider, and a collapsed pane
+            // leaves no divider to drag back — so the only guaranteed way back
+            // must live outside the sidebar. AppKit supplies this item, keeps
+            // its icon and Hide/Show label in step with the pane, and routes
+            // it to `toggleSidebar(_:)` down the responder chain.
+            .toggleSidebar,
             Self.toolbarStatusRefreshIdentifier,
             .flexibleSpace,
             Self.toolbarShareIdentifier,
@@ -4666,6 +4741,21 @@ private final class AppDelegate: NSObject, NSApplicationDelegate,
         )
         refresh.target = self
         viewMenu.addItem(refresh)
+        // The standard macOS sidebar command, on the standard key equivalent.
+        // A collapsed sidebar has no divider left to drag, so this and the
+        // toolbar item are the two ways back; the title is rewritten to
+        // Hide/Show by the chrome's validation. Target stays nil so the
+        // responder chain delivers it to whichever dashboard window is key,
+        // and the item disables itself when none is.
+        viewMenu.addItem(NSMenuItem.separator())
+        let toggleSidebar = NSMenuItem(
+            title: TiboTattleLocalization.string(.nativeDashboardHideSidebar),
+            action: #selector(NSSplitViewController.toggleSidebar(_:)),
+            keyEquivalent: "s"
+        )
+        toggleSidebar.keyEquivalentModifierMask = [.control, .command]
+        toggleSidebar.target = nil
+        viewMenu.addItem(toggleSidebar)
         viewItem.submenu = viewMenu
         mainMenu.addItem(viewItem)
         NSApp.mainMenu = mainMenu
@@ -8477,6 +8567,182 @@ private enum NativeDashboardLayoutSmokeTest {
     }
 }
 
+/// Proves a collapsed sidebar can always be reopened.
+///
+/// Source text can show that a toolbar item and a menu command exist; it cannot
+/// show that either one reaches a live target, nor that the pane actually comes
+/// back with usable width. This drives the real chrome: collapse it the way a
+/// divider drag leaves it, then reopen it through the same action the toolbar
+/// and menu send, and check the one-time rescue for sidebars that older builds
+/// stranded shut.
+@MainActor
+private enum NativeDashboardSidebarRecoverySmokeTest {
+    static func run() -> Int32 {
+        let application = NSApplication.shared
+        application.setActivationPolicy(.accessory)
+        let defaults = UserDefaults.standard
+        // This runs inside the shipped bundle's own defaults domain, so the
+        // markers it must forge are saved and put back before returning.
+        let rescueKey = NativeDashboardChrome.sidebarRescuedDefaultsKey
+        let priorRescue = defaults.object(forKey: rescueKey)
+        defer {
+            if let priorRescue {
+                defaults.set(priorRescue, forKey: rescueKey)
+            } else {
+                defaults.removeObject(forKey: rescueKey)
+            }
+            // Defaults writes are asynchronous and this process exits
+            // immediately after returning; without the flush the restore is
+            // lost and the smoke would silently consume the real one-time
+            // rescue belonging to whoever ran it.
+            defaults.synchronize()
+        }
+
+        func makeChrome() -> (NativeDashboardChrome, NSWindow) {
+            let host = DashboardWebHost(
+                onLoaded: {},
+                onFailure: { _ in },
+                onDownloadFailure: {},
+                openExternally: { _ in },
+                onNavigation: { _ in },
+                onLanguagePreferenceChange: { _ in }
+            )
+            let chrome = NativeDashboardChrome(webView: host.webView)
+            let window = NSWindow(
+                contentRect: NSRect(x: 0, y: 0, width: 1_180, height: 860),
+                styleMask: [.titled, .closable, .miniaturizable, .resizable],
+                backing: .buffered,
+                defer: false
+            )
+            window.contentViewController = chrome
+            window.setContentSize(NSSize(width: 1_180, height: 860))
+            window.displayIfNeeded()
+            chrome.view.layoutSubtreeIfNeeded()
+            return (chrome, window)
+        }
+
+        // A collapsed item keeps its own pane's width — AppKit hides the pane
+        // rather than zeroing it — so the width alone cannot tell the states
+        // apart. What the user actually sees is where the report begins: flush
+        // against the window's leading edge with the sidebar gone, or pushed
+        // right by the sidebar's full width when it is back.
+        func panes(
+            _ chrome: NativeDashboardChrome,
+            _ window: NSWindow
+        ) -> (sidebar: CGFloat, report: CGFloat, reportLeading: CGFloat) {
+            chrome.view.layoutSubtreeIfNeeded()
+            guard let reference = window.contentView else { return (0, 0, 0) }
+            let metrics = chrome.measure(in: reference)
+            return (
+                metrics.sidebarPane.width,
+                metrics.reportPane.width,
+                metrics.reportPane.minX
+            )
+        }
+
+        let (chrome, window) = makeChrome()
+
+        // 1. Collapse the way a divider dragged to the leading edge leaves it.
+        chrome.splitViewItems.first?.isCollapsed = true
+        let collapsed = chrome.sidebarIsCollapsed
+        let collapsedPanes = panes(chrome, window)
+        let collapsedWidth = collapsedPanes.sidebar
+
+        // 2. The action both affordances send must reach a live target.
+        let selector = #selector(NSSplitViewController.toggleSidebar(_:))
+        let responds = chrome.responds(to: selector)
+
+        // 3. Validation enables the command and names the state it will move
+        //    to, in both directions.
+        let probe = NSMenuItem(
+            title: "",
+            action: selector,
+            keyEquivalent: ""
+        )
+        let enabledWhileCollapsed = chrome.validateUserInterfaceItem(probe)
+        let showTitle = probe.title
+
+        // 4. Reopening restores a pane at or above the enforced minimum, and
+        //    the report gives back the width the sidebar now occupies.
+        let revealed = chrome.revealSidebar()
+        let revealedPanes = panes(chrome, window)
+        let revealedWidth = revealedPanes.sidebar
+        let reportYielded = collapsedPanes.report - revealedPanes.report
+        _ = chrome.validateUserInterfaceItem(probe)
+        let hideTitle = probe.title
+
+        // 5. A sidebar stranded by an older build reopens once on upgrade.
+        defaults.removeObject(forKey: rescueKey)
+        let (stranded, strandedWindow) = makeChrome()
+        _ = strandedWindow
+        stranded.splitViewItems.first?.isCollapsed = true
+        stranded.viewDidAppear()
+        let rescued = !stranded.sidebarIsCollapsed
+
+        // 6. After that one rescue a deliberate collapse is left alone: the
+        //    marker is set, and the user can reopen it themselves now.
+        let (afterRescue, afterWindow) = makeChrome()
+        _ = afterWindow
+        afterRescue.splitViewItems.first?.isCollapsed = true
+        afterRescue.viewDidAppear()
+        let respectsChoice = afterRescue.sidebarIsCollapsed
+
+        let minimum = NativeDashboardChrome.sidebarMinimumThickness
+        guard collapsed,
+              // Nothing between the window edge and the report.
+              collapsedPanes.reportLeading < 1,
+              // The sidebar is back in front of it, at its enforced width.
+              revealedPanes.reportLeading >= minimum,
+              responds,
+              enabledWhileCollapsed,
+              showTitle == TiboTattleLocalization.string(
+                  .nativeDashboardShowSidebar
+              ),
+              revealed,
+              revealedWidth >= minimum,
+              reportYielded >= minimum,
+              hideTitle == TiboTattleLocalization.string(
+                  .nativeDashboardHideSidebar
+              ),
+              rescued,
+              respectsChoice
+        else {
+            FileHandle.standardError.write(
+                Data(
+                    ("macOS sidebar recovery smoke failed "
+                        + "collapsed=\(collapsed) "
+                        + "collapsed_width=\(Int(collapsedWidth)) "
+                        + "collapsed_report_leading="
+                        + "\(Int(collapsedPanes.reportLeading)) "
+                        + "revealed_report_leading="
+                        + "\(Int(revealedPanes.reportLeading)) "
+                        + "responds=\(responds) "
+                        + "enabled=\(enabledWhileCollapsed) "
+                        + "show_title=\(showTitle) "
+                        + "revealed=\(revealed) "
+                        + "revealed_width=\(Int(revealedWidth)) "
+                        + "report_yielded=\(Int(reportYielded)) "
+                        + "hide_title=\(hideTitle) "
+                        + "rescued=\(rescued) "
+                        + "respects_choice=\(respectsChoice)\n").utf8
+                )
+            )
+            return 1
+        }
+        print(
+            "USAGE_MONITOR_MACOS_SIDEBAR_RECOVERY "
+                + "collapse=true "
+                + "responds=true "
+                + "menu_enabled=true "
+                + "reveal=true "
+                + "width=\(Int(revealedWidth)) "
+                + "rescue_once=true "
+                + "respects_choice=true"
+        )
+        return 0
+    }
+}
+
 /// Opens the shipped dashboard window and measures the chrome in it. This is
 /// the guard for the reported "the menu is not seamless, not rounded, and not
 /// even the right size" defect, and the three things it pins are the three
@@ -8887,6 +9153,11 @@ private struct UsageMonitorMain {
         if arguments.contains("--native-dashboard-layout-smoke-test") {
             exit(MainActor.assumeIsolated {
                 NativeDashboardLayoutSmokeTest.run()
+            })
+        }
+        if arguments.contains("--native-dashboard-sidebar-recovery-smoke-test") {
+            exit(MainActor.assumeIsolated {
+                NativeDashboardSidebarRecoverySmokeTest.run()
             })
         }
         let application = NSApplication.shared

--- a/docs/runbooks/sidebar-stranded-collapsed-rescue.md
+++ b/docs/runbooks/sidebar-stranded-collapsed-rescue.md
@@ -1,0 +1,89 @@
+# Rescue: the dashboard sidebar is collapsed and will not come back
+
+Applies to TiboTattle **0.1.16 and earlier**. Builds after that carry the fix
+described at the bottom and need none of this.
+
+## What the person sees
+
+The dashboard window opens with the report content flush against the left edge
+and no sidebar: no Overview, Usage, Trends, or Community rows, and therefore no
+way to change page. Quitting and reopening does not help. Reinstalling does not
+help either.
+
+## Why it happens
+
+The sidebar is a real `NSSplitViewItem` with `canCollapse = true`, so dragging
+its divider to the leading edge collapses it — normal Mac behaviour. Three
+things then combine into a trap:
+
+1. The split view's `autosaveName` persists the collapsed state, so it survives
+   quit, relaunch, and reinstall (the state lives in user defaults, not in the
+   app bundle).
+2. A collapsed pane leaves no divider to drag back.
+3. Builds through 0.1.16 shipped **no** toolbar item, menu command, or key
+   equivalent that could reopen it.
+
+With all navigation living in that sidebar — the web report hides its own
+sidebar when running inside the app — the window is left with no way to
+navigate and no way back.
+
+## The rescue (works on the build they already have)
+
+The persisted geometry is a single user-defaults key. Deleting it discards the
+collapsed state; the next launch lays the sidebar out fresh.
+
+```bash
+defaults delete com.usagemonitor.local "NSSplitView Subview Frames com.usagemonitor.local.dashboard-split.v1"
+```
+
+Then quit TiboTattle completely (⌘Q, or Force Quit if the window is unusable)
+and reopen it. The sidebar comes back.
+
+Deleting only that key restores the sidebar at its minimum width (about 188pt)
+because the one-time width seeding has already run. To have it reopen at the
+designed 216pt instead, delete the seeding marker as well before relaunching:
+
+```bash
+defaults delete com.usagemonitor.local "tibotattle.dashboard-split-seeded.v1"
+```
+
+Neither command touches usage data, cached analysis, sign-in state, device
+credentials, or settings. Both only discard window geometry.
+
+### Verified
+
+Measured against a real build on 2026-08-22, driving the packaged app's chrome
+smoke with a forged collapsed autosave:
+
+| state | result |
+|---|---|
+| collapsed geometry persisted | report pane at x=0, sidebar out of layout — reproduces the report |
+| after deleting the autosave key | sidebar restored, 188pt |
+| after deleting both keys | sidebar restored at the designed 216pt |
+
+## The fix (0.1.17 and later)
+
+Three changes, so this state is neither reachable-without-recovery nor sticky:
+
+- **Toolbar**: the system `.toggleSidebar` item, in both the default and
+  allowed identifier sets. AppKit owns its icon and its Hide/Show label.
+- **View menu**: a *Hide/Show Sidebar* command on the standard ⌃⌘S key
+  equivalent, dispatched down the responder chain so it reaches whichever
+  dashboard window is key. Its title is rewritten by the chrome's
+  `validateUserInterfaceItem`.
+- **One-time rescue**: on the first launch of a build that can undo a collapse,
+  an already-stranded sidebar is reopened once and a marker is recorded. After
+  that a deliberate collapse is respected, because it is now reversible. The
+  rescue deliberately runs *before* the width-seeding early return — every
+  already-installed user has the seeding marker set, which is precisely the
+  population that can be stranded.
+
+`--native-dashboard-sidebar-recovery-smoke-test` on the packaged binary drives
+all of it against real chrome: collapse, reopen through the same action the
+toolbar and menu send, the enforced minimum width on return, the menu title
+flip, the one-time rescue, and that a later deliberate collapse is left alone.
+
+## General rule
+
+Any pane that can be collapsed needs a way back that does **not** live inside
+that pane. A divider is not an affordance once it is gone.

--- a/docs/runbooks/sidebar-stranded-collapsed-rescue.md
+++ b/docs/runbooks/sidebar-stranded-collapsed-rescue.md
@@ -32,16 +32,41 @@ navigate and no way back.
 The persisted geometry is a single user-defaults key. Deleting it discards the
 collapsed state; the next launch lays the sidebar out fresh.
 
+### Easiest option: update the app
+
+Updating to 0.1.17 or later fixes this by itself — that build reopens a
+stranded sidebar once on first launch, and from then on carries a toolbar
+button and a ⌃⌘S menu command. Anyone willing to wait for the update needs
+none of the steps below.
+
+### Manual rescue, step by step
+
+The commands run in **Terminal**, the app built into macOS. To open it: press
+⌘Space, type `Terminal`, press Return (or find it in Finder under
+Applications → Utilities → Terminal).
+
+**Order matters. Quit the app first.** A running TiboTattle holds its own copy
+of these settings and rewrites them when it quits, which would put the
+collapsed state straight back. So:
+
+1. **Quit TiboTattle completely** — ⌘Q, or right-click its Dock icon and
+   choose Quit. If the window is unusable, use Force Quit (⌥⌘Esc). Also quit
+   it from the menu-bar icon if it is running there.
+2. Open Terminal.
+3. Paste this line and press Return. It prints nothing when it works:
+
 ```bash
 defaults delete com.usagemonitor.local "NSSplitView Subview Frames com.usagemonitor.local.dashboard-split.v1"
 ```
 
-Then quit TiboTattle completely (⌘Q, or Force Quit if the window is unusable)
-and reopen it. The sidebar comes back.
+4. Reopen TiboTattle. The sidebar is back.
 
-Deleting only that key restores the sidebar at its minimum width (about 188pt)
-because the one-time width seeding has already run. To have it reopen at the
-designed 216pt instead, delete the seeding marker as well before relaunching:
+If step 3 prints `does not exist`, the setting was already cleared — carry on
+to step 4 anyway.
+
+That restores the sidebar at its minimum width (about 188pt), because the
+one-time width seeding has already run. To have it reopen at the designed
+216pt instead, run this as well, still before reopening the app:
 
 ```bash
 defaults delete com.usagemonitor.local "tibotattle.dashboard-split-seeded.v1"

--- a/test/macos-app-bundle.test.js
+++ b/test/macos-app-bundle.test.js
@@ -1321,8 +1321,14 @@ test("native launcher keeps the requested foreground-only lifecycle", async () =
   );
   assert.equal(
     source.match(/setActivationPolicy\(\.accessory\)/gu)?.length,
-    3,
+    4,
     "only isolated AppKit smoke modes may use accessory activation",
+  );
+  // The fourth is the sidebar-recovery smoke, which builds real chrome in a
+  // window it never brings forward.
+  assert.match(
+    source,
+    /private enum NativeDashboardSidebarRecoverySmokeTest \{[\s\S]*?application\.setActivationPolicy\(\.accessory\)/u,
   );
   for (const forbidden of [
     "LSUIElement",
@@ -1907,6 +1913,56 @@ test("dashboard sidebar resizes for real, wears the brand palette, and the title
   assert.match(
     source,
     /NativeDashboardChrome\.sidebarMinimumThickness - 1/u,
+  );
+  // 1b. A collapsed sidebar must always be reopenable. The sidebar can be
+  // collapsed by dragging its divider to the leading edge, the split view's
+  // autosave persists that across relaunches, and a collapsed pane leaves no
+  // divider to drag back — so builds through 0.1.16, which had neither a
+  // toolbar item nor a menu command for it, stranded the window with no
+  // navigation at all (owner-reported, 2026-08-22). Two independent ways back
+  // are pinned here because the sidebar is the only navigation the packaged
+  // app has: the web report hides its own sidebar in native mode.
+  assert.match(source, /sidebarItem\.canCollapse = true/u);
+  // The system toolbar toggle, in both the allowed and the default sets, so
+  // it is present on a fresh install and cannot be customized away without
+  // the menu command below still existing.
+  const toolbarDefaults = source.match(
+    /func toolbarDefaultItemIdentifiers\(\s*\n\s*_ toolbar: NSToolbar\s*\n\s*\) -> \[NSToolbarItem\.Identifier\] \{([\s\S]*?)\n    \}/u,
+  )?.[1];
+  assert.ok(toolbarDefaults, "the toolbar default identifiers are available");
+  assert.match(toolbarDefaults, /\.toggleSidebar/u);
+  const toolbarAllowed = source.match(
+    /func toolbarAllowedItemIdentifiers\(\s*\n\s*_ toolbar: NSToolbar\s*\n\s*\) -> \[NSToolbarItem\.Identifier\] \{([\s\S]*?)\n    \}/u,
+  )?.[1];
+  assert.ok(toolbarAllowed, "the toolbar allowed identifiers are available");
+  assert.match(toolbarAllowed, /\.toggleSidebar/u);
+  // The standard macOS command and key equivalent, on the responder chain so
+  // it reaches whichever dashboard window is key.
+  assert.match(
+    source,
+    /action: #selector\(NSSplitViewController\.toggleSidebar\(_:\)\),\s*\n\s*keyEquivalent: "s"/u,
+  );
+  assert.match(
+    source,
+    /toggleSidebar\.keyEquivalentModifierMask = \[\.control, \.command\]/u,
+  );
+  // The one-time rescue must run BEFORE the seeding gate returns: every
+  // already-installed user has the seeded marker set, and a stranded sidebar
+  // is exactly the state those users are in, so a rescue behind that early
+  // return would never execute for the people who need it.
+  const viewDidAppear = source.match(
+    /override func viewDidAppear\(\) \{([\s\S]*?)\n    \}/u,
+  )?.[1];
+  assert.ok(viewDidAppear, "the chrome's viewDidAppear is available");
+  assert.ok(
+    viewDidAppear.indexOf("rescueStrandedSidebar(defaults)")
+      < viewDidAppear.indexOf("guard !defaults.bool(forKey: Self.splitSeededDefaultsKey)"),
+    "the stranded-sidebar rescue must precede the seeding early return",
+  );
+  // The rescue fires once and then never fights a deliberate collapse.
+  assert.match(
+    source,
+    /private func rescueStrandedSidebar\(_ defaults: UserDefaults\) \{\s*\n\s*guard !defaults\.bool\(forKey: Self\.sidebarRescuedDefaultsKey\) else \{\s*\n\s*return\s*\n\s*\}\s*\n\s*defaults\.set\(true, forKey: Self\.sidebarRescuedDefaultsKey\)/u,
   );
   // 2. The sidebar carries the web report's warm-paper palette over the
   // system material, and the selected row uses the brand's deep green
@@ -6020,6 +6076,26 @@ macOSArtifactTest("reproducible ad-hoc-signed app passes orderly and launcher-SI
     assert.match(
       nativeDashboardLayoutSmoke.stdout,
       /^USAGE_MONITOR_MACOS_NATIVE_DASHBOARD_LAYOUT web_width=[6-9][0-9]{2,} web_height=[6-9][0-9]{2,}$/mu,
+    );
+    // A sidebar that cannot be reopened is a window with no navigation: the
+    // rows live only here, because the web report hides its own sidebar in
+    // native mode. Source text can show a toolbar item and a menu command
+    // exist; only this proves the action reaches a live target, that the pane
+    // returns at its enforced width, and that a sidebar stranded shut by an
+    // older build reopens exactly once on upgrade.
+    const sidebarRecoverySmoke = spawnSync(
+      join(outputA, "Contents", "MacOS", "TiboTattle"),
+      ["--native-dashboard-sidebar-recovery-smoke-test"],
+      { encoding: "utf8", timeout: 15_000 },
+    );
+    assert.equal(
+      sidebarRecoverySmoke.status,
+      0,
+      sidebarRecoverySmoke.stderr || sidebarRecoverySmoke.stdout,
+    );
+    assert.match(
+      sidebarRecoverySmoke.stdout,
+      /^USAGE_MONITOR_MACOS_SIDEBAR_RECOVERY collapse=true responds=true menu_enabled=true reveal=true width=[12][0-9]{2} rescue_once=true respects_choice=true$/mu,
     );
     const generatedFiles = bundleFiles
       .map(({ relativePath }) => relativePath)


### PR DESCRIPTION
## The bug

A user collapsed the dashboard sidebar and could not get it back. Reproduced
against a real build — three things combined into a one-way door:

1. The sidebar is a real `NSSplitViewItem` with `canCollapse = true`, so
   dragging its divider to the leading edge collapses it. Normal Mac behaviour.
2. `splitView.autosaveName` persists that collapse across quit, relaunch **and
   reinstall** — the state lives in user defaults, not in the app bundle.
3. A collapsed pane leaves no divider to drag back, and builds through 0.1.16
   shipped **no** toolbar item, menu command, or key equivalent that could
   reopen it.

Because the packaged app hides the web report's own sidebar
(`html.native-dashboard .dashboard-sidebar { display: none }`) and keeps every
navigation row in this one pane, the result was a window with no way to change
page and no way back.

Forging the collapsed autosave and driving the packaged chrome smoke reproduces
the user's screenshot exactly: report pane at `x=0`, sidebar out of the layout.

## Rescue for anyone already stuck (no update needed)

The persisted geometry is a single user-defaults key. **Quit TiboTattle first** —
a running app rewrites these settings on quit and would put the collapse
straight back — then in Terminal:

```bash
defaults delete com.usagemonitor.local "NSSplitView Subview Frames com.usagemonitor.local.dashboard-split.v1"
```

Reopen the app and the sidebar is back. `does not exist` means it was already
cleared; reopen anyway. Optionally also delete
`tibotattle.dashboard-split-seeded.v1` to have it reopen at the designed 216pt
rather than its 188pt minimum. Neither command touches usage data, cached
analysis, sign-in state, device credentials, or settings — only window geometry.

Full runbook: `docs/runbooks/sidebar-stranded-collapsed-rescue.md`.

## The fix

- **Toolbar**: the system `.toggleSidebar` item, in both the default and allowed
  identifier sets. AppKit owns its icon and its Hide/Show label.
- **View menu**: a Hide/Show Sidebar command on the standard ⌃⌘S, dispatched
  down the responder chain so it reaches whichever dashboard window is key. Its
  title is rewritten by the chrome's `validateUserInterfaceItem`.
- **One-time rescue**: on the first launch of a build that *can* undo a
  collapse, an already-stranded sidebar is reopened once and a marker recorded.
  After that a deliberate collapse is respected, because it is now reversible.
  This deliberately runs **before** the width-seeding early return — every
  already-installed user has the seeding marker set, and that is exactly the
  population that can be stranded.

## Testing

New `--native-dashboard-sidebar-recovery-smoke-test` drives real chrome rather
than asserting on source text: collapse, reopen through the same action both
affordances send, the enforced minimum width on return, the report yielding that
width back, the menu title flip in both directions, the one-time rescue against
genuinely persisted state, and a later deliberate collapse left alone. Its
defaults cleanup flushes synchronously so the smoke cannot consume the real
one-time rescue of whoever runs it.

Two things the runtime test caught that source review would not have: a
collapsed `NSSplitViewItem` keeps its own pane width (measured 217, not 0 —
AppKit hides the pane rather than zeroing it), so the honest assertion is where
the report *starts*; and the accessory-activation governance pin needed its
count bumped for the new smoke.

macOS bundle suite **51/51** on this branch, rebased onto current main
(includes #56). Verified end to end against a real build: forged collapsed
state reproduces the bug, and both recovery paths — the defaults command and
the in-app one-time rescue — restore the sidebar.

## General rule

Any pane that can be collapsed needs a way back that does **not** live inside
that pane. A divider is not an affordance once it is gone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
