### PR TITLE
feat(macos): show native dashboard boot state

### DIFF
--- a/apps/web/public/index.html
+++ b/apps/web/public/index.html
@@ -109,6 +109,26 @@
       </aside>
       <div class="dashboard-content">
     <main id="main">
+      <section
+        class="dashboard-boot-state"
+        id="dashboard-boot-state"
+        role="status"
+        aria-live="polite"
+        aria-atomic="true"
+        aria-busy="true"
+      >
+        <div class="dashboard-boot-card">
+          <span class="state-pill state-connecting">
+            <span class="state-dot" aria-hidden="true"></span>
+            Connecting
+          </span>
+          <strong class="dashboard-boot-title">Loading saved results…</strong>
+          <p class="dashboard-boot-copy">
+            Checking the summary on this Mac. Nothing is sent while you look at it.
+          </p>
+        </div>
+      </section>
+
       <div class="page-heading" data-dashboard-page="overview">
         <div>
           <p class="eyebrow">Local evidence dashboard</p>

--- a/apps/web/public/styles.css
+++ b/apps/web/public/styles.css
@@ -227,6 +227,41 @@ body.native-dashboard .dashboard-shell {
   width: 100%;
   min-height: 0;
 }
+/* The AppKit shell marks this document before page scripts run. Give that
+   otherwise blank interval one static, truthful surface, then let the
+   existing first-result marker remove it. The normal browser keeps its
+   current dashboard-first rendering because this surface is native-only. */
+.dashboard-boot-state { display: none; }
+html.native-dashboard:not([data-local-dashboard-ready="true"]) .dashboard-boot-state,
+html:not([data-local-dashboard-ready="true"]) body.native-dashboard .dashboard-boot-state {
+  display: grid;
+  min-height: clamp(280px, 72vh, 560px);
+  padding: clamp(28px, 7vw, 72px) 0;
+  place-items: center;
+}
+.dashboard-boot-card {
+  display: grid;
+  gap: var(--space-4);
+  width: min(34rem, 100%);
+  padding: clamp(24px, 5vw, 40px);
+  border: 1px solid var(--line);
+  border-radius: var(--radius-lg);
+  background: var(--surface-raised);
+  box-shadow: var(--shadow-card);
+}
+.dashboard-boot-card .state-pill { margin-bottom: var(--space-1); }
+.dashboard-boot-title {
+  font-size: clamp(1.55rem, 3vw, 2.2rem);
+  font-weight: var(--weight-semibold);
+  letter-spacing: -.025em;
+  line-height: 1.1;
+}
+.dashboard-boot-copy {
+  max-width: 29rem;
+  margin-bottom: 0;
+  color: var(--muted);
+  font-size: .88rem;
+}
 html.native-dashboard main,
 html.native-dashboard footer,
 body.native-dashboard main,
@@ -2503,6 +2538,15 @@ footer p { margin: 0; }
     gap: 0;
     overflow: hidden;
     font-size: 0;
+  }
+  /* The toolbar saves space with a dot at this width. The boot card has the
+     room — and its whole purpose is to name the state — so keep its label. */
+  .dashboard-boot-card .state-pill {
+    width: max-content;
+    height: auto;
+    padding: .38rem .62rem;
+    gap: .45rem;
+    font-size: .67rem;
   }
   .primary-nav a {
     flex: 0 0 auto;

--- a/apps/web/test/lib.test.mjs
+++ b/apps/web/test/lib.test.mjs
@@ -5082,7 +5082,11 @@ test("public interface is dashboard-first and never substitutes demo data automa
 });
 
 test("native dashboard readiness follows both first-render outcomes", async () => {
-  const appSource = await readFile(new URL("../public/app.js", import.meta.url), "utf8");
+  const [html, appSource, styles] = await Promise.all([
+    readFile(new URL("../public/index.html", import.meta.url), "utf8"),
+    readFile(new URL("../public/app.js", import.meta.url), "utf8"),
+    readFile(new URL("../public/styles.css", import.meta.url), "utf8"),
+  ]);
   const markerStart = appSource.indexOf("function markLocalDashboardReady() {");
   const markerEnd = appSource.indexOf(
     "\n}\n\nasync function loadLocalDashboard",
@@ -5098,6 +5102,30 @@ test("native dashboard readiness follows both first-render outcomes", async () =
 
   const marker = appSource.slice(markerStart, markerEnd);
   const loader = appSource.slice(loadStart, loadEnd);
+  const bootSurface = html.match(
+    /<section[\s\S]*?id="dashboard-boot-state"[\s\S]*?<\/section>/u,
+  )?.[0] ?? "";
+  assert.ok(bootSurface, "the native dashboard has a static boot surface");
+  assert.match(bootSurface, /role="status"/u);
+  assert.match(bootSurface, /aria-live="polite"/u);
+  assert.match(bootSurface, /aria-busy="true"/u);
+  assert.match(bootSurface, /Loading saved results…/u);
+  assert.match(
+    bootSurface,
+    /Checking the summary on this Mac\. Nothing is sent while you look at it\./u,
+  );
+  const bootOpeningTag = bootSurface.match(/^<section[\s\S]*?>/u)?.[0] ?? "";
+  assert.doesNotMatch(bootOpeningTag, /\shidden(?:\s|=|>)/u);
+  assert.doesNotMatch(bootSurface, /data-requires-evidence/u);
+  assert.match(styles, /\.dashboard-boot-state \{ display: none; \}/u);
+  assert.match(
+    styles,
+    /html\.native-dashboard:not\(\[data-local-dashboard-ready="true"\]\) \.dashboard-boot-state,[\s\S]*?display: grid;/u,
+  );
+  assert.match(
+    styles,
+    /@media \(max-width: 520px\)[\s\S]*?\.dashboard-boot-card \.state-pill \{[\s\S]*?width: max-content;[\s\S]*?font-size: \.67rem;/u,
+  );
   assert.match(
     marker,
     /document\.documentElement\.dataset\.localDashboardReady = "true";/u,


### PR DESCRIPTION
## Summary
- render a static native-only loading card before dashboard JavaScript initializes
- hide it through the existing first-result readiness marker for both available and unavailable outcomes
- keep the hosted browser page unchanged and preserve readable loading copy at narrow widths

## Risk boundary
- no new JavaScript state, timers, animations, API calls, or native layout changes
- no companion, indexing, accounting, persistence, or schema changes
- normal dashboard content remains available beneath the boot surface

## Validation
- `npm run product:ui:test` (324/324)
- `npm run test:macos:source` (49 relevant assertions; 3 artifact-only skips)
- `npm run test:macos:smoke` (1/1 compiled launcher smoke)
- isolated rendered desktop and narrow-viewport boot/ready transition QA
- release-site isolation assertions (26/26 relevant checks)

## Additional artifact evidence
- the core signed-app, DMG, Login Item, and watchdog path passed on retry
- additional preview/central variant builds reached the host-side 120s/30s compile ceilings; no content or readiness assertion failed