### PR TITLE
feat(macos): add Forest Ink dark appearance

### DIFF
--- a/apps/macos/Resources/en.lproj/Localizable.strings
+++ b/apps/macos/Resources/en.lproj/Localizable.strings
@@ -18,6 +18,12 @@
 "settings.aboutProduct" = "About %@";
 "settings.aboutTab" = "About";
 "settings.aboutSummary" = "Local Codex allowance, measured on your Mac.";
+"settings.appearance" = "Appearance";
+"settings.appearanceDark" = "Dark";
+"settings.appearanceLight" = "Light";
+"settings.appearancePickerHint" = "Choose how TiboTattle looks.";
+"settings.appearanceSummary" = "Uses your Mac appearance by default.";
+"settings.appearanceSystem" = "System";
 "settings.automaticUpdates" = "Automatic updates";
 "settings.automaticUpdatesOff" = "Automatic downloads are off.";
 "settings.automaticUpdatesOn" = "Automatic downloads are on.";

--- a/apps/macos/Resources/es.lproj/Localizable.strings
+++ b/apps/macos/Resources/es.lproj/Localizable.strings
@@ -81,6 +81,12 @@
 "settings.aboutProduct" = "Acerca de %@";
 "settings.aboutTab" = "Acerca de";
 "settings.aboutSummary" = "Límite local de Codex, medido en tu Mac.";
+"settings.appearance" = "Apariencia";
+"settings.appearanceDark" = "Oscuro";
+"settings.appearanceLight" = "Claro";
+"settings.appearancePickerHint" = "Elige cómo se ve TiboTattle.";
+"settings.appearanceSummary" = "Usa la apariencia de tu Mac de forma predeterminada.";
+"settings.appearanceSystem" = "Sistema";
 "settings.automaticUpdates" = "Actualizaciones automáticas";
 "settings.automaticUpdatesOff" = "Las descargas automáticas están desactivadas.";
 "settings.automaticUpdatesOn" = "Las descargas automáticas están activadas.";

--- a/apps/macos/Resources/zh-Hans.lproj/Localizable.strings
+++ b/apps/macos/Resources/zh-Hans.lproj/Localizable.strings
@@ -81,6 +81,12 @@
 "settings.aboutProduct" = "关于 %@";
 "settings.aboutTab" = "关于";
 "settings.aboutSummary" = "在你的 Mac 上测量本地 Codex 额度。";
+"settings.appearance" = "外观";
+"settings.appearanceDark" = "深色";
+"settings.appearanceLight" = "浅色";
+"settings.appearancePickerHint" = "选择 TiboTattle 的外观。";
+"settings.appearanceSummary" = "默认使用这台 Mac 的外观。";
+"settings.appearanceSystem" = "跟随系统";
 "settings.automaticUpdates" = "自动更新";
 "settings.automaticUpdatesOff" = "自动下载已关闭。";
 "settings.automaticUpdatesOn" = "自动下载已开启。";

--- a/apps/macos/Sources/Localization.swift
+++ b/apps/macos/Sources/Localization.swift
@@ -252,6 +252,12 @@ enum TiboTattleLocalization {
         case settingsAboutProduct = "settings.aboutProduct"
         case settingsAboutTab = "settings.aboutTab"
         case settingsAboutSummary = "settings.aboutSummary"
+        case settingsAppearance = "settings.appearance"
+        case settingsAppearanceDark = "settings.appearanceDark"
+        case settingsAppearanceLight = "settings.appearanceLight"
+        case settingsAppearancePickerHint = "settings.appearancePickerHint"
+        case settingsAppearanceSummary = "settings.appearanceSummary"
+        case settingsAppearanceSystem = "settings.appearanceSystem"
         case settingsAutomaticUpdates = "settings.automaticUpdates"
         case settingsAutomaticUpdatesOff = "settings.automaticUpdatesOff"
         case settingsAutomaticUpdatesOn = "settings.automaticUpdatesOn"
@@ -722,6 +728,18 @@ enum TiboTattleLocalization {
                 "About"
             case .settingsAboutSummary:
                 "Local Codex allowance, measured on your Mac."
+            case .settingsAppearance:
+                "Appearance"
+            case .settingsAppearanceDark:
+                "Dark"
+            case .settingsAppearanceLight:
+                "Light"
+            case .settingsAppearancePickerHint:
+                "Choose how TiboTattle looks."
+            case .settingsAppearanceSummary:
+                "Uses your Mac appearance by default."
+            case .settingsAppearanceSystem:
+                "System"
             case .settingsAutomaticUpdates:
                 "Automatic updates"
             case .settingsAutomaticUpdatesOff:

--- a/apps/macos/UsageMonitorApp.swift
+++ b/apps/macos/UsageMonitorApp.swift
@@ -317,6 +317,65 @@ private enum NativeRefreshIntervalPreference {
     }
 }
 
+/// One persisted appearance choice owns both AppKit and the embedded report.
+/// `system` stores an explicit preference, but leaves `NSApp.appearance` nil so
+/// scheduled and user-driven macOS appearance changes continue to flow
+/// through without the app guessing at the system setting.
+private enum NativeAppearancePreference: String, CaseIterable {
+    case system
+    case light
+    case dark
+
+    static let defaultsKey = "tibotattle.appearance.v1"
+
+    static var current: NativeAppearancePreference {
+        current(in: .standard)
+    }
+
+    static func current(
+        in defaults: UserDefaults
+    ) -> NativeAppearancePreference {
+        guard let rawValue = defaults.string(forKey: defaultsKey),
+              let preference = NativeAppearancePreference(rawValue: rawValue)
+        else {
+            return .system
+        }
+        return preference
+    }
+
+    static func set(
+        _ preference: NativeAppearancePreference,
+        in defaults: UserDefaults = .standard
+    ) {
+        defaults.set(preference.rawValue, forKey: defaultsKey)
+    }
+
+    var applicationAppearance: NSAppearance? {
+        switch self {
+        case .system:
+            nil
+        case .light:
+            NSAppearance(named: .aqua)
+        case .dark:
+            NSAppearance(named: .darkAqua)
+        }
+    }
+
+    func resolvedTheme(for systemAppearance: NSAppearance) -> String {
+        switch self {
+        case .light:
+            return "light"
+        case .dark:
+            return "dark"
+        case .system:
+            return systemAppearance.bestMatch(from: [.darkAqua, .aqua])
+                == .darkAqua
+                ? "dark"
+                : "light"
+        }
+    }
+}
+
 private enum NativeRefreshIntervalSelection {
     @discardableResult
     static func apply(
@@ -2024,6 +2083,48 @@ private final class DashboardWebHost: NSObject, WKNavigationDelegate, WKUIDelega
         return "window.__TIBOTATTLE_LOCALIZATION__ = \(json);"
     }
 
+    /// Paint the report in the native appearance before its stylesheet gets a
+    /// first frame. The preference and its resolved light/dark value are both
+    /// handed over: the former is useful context, while the latter is the only
+    /// bounded value the page is permitted to render.
+    private static func appearanceHandoffScript() -> String {
+        let preference = NativeAppearancePreference.current
+        let resolvedTheme = preference.resolvedTheme(
+            for: NSApp.effectiveAppearance
+        )
+        let payload: [String: Any] = [
+            "schemaVersion": 1,
+            "host": "native",
+            "preference": preference.rawValue,
+            "resolvedTheme": resolvedTheme,
+        ]
+        guard let data = try? JSONSerialization.data(withJSONObject: payload),
+              let json = String(data: data, encoding: .utf8)
+        else {
+            return "window.__TIBOTATTLE_APPEARANCE__ = null;"
+        }
+        return """
+        window.__TIBOTATTLE_APPEARANCE__ = \(json);
+        (function () {
+          function applyNativeAppearance() {
+            const handoff = window.__TIBOTATTLE_APPEARANCE__;
+            const theme = handoff?.resolvedTheme;
+            if (theme !== 'light' && theme !== 'dark') return;
+            if (document.documentElement) {
+              document.documentElement.dataset.theme = theme;
+              document.documentElement.style.colorScheme = theme;
+            }
+            const themeColor = document.querySelector?.('meta[name="theme-color"]');
+            if (themeColor) {
+              themeColor.content = theme === 'dark' ? '#141a17' : '#f5f1e8';
+            }
+          }
+          applyNativeAppearance();
+          document.addEventListener('DOMContentLoaded', applyNativeAppearance, { once: true });
+        })();
+        """
+    }
+
     /// The AppKit frame owns navigation and refresh in the installed app.
     /// Install this fixed marker before any dashboard script runs so the
     /// public-web header cannot flash, or remain visible if WebKit delays a
@@ -2048,6 +2149,13 @@ private final class DashboardWebHost: NSObject, WKNavigationDelegate, WKUIDelega
     private static func addDocumentStartScripts(
         to controller: WKUserContentController
     ) {
+        controller.addUserScript(
+            WKUserScript(
+                source: appearanceHandoffScript(),
+                injectionTime: .atDocumentStart,
+                forMainFrameOnly: true
+            )
+        )
         controller.addUserScript(
             WKUserScript(
                 source: localizationHandoffScript(),
@@ -2223,6 +2331,36 @@ private final class DashboardWebHost: NSObject, WKNavigationDelegate, WKUIDelega
         // other width-sensitive controls measure their translated labels
         // after that redraw has committed, without reloading the document or
         // interrupting the active hosted-sign-in attempt.
+        window.requestAnimationFrame?.(() => {
+          window.dispatchEvent(new Event('resize'));
+        });
+        """)
+    }
+
+    /// Change the live document without reloading it. The native shell has
+    /// already applied this appearance to AppKit; the resolved value makes the
+    /// report follow the same effective appearance when the stored choice is
+    /// `system`.
+    func notifyAppearancePreferenceChange(
+        _ preference: NativeAppearancePreference
+    ) {
+        guard hasDashboardTarget else { return }
+        let payload: [String: Any] = [
+            "schemaVersion": 1,
+            "host": "native",
+            "preference": preference.rawValue,
+            "resolvedTheme": preference.resolvedTheme(
+                for: NSApp.effectiveAppearance
+            ),
+        ]
+        guard let data = try? JSONSerialization.data(withJSONObject: payload),
+              let json = String(data: data, encoding: .utf8)
+        else { return }
+        webView.evaluateJavaScript("""
+        window.__TIBOTATTLE_APPEARANCE__ = \(json);
+        window.dispatchEvent(new CustomEvent('tibotattle:appearance-override', {
+          detail: window.__TIBOTATTLE_APPEARANCE__
+        }));
         window.requestAnimationFrame?.(() => {
           window.dispatchEvent(new Event('resize'));
         });
@@ -2624,24 +2762,16 @@ private enum NativeDashboardDestination: String, CaseIterable {
 /// that has, twice, resolved to zero before the window existed.
 @MainActor
 private final class NativeDashboardReportPane: NSView {
-    /// `--paper` from the dashboard stylesheet. The report document has no
-    /// dark variant, so a fixed value is the honest match. Painting it here
-    /// means no system grey is ever visible in the strip the title bar
-    /// reserves, or in the instant before WebKit has drawn.
-    private static let paper = NSColor(
-        srgbRed: 0xF5 / 255,
-        green: 0xF1 / 255,
-        blue: 0xE8 / 255,
-        alpha: 1
-    )
-
     private let webView: WKWebView
+    var onAppearanceChange: (() -> Void)?
+
+    override var wantsUpdateLayer: Bool { true }
 
     init(webView: WKWebView) {
         self.webView = webView
         super.init(frame: .zero)
         wantsLayer = true
-        layer?.backgroundColor = Self.paper.cgColor
+        layer?.backgroundColor = NativeBrandPalette.reportPaper.cgColor
         webView.translatesAutoresizingMaskIntoConstraints = true
         // Deliberately no autoresizing mask.  The pane now insets WebKit by
         // its own safe area, and a mask would spring the view back to the full
@@ -2653,6 +2783,19 @@ private final class NativeDashboardReportPane: NSView {
 
     required init?(coder: NSCoder) {
         nil
+    }
+
+    /// Match the report's `--paper` token during the gap before WebKit paints
+    /// and in the titlebar safe-area strip. Dynamic colors must be re-resolved
+    /// here because a CALayer does not track appearance changes on its own.
+    override func updateLayer() {
+        layer?.backgroundColor = NativeBrandPalette.reportPaper.cgColor
+    }
+
+    override func viewDidChangeEffectiveAppearance() {
+        super.viewDidChangeEffectiveAppearance()
+        needsDisplay = true
+        onAppearanceChange?()
     }
 
     override func layout() {
@@ -2741,13 +2884,13 @@ private struct NativeDashboardChromeMetrics {
 /// accent is lifted for contrast and the paper wash becomes a deep-green
 /// cast rather than a glaring cream sheet.
 private enum NativeBrandPalette {
-    /// Web accent #174f45, lifted for dark backgrounds.
+    /// Web accent #174f45 in light appearance and Forest Ink #76aa9c in dark.
     static let accent = NSColor(name: nil) { appearance in
         appearance.bestMatch(from: [.darkAqua, .aqua]) == .darkAqua
             ? NSColor(
-                srgbRed: 122 / 255,
-                green: 184 / 255,
-                blue: 170 / 255,
+                srgbRed: 118 / 255,
+                green: 170 / 255,
+                blue: 156 / 255,
                 alpha: 1
             )
             : NSColor(
@@ -2758,14 +2901,32 @@ private enum NativeBrandPalette {
             )
     }
 
+    /// Exact web report paper in each appearance. Painting this behind
+    /// WKWebView prevents a mismatched system-grey flash at launch or reload.
+    static let reportPaper = NSColor(name: nil) { appearance in
+        appearance.bestMatch(from: [.darkAqua, .aqua]) == .darkAqua
+            ? NSColor(
+                srgbRed: 20 / 255,
+                green: 26 / 255,
+                blue: 23 / 255,
+                alpha: 1
+            )
+            : NSColor(
+                srgbRed: 245 / 255,
+                green: 241 / 255,
+                blue: 232 / 255,
+                alpha: 1
+            )
+    }
+
     /// Web background #f5f1e8, washed over the system sidebar material so
     /// vibrancy still reads through it.
     static let sidebarWash = NSColor(name: nil) { appearance in
         appearance.bestMatch(from: [.darkAqua, .aqua]) == .darkAqua
             ? NSColor(
-                srgbRed: 23 / 255,
-                green: 79 / 255,
-                blue: 69 / 255,
+                srgbRed: 45 / 255,
+                green: 116 / 255,
+                blue: 102 / 255,
                 alpha: 0.22
             )
             : NSColor(
@@ -3025,6 +3186,11 @@ private final class NativeDashboardChrome: NSSplitViewController {
     private var restingWidthSeeded = false
 
     var onNavigate: ((NativeDashboardDestination) -> Void)?
+    var onAppearanceChange: (() -> Void)? {
+        didSet {
+            reportPane.onAppearanceChange = onAppearanceChange
+        }
+    }
 
     init(webView: WKWebView) {
         reportPane = NativeDashboardReportPane(webView: webView)
@@ -3425,6 +3591,7 @@ private final class AppDelegate: NSObject, NSApplicationDelegate,
     private weak var settingsQuotaNotificationsSwitch: NSSwitch?
     private weak var settingsQuotaNotificationThresholds: NSSegmentedControl?
     private weak var settingsQuotaNotificationStatusLabel: NSTextField?
+    private weak var settingsAppearancePicker: NSPopUpButton?
     private weak var settingsRefreshIntervalPicker: NSPopUpButton?
     private let nativeEvidenceReader = LocalCompanionEvidenceReader()
     private var quotaNotificationCoordinator: QuotaNotificationCoordinator?
@@ -3546,6 +3713,7 @@ private final class AppDelegate: NSObject, NSApplicationDelegate,
 
     func applicationDidFinishLaunching(_ notification: Notification) {
         _ = umask(0o077)
+        applyAppearancePreference(notifyDashboard: false)
         installApplicationMenu()
         createWindow()
         // Installed before any early return below so a launch that fails still
@@ -3612,6 +3780,10 @@ private final class AppDelegate: NSObject, NSApplicationDelegate,
         // Read-only resynchronization after a user changes notification
         // permission in System Settings. This path cannot prompt by itself.
         quotaNotificationCoordinator?.refreshAuthorization()
+        // System appearance can change while TiboTattle is inactive. AppKit
+        // already updates native dynamic colors; this keeps the live report's
+        // explicit document theme synchronized when the window returns.
+        synchronizeResolvedAppearance()
     }
 
     private func showFirstRunDisclosure() -> Bool {
@@ -4355,6 +4527,9 @@ private final class AppDelegate: NSObject, NSApplicationDelegate,
         webView: WKWebView
     ) -> NativeDashboardChrome {
         let chrome = NativeDashboardChrome(webView: webView)
+        chrome.onAppearanceChange = { [weak self] in
+            self?.synchronizeResolvedAppearance()
+        }
         dashboardContentController?.addChild(chrome)
         let chromeView = chrome.view
         chromeView.translatesAutoresizingMaskIntoConstraints = false
@@ -5480,6 +5655,39 @@ private final class AppDelegate: NSObject, NSApplicationDelegate,
         refitSettingsWindowToContent()
     }
 
+    private func updateAppearanceSettingsControl() {
+        guard let picker = settingsAppearancePicker else { return }
+        let preference = NativeAppearancePreference.current
+        if let index = picker.itemArray.firstIndex(where: {
+            ($0.representedObject as? String) == preference.rawValue
+        }) {
+            picker.selectItem(at: index)
+        }
+    }
+
+    private func applyAppearancePreference(
+        notifyDashboard: Bool = true
+    ) {
+        let preference = NativeAppearancePreference.current
+        NSApp.appearance = preference.applicationAppearance
+        updateAppearanceSettingsControl()
+        window?.contentView?.needsDisplay = true
+        if notifyDashboard {
+            dashboardWebHost?.notifyAppearancePreferenceChange(preference)
+        }
+    }
+
+    private func synchronizeResolvedAppearance() {
+        let preference = NativeAppearancePreference.current
+        updateAppearanceSettingsControl()
+        window?.contentView?.needsDisplay = true
+        // Explicit Light and Dark are intentionally insulated from later
+        // system changes. Only System follows the effective AppKit appearance;
+        // selecting any preference already sends its own immediate update.
+        guard preference == .system else { return }
+        dashboardWebHost?.notifyAppearancePreferenceChange(preference)
+    }
+
     private func updateRefreshIntervalSettingsControl() {
         guard let picker = settingsRefreshIntervalPicker else { return }
         let value = NativeRefreshIntervalPreference.seconds
@@ -5851,6 +6059,22 @@ private final class AppDelegate: NSObject, NSApplicationDelegate,
         showSettings(selecting: 2)
     }
 
+    @objc private func selectAppearancePreference(
+        _ sender: NSPopUpButton
+    ) {
+        guard let rawPreference = sender.selectedItem?.representedObject
+            as? String,
+              let preference = NativeAppearancePreference(
+                  rawValue: rawPreference
+              )
+        else {
+            updateAppearanceSettingsControl()
+            return
+        }
+        NativeAppearancePreference.set(preference)
+        applyAppearancePreference()
+    }
+
     @objc private func selectLanguagePreference(_ sender: NSPopUpButton) {
         guard let rawPreference = sender.selectedItem?.representedObject
             as? String,
@@ -5922,6 +6146,7 @@ private final class AppDelegate: NSObject, NSApplicationDelegate,
         settingsAutomaticUpdatesSwitch = nil
         settingsAboutAutomaticUpdatesDetailLabel = nil
         settingsCheckForUpdatesButton = nil
+        settingsAppearancePicker = nil
         settingsRefreshIntervalPicker = nil
         if shouldRestoreSettings {
             showSettings(selecting: selectedSettingsTab)
@@ -5958,6 +6183,7 @@ private final class AppDelegate: NSObject, NSApplicationDelegate,
             settingsTabs.selectedTabViewItemIndex = index
             updateSettingsCodexHomeSummary()
             updateAutomaticUpdatesSettingsControl()
+            updateAppearanceSettingsControl()
             updateRefreshIntervalSettingsControl()
             updateStartAtLoginSettingsControl()
             quotaNotificationCoordinator?.refreshAuthorization()
@@ -5985,6 +6211,49 @@ private final class AppDelegate: NSObject, NSApplicationDelegate,
             action: #selector(useDefaultCodexHome)
         )
         let sourceActions = settingsControlRow([chooseSource, useDefaultSource])
+        let appearancePicker = NSPopUpButton(
+            frame: .zero,
+            pullsDown: false
+        )
+        let appearanceChoices: [(
+            NativeAppearancePreference,
+            TiboTattleLocalization.Key
+        )] = [
+            (.system, .settingsAppearanceSystem),
+            (.light, .settingsAppearanceLight),
+            (.dark, .settingsAppearanceDark),
+        ]
+        for (preference, key) in appearanceChoices {
+            appearancePicker.addItem(
+                withTitle: TiboTattleLocalization.string(key)
+            )
+            appearancePicker.lastItem?.representedObject = preference.rawValue
+        }
+        appearancePicker.target = self
+        appearancePicker.action = #selector(selectAppearancePreference(_:))
+        appearancePicker.toolTip = TiboTattleLocalization.string(
+            .settingsAppearancePickerHint
+        )
+        appearancePicker.setAccessibilityLabel(
+            TiboTattleLocalization.string(.settingsAppearance)
+        )
+        settingsAppearancePicker = appearancePicker
+        updateAppearanceSettingsControl()
+        let appearanceRow = NSStackView(views: [appearancePicker])
+        appearanceRow.orientation = .horizontal
+        appearanceRow.alignment = .centerY
+        let appearanceSection = settingsGroup(
+            title: TiboTattleLocalization.string(.settingsAppearance),
+            symbolName: "circle.lefthalf.filled",
+            views: [
+                appearanceRow,
+                settingsLabel(
+                    TiboTattleLocalization.string(.settingsAppearanceSummary),
+                    font: .systemFont(ofSize: 12),
+                    color: .secondaryLabelColor
+                ),
+            ]
+        )
         let languagePicker = NSPopUpButton(
             frame: .zero,
             pullsDown: false
@@ -6278,6 +6547,7 @@ private final class AppDelegate: NSObject, NSApplicationDelegate,
             title: TiboTattleLocalization.string(.settingsGeneral),
             summary: TiboTattleLocalization.string(.settingsGeneralSummary),
             views: [
+                appearanceSection,
                 languageSection,
                 sourceSection,
                 refreshIntervalSection,
@@ -7684,6 +7954,88 @@ private enum NativeRefreshSettingsContractSmokeTest {
                 + "picker_action=true picker_persisted=true "
                 + "scheduler=300->900 "
                 + "invalid_ignored=true"
+        )
+        return 0
+    }
+}
+
+/// Exercises the complete persisted appearance contract in an isolated
+/// defaults suite. This proves that explicit choices never depend on AppKit
+/// timing, while System follows both light and dark effective appearances.
+/// It does not mutate the developer's normal TiboTattle preference.
+private enum NativeAppearanceSettingsContractSmokeTest {
+    private static let suiteName =
+        "com.usagemonitor.local.native-appearance-settings-contract"
+
+    static func run() -> Int32 {
+        guard let defaults = UserDefaults(suiteName: suiteName),
+              let aqua = NSAppearance(named: .aqua),
+              let darkAqua = NSAppearance(named: .darkAqua)
+        else {
+            return 1
+        }
+        defaults.removePersistentDomain(forName: suiteName)
+        defer {
+            defaults.removePersistentDomain(forName: suiteName)
+        }
+
+        guard NativeAppearancePreference.current(in: defaults) == .system,
+              NativeAppearancePreference.system.applicationAppearance == nil,
+              NativeAppearancePreference.system.resolvedTheme(for: aqua)
+                == "light",
+              NativeAppearancePreference.system.resolvedTheme(for: darkAqua)
+                == "dark"
+        else {
+            return 1
+        }
+
+        NativeAppearancePreference.set(.light, in: defaults)
+        defaults.synchronize()
+        guard let reloaded = UserDefaults(suiteName: suiteName),
+              NativeAppearancePreference.current(in: reloaded) == .light,
+              NativeAppearancePreference.light.applicationAppearance?.name
+                == .aqua,
+              NativeAppearancePreference.light.resolvedTheme(for: darkAqua)
+                == "light"
+        else {
+            return 1
+        }
+
+        NativeAppearancePreference.set(.dark, in: reloaded)
+        reloaded.synchronize()
+        guard let darkReloaded = UserDefaults(suiteName: suiteName),
+              NativeAppearancePreference.current(in: darkReloaded) == .dark,
+              NativeAppearancePreference.dark.applicationAppearance?.name
+                == .darkAqua,
+              NativeAppearancePreference.dark.resolvedTheme(for: aqua)
+                == "dark"
+        else {
+            return 1
+        }
+
+        NativeAppearancePreference.set(.system, in: darkReloaded)
+        darkReloaded.synchronize()
+        guard let systemReloaded = UserDefaults(suiteName: suiteName),
+              NativeAppearancePreference.current(in: systemReloaded) == .system
+        else {
+            return 1
+        }
+
+        systemReloaded.set(
+            "unsupported",
+            forKey: NativeAppearancePreference.defaultsKey
+        )
+        guard NativeAppearancePreference.current(in: systemReloaded) == .system
+        else {
+            return 1
+        }
+
+        print(
+            "USAGE_MONITOR_MACOS_APPEARANCE_SETTINGS_CONTRACT "
+                + "default=system persisted=light,dark,system "
+                + "invalid=system system_resolution=light,dark "
+                + "explicit_resolution=light,dark "
+                + "appkit=system,aqua,darkAqua"
         )
         return 0
     }
@@ -9613,6 +9965,11 @@ private struct UsageMonitorMain {
         }
         if arguments.contains("--native-refresh-settings-contract-smoke-test") {
             exit(NativeRefreshSettingsContractSmokeTest.run())
+        }
+        if arguments.contains(
+            "--native-appearance-settings-contract-smoke-test"
+        ) {
+            exit(NativeAppearanceSettingsContractSmokeTest.run())
         }
         if arguments.contains("--native-analysis-progress-contract-smoke-test") {
             exit(NativeAnalysisProgressContractSmokeTest.run())

--- a/apps/macos/UsageMonitorApp.swift
+++ b/apps/macos/UsageMonitorApp.swift
@@ -2345,6 +2345,13 @@ private final class DashboardWebHost: NSObject, WKNavigationDelegate, WKUIDelega
         _ preference: NativeAppearancePreference
     ) {
         guard hasDashboardTarget else { return }
+        // The live event below updates the current document, but WebKit's
+        // context-menu Reload creates a new document without passing through
+        // loadWhenViewportIsReady(). Refresh the document-start snapshot now
+        // so that later manual reload starts in the same resolved appearance
+        // instead of replaying whichever theme was current when this host was
+        // first constructed.
+        refreshDocumentStartScripts()
         let payload: [String: Any] = [
             "schemaVersion": 1,
             "host": "native",

--- a/apps/web/public/app.js
+++ b/apps/web/public/app.js
@@ -66,6 +66,29 @@ import {
   USER_TIME_ZONE,
 } from "./ui-format.js";
 
+const NATIVE_APPEARANCE_THEMES = new Set(["light", "dark"]);
+
+function applyNativeAppearanceTheme(theme) {
+  if (!NATIVE_APPEARANCE_THEMES.has(theme)) return false;
+  document.documentElement.dataset.theme = theme;
+  document.documentElement.style.colorScheme = theme;
+  const themeColor = document.querySelector('meta[name="theme-color"]');
+  if (themeColor) {
+    themeColor.content = theme === "dark" ? "#141a17" : "#f5f1e8";
+  }
+  return true;
+}
+
+// WKWebView installs this handoff at document start, before the stylesheet can
+// paint. Reapplying it here owns live Settings changes and keeps the browser
+// metadata in step without reloading a dashboard or losing in-memory state.
+applyNativeAppearanceTheme(
+  globalThis.__TIBOTATTLE_APPEARANCE__?.resolvedTheme,
+);
+window.addEventListener("tibotattle:appearance-override", (event) => {
+  applyNativeAppearanceTheme(event.detail?.resolvedTheme);
+});
+
 const localization = createBrowserLocalization();
 setFormattingLocale(localization.formatLocale());
 setMessageLocale(localization.locale());

--- a/apps/web/public/styles.css
+++ b/apps/web/public/styles.css
@@ -34,6 +34,17 @@
   --blue: #2c5878;
   --blue-soft: #e0eaf1;
 
+  /* Semantic pairs for the few components that invert their foreground and
+     background together. Keeping these separate from `--green` lets the dark
+     theme lift links and chart strokes without turning filled controls into
+     low-contrast mint panels. */
+  --action-bg: var(--green);
+  --action-bg-hover: var(--green-2);
+  --action-ink: #fff;
+  --feature-bg: var(--green);
+  --feature-ink: #fff;
+  --feature-muted: rgba(255, 255, 255, .76);
+
   /* Surfaces. Every panel, card and tile picks one of these four so nothing
      falls back to an untinted grey or to the raw border colour. */
   --surface: rgba(255, 254, 249, .78);
@@ -119,8 +130,8 @@ button:focus-visible, input:focus-visible, select:focus-visible, a:focus-visible
   top: -4rem;
   inset-inline-start: 1rem;
   padding: .7rem 1rem;
-  color: white;
-  background: var(--green);
+  color: var(--action-ink);
+  background: var(--action-bg);
   border-radius: var(--radius-sm);
 }
 .skip-link:focus { top: 1rem; }
@@ -370,8 +381,8 @@ body.native-dashboard #setup-card { display: none !important; }
 .button:hover:not(:disabled) { transform: translateY(-1px); box-shadow: var(--shadow-card); }
 .button:active:not(:disabled) { transform: translateY(0); box-shadow: none; }
 .button:disabled { opacity: .45; cursor: not-allowed; }
-.button-primary { color: white; background: var(--green); }
-.button-primary:hover:not(:disabled) { background: var(--green-2); }
+.button-primary { color: var(--action-ink); background: var(--action-bg); }
+.button-primary:hover:not(:disabled) { background: var(--action-bg-hover); }
 .button-secondary, .button-quiet { color: var(--ink); border-color: var(--line); background: var(--surface); }
 .button-secondary:hover:not(:disabled), .button-quiet:hover:not(:disabled) {
   border-color: var(--line-strong);
@@ -598,7 +609,7 @@ h1 {
   justify-self: start;
   margin-top: 4px;
 }
-.companion-steps .button-primary { color: white; }
+.companion-steps .button-primary { color: var(--action-ink); }
 .installer-details {
   display: grid;
   gap: 3px;
@@ -1318,7 +1329,7 @@ h2 {
 
 .segmented-control { display: inline-flex; padding: 3px; border: 1px solid var(--line); border-radius: var(--radius-sm); background: var(--surface-raised); }
 .segmented-control button { padding: .5rem .7rem; border: 0; border-radius: var(--radius-xs); color: var(--muted); background: transparent; font-size: .7rem; font-weight: var(--weight-semibold); cursor: pointer; }
-.segmented-control button.active { color: white; background: var(--green); }
+.segmented-control button.active { color: var(--action-ink); background: var(--action-bg); }
 .timeline-controls,
 .calibration-controls { display: grid; justify-items: end; gap: 7px; }
 /* Grouping, date range, and legend used to occupy one stacked row each, so the
@@ -1639,14 +1650,14 @@ tbody tr:last-child td { border-bottom: 0; }
   align-items: center;
   margin-bottom: 18px;
   padding: 34px;
-  color: white;
-  background: var(--green);
+  color: var(--feature-ink);
+  background: var(--feature-bg);
   border-radius: var(--radius-md);
 }
 .weekly-hero > div:first-child { display: flex; flex-direction: column; }
-.weekly-hero span, .weekly-hero small { color: rgba(255,255,255,.7); font-size: .72rem; }
+.weekly-hero span, .weekly-hero small { color: var(--feature-muted); font-size: .72rem; }
 .weekly-hero > div:first-child strong { margin: .2rem 0; font-family: var(--serif); font-size: clamp(3rem, 6vw, 5rem); font-weight: var(--weight-regular); line-height: 1; }
-.weekly-hero > p { max-width: 55ch; margin: 0; color: rgba(255,255,255,.8); font-size: .86rem; line-height: 1.5; }
+.weekly-hero > p { max-width: 55ch; margin: 0; color: var(--feature-muted); font-size: .86rem; line-height: 1.5; }
 /*
  * Pace forecast card.
  *
@@ -3975,3 +3986,231 @@ footer p { margin: 0; }
 }
 
 .share-toast-action { margin-inline-start: .75rem; flex: 0 0 auto; }
+
+/*
+ * Forest Ink dark appearance.
+ *
+ * The public dashboard remains light unless a trusted host explicitly sets
+ * `data-theme="dark"` on the document element. The native app installs that
+ * marker at document start, before this sheet paints, so there is no cream
+ * flash when the Mac is using Dark appearance. These values deliberately
+ * stay in the light design's cream-and-forest family: the hierarchy and
+ * component shapes are unchanged; only their surface roles are remapped.
+ */
+html[data-theme="dark"] {
+  color-scheme: dark;
+  --paper: #141a17;
+  --paper-2: #101512;
+  --white: #f5f1e8;
+  --ink: #f5f1e8;
+  --text: #f5f1e8;
+  --muted: #bec5bd;
+  --line: rgba(245, 241, 232, .14);
+  --line-strong: rgba(245, 241, 232, .21);
+  --green: #76aa9c;
+  --green-2: #99c5ba;
+  --green-text: #99c5ba;
+  --chart-accent: #99c5ba;
+  --green-soft: rgba(118, 170, 156, .14);
+  --rust: #bd735f;
+  --rust-soft: rgba(189, 115, 95, .14);
+  --amber: #c5a46a;
+  --amber-soft: rgba(197, 164, 106, .14);
+  --blue: #7d9eb8;
+  --blue-soft: rgba(125, 158, 184, .14);
+  --action-bg: #76aa9c;
+  --action-bg-hover: #99c5ba;
+  --action-ink: #141a17;
+  --feature-bg: #2d7466;
+  --feature-ink: #fffef9;
+  --feature-muted: rgba(255, 254, 249, .76);
+  --surface: rgba(27, 37, 33, .9);
+  --surface-raised: #24322c;
+  --surface-quiet: rgba(27, 37, 33, .72);
+  --surface-sunken: #101512;
+  --shadow: 0 18px 50px rgba(0, 0, 0, .28);
+  --shadow-card: 0 10px 28px rgba(0, 0, 0, .18);
+}
+
+html[data-theme="dark"],
+html[data-theme="dark"] body,
+html[data-theme="dark"] body.community-site {
+  background:
+    radial-gradient(circle at 85% 4%, rgba(45, 116, 102, .13), transparent 27rem),
+    var(--paper);
+}
+
+html[data-theme="dark"] .topbar {
+  background: rgba(20, 26, 23, .92);
+}
+
+html[data-theme="dark"] .primary-nav a:hover,
+html[data-theme="dark"] .primary-nav a.active,
+html[data-theme="dark"] .state-pill,
+html[data-theme="dark"] .evidence-chip {
+  border-color: rgba(118, 170, 156, .24);
+}
+
+html[data-theme="dark"] .notice p,
+html[data-theme="dark"] .timeline-confidence.low,
+html[data-theme="dark"] .series-coverage,
+html[data-theme="dark"] .evidence-warning,
+html[data-theme="dark"] .installer-unavailable {
+  color: #d7ba84;
+}
+
+html[data-theme="dark"] .notice-error p,
+html[data-theme="dark"] .evidence-warning:not(.progress):not(.informational) {
+  color: #d89a88;
+}
+
+html[data-theme="dark"] .notice-demo p,
+html[data-theme="dark"] .notice-info p,
+html[data-theme="dark"] .history-index-badge-headline,
+html[data-theme="dark"] .history-index-badge-detail,
+html[data-theme="dark"] .evidence-warning.progress,
+html[data-theme="dark"] .evidence-warning.informational,
+html[data-theme="dark"] .plain-result {
+  color: #afc8db;
+}
+
+html[data-theme="dark"] .metric-card.quota-card-spark {
+  border-color: rgba(125, 158, 184, .28);
+  background: linear-gradient(145deg, rgba(125, 158, 184, .13), rgba(36, 50, 44, .92));
+}
+
+/* Forest Ink uses the selected balanced treatment: the metric retains one
+   confident brand band while the explanation stays part of the dark report. */
+html[data-theme="dark"] .weekly-hero {
+  gap: 0;
+  padding: 0;
+  overflow: hidden;
+  color: var(--ink);
+  border: 1px solid rgba(118, 170, 156, .3);
+  background: var(--surface);
+}
+
+html[data-theme="dark"] .weekly-hero > div:first-child {
+  padding: 34px;
+  color: var(--feature-ink);
+  background: var(--feature-bg);
+}
+
+html[data-theme="dark"] .weekly-hero > div:first-child span,
+html[data-theme="dark"] .weekly-hero > div:first-child small {
+  color: var(--feature-muted);
+}
+
+html[data-theme="dark"] .weekly-hero > p {
+  padding: 34px;
+  margin: 0;
+  color: var(--muted);
+}
+
+html[data-theme="dark"] .weekly-pace-forecast {
+  background: linear-gradient(100deg, var(--pace-accent-wash), var(--surface));
+}
+
+html[data-theme="dark"] .weekly-pace-forecast:not(.is-on-pace):not(.is-over-pace):not(.is-insufficient) {
+  --pace-accent-edge: rgba(118, 170, 156, .28);
+  --pace-accent-wash: rgba(118, 170, 156, .13);
+}
+
+html[data-theme="dark"] .weekly-pace-forecast.is-on-pace,
+html[data-theme="dark"] .weekly-pace-forecast.is-insufficient {
+  --pace-accent-edge: rgba(125, 158, 184, .28);
+  --pace-accent-wash: rgba(125, 158, 184, .13);
+}
+
+html[data-theme="dark"] .weekly-pace-forecast.is-over-pace {
+  --pace-accent-edge: rgba(197, 164, 106, .28);
+  --pace-accent-wash: rgba(197, 164, 106, .13);
+}
+
+html[data-theme="dark"] .weekly-pace-forecast.is-over-pace.is-critical {
+  --pace-accent-edge: rgba(189, 115, 95, .28);
+  --pace-accent-wash: rgba(189, 115, 95, .13);
+}
+
+html[data-theme="dark"] .notice.notice-info.accounting-disclosure {
+  border-color: rgba(125, 158, 184, .2);
+  border-inline-start: 3px solid var(--blue);
+  background: var(--surface);
+}
+
+html[data-theme="dark"] .chart-grid {
+  stroke: rgba(245, 241, 232, .1);
+}
+
+html[data-theme="dark"] .chart-error-bar-weekly .chart-error-bar-line,
+html[data-theme="dark"] .chart-error-bar-weekly .chart-error-bar-cap {
+  stroke: rgba(125, 158, 184, .86);
+}
+
+html[data-theme="dark"] .chart-area-confidence {
+  fill: rgba(125, 158, 184, .14);
+}
+
+html[data-theme="dark"] .chart-point-weekly-mature {
+  fill: var(--blue);
+  stroke: var(--paper);
+}
+
+html[data-theme="dark"] .contribution-cta {
+  border-color: rgba(118, 170, 156, .3);
+  border-top-color: var(--green);
+  background:
+    radial-gradient(circle at 8% 10%, rgba(45, 116, 102, .18), transparent 52%),
+    var(--surface-raised);
+  box-shadow: 0 18px 46px rgba(0, 0, 0, .24);
+}
+
+html[data-theme="dark"] .info-popover,
+html[data-theme="dark"] .share-toast {
+  color: var(--ink);
+  background: var(--surface-raised);
+  box-shadow: 0 14px 30px rgba(0, 0, 0, .34);
+}
+
+html[data-theme="dark"] .provider-button-google {
+  color: #17211e;
+  background: #fff;
+  border-color: #aeb8b3;
+}
+
+html[data-theme="dark"] .provider-button-apple {
+  color: #f5f1e8;
+  background: #070908;
+  border-color: #070908;
+}
+
+html[data-theme="dark"] input:not([type="checkbox"]):not([type="radio"]),
+html[data-theme="dark"] select,
+html[data-theme="dark"] textarea {
+  color: var(--ink);
+  border-color: var(--line);
+  background-color: var(--surface-raised);
+}
+
+html[data-theme="dark"] .share-preview canvas {
+  /* Portable share-card exports deliberately keep the existing light brand
+     artwork in the first release, independent of the viewer's preference. */
+  background: #f5f1e8;
+}
+
+html[data-theme="dark"] .skeleton-card {
+  background: linear-gradient(100deg, rgba(245, 241, 232, .04) 35%, rgba(245, 241, 232, .13) 50%, rgba(245, 241, 232, .04) 65%);
+  background-size: 300% 100%;
+}
+
+html[data-theme="dark"] .noscript {
+  color: #141a17;
+  background: var(--rust);
+}
+
+@media (max-width: 700px) {
+  html[data-theme="dark"] .weekly-hero > div:first-child,
+  html[data-theme="dark"] .weekly-hero > p {
+    padding: 24px;
+  }
+}

--- a/apps/web/test/lib.test.mjs
+++ b/apps/web/test/lib.test.mjs
@@ -12591,3 +12591,55 @@ test("the journey names the unanswered health, never an index that is not the bl
   assert.doesNotMatch(appSource, /journey\.community\.waitingCompanion/u);
   assert.doesNotMatch(localizationSource, /journey\.community\.waitingCompanion/u);
 });
+
+test("Forest Ink dark appearance is explicit, balanced, and live-updateable", async () => {
+  const [styles, appSource] = await Promise.all([
+    readFile(new URL("../public/styles.css", import.meta.url), "utf8"),
+    readFile(new URL("../public/app.js", import.meta.url), "utf8"),
+  ]);
+
+  assert.match(styles, /html\[data-theme="dark"\] \{/u);
+  assert.match(styles, /--paper: #141a17;/u);
+  assert.match(styles, /--surface-raised: #24322c;/u);
+  assert.match(styles, /--ink: #f5f1e8;/u);
+  assert.match(styles, /--green: #76aa9c;/u);
+  assert.match(styles, /--feature-bg: #2d7466;/u);
+  assert.match(styles, /--chart-accent: #99c5ba;/u);
+  assert.match(styles, /--blue: #7d9eb8;/u);
+  assert.match(
+    styles,
+    /html\[data-theme="dark"\] \.weekly-hero \{[\s\S]*?gap: 0;[\s\S]*?padding: 0;[\s\S]*?background: var\(--surface\);/u,
+  );
+  assert.match(
+    styles,
+    /html\[data-theme="dark"\] \.weekly-hero > div:first-child \{[\s\S]*?background: var\(--feature-bg\);/u,
+  );
+  assert.match(
+    styles,
+    /html\[data-theme="dark"\] \.notice\.notice-info\.accounting-disclosure \{[\s\S]*?border-inline-start: 3px solid var\(--blue\);[\s\S]*?background: var\(--surface\);/u,
+  );
+  assert.match(
+    styles,
+    /Portable share-card exports deliberately keep the existing light brand/u,
+  );
+  assert.doesNotMatch(
+    styles,
+    /@media[^\{]*prefers-color-scheme[^\{]*\{[\s\S]*?--paper: #141a17/u,
+  );
+
+  assert.match(
+    appSource,
+    /const NATIVE_APPEARANCE_THEMES = new Set\(\["light", "dark"\]\)/u,
+  );
+  assert.match(
+    appSource,
+    /if \(!NATIVE_APPEARANCE_THEMES\.has\(theme\)\) return false;/u,
+  );
+  assert.match(appSource, /document\.documentElement\.dataset\.theme = theme/u);
+  assert.match(appSource, /__TIBOTATTLE_APPEARANCE__\?\.resolvedTheme/u);
+  assert.match(appSource, /"tibotattle:appearance-override"/u);
+  assert.match(
+    appSource,
+    /theme === "dark" \? "#141a17" : "#f5f1e8"/u,
+  );
+});

--- a/docs/design/2026-08-23-dark-mode-implementation.md
+++ b/docs/design/2026-08-23-dark-mode-implementation.md
@@ -1,0 +1,66 @@
+---
+title: Forest Ink dark mode implementation
+date: 2026-08-23
+type: decision-record
+status: implemented
+---
+
+# Forest Ink dark mode implementation
+
+## Decision
+
+Implement the selected Forest Ink direction as an explicit native-app
+appearance, with **System**, **Light**, and **Dark** choices. System is the
+default. The hosted public dashboard remains light unless a trusted native
+host sets the document theme.
+
+Selected visual reference:
+`/Users/adamallcock/.codex/generated_images/01a02a7e-c752-7372-9a03-d31f0c75156b/exec-bbc7e489-fa82-40c9-a211-588d765f5c37.png`
+
+## Palette
+
+| Role | Value |
+| --- | --- |
+| Page | `#141A17` |
+| Primary card | `#1B2521` |
+| Raised control | `#24322C` |
+| Primary text | `#F5F1E8` |
+| Secondary text | `#BEC5BD` |
+| Action accent | `#76AA9C` |
+| Allowance feature band | `#2D7466` |
+| Chart median | `#99C5BA` |
+| Observed and informational | `#7D9EB8` |
+| Warning | `#C5A46A` |
+| Error | `#BD735F` |
+
+## Implementation boundary
+
+- Preserve every existing page, route, data contract, and component structure.
+- Add a small semantic token split for inverted actions and feature surfaces.
+- Apply the balanced allowance hero treatment: green metric band over a quiet
+  dark explanation surface.
+- Change the accounting information card to a quiet surface with a blue rail.
+- Set the theme at WKWebView document start to prevent a light flash.
+- Keep AppKit chrome and the embedded report on the same resolved appearance.
+- Keep exported share-card artwork light and preference-independent in this
+  release so a portable artifact does not vary by the viewer's local setting.
+
+## Activation contract
+
+The native host owns `window.__TIBOTATTLE_APPEARANCE__` and
+`html[data-theme]`. Only `light` and `dark` are accepted resolved values. A
+live `tibotattle:appearance-override` event updates the open dashboard without
+reloading it or disturbing in-memory contribution and chart state.
+
+Explicit Light and Dark choices resolve deterministically and do not depend on
+AppKit update timing. System alone reads `NSApp.effectiveAppearance`, maps it
+through AppKit's Aqua/Dark Aqua match, and resynchronizes the open report when
+the report pane's effective appearance changes or the app becomes active.
+
+## Verification gate
+
+The work is complete only after focused web and native tests pass, every real
+dashboard route is visually inspected in the rendered app, and the comparison
+against the selected reference is recorded in the durable
+[`Forest Ink dark mode verification`](../qa/2026-08-23-forest-ink-dark-mode.md)
+receipt with `final result: passed`.

--- a/docs/design/2026-08-23-dark-mode-implementation.md
+++ b/docs/design/2026-08-23-dark-mode-implementation.md
@@ -50,7 +50,10 @@ Selected visual reference:
 The native host owns `window.__TIBOTATTLE_APPEARANCE__` and
 `html[data-theme]`. Only `light` and `dark` are accepted resolved values. A
 live `tibotattle:appearance-override` event updates the open dashboard without
-reloading it or disturbing in-memory contribution and chart state.
+reloading it or disturbing in-memory contribution and chart state. The same
+update refreshes the native document-start snapshot so a later WebView
+context-menu Reload begins in the current resolved appearance rather than the
+appearance that was active when the host was constructed.
 
 Explicit Light and Dark choices resolve deterministically and do not depend on
 AppKit update timing. System alone reads `NSApp.effectiveAppearance`, maps it

--- a/docs/qa/2026-08-23-forest-ink-dark-mode.md
+++ b/docs/qa/2026-08-23-forest-ink-dark-mode.md
@@ -14,8 +14,8 @@ receipt.
 ## Scope
 
 - Review base: current `origin/main` as fetched on 2026-08-23.
-- Branch delta: one Forest Ink feature commit and no unrelated local-main
-  commits.
+- Branch delta: one Forest Ink feature commit plus one focused manual-reload
+  correction, with no unrelated local-main commits.
 - Browser state: real `apps/web/public` modules in the native-dashboard shell,
   using the repository's built-in and visibly labelled `demoDashboard()`
   fixture.
@@ -54,9 +54,9 @@ readiness relay.
 ### Development build receipt
 
 - Payload SHA-256:
-  `260c2ee5299fc3a7a95f25623fc6426eb4370b83acc96a11286ef7a2d7656b47`
+  `2fb6ae8a24eaa30682db1321148501c429216f10c942f163097dfa7b1c65cde7`
 - Source SHA-256:
-  `82960c9b4c14f4ed73a85017426b3fe8cdc673ba8e18c047d63af4fd77d74cb3`
+  `44f6028260747f3eb5ea3d96bf8ef3d86f0a2172653b75548b287f1315bb2794`
 - Channel: development
 - Signing: ad hoc only
 - External distribution requested: false
@@ -72,6 +72,9 @@ readiness relay.
 - A missing theme-color element and an invalid live event are safe no-ops.
 - The open report receives a live event rather than reloading and losing page
   or chart state.
+- Every live appearance update also refreshes the bounded document-start
+  snapshot, so a later WebView context-menu Reload cannot replay the theme
+  that was current when the host was first constructed.
 - System appearance changes are relayed from the report pane while active and
   resynchronized when the app becomes active again.
 - Native report paper, sidebar wash, and accent use the same resolved palette
@@ -99,6 +102,13 @@ uses, without navigation or reload. Light changed `html[data-theme]`, computed
 values. An unsupported `sepia` value was ignored and left Light intact. Dark
 restored all four dark values while the `#weekly` route and in-memory document
 were preserved.
+
+After the owner reported that WebKit's context-menu Reload could replay a
+stale initial theme, the native host was corrected to refresh its
+document-start snapshot whenever the resolved appearance changes. The rebuilt
+source contract is covered by the native bundle suite. A separate full-page
+browser reload preserved `html[data-theme="dark"]`, computed dark color scheme,
+the `#weekly` route, the `#141A17` page background, and a clean console.
 
 The earlier route pass covered Overview, Allowance, Trends, Usage and costs,
 Community, and the information popover at 962, 700, and 390 CSS px. It found no
@@ -131,8 +141,11 @@ generated images or demo output in source control.
 ## Remaining release boundary
 
 The implementation is ready for team code and design review. A separately
-installed, signed app should still exercise System → Light → Dark → System on
-real user data before release. No installed app, stable artifact, notarized
-artifact, appcast, or public deployment was changed by this work.
+installed, signed app should still exercise System → Light → Dark → System and
+context-menu Reload after each choice on real user data before release. A
+local interactive attempt was excluded from the receipt because another
+development bundle owned the shared companion and an experimental future index
+schema was present; neither was changed. No installed app, stable artifact,
+notarized artifact, appcast, or public deployment was changed by this work.
 
 final result: passed

--- a/docs/qa/2026-08-23-forest-ink-dark-mode.md
+++ b/docs/qa/2026-08-23-forest-ink-dark-mode.md
@@ -1,0 +1,138 @@
+---
+title: Forest Ink dark mode verification
+date: 2026-08-23
+type: qa
+status: passed
+---
+
+# Forest Ink dark mode verification
+
+This receipt qualifies the Forest Ink implementation for source review. It is
+not a signed-app, notarization, installation, release, or update-channel
+receipt.
+
+## Scope
+
+- Review base: current `origin/main` as fetched on 2026-08-23.
+- Branch delta: one Forest Ink feature commit and no unrelated local-main
+  commits.
+- Browser state: real `apps/web/public` modules in the native-dashboard shell,
+  using the repository's built-in and visibly labelled `demoDashboard()`
+  fixture.
+- Native state: freshly compiled development bundle with ad-hoc signing only.
+- Appearance choices: System, Light, and Dark, with System as the invalid or
+  unset preference fallback.
+
+The public dashboard remains light unless the native host supplies the closed
+`light` or `dark` appearance contract. The portable share-card artwork remains
+light and preference-independent.
+
+## Automated verification
+
+| Gate | Result |
+| --- | --- |
+| `npm run product:ui:test` | 325 passed, 0 failed, 0 skipped |
+| `node --test --test-concurrency=1 test/macos-app-bundle.test.js` | 51 passed, 0 failed, 1 skipped |
+| `npm run product:macos:build` | Development bundle built successfully |
+| `--native-appearance-settings-contract-smoke-test` | Passed; default, persistence, fallback, System resolution, and explicit overrides |
+| `--native-settings-layout-smoke-test` | Passed; no page or control overflow |
+| `--native-dashboard-layout-smoke-test` | Passed at 974 × 860 points |
+| `npm run architecture:check` | Passed; 373 production files and 1,467 imports |
+| `npm run docs:links:check` | Passed; documentation links normalized |
+| `git diff --check origin/main...HEAD` | Passed |
+
+The one native-suite skip is the existing preview-distribution test, which is
+explicitly skipped when the pinned Sparkle framework has not been prepared in
+the checkout. It does not skip the appearance implementation or development
+bundle.
+
+The first sandboxed native-suite attempt could not bind its loopback fixture
+and could not observe one spawned-app termination. The required rerun outside
+that sandbox passed both cases, including the signed-app watchdog and central
+readiness relay.
+
+### Development build receipt
+
+- Payload SHA-256:
+  `260c2ee5299fc3a7a95f25623fc6426eb4370b83acc96a11286ef7a2d7656b47`
+- Source SHA-256:
+  `82960c9b4c14f4ed73a85017426b3fe8cdc673ba8e18c047d63af4fd77d74cb3`
+- Channel: development
+- Signing: ad hoc only
+- External distribution requested: false
+
+## Structural and edge-case verification
+
+- A missing or unrecognized persisted appearance resolves to System.
+- System leaves `NSApp.appearance` unset so macOS remains the source of truth.
+- Light and Dark resolve deterministically to AppKit Aqua and Dark Aqua and
+  remain fixed even when given the opposite effective system appearance.
+- The WKWebView document-start handoff accepts only `light` and `dark` before
+  stylesheet paint, then retries the theme-color update at DOM readiness.
+- A missing theme-color element and an invalid live event are safe no-ops.
+- The open report receives a live event rather than reloading and losing page
+  or chart state.
+- System appearance changes are relayed from the report pane while active and
+  resynchronized when the app becomes active again.
+- Native report paper, sidebar wash, and accent use the same resolved palette
+  as the embedded report.
+- Appearance labels are present in English, Spanish, and Simplified Chinese;
+  the compiled development bundle validates the `.strings` files.
+
+## Rendered verification
+
+The final branch was reloaded in the Codex in-app browser at a 506 × 737 CSS-px
+viewport with DPR 2.66. The rendered page reported:
+
+- `html[data-theme="dark"]` and computed `color-scheme: dark`;
+- page background `rgb(20, 26, 23)` (`#141A17`);
+- allowance feature background `rgb(45, 116, 102)` (`#2D7466`);
+- explanation text `rgb(190, 197, 189)` (`#BEC5BD`);
+- the weekly route as the only visible dashboard section;
+- a visible labelled-demo disclosure;
+- zero horizontal overflow; and
+- no captured browser warnings or errors.
+
+The loaded page was then exercised through the same live event the native host
+uses, without navigation or reload. Light changed `html[data-theme]`, computed
+`color-scheme`, the page background, and the theme-color metadata to the light
+values. An unsupported `sepia` value was ignored and left Light intact. Dark
+restored all four dark values while the `#weekly` route and in-memory document
+were preserved.
+
+The earlier route pass covered Overview, Allowance, Trends, Usage and costs,
+Community, and the information popover at 962, 700, and 390 CSS px. It found no
+clipping, overlapping controls, or hidden content. The rebased feature applied
+cleanly to current `origin/main`, and the fresh narrow rendered pass preserved
+that responsive behavior.
+
+Measured contrast ratios were 15.66:1 for primary text on the page, 10.01:1
+for secondary text on the page, 5.47:1 for feature text, and 6.72:1 for dark
+action ink. Informational, warning, and error copy measured 9.08:1, 8.44:1,
+and 6.67:1 on primary cards.
+
+## Local visual artifact hashes
+
+Screenshots remain transient local QA artifacts, consistent with repository
+policy. Their hashes make the reviewed captures identifiable without placing
+generated images or demo output in source control.
+
+| Capture | SHA-256 |
+| --- | --- |
+| Full reference comparison | `e3a0e16b7fd1e3610bd370dead8ceec7f2bc88640fb27ad05729c5d461d46aea` |
+| Focused 700 px comparison | `fffb4e0b05ce140fb084b64d9f54c9a9b384f3eb0498f7301183ebd390fd9f9e` |
+| Overview | `95143a8b6384f62ff9106bfc7c23fb87e9eb2f338b62ca51854062e884f15ae7` |
+| Allowance | `189c6068c5f3bfac64248ff56685c40fee39dc2deae3b132a4da847fc84ed8c2` |
+| Trends | `c73afd68a58e5337dadb1f03ee1a9097866622470666c40a7378cce25ee2d439` |
+| Usage and costs | `ec1b106a0296cdcc379c0dd8114a6b7bb58639deddf7cbb3a700ceff4cd5b0e5` |
+| Community | `72ecc5cce46dfd0e2613aa577c175f6e0045d0f7ce0c174b824b080efda25ca5` |
+| Information popover | `fa98dff0215380b4811ccff25c5fa0cc26985450676b65516855009c7d34d1b5` |
+
+## Remaining release boundary
+
+The implementation is ready for team code and design review. A separately
+installed, signed app should still exercise System → Light → Dark → System on
+real user data before release. No installed app, stable artifact, notarized
+artifact, appcast, or public deployment was changed by this work.
+
+final result: passed

--- a/test/macos-app-bundle.test.js
+++ b/test/macos-app-bundle.test.js
@@ -1490,7 +1490,7 @@ test("the in-app dashboard web view stays pinned to the loopback companion", asy
   assert.match(source, /theme !== 'light' && theme !== 'dark'/u);
   assert.match(
     source,
-    /func notifyAppearancePreferenceChange\([\s\S]*?tibotattle:appearance-override/u,
+    /func notifyAppearancePreferenceChange\([\s\S]*?refreshDocumentStartScripts\(\)[\s\S]*?tibotattle:appearance-override/u,
   );
   assert.match(
     source,

--- a/test/macos-app-bundle.test.js
+++ b/test/macos-app-bundle.test.js
@@ -947,6 +947,18 @@ test("native launcher keeps the requested foreground-only lifecycle", async () =
   );
   assert.match(
     source,
+    /TiboTattleLocalization\.string\(\.settingsAppearance\)/u,
+  );
+  assert.match(
+    source,
+    /\(\.system, \.settingsAppearanceSystem\)/u,
+  );
+  assert.match(
+    source,
+    /TiboTattleLocalization\.string\(\.settingsAppearanceSummary\)/u,
+  );
+  assert.match(
+    source,
     /settingsAboutAutomaticUpdatesDetailLabel\?\.stringValue\s*=\s*automaticUpdatesSettingsSummary\(\)/u,
   );
   assert.doesNotMatch(
@@ -966,7 +978,7 @@ test("native launcher keeps the requested foreground-only lifecycle", async () =
   assert.ok(generalSettings, "general settings page wiring should be present");
   assert.match(
     generalSettings,
-    /languageSection[\s\S]*sourceSection[\s\S]*refreshIntervalSection[\s\S]*startAtLoginSection/u,
+    /appearanceSection[\s\S]*languageSection[\s\S]*sourceSection[\s\S]*refreshIntervalSection[\s\S]*startAtLoginSection/u,
   );
   assert.doesNotMatch(generalSettings, /quotaNotificationsSection/u);
   assert.doesNotMatch(
@@ -1019,6 +1031,7 @@ test("native launcher keeps the requested foreground-only lifecycle", async () =
     );
   }
   assert.match(settingsSource, /symbolName: "globe"/u);
+  assert.match(settingsSource, /symbolName: "circle\.lefthalf\.filled"/u);
   assert.match(settingsSource, /symbolName: "folder"/u);
   assert.match(settingsSource, /symbolName: "clock"/u);
   assert.match(source, /settingsOpenNotifications/u);
@@ -1035,6 +1048,38 @@ test("native launcher keeps the requested foreground-only lifecycle", async () =
   assert.match(
     localizationSource,
     /Start TiboTattle when you sign in\. Manage this in System Settings → Login Items\./iu,
+  );
+  assert.match(localizationSource, /Uses your Mac appearance by default\./iu);
+  assert.match(source, /static let defaultsKey = "tibotattle\.appearance\.v1"/u);
+  assert.match(source, /case system\s*\n\s*case light\s*\n\s*case dark/u);
+  assert.match(
+    source,
+    /guard let rawValue = defaults\.string\(forKey: defaultsKey\),[\s\S]*?else \{\s*\n\s*return \.system\s*\n\s*\}/u,
+  );
+  assert.match(
+    source,
+    /var applicationAppearance: NSAppearance\? \{[\s\S]*?case \.system:\s*\n\s*nil[\s\S]*?case \.light:\s*\n\s*NSAppearance\(named: \.aqua\)[\s\S]*?case \.dark:\s*\n\s*NSAppearance\(named: \.darkAqua\)/u,
+  );
+  assert.match(
+    source,
+    /func resolvedTheme\(for systemAppearance: NSAppearance\) -> String \{[\s\S]*?case \.light:\s*\n\s*return "light"[\s\S]*?case \.dark:\s*\n\s*return "dark"[\s\S]*?case \.system:[\s\S]*?systemAppearance\.bestMatch\(from: \[\.darkAqua, \.aqua\]\)[\s\S]*?\? "dark"\s*\n\s*: "light"/u,
+  );
+  assert.match(source, /NSApp\.appearance = preference\.applicationAppearance/u);
+  assert.match(
+    source,
+    /private func synchronizeResolvedAppearance\(\) \{[\s\S]*?let preference = NativeAppearancePreference\.current[\s\S]*?guard preference == \.system else \{ return \}[\s\S]*?notifyAppearancePreferenceChange\(preference\)/u,
+  );
+  assert.match(
+    source,
+    /func applicationDidBecomeActive\([\s\S]*?synchronizeResolvedAppearance\(\)/u,
+  );
+  assert.match(
+    source,
+    /chrome\.onAppearanceChange = \{ \[weak self\] in\s*\n\s*self\?\.synchronizeResolvedAppearance\(\)/u,
+  );
+  assert.match(
+    source,
+    /private func selectAppearancePreference\([\s\S]*?NativeAppearancePreference\.set\(preference\)[\s\S]*?applyAppearancePreference\(\)/u,
   );
   assert.match(source, /NSApp\.applicationIconImage/u);
   assert.doesNotMatch(source, /showAutomaticUpdateOptions/u);
@@ -1108,6 +1153,7 @@ test("native launcher keeps the requested foreground-only lifecycle", async () =
   assert.match(source, /DispatchQueue\.main\.asyncAfter\(deadline: deadline, execute: work\)/u);
   assert.match(source, /setSeconds\(value, in: UserDefaults\.standard\)/u);
   assert.match(source, /--native-refresh-settings-contract-smoke-test/u);
+  assert.match(source, /--native-appearance-settings-contract-smoke-test/u);
   assert.doesNotMatch(source, /nativeRefreshIntervalSeconds/u);
   assert.match(source, /private func scheduleNativeRefresh\(\)/u);
   const refreshIntervalSelectionSource = source.match(
@@ -1436,6 +1482,16 @@ test("the in-app dashboard web view stays pinned to the loopback companion", asy
   );
   assert.match(source, /WKUserScript\([\s\S]*injectionTime: \.atDocumentStart/u);
   assert.match(source, /document\.documentElement\.classList\.add\('native-dashboard'\)/u);
+  assert.equal(
+    source.includes("window.__TIBOTATTLE_APPEARANCE__ = \\(json);"),
+    true,
+  );
+  assert.match(source, /document\.documentElement\.dataset\.theme = theme/u);
+  assert.match(source, /theme !== 'light' && theme !== 'dark'/u);
+  assert.match(
+    source,
+    /func notifyAppearancePreferenceChange\([\s\S]*?tibotattle:appearance-override/u,
+  );
   assert.match(
     source,
     /func notifyHostedSignInReturn\(\) \{[\s\S]*?window\.dispatchEvent\(new Event\('tibotattle:hosted-sign-in-return'\)\)/u,
@@ -2058,18 +2114,39 @@ test("dashboard sidebar resizes for real, wears the brand palette, and the title
     source,
     /private func rescueStrandedSidebar\(_ defaults: UserDefaults\) \{\s*\n\s*guard !defaults\.bool\(forKey: Self\.sidebarRescuedDefaultsKey\) else \{\s*\n\s*return\s*\n\s*\}\s*\n\s*defaults\.set\(true, forKey: Self\.sidebarRescuedDefaultsKey\)/u,
   );
-  // 2. The sidebar carries the web report's warm-paper palette over the
-  // system material, and the selected row uses the brand's deep green
-  // instead of the user's system accent. Both mirror the web tokens
-  // --paper #f5f1e8 and --green #174f45 and resolve per appearance.
-  assert.match(source, /private enum NativeBrandPalette/u);
+  // 2. The sidebar and report carry the exact light and Forest Ink tokens over
+  // native material instead of inheriting the user's unrelated system accent.
+  const nativeBrandPalette = source.match(
+    /private enum NativeBrandPalette \{[\s\S]*?\n\}/u,
+  )?.[0];
+  assert.ok(nativeBrandPalette, "native brand palette should be present");
   assert.match(
-    source,
-    /srgbRed: 245 \/ 255,\s*\n\s*green: 241 \/ 255,\s*\n\s*blue: 232 \/ 255/u,
+    nativeBrandPalette,
+    /static let accent = NSColor\(name: nil\)[\s\S]*?srgbRed: 118 \/ 255,[\s\S]*?green: 170 \/ 255,[\s\S]*?blue: 156 \/ 255/u,
+  );
+  assert.match(
+    nativeBrandPalette,
+    /static let accent = NSColor\(name: nil\)[\s\S]*?srgbRed: 23 \/ 255,[\s\S]*?green: 79 \/ 255,[\s\S]*?blue: 69 \/ 255/u,
+  );
+  assert.match(
+    nativeBrandPalette,
+    /static let reportPaper = NSColor\(name: nil\)[\s\S]*?srgbRed: 20 \/ 255,[\s\S]*?green: 26 \/ 255,[\s\S]*?blue: 23 \/ 255/u,
+  );
+  assert.match(
+    nativeBrandPalette,
+    /static let reportPaper = NSColor\(name: nil\)[\s\S]*?srgbRed: 245 \/ 255,[\s\S]*?green: 241 \/ 255,[\s\S]*?blue: 232 \/ 255/u,
+  );
+  assert.match(
+    nativeBrandPalette,
+    /static let sidebarWash = NSColor\(name: nil\)[\s\S]*?srgbRed: 45 \/ 255,[\s\S]*?green: 116 \/ 255,[\s\S]*?blue: 102 \/ 255,[\s\S]*?alpha: 0\.22/u,
   );
   assert.match(
     source,
-    /srgbRed: 23 \/ 255,\s*\n\s*green: 79 \/ 255,\s*\n\s*blue: 69 \/ 255/u,
+    /private final class NativeDashboardReportPane[\s\S]*?override var wantsUpdateLayer: Bool \{ true \}[\s\S]*?NativeBrandPalette\.reportPaper\.cgColor/u,
+  );
+  assert.match(
+    source,
+    /override func viewDidChangeEffectiveAppearance\(\)[\s\S]*?onAppearanceChange\?\(\)/u,
   );
   assert.match(source, /private final class NativeSidebarBrandWash: NSView/u);
   assert.match(source, /sidebar\.addSubview\(sidebarWash\)/u);
@@ -6159,6 +6236,20 @@ macOSArtifactTest("reproducible ad-hoc-signed app passes orderly and launcher-SI
     assert.match(
       refreshSettingsSmoke.stdout,
       /^USAGE_MONITOR_MACOS_REFRESH_SETTINGS_CONTRACT default=300 persisted=900 reloaded=900 picker_action=true picker_persisted=true scheduler=300->900 invalid_ignored=true$/mu,
+    );
+    const appearanceSettingsSmoke = spawnSync(
+      join(outputA, "Contents", "MacOS", "TiboTattle"),
+      ["--native-appearance-settings-contract-smoke-test"],
+      { encoding: "utf8", timeout: 5_000 },
+    );
+    assert.equal(
+      appearanceSettingsSmoke.status,
+      0,
+      appearanceSettingsSmoke.stderr || appearanceSettingsSmoke.stdout,
+    );
+    assert.match(
+      appearanceSettingsSmoke.stdout,
+      /^USAGE_MONITOR_MACOS_APPEARANCE_SETTINGS_CONTRACT default=system persisted=light,dark,system invalid=system system_resolution=light,dark explicit_resolution=light,dark appkit=system,aqua,darkAqua$/mu,
     );
     // The settings window is sized from what its pages measure. Source text
     // cannot show whether a page then fits, so this measures the real frames:


### PR DESCRIPTION
## Summary

- add the selected Forest Ink dark appearance across the real dashboard pages and native macOS chrome while preserving the existing light appearance
- add System, Light, and Dark appearance settings, defaulting to System and following live macOS appearance changes without reloading the dashboard
- keep a later WebView context-menu Reload in the current resolved appearance by refreshing the native document-start snapshot on every appearance change

## Release

Intended for TiboTattle 0.1.17, the next client release after the current 0.1.16.

Refs #11

## Validation

- `node --test --test-concurrency=1 test/macos-app-bundle.test.js` — 51 passed, 1 existing preview-framework skip
- `npm run product:ui:test` — 326 passed
- `npm run docs:links:check`
- compiled `--native-appearance-settings-contract-smoke-test`
- reproducible development bundle build, payload SHA-256 `2fb6ae8a24eaa30682db1321148501c429216f10c942f163097dfa7b1c65cde7`
- rendered route and responsive QA across Overview, Allowance, Trends, Usage and costs, Community, and the information popover; browser reload preserved Dark, `#weekly`, and a clean console

## Release boundary

This PR merges source only. The separately installed and signed 0.1.17 candidate should still exercise System → Light → Dark → System and context-menu Reload after each choice on real user data before publication.
