### PR TITLE
feat(macos): narrate local analysis progress

### DIFF
--- a/apps/macos/Resources/en.lproj/Localizable.strings
+++ b/apps/macos/Resources/en.lproj/Localizable.strings
@@ -123,6 +123,15 @@
 "nativeDashboard.localOnly" = "Local only";
 "nativeDashboard.localOnlyTooltip" = "Analysis and cached results stay on this Mac. Community contribution is optional.";
 "nativeDashboard.overview" = "Overview";
+"nativeDashboard.progressAnalyzing" = "Analyzing local history…";
+"nativeDashboard.progressAnalyzingFiles" = "Analyzing %@ of %@ files…";
+"nativeDashboard.progressArchiveIndex" = "Updating older history…";
+"nativeDashboard.progressDiscovering" = "Finding local history…";
+"nativeDashboard.progressFinishing" = "Finishing analysis…";
+"nativeDashboard.progressProspective" = "Preparing ongoing tracking…";
+"nativeDashboard.progressQuickResult" = "Headline ready · finishing analysis…";
+"nativeDashboard.progressQuotaRefresh" = "Refreshing allowance…";
+"nativeDashboard.progressSaving" = "Saving analysis progress…";
 "nativeDashboard.refreshUsage" = "Refresh";
 "nativeDashboard.refreshUsageTooltip" = "Update local usage now. This reads only the selected Codex folders on this Mac.";
 "nativeDashboard.share" = "Share";

--- a/apps/macos/Resources/es.lproj/Localizable.strings
+++ b/apps/macos/Resources/es.lproj/Localizable.strings
@@ -17,6 +17,15 @@
 "nativeDashboard.localOnly" = "Solo local";
 "nativeDashboard.localOnlyTooltip" = "El análisis y los resultados en caché permanecen en este Mac. La contribución a la comunidad es opcional.";
 "nativeDashboard.overview" = "Resumen";
+"nativeDashboard.progressAnalyzing" = "Analizando el historial local…";
+"nativeDashboard.progressAnalyzingFiles" = "Analizando %@ de %@ archivos…";
+"nativeDashboard.progressArchiveIndex" = "Actualizando el historial anterior…";
+"nativeDashboard.progressDiscovering" = "Buscando el historial local…";
+"nativeDashboard.progressFinishing" = "Finalizando el análisis…";
+"nativeDashboard.progressProspective" = "Preparando el seguimiento continuo…";
+"nativeDashboard.progressQuickResult" = "Resumen listo · finalizando el análisis…";
+"nativeDashboard.progressQuotaRefresh" = "Actualizando el límite…";
+"nativeDashboard.progressSaving" = "Guardando el progreso del análisis…";
 "nativeDashboard.refreshUsage" = "Actualizar";
 "nativeDashboard.refreshUsageTooltip" = "Actualiza ahora el uso local. Solo lee las carpetas de Codex seleccionadas en este Mac.";
 "nativeDashboard.share" = "Compartir";

--- a/apps/macos/Resources/zh-Hans.lproj/Localizable.strings
+++ b/apps/macos/Resources/zh-Hans.lproj/Localizable.strings
@@ -17,6 +17,15 @@
 "nativeDashboard.localOnly" = "仅限本机";
 "nativeDashboard.localOnlyTooltip" = "分析结果和缓存结果保留在这台 Mac 上。是否贡献给社区由你自行选择。";
 "nativeDashboard.overview" = "概览";
+"nativeDashboard.progressAnalyzing" = "正在分析本地历史记录…";
+"nativeDashboard.progressAnalyzingFiles" = "正在分析 %@ / %@ 个文件…";
+"nativeDashboard.progressArchiveIndex" = "正在更新较早的历史记录…";
+"nativeDashboard.progressDiscovering" = "正在查找本地历史记录…";
+"nativeDashboard.progressFinishing" = "正在完成分析…";
+"nativeDashboard.progressProspective" = "正在准备持续跟踪…";
+"nativeDashboard.progressQuickResult" = "摘要已就绪 · 正在完成分析…";
+"nativeDashboard.progressQuotaRefresh" = "正在刷新额度…";
+"nativeDashboard.progressSaving" = "正在保存分析进度…";
 "nativeDashboard.refreshUsage" = "刷新";
 "nativeDashboard.refreshUsageTooltip" = "立即更新本地使用情况。只会读取这台 Mac 上选定的 Codex 文件夹。";
 "nativeDashboard.share" = "分享";

--- a/apps/macos/Sources/Localization.swift
+++ b/apps/macos/Sources/Localization.swift
@@ -182,6 +182,15 @@ enum TiboTattleLocalization {
         case nativeDashboardLocalOnly = "nativeDashboard.localOnly"
         case nativeDashboardLocalOnlyTooltip = "nativeDashboard.localOnlyTooltip"
         case nativeDashboardOverview = "nativeDashboard.overview"
+        case nativeDashboardProgressAnalyzing = "nativeDashboard.progressAnalyzing"
+        case nativeDashboardProgressAnalyzingFiles = "nativeDashboard.progressAnalyzingFiles"
+        case nativeDashboardProgressArchiveIndex = "nativeDashboard.progressArchiveIndex"
+        case nativeDashboardProgressDiscovering = "nativeDashboard.progressDiscovering"
+        case nativeDashboardProgressFinishing = "nativeDashboard.progressFinishing"
+        case nativeDashboardProgressProspective = "nativeDashboard.progressProspective"
+        case nativeDashboardProgressQuickResult = "nativeDashboard.progressQuickResult"
+        case nativeDashboardProgressQuotaRefresh = "nativeDashboard.progressQuotaRefresh"
+        case nativeDashboardProgressSaving = "nativeDashboard.progressSaving"
         case nativeDashboardRefreshUsage = "nativeDashboard.refreshUsage"
         case nativeDashboardRefreshUsageTooltip = "nativeDashboard.refreshUsageTooltip"
         case nativeDashboardShare = "nativeDashboard.share"
@@ -571,6 +580,24 @@ enum TiboTattleLocalization {
                 "Analysis and cached results stay on this Mac. Community contribution is optional."
             case .nativeDashboardOverview:
                 "Overview"
+            case .nativeDashboardProgressAnalyzing:
+                "Analyzing local history…"
+            case .nativeDashboardProgressAnalyzingFiles:
+                "Analyzing %@ of %@ files…"
+            case .nativeDashboardProgressArchiveIndex:
+                "Updating older history…"
+            case .nativeDashboardProgressDiscovering:
+                "Finding local history…"
+            case .nativeDashboardProgressFinishing:
+                "Finishing analysis…"
+            case .nativeDashboardProgressProspective:
+                "Preparing ongoing tracking…"
+            case .nativeDashboardProgressQuickResult:
+                "Headline ready · finishing analysis…"
+            case .nativeDashboardProgressQuotaRefresh:
+                "Refreshing allowance…"
+            case .nativeDashboardProgressSaving:
+                "Saving analysis progress…"
             case .nativeDashboardRefreshUsage:
                 "Refresh"
             case .nativeDashboardRefreshUsageTooltip:
@@ -1050,6 +1077,11 @@ enum TiboTattleLocalization {
         return formatter.string(
             from: NSNumber(value: Double(value) / 100)
         ) ?? "\(value)%"
+    }
+
+    static func integerString(_ value: Int) -> String {
+        decimalNumberFormatter(maximumFractionDigits: 0)
+            .string(from: NSNumber(value: value)) ?? String(value)
     }
 
     static func dateFormatter(

--- a/apps/macos/Sources/MenuBarStatus.swift
+++ b/apps/macos/Sources/MenuBarStatus.swift
@@ -189,12 +189,81 @@ struct LocalContributionDiagnostics: Equatable {
     }
 }
 
+/// Privacy-reviewed progress from the companion's existing refresh receipt.
+/// The phase is a closed vocabulary and the only counts retained are bounded
+/// file totals used by the native toolbar. No server-provided prose crosses
+/// this projection.
+struct LocalAnalysisProgress: Equatable {
+    enum Phase: String, Equatable {
+        case discovering
+        case rolloutIndex = "rollout_index"
+        case quotaRefresh = "quota_refresh"
+        case quickResult = "quick_result"
+        case complete
+        case paused
+        case prospective
+        case archiveIndex = "archive_index"
+    }
+
+    let phase: Phase
+    let filesSelected: Int?
+    let filesProcessed: Int?
+
+    var nativeToolbarTitle: String {
+        switch phase {
+        case .discovering:
+            return TiboTattleLocalization.string(
+                .nativeDashboardProgressDiscovering
+            )
+        case .rolloutIndex:
+            guard let filesSelected,
+                  let filesProcessed,
+                  filesSelected > 0,
+                  filesProcessed <= filesSelected
+            else {
+                return TiboTattleLocalization.string(
+                    .nativeDashboardProgressAnalyzing
+                )
+            }
+            return TiboTattleLocalization.format(
+                .nativeDashboardProgressAnalyzingFiles,
+                TiboTattleLocalization.integerString(filesProcessed),
+                TiboTattleLocalization.integerString(filesSelected)
+            )
+        case .quotaRefresh:
+            return TiboTattleLocalization.string(
+                .nativeDashboardProgressQuotaRefresh
+            )
+        case .quickResult:
+            return TiboTattleLocalization.string(
+                .nativeDashboardProgressQuickResult
+            )
+        case .complete:
+            return TiboTattleLocalization.string(
+                .nativeDashboardProgressFinishing
+            )
+        case .paused:
+            return TiboTattleLocalization.string(
+                .nativeDashboardProgressSaving
+            )
+        case .prospective:
+            return TiboTattleLocalization.string(
+                .nativeDashboardProgressProspective
+            )
+        case .archiveIndex:
+            return TiboTattleLocalization.string(
+                .nativeDashboardProgressArchiveIndex
+            )
+        }
+    }
+}
+
 /// Whether an explicit local analysis pass is running, from whichever surface
 /// started it. The dashboard and the menu bar share one controller in the
 /// companion, so the menu bar can never start a second concurrent pass.
 enum LocalAnalysisActivity: Equatable {
     case idle(refreshID: String?)
-    case running(refreshID: String?)
+    case running(refreshID: String?, progress: LocalAnalysisProgress?)
 }
 
 /// Result of asking the companion to start the existing refresh pass.
@@ -827,7 +896,7 @@ final class LocalCompanionEvidenceReader {
         return data
     }
 
-    private static func decodeActivity(_ data: Data) -> LocalAnalysisActivity? {
+    static func decodeActivity(_ data: Data) -> LocalAnalysisActivity? {
         guard let root = try? JSONSerialization.jsonObject(with: data)
             as? [String: Any],
             let refresh = root["refresh"] as? [String: Any],
@@ -837,8 +906,53 @@ final class LocalCompanionEvidenceReader {
         }
         let refreshID = decodeRefreshID(refresh)
         return ["running", "cancelling"].contains(status)
-            ? .running(refreshID: refreshID)
+            ? .running(
+                refreshID: refreshID,
+                progress: decodeProgress(refresh["progress"])
+            )
             : .idle(refreshID: refreshID)
+    }
+
+    private static func decodeProgress(_ value: Any?) -> LocalAnalysisProgress? {
+        guard let progress = value as? [String: Any] else { return nil }
+        if progress["kind"] as? String == "archive_index" {
+            guard progress["status"] as? String == "scanning" else {
+                return nil
+            }
+            return LocalAnalysisProgress(
+                phase: .archiveIndex,
+                filesSelected: nil,
+                filesProcessed: nil
+            )
+        }
+        guard let rawPhase = progress["phase"] as? String,
+              let phase = LocalAnalysisProgress.Phase(rawValue: rawPhase),
+              phase != .archiveIndex
+        else {
+            return nil
+        }
+        return LocalAnalysisProgress(
+            phase: phase,
+            filesSelected: decodeProgressCount(progress["filesSelected"]),
+            filesProcessed: decodeProgressCount(progress["filesProcessed"])
+        )
+    }
+
+    private static let maximumProgressCount = 1_000_000_000
+
+    private static func decodeProgressCount(_ value: Any?) -> Int? {
+        guard let number = value as? NSNumber, !(value is Bool) else {
+            return nil
+        }
+        let doubleValue = number.doubleValue
+        guard doubleValue.isFinite,
+              doubleValue.rounded(.towardZero) == doubleValue,
+              doubleValue >= 0,
+              doubleValue <= Double(maximumProgressCount)
+        else {
+            return nil
+        }
+        return Int(doubleValue)
     }
 
     private static func decodeRefreshID(_ data: Data) -> String? {

--- a/apps/macos/UsageMonitorApp.swift
+++ b/apps/macos/UsageMonitorApp.swift
@@ -3252,6 +3252,7 @@ private final class AppDelegate: NSObject, NSApplicationDelegate,
     private var nativeRefreshPoll: DispatchWorkItem?
     private var nativeRefreshSchedule: DispatchWorkItem?
     private var nativeRefreshInFlight = false
+    private var nativeRefreshProgress: LocalAnalysisProgress?
     /// One launch-only refresh waits until the page has rendered its first
     /// local result. This prevents the heavy collector from winning the
     /// loopback race against the dashboard's own initial reads.
@@ -3937,11 +3938,16 @@ private final class AppDelegate: NSObject, NSApplicationDelegate,
             nativeStatusPill = pill
             nativeStatusToolbarItem = item
             updateNativeToolbar(
-                title: nativeToolbarEvidenceTitle(
-                    fallback: TiboTattleLocalization.string(
-                        .launcherStartingLocally
-                    )
-                ),
+                title: nativeRefreshInFlight
+                    ? nativeRefreshProgress?.nativeToolbarTitle
+                        ?? TiboTattleLocalization.string(
+                            .nativeDashboardUpdating
+                        )
+                    : nativeToolbarEvidenceTitle(
+                        fallback: TiboTattleLocalization.string(
+                            .launcherStartingLocally
+                        )
+                    ),
                 isRefreshing: nativeRefreshInFlight,
                 refreshEnabled: dashboardURL != nil
             )
@@ -3987,18 +3993,18 @@ private final class AppDelegate: NSObject, NSApplicationDelegate,
         refreshEnabled: Bool
     ) {
         let statusTitle = isRefreshing
-            ? TiboTattleLocalization.string(.nativeDashboardUpdating)
+            ? title
             : nativeToolbarEvidenceTitle(fallback: title)
         nativeStatusRefreshButton?.title = statusTitle
         nativeStatusRefreshButton?.toolTip = isRefreshing
-            ? TiboTattleLocalization.string(.nativeDashboardUpdating)
+            ? statusTitle
             : nativeRefreshToolbarTooltip()
         nativeStatusRefreshButton?.image = NSImage(
             systemSymbolName: isRefreshing
                 ? "arrow.triangle.2.circlepath.circle.fill"
                 : "arrow.clockwise",
             accessibilityDescription: isRefreshing
-                ? TiboTattleLocalization.string(.nativeDashboardUpdating)
+                ? statusTitle
                 : TiboTattleLocalization.string(
                     .nativeDashboardRefreshUsage
                 )
@@ -4038,7 +4044,8 @@ private final class AppDelegate: NSObject, NSApplicationDelegate,
 
     private func refreshNativeToolbarLocalization() {
         let statusTitle = nativeRefreshInFlight
-            ? TiboTattleLocalization.string(.nativeDashboardUpdating)
+            ? nativeRefreshProgress?.nativeToolbarTitle
+                ?? TiboTattleLocalization.string(.nativeDashboardUpdating)
             : nativeToolbarEvidenceTitle(
                 fallback: TiboTattleLocalization.string(
                     .nativeDashboardStatus
@@ -4046,14 +4053,14 @@ private final class AppDelegate: NSObject, NSApplicationDelegate,
             )
         nativeStatusRefreshButton?.title = statusTitle
         nativeStatusRefreshButton?.toolTip = nativeRefreshInFlight
-            ? TiboTattleLocalization.string(.nativeDashboardUpdating)
+            ? statusTitle
             : nativeRefreshToolbarTooltip()
         nativeStatusRefreshButton?.image = NSImage(
             systemSymbolName: nativeRefreshInFlight
                 ? "arrow.triangle.2.circlepath.circle.fill"
                 : "arrow.clockwise",
             accessibilityDescription: nativeRefreshInFlight
-                ? TiboTattleLocalization.string(.nativeDashboardUpdating)
+                ? statusTitle
                 : TiboTattleLocalization.string(
                     .nativeDashboardRefreshUsage
                 )
@@ -4226,7 +4233,10 @@ private final class AppDelegate: NSObject, NSApplicationDelegate,
             TiboTattleLocalization.string(.launcherLoadingPrivateDashboard)
         updateNativeToolbar(
             title: nativeRefreshInFlight
-                ? TiboTattleLocalization.string(.nativeDashboardUpdating)
+                ? nativeRefreshProgress?.nativeToolbarTitle
+                    ?? TiboTattleLocalization.string(
+                        .nativeDashboardUpdating
+                    )
                 : TiboTattleLocalization.string(.nativeDashboardStarting),
             isRefreshing: nativeRefreshInFlight,
             refreshEnabled: dashboardURL != nil
@@ -4255,7 +4265,10 @@ private final class AppDelegate: NSObject, NSApplicationDelegate,
         openInBrowserButton.isEnabled = true
         updateNativeToolbar(
             title: nativeRefreshInFlight
-                ? "Updating local usage…"
+                ? nativeRefreshProgress?.nativeToolbarTitle
+                    ?? TiboTattleLocalization.string(
+                        .nativeDashboardUpdating
+                    )
                 : "Local report ready",
             isRefreshing: nativeRefreshInFlight,
             refreshEnabled: dashboardURL != nil
@@ -4312,6 +4325,7 @@ private final class AppDelegate: NSObject, NSApplicationDelegate,
         cancelNativeRefreshSchedule()
         cancelNativeIndexingCoveragePoll()
         nativeRefreshInFlight = true
+        nativeRefreshProgress = nil
         updateNativeToolbar(
             title: automatic
                 ? TiboTattleLocalization.string(.launcherUpdatingAutomatically)
@@ -4366,8 +4380,17 @@ private final class AppDelegate: NSObject, NSApplicationDelegate,
                 }
                 let terminalRefreshID: String?
                 switch activity {
-                case .running:
+                case let .running(_, progress):
                     terminalRefreshID = nil
+                    self.nativeRefreshProgress = progress
+                    self.updateNativeToolbar(
+                        title: progress?.nativeToolbarTitle
+                            ?? TiboTattleLocalization.string(
+                                .nativeDashboardUpdating
+                            ),
+                        isRefreshing: true,
+                        refreshEnabled: false
+                    )
                     if remainingAttempts > 0 {
                         self.pollNativeRefresh(
                             base: base,
@@ -4444,6 +4467,7 @@ private final class AppDelegate: NSObject, NSApplicationDelegate,
 
     private func finishNativeRefresh(title: String, refreshEnabled: Bool) {
         nativeRefreshInFlight = false
+        nativeRefreshProgress = nil
         nativeRefreshID = nil
         cancelNativeRefreshPoll()
         updateNativeToolbar(
@@ -4750,6 +4774,7 @@ private final class AppDelegate: NSObject, NSApplicationDelegate,
         nativeHistoryIndexingCoverage = nil
         nativeRefreshFailure = nil
         nativeRefreshInFlight = false
+        nativeRefreshProgress = nil
         nativeRefreshID = nil
         dashboardWebHost?.stop()
         updateNativeToolbar(
@@ -7661,6 +7686,155 @@ private enum LoginItemContractSmokeTest {
     }
 }
 
+/// Exercises the closed refresh-progress projection without contacting the
+/// companion. This proves that only allowlisted phases and bounded counts can
+/// reach native presentation, while the existing idle/running contract remains
+/// intact for unknown or forged fields.
+private enum NativeAnalysisProgressContractSmokeTest {
+    private static let refreshID = "123e4567-e89b-42d3-a456-426614174000"
+
+    private static func decode(
+        progress: [String: Any],
+        status: String = "running"
+    ) -> LocalAnalysisActivity? {
+        guard let data = try? JSONSerialization.data(withJSONObject: [
+            "refresh": [
+                "status": status,
+                "refreshId": refreshID,
+                "progress": progress,
+            ],
+        ]) else {
+            return nil
+        }
+        return LocalCompanionEvidenceReader.decodeActivity(data)
+    }
+
+    static func run() -> Int32 {
+        let phases: [(String, LocalAnalysisProgress.Phase)] = [
+            ("discovering", .discovering),
+            ("rollout_index", .rolloutIndex),
+            ("quota_refresh", .quotaRefresh),
+            ("quick_result", .quickResult),
+            ("complete", .complete),
+            ("paused", .paused),
+            ("prospective", .prospective),
+        ]
+        for (rawPhase, expectedPhase) in phases {
+            guard case let .running(decodedRefreshID, progress) = decode(
+                progress: ["phase": rawPhase]
+            ),
+                decodedRefreshID == refreshID,
+                progress?.phase == expectedPhase,
+                progress?.nativeToolbarTitle.isEmpty == false
+            else {
+                return failure("phase \(rawPhase)")
+            }
+        }
+
+        let counted = decode(progress: [
+            "phase": "rollout_index",
+            "filesSelected": 180,
+            "filesProcessed": 42,
+            "message": "/Users/private/repository",
+        ])
+        let expectedCountedTitle = TiboTattleLocalization.format(
+            .nativeDashboardProgressAnalyzingFiles,
+            TiboTattleLocalization.integerString(42),
+            TiboTattleLocalization.integerString(180)
+        )
+        guard case let .running(_, countedProgress) = counted,
+              countedProgress == LocalAnalysisProgress(
+                phase: .rolloutIndex,
+                filesSelected: 180,
+                filesProcessed: 42
+              ),
+              countedProgress?.nativeToolbarTitle == expectedCountedTitle
+        else {
+            return failure("bounded counts")
+        }
+
+        let unsafe = decode(progress: [
+            "phase": "rollout_index",
+            "filesSelected": 1_000_000_001,
+            "filesProcessed": -1,
+        ])
+        guard case let .running(_, unsafeProgress) = unsafe,
+              unsafeProgress?.filesSelected == nil,
+              unsafeProgress?.filesProcessed == nil
+        else {
+            return failure("unsafe counts")
+        }
+
+        let malformed = decode(progress: [
+            "phase": "rollout_index",
+            "filesSelected": true,
+            "filesProcessed": 4.5,
+        ])
+        guard case let .running(_, malformedProgress) = malformed,
+              malformedProgress?.filesSelected == nil,
+              malformedProgress?.filesProcessed == nil
+        else {
+            return failure("malformed counts")
+        }
+
+        let contradictory = decode(progress: [
+            "phase": "rollout_index",
+            "filesSelected": 2,
+            "filesProcessed": 3,
+        ])
+        guard case let .running(_, contradictoryProgress) = contradictory,
+              contradictoryProgress?.nativeToolbarTitle
+                == TiboTattleLocalization.string(
+                    .nativeDashboardProgressAnalyzing
+                )
+        else {
+            return failure("contradictory counts")
+        }
+
+        let archive = decode(progress: [
+            "kind": "archive_index",
+            "status": "scanning",
+        ])
+        guard case let .running(_, archiveProgress) = archive,
+              archiveProgress?.phase == .archiveIndex
+        else {
+            return failure("archive phase")
+        }
+
+        let unknown = decode(progress: [
+            "phase": "server_supplied_unreviewed_phase",
+            "message": "server supplied prose",
+        ])
+        guard case let .running(_, unknownProgress) = unknown,
+              unknownProgress == nil
+        else {
+            return failure("unknown phase")
+        }
+
+        guard decode(
+            progress: ["phase": "discovering"],
+            status: "succeeded"
+        ) == .idle(refreshID: refreshID) else {
+            return failure("idle contract")
+        }
+
+        print(
+            "USAGE_MONITOR_MACOS_ANALYSIS_PROGRESS_CONTRACT "
+                + "phases=allowlisted archive=scanning counts=bounded "
+                + "contradictory=generic unknown=generic free_text=ignored "
+                + "idle=unchanged percent=false eta=false"
+        )
+        return 0
+    }
+
+    private static func failure(_ detail: String) -> Int32 {
+        FileHandle.standardError.write(
+            Data("macOS analysis progress contract failed: \(detail)\n".utf8)
+        )
+        return 1
+    }
+}
+
 /// Exercises the real AppKit status item without starting the local companion
 /// or reading any local evidence. This catches the class of regression where a
 /// custom menu view has no measured frame and leaves an apparently empty menu
@@ -8867,6 +9041,9 @@ private struct UsageMonitorMain {
         }
         if arguments.contains("--native-refresh-settings-contract-smoke-test") {
             exit(NativeRefreshSettingsContractSmokeTest.run())
+        }
+        if arguments.contains("--native-analysis-progress-contract-smoke-test") {
+            exit(NativeAnalysisProgressContractSmokeTest.run())
         }
         if arguments.contains("--menu-bar-contract-smoke-test") {
             exit(MainActor.assumeIsolated {

--- a/test/macos-app-bundle.test.js
+++ b/test/macos-app-bundle.test.js
@@ -1619,6 +1619,40 @@ test("native app disables AppKit window tabbing before startup", async () => {
   );
 });
 
+test("native refresh progress stays fixed-vocabulary and count-bounded", async () => {
+  const [source, menuBarStatusSource] = await Promise.all([
+    readFile(SWIFT_SOURCE, "utf8"),
+    readFile(MENU_BAR_STATUS_SOURCE, "utf8"),
+  ]);
+  const progressProjection = menuBarStatusSource.match(
+    /struct LocalAnalysisProgress:[\s\S]*?(?=\n\/\/\/ Whether an explicit local analysis pass)/u,
+  )?.[0] ?? "";
+  const activityDecoder = menuBarStatusSource.match(
+    /static func decodeActivity\([\s\S]*?(?=\n    private static func decodeRefreshID)/u,
+  )?.[0] ?? "";
+  const refreshPoll = source.match(
+    /private func pollNativeRefresh\([\s\S]*?(?=\n    private func finishNativeRefresh)/u,
+  )?.[0] ?? "";
+
+  assert.ok(progressProjection, "native progress projection is present");
+  assert.match(progressProjection, /case discovering/u);
+  assert.match(progressProjection, /case rolloutIndex = "rollout_index"/u);
+  assert.match(progressProjection, /case quotaRefresh = "quota_refresh"/u);
+  assert.match(progressProjection, /case quickResult = "quick_result"/u);
+  assert.match(progressProjection, /case archiveIndex = "archive_index"/u);
+  assert.doesNotMatch(progressProjection, /\b(?:percentage|percent|eta)\b/iu);
+  assert.match(activityDecoder, /maximumProgressCount = 1_000_000_000/u);
+  assert.match(activityDecoder, /doubleValue\.rounded\(\.towardZero\)/u);
+  assert.match(activityDecoder, /progress\["phase"\]/u);
+  assert.match(activityDecoder, /progress\["kind"\][\s\S]*?"archive_index"/u);
+  assert.doesNotMatch(activityDecoder, /progress\["message"\]/u);
+  assert.match(
+    refreshPoll,
+    /case let \.running\(_, progress\):[\s\S]*?progress\?\.nativeToolbarTitle[\s\S]*?pollNativeRefresh/u,
+  );
+  assert.match(source, /--native-analysis-progress-contract-smoke-test/u);
+});
+
 test("unified toolbar preserves the rich loopback report and single authority", async () => {
   const source = await readFile(SWIFT_SOURCE, "utf8");
   assert.match(
@@ -5959,6 +5993,20 @@ macOSArtifactTest("reproducible ad-hoc-signed app passes orderly and launcher-SI
     assert.match(
       menuBarSmoke.stdout,
       /^USAGE_MONITOR_MACOS_MENU_BAR_CONTRACT native_rows=true titles=true states=starting,unavailable shortcuts=cmd-r,cmd-comma,cmd-q dismissal=native,escape,same-app,deactivation weekly_position=fresh-only$/mu,
+    );
+    const analysisProgressSmoke = spawnSync(
+      join(outputA, "Contents", "MacOS", "TiboTattle"),
+      ["--native-analysis-progress-contract-smoke-test"],
+      { encoding: "utf8", timeout: 5_000 },
+    );
+    assert.equal(
+      analysisProgressSmoke.status,
+      0,
+      analysisProgressSmoke.stderr || analysisProgressSmoke.stdout,
+    );
+    assert.match(
+      analysisProgressSmoke.stdout,
+      /^USAGE_MONITOR_MACOS_ANALYSIS_PROGRESS_CONTRACT phases=allowlisted archive=scanning counts=bounded contradictory=generic unknown=generic free_text=ignored idle=unchanged percent=false eta=false$/mu,
     );
     const quotaNotificationSmoke = spawnSync(
       join(outputA, "Contents", "MacOS", "TiboTattle"),

--- a/test/macos-test-build.test.mjs
+++ b/test/macos-test-build.test.mjs
@@ -48,6 +48,20 @@ test("test compiler profile builds a development-only launcher that runs", {
     });
     assert.equal(smoke.status, 0, smoke.error?.message ?? smoke.stderr);
     assert.match(smoke.stdout, /runtime=development_disabled/u);
+    const progressSmoke = spawnSync(
+      launcher,
+      ["--native-analysis-progress-contract-smoke-test"],
+      { encoding: "utf8", timeout: 10_000 },
+    );
+    assert.equal(
+      progressSmoke.status,
+      0,
+      progressSmoke.error?.message ?? progressSmoke.stderr,
+    );
+    assert.match(
+      progressSmoke.stdout,
+      /phases=allowlisted[\s\S]*counts=bounded[\s\S]*unknown=generic[\s\S]*free_text=ignored/u,
+    );
   } finally {
     await rm(temporaryRoot, { recursive: true, force: true });
   }


### PR DESCRIPTION
## Summary
- project the companion’s existing allowlisted refresh phases into the native toolbar
- show bounded file progress and fixed localized phase copy without exposing server prose
- preserve generic fallback for unknown or malformed data and keep menu-bar behavior unchanged

## Risk boundary
- no companion API, indexer, accounting, persistence, or schema changes
- no percentages or ETAs
- no server-provided text crosses into native presentation

## Validation
- `npm run test:macos:source`
- `npm run test:macos:smoke`
- `npm run test:macos:artifact`
- rendered development-build toolbar inspection