### PR TITLE
perf(macos): release dashboard readiness after primary render

### DIFF
--- a/apps/web/public/app.js
+++ b/apps/web/public/app.js
@@ -10004,12 +10004,15 @@ async function loadLocalDashboard() {
     // companion answers are still unsettled — and an onboarding verdict this
     // load already holds is not one of them.
     renderLocalOnboarding(onboarding);
+    // The primary local result is now rendered. Do not keep the native
+    // readiness signal waiting on the secondary contribution-status read;
+    // its consent invariant still completes before the preview renders.
+    markLocalDashboardReady();
     // Consent state is read from the companion before the queue renders, so
     // an already-approved Mac never re-prepares a review instance it no
     // longer needs.
     await loadIncrementalSyncStatus();
     renderContributionSyncPreview(sync.preview);
-    markLocalDashboardReady();
   } catch {
     const [localHealth, onboarding] = await Promise.all([
       localClient.health().catch(() => null),

--- a/apps/web/test/lib.test.mjs
+++ b/apps/web/test/lib.test.mjs
@@ -5117,6 +5117,41 @@ test("native dashboard readiness follows both first-render outcomes", async () =
   );
 });
 
+test("native dashboard readiness does not wait on secondary contribution status", async () => {
+  const appSource = await readFile(new URL("../public/app.js", import.meta.url), "utf8");
+  const loadStart = appSource.indexOf("async function loadLocalDashboard() {");
+  const loadEnd = appSource.indexOf(
+    "\n}\n\n// The \"preparation identity\"",
+    loadStart,
+  );
+  assert.ok(loadStart >= 0 && loadEnd > loadStart, "dashboard loader is present");
+
+  const loader = appSource.slice(loadStart, loadEnd);
+  const successEnd = loader.indexOf(
+    "\n  } catch {",
+    loader.indexOf("renderContributionSyncPreview(sync.preview);"),
+  );
+  const successPath = loader.slice(0, successEnd);
+  const dashboardRender = successPath.indexOf("renderDashboard(data);");
+  const onboardingRender = successPath.indexOf("renderLocalOnboarding(onboarding);");
+  const readinessMarker = successPath.indexOf("markLocalDashboardReady();");
+  const secondaryStatus = successPath.indexOf("await loadIncrementalSyncStatus();");
+  const contributionPreview = successPath.indexOf(
+    "renderContributionSyncPreview(sync.preview);",
+  );
+
+  assert.ok(dashboardRender >= 0, "the primary dashboard render is present");
+  assert.ok(onboardingRender > dashboardRender, "onboarding joins the primary render");
+  assert.ok(
+    readinessMarker > onboardingRender && readinessMarker < secondaryStatus,
+    "the native shell is released after the primary render and before secondary status",
+  );
+  assert.ok(
+    contributionPreview > secondaryStatus,
+    "the consent status still resolves before the contribution preview",
+  );
+});
+
 test("first run is a truthful install and local preflight journey", async () => {
   const html = await readFile(new URL("../public/index.html", import.meta.url), "utf8");
   const appSource = await readFile(new URL("../public/app.js", import.meta.url), "utf8");


### PR DESCRIPTION
## Summary
- release the existing native dashboard-readiness marker as soon as the primary local result, identity, sync summary, and onboarding have rendered
- keep the secondary incremental contribution-status read awaited before its preview renders
- add an ordering regression test for both boundaries

## Measurement gate
Real Chromium loaded the complete dashboard over an isolated loopback server. Only the secondary status read was delayed by 750 ms; baseline and candidate alternated for 30 paired samples each.

| Metric | Baseline | Candidate |
| --- | ---: | ---: |
| Primary-ready median | 801.25 ms | 27.50 ms |
| Primary-ready p95 | 833.50 ms | 57.30 ms |
| Secondary-completion median | 800.90 ms | 790.45 ms |

Median primary-ready improved by 773.75 ms / 96.57%, clearing the predeclared ≥200 ms and ≥20% gate. All 60 runs produced the same primary DOM signature and available outcome. Paired savings ranged from 755.80 ms to 797.10 ms.

## Risk boundary
- no new request, cancellation, concurrency, timer, or background task
- no companion, indexing, accounting, persistence, schema, or unavailable-path change
- the consent-status invariant still resolves before the contribution preview

## Validation
- `npm run product:ui:test` (325/325)
- `npm run test:macos:source` (49 relevant assertions; 3 artifact-only skips)
- `npm run test:macos:smoke` (1/1 compiled launcher smoke)
- exact implemented source smoke in real Chromium with no console warnings or errors