### PR TITLE
fix(macos): clarify dashboard startup failures

### DIFF
--- a/apps/macos/Resources/en.lproj/Localizable.strings
+++ b/apps/macos/Resources/en.lproj/Localizable.strings
@@ -234,6 +234,7 @@
 
 "launcher.codexFolderUpdated" = "Codex folder updated";
 "launcher.dashboardDidNotOpen" = "Dashboard didn’t open";
+"launcher.dashboardTakingLonger" = "Dashboard is taking longer than expected";
 "launcher.localDataMovedToTrash" = "Local data moved to Trash";
 "launcher.localDashboardCouldNotStart" = "The local dashboard could not be started.";
 "launcher.localDataMovedToTrashDetail" = "A fresh owner-only local store will be created now. Codex logs were not changed.";
@@ -250,7 +251,11 @@
 "launcher.errorCompanionLaunch" = "The local companion could not be started.";
 "launcher.errorCompanionTimeout" = "The local companion did not become ready in time.";
 "launcher.errorCodexHomeSettingsWrite" = "The selected Codex folder could not be saved privately.";
+"launcher.errorDashboardContentProcessTerminated" = "The macOS web content process stopped while opening the local dashboard.";
 "launcher.errorDashboardDownloadFailed" = "The dashboard could not save that file to your Downloads folder.";
+"launcher.errorDashboardNavigationFailed" = "The in-app dashboard could not load its local page.";
+"launcher.errorDashboardReadinessTimeout" = "The local dashboard page loaded, but it did not become ready during the initial wait.";
+"launcher.errorDashboardViewportUnavailable" = "The in-app dashboard did not receive a usable window size.";
 "launcher.errorDashboardWebViewUnavailable" = "The in-app dashboard view could not be displayed.";
 "launcher.errorDataErase" = "The local %@ data could not be moved to Trash.";
 "launcher.errorFirstRunStateWrite" = "The first-run acknowledgement could not be saved privately.";
@@ -269,7 +274,7 @@
 "launcher.recoveryCheckAccess" = "Check access to your home and Application Support folders, then retry.";
 "launcher.recoveryChooseCodexHome" = "Choose Codex Source and select a readable Codex home owned by your macOS user account, or restore the default.";
 "launcher.recoveryDashboardDownload" = "Check access to your Downloads folder, then save the file again.";
-"launcher.recoveryDashboardWebView" = "Choose Open Dashboard to try again, or Open in Browser to use the same local dashboard in your browser.";
+"launcher.recoveryDashboardWebView" = "Choose Open Dashboard to try the local view again. If it still does not open, choose Retry.";
 "launcher.recoveryDataErase" = "Quit other processes using %@ data, then try the erase again.";
 "launcher.recoveryExistingWindow" = "Open the existing %@ window, or quit it before starting another copy.";
 "launcher.recoveryKeychainDenied" = "Retry the reset and approve the macOS Keychain prompt.";

--- a/apps/macos/Resources/es.lproj/Localizable.strings
+++ b/apps/macos/Resources/es.lproj/Localizable.strings
@@ -168,6 +168,7 @@
 
 "launcher.codexFolderUpdated" = "Carpeta de Codex actualizada";
 "launcher.dashboardDidNotOpen" = "El panel no se abrió";
+"launcher.dashboardTakingLonger" = "El panel está tardando más de lo esperado";
 "launcher.localDataMovedToTrash" = "Los datos locales se movieron a la Papelera";
 "launcher.localDashboardCouldNotStart" = "No se pudo iniciar el panel local.";
 "launcher.localDataMovedToTrashDetail" = "Ahora se creará un nuevo almacén local disponible solo para el propietario. Los registros de Codex no se modificaron.";
@@ -184,7 +185,11 @@
 "launcher.errorCompanionLaunch" = "No se pudo iniciar el acompañante local.";
 "launcher.errorCompanionTimeout" = "El acompañante local no estuvo listo a tiempo.";
 "launcher.errorCodexHomeSettingsWrite" = "No se pudo guardar de forma privada la carpeta de Codex seleccionada.";
+"launcher.errorDashboardContentProcessTerminated" = "El proceso de contenido web de macOS se detuvo mientras se abría el panel local.";
 "launcher.errorDashboardDownloadFailed" = "El panel no pudo guardar ese archivo en tu carpeta Descargas.";
+"launcher.errorDashboardNavigationFailed" = "El panel integrado no pudo cargar su página local.";
+"launcher.errorDashboardReadinessTimeout" = "La página del panel local se cargó, pero no estuvo lista durante la espera inicial.";
+"launcher.errorDashboardViewportUnavailable" = "El panel integrado no recibió un tamaño de ventana utilizable.";
 "launcher.errorDashboardWebViewUnavailable" = "No se pudo mostrar la vista integrada del panel.";
 "launcher.errorDataErase" = "No se pudieron mover a la Papelera los datos locales de %@.";
 "launcher.errorFirstRunStateWrite" = "No se pudo guardar de forma privada la confirmación de primera ejecución.";
@@ -203,7 +208,7 @@
 "launcher.recoveryCheckAccess" = "Comprueba el acceso a tus carpetas de inicio y Application Support, y vuelve a intentarlo.";
 "launcher.recoveryChooseCodexHome" = "Elige Origen de Codex y selecciona una carpeta de inicio de Codex legible que pertenezca a tu cuenta de usuario de macOS, o restaura el valor predeterminado.";
 "launcher.recoveryDashboardDownload" = "Comprueba el acceso a tu carpeta Descargas y vuelve a guardar el archivo.";
-"launcher.recoveryDashboardWebView" = "Elige Abrir panel para intentarlo de nuevo, o Abrir en el navegador para usar el mismo panel local en tu navegador.";
+"launcher.recoveryDashboardWebView" = "Elige Abrir panel para volver a intentar la vista local. Si aún no se abre, elige Reintentar.";
 "launcher.recoveryDataErase" = "Cierra otros procesos que usen datos de %@ y vuelve a intentar el borrado.";
 "launcher.recoveryExistingWindow" = "Abre la ventana existente de %@ o ciérrala antes de iniciar otra copia.";
 "launcher.recoveryKeychainDenied" = "Vuelve a intentar el restablecimiento y aprueba el aviso del Llavero de macOS.";

--- a/apps/macos/Resources/zh-Hans.lproj/Localizable.strings
+++ b/apps/macos/Resources/zh-Hans.lproj/Localizable.strings
@@ -168,6 +168,7 @@
 
 "launcher.codexFolderUpdated" = "Codex 文件夹已更新";
 "launcher.dashboardDidNotOpen" = "仪表板未能打开";
+"launcher.dashboardTakingLonger" = "仪表板所需时间比预期更长";
 "launcher.localDataMovedToTrash" = "本地数据已移到废纸篓";
 "launcher.localDashboardCouldNotStart" = "无法启动本地仪表板。";
 "launcher.localDataMovedToTrashDetail" = "现在将创建新的仅所有者可访问的本地存储。未更改 Codex 日志。";
@@ -184,7 +185,11 @@
 "launcher.errorCompanionLaunch" = "无法启动本地伴随程序。";
 "launcher.errorCompanionTimeout" = "本地伴随程序未能及时准备就绪。";
 "launcher.errorCodexHomeSettingsWrite" = "无法私密地保存所选 Codex 文件夹。";
+"launcher.errorDashboardContentProcessTerminated" = "打开本地仪表板时，macOS 网页内容进程已停止。";
 "launcher.errorDashboardDownloadFailed" = "仪表板无法将该文件保存到“下载”文件夹。";
+"launcher.errorDashboardNavigationFailed" = "应用内仪表板无法加载其本地页面。";
+"launcher.errorDashboardReadinessTimeout" = "本地仪表板页面已加载，但未能在初始等待期间准备就绪。";
+"launcher.errorDashboardViewportUnavailable" = "应用内仪表板未获得可用的窗口尺寸。";
 "launcher.errorDashboardWebViewUnavailable" = "无法显示应用内仪表板视图。";
 "launcher.errorDataErase" = "无法将 %@ 的本地数据移到废纸篓。";
 "launcher.errorFirstRunStateWrite" = "无法私密地保存首次运行确认。";
@@ -203,7 +208,7 @@
 "launcher.recoveryCheckAccess" = "请检查对主目录和 Application Support 文件夹的访问权限，然后重试。";
 "launcher.recoveryChooseCodexHome" = "请选择“Codex 来源”并选择可读取且归你的 macOS 用户帐户所有的 Codex 主文件夹，或恢复默认设置。";
 "launcher.recoveryDashboardDownload" = "请检查对“下载”文件夹的访问权限，然后再次保存该文件。";
-"launcher.recoveryDashboardWebView" = "请选择“打开仪表板”重试，或选择“在浏览器中打开”以在浏览器中使用同一份本地仪表板。";
+"launcher.recoveryDashboardWebView" = "请选择“打开仪表板”再次尝试本地视图。如果仍无法打开，请选择“重试”。";
 "launcher.recoveryDataErase" = "请退出正在使用 %@ 数据的其他进程，然后再次尝试抹掉。";
 "launcher.recoveryExistingWindow" = "请打开现有的 %@ 窗口，或先退出它再启动另一份副本。";
 "launcher.recoveryKeychainDenied" = "请重试重置并批准 macOS 钥匙串提示。";

--- a/apps/macos/Sources/Localization.swift
+++ b/apps/macos/Sources/Localization.swift
@@ -110,13 +110,18 @@ enum TiboTattleLocalization {
         case launcherCodexFolderUpdated = "launcher.codexFolderUpdated"
         case launcherDataDiagnostics = "launcher.dataDiagnostics"
         case launcherDashboardDidNotOpen = "launcher.dashboardDidNotOpen"
+        case launcherDashboardTakingLonger = "launcher.dashboardTakingLonger"
         case launcherDetailPreparingLocalDashboard = "launcher.detailPreparingLocalDashboard"
         case launcherErrorCompanionAlreadyRunning = "launcher.errorCompanionAlreadyRunning"
         case launcherErrorCompanionExited = "launcher.errorCompanionExited"
         case launcherErrorCompanionLaunch = "launcher.errorCompanionLaunch"
         case launcherErrorCompanionTimeout = "launcher.errorCompanionTimeout"
         case launcherErrorCodexHomeSettingsWrite = "launcher.errorCodexHomeSettingsWrite"
+        case launcherErrorDashboardContentProcessTerminated = "launcher.errorDashboardContentProcessTerminated"
         case launcherErrorDashboardDownloadFailed = "launcher.errorDashboardDownloadFailed"
+        case launcherErrorDashboardNavigationFailed = "launcher.errorDashboardNavigationFailed"
+        case launcherErrorDashboardReadinessTimeout = "launcher.errorDashboardReadinessTimeout"
+        case launcherErrorDashboardViewportUnavailable = "launcher.errorDashboardViewportUnavailable"
         case launcherErrorDashboardWebViewUnavailable = "launcher.errorDashboardWebViewUnavailable"
         case launcherErrorDataErase = "launcher.errorDataErase"
         case launcherErrorFirstRunStateWrite = "launcher.errorFirstRunStateWrite"
@@ -438,6 +443,8 @@ enum TiboTattleLocalization {
                 "Data & Diagnostics…"
             case .launcherDashboardDidNotOpen:
                 "Dashboard didn’t open"
+            case .launcherDashboardTakingLonger:
+                "Dashboard is taking longer than expected"
             case .launcherDetailPreparingLocalDashboard:
                 "Preparing the private local dashboard and its bounded foreground update."
             case .launcherErrorCompanionAlreadyRunning:
@@ -450,8 +457,16 @@ enum TiboTattleLocalization {
                 "The local companion did not become ready in time."
             case .launcherErrorCodexHomeSettingsWrite:
                 "The selected Codex folder could not be saved privately."
+            case .launcherErrorDashboardContentProcessTerminated:
+                "The macOS web content process stopped while opening the local dashboard."
             case .launcherErrorDashboardDownloadFailed:
                 "The dashboard could not save that file to your Downloads folder."
+            case .launcherErrorDashboardNavigationFailed:
+                "The in-app dashboard could not load its local page."
+            case .launcherErrorDashboardReadinessTimeout:
+                "The local dashboard page loaded, but it did not become ready during the initial wait."
+            case .launcherErrorDashboardViewportUnavailable:
+                "The in-app dashboard did not receive a usable window size."
             case .launcherErrorDashboardWebViewUnavailable:
                 "The in-app dashboard view could not be displayed."
             case .launcherErrorDataErase:
@@ -525,7 +540,7 @@ enum TiboTattleLocalization {
             case .launcherRecoveryDashboardDownload:
                 "Check access to your Downloads folder, then save the file again."
             case .launcherRecoveryDashboardWebView:
-                "Choose Open Dashboard to try again, or Open in Browser to use the same local dashboard in your browser."
+                "Choose Open Dashboard to try the local view again. If it still does not open, choose Retry."
             case .launcherRecoveryDataErase:
                 "Quit other processes using %@ data, then try the erase again."
             case .launcherRecoveryExistingWindow:

--- a/apps/macos/UsageMonitorApp.swift
+++ b/apps/macos/UsageMonitorApp.swift
@@ -833,7 +833,11 @@ private enum LauncherError: LocalizedError {
     case companionLaunch(String)
     case companionTimeout
     case codexHomeSettingsWrite
+    case dashboardContentProcessTerminated
     case dashboardDownloadFailed
+    case dashboardNavigationFailed
+    case dashboardReadinessTimeout
+    case dashboardViewportUnavailable
     case dashboardWebViewUnavailable
     case dataErase
     case firstRunStateWrite
@@ -881,9 +885,25 @@ private enum LauncherError: LocalizedError {
             return TiboTattleLocalization.string(
                 .launcherErrorCodexHomeSettingsWrite
             )
+        case .dashboardContentProcessTerminated:
+            return TiboTattleLocalization.string(
+                .launcherErrorDashboardContentProcessTerminated
+            )
         case .dashboardDownloadFailed:
             return TiboTattleLocalization.string(
                 .launcherErrorDashboardDownloadFailed
+            )
+        case .dashboardNavigationFailed:
+            return TiboTattleLocalization.string(
+                .launcherErrorDashboardNavigationFailed
+            )
+        case .dashboardReadinessTimeout:
+            return TiboTattleLocalization.string(
+                .launcherErrorDashboardReadinessTimeout
+            )
+        case .dashboardViewportUnavailable:
+            return TiboTattleLocalization.string(
+                .launcherErrorDashboardViewportUnavailable
             )
         case .dashboardWebViewUnavailable:
             return TiboTattleLocalization.string(
@@ -937,8 +957,16 @@ private enum LauncherError: LocalizedError {
             return "UM_MACOS_COMPANION_START_TIMEOUT"
         case .codexHomeSettingsWrite:
             return "UM_MACOS_CODEX_HOME_SETTINGS_WRITE_FAILED"
+        case .dashboardContentProcessTerminated:
+            return "UM_MACOS_DASHBOARD_WEB_PROCESS_TERMINATED"
         case .dashboardDownloadFailed:
             return "UM_MACOS_DASHBOARD_DOWNLOAD_FAILED"
+        case .dashboardNavigationFailed:
+            return "UM_MACOS_DASHBOARD_NAVIGATION_FAILED"
+        case .dashboardReadinessTimeout:
+            return "UM_MACOS_DASHBOARD_READY_TIMEOUT"
+        case .dashboardViewportUnavailable:
+            return "UM_MACOS_DASHBOARD_VIEWPORT_UNAVAILABLE"
         case .dashboardWebViewUnavailable:
             return "UM_MACOS_DASHBOARD_VIEW_UNAVAILABLE"
         case .dataErase:
@@ -981,7 +1009,9 @@ private enum LauncherError: LocalizedError {
             return TiboTattleLocalization.string(
                 .launcherRecoveryDashboardDownload
             )
-        case .dashboardWebViewUnavailable:
+        case .dashboardContentProcessTerminated, .dashboardNavigationFailed,
+             .dashboardReadinessTimeout, .dashboardViewportUnavailable,
+             .dashboardWebViewUnavailable:
             return TiboTattleLocalization.string(
                 .launcherRecoveryDashboardWebView
             )
@@ -1915,7 +1945,7 @@ private final class NativeDashboardWebView: WKWebView {
 private final class DashboardWebHost: NSObject, WKNavigationDelegate, WKUIDelegate,
     WKDownloadDelegate, WKScriptMessageHandler {
     private let onLoaded: () -> Void
-    private let onFailure: (String) -> Void
+    private let onFailure: (LauncherError) -> Void
     private let onDownloadFailure: () -> Void
     private let openExternally: (URL) -> Void
     private let onNavigation: (String) -> Void
@@ -1943,7 +1973,7 @@ private final class DashboardWebHost: NSObject, WKNavigationDelegate, WKUIDelega
 
     init(
         onLoaded: @escaping () -> Void,
-        onFailure: @escaping (String) -> Void,
+        onFailure: @escaping (LauncherError) -> Void,
         onDownloadFailure: @escaping () -> Void,
         openExternally: @escaping (URL) -> Void,
         onNavigation: @escaping (String) -> Void,
@@ -2080,7 +2110,7 @@ private final class DashboardWebHost: NSObject, WKNavigationDelegate, WKUIDelega
               url.host == loopbackHost,
               let port = url.port
         else {
-            onFailure(LauncherError.healthCheck.failureCode)
+            onFailure(.healthCheck)
             return
         }
         allowedPort = port
@@ -2103,7 +2133,7 @@ private final class DashboardWebHost: NSObject, WKNavigationDelegate, WKUIDelega
             guard viewportPreparationAttempts < 20 else {
                 pendingDashboardURL = nil
                 hasDashboardTarget = false
-                onFailure(LauncherError.dashboardWebViewUnavailable.failureCode)
+                onFailure(.dashboardViewportUnavailable)
                 return
             }
             viewportPreparationAttempts += 1
@@ -2363,7 +2393,7 @@ private final class DashboardWebHost: NSObject, WKNavigationDelegate, WKUIDelega
             }
             guard Date() < deadline else {
                 self.hasDashboardTarget = false
-                self.onFailure(LauncherError.dashboardWebViewUnavailable.failureCode)
+                self.onFailure(.dashboardReadinessTimeout)
                 return
             }
             DispatchQueue.main.asyncAfter(
@@ -2393,7 +2423,7 @@ private final class DashboardWebHost: NSObject, WKNavigationDelegate, WKUIDelega
     func webViewWebContentProcessDidTerminate(_ webView: WKWebView) {
         guard hasDashboardTarget else { return }
         hasDashboardTarget = false
-        onFailure(LauncherError.dashboardWebViewUnavailable.failureCode)
+        onFailure(.dashboardContentProcessTerminated)
     }
 
     private func reportNavigationFailure(_ error: Error) {
@@ -2406,7 +2436,7 @@ private final class DashboardWebHost: NSObject, WKNavigationDelegate, WKUIDelega
             return
         }
         hasDashboardTarget = false
-        onFailure(LauncherError.dashboardWebViewUnavailable.failureCode)
+        onFailure(.dashboardNavigationFailed)
     }
 
     // MARK: - Window, dialog, and file affordances
@@ -4418,8 +4448,8 @@ private final class AppDelegate: NSObject, NSApplicationDelegate,
         let host = dashboardWebHost ?? {
             let created = DashboardWebHost(
                 onLoaded: { [weak self] in self?.dashboardWebViewLoaded() },
-                onFailure: { [weak self] code in
-                    self?.dashboardWebViewFailed(code: code)
+                onFailure: { [weak self] failure in
+                    self?.dashboardWebViewFailed(failure)
                 },
                 onDownloadFailure: { [weak self] in
                     self?.reportDashboardDownloadFailure()
@@ -4943,7 +4973,7 @@ private final class AppDelegate: NSObject, NSApplicationDelegate,
         alert.runModal()
     }
 
-    private func dashboardWebViewFailed(code: String) {
+    private func dashboardWebViewFailed(_ failure: LauncherError) {
         cancelNativeRefreshSchedule()
         startupAutomaticRefreshPending = false
         nativeEvidenceState = .readFailed
@@ -4951,13 +4981,27 @@ private final class AppDelegate: NSObject, NSApplicationDelegate,
         dashboardContainer.isHidden = true
         statusStack.isHidden = false
         actionRow.isHidden = false
-        let failure = LauncherError.dashboardWebViewUnavailable
-        lastLifecycleStatus = "Dashboard unavailable"
+        let headline: TiboTattleLocalization.Key
+        switch failure {
+        case .dashboardContentProcessTerminated:
+            lastLifecycleStatus = "Dashboard web process terminated"
+            headline = .launcherDashboardDidNotOpen
+        case .dashboardNavigationFailed:
+            lastLifecycleStatus = "Dashboard navigation failed"
+            headline = .launcherDashboardDidNotOpen
+        case .dashboardReadinessTimeout:
+            lastLifecycleStatus = "Dashboard readiness timed out"
+            headline = .launcherDashboardTakingLonger
+        case .dashboardViewportUnavailable:
+            lastLifecycleStatus = "Dashboard viewport unavailable"
+            headline = .launcherDashboardDidNotOpen
+        default:
+            lastLifecycleStatus = "Dashboard unavailable"
+            headline = .launcherDashboardDidNotOpen
+        }
         lastFailureCode = failure.failureCode
         lastRecoverySuggestion = failure.recoverySuggestion
-        statusLabel.stringValue = TiboTattleLocalization.string(
-            .launcherDashboardDidNotOpen
-        )
+        statusLabel.stringValue = TiboTattleLocalization.string(headline)
         detailLabel.stringValue = TiboTattleLocalization.format(
             .launcherFailureDetails,
             failure.errorDescription ?? "",

--- a/test/macos-app-bundle.test.js
+++ b/test/macos-app-bundle.test.js
@@ -1524,11 +1524,11 @@ test("the in-app dashboard web view stays pinned to the loopback companion", asy
   // stack and the native recovery controls return together.
   assert.match(
     source,
-    /private func dashboardWebViewFailed\(code: String\) \{[\s\S]*?dashboardContainer\.isHidden = true\s*\n\s*statusStack\.isHidden = false/u,
+    /private func dashboardWebViewFailed\(_ failure: LauncherError\) \{[\s\S]*?dashboardContainer\.isHidden = true\s*\n\s*statusStack\.isHidden = false/u,
   );
   assert.match(
     source,
-    /private func dashboardWebViewFailed\(code: String\) \{[\s\S]*?retryButton\.isEnabled = retryAllowed && firstRunAcknowledged/u,
+    /private func dashboardWebViewFailed\(_ failure: LauncherError\) \{[\s\S]*?retryButton\.isEnabled = retryAllowed && firstRunAcknowledged/u,
   );
   assert.match(
     source,
@@ -1544,12 +1544,47 @@ test("the in-app dashboard web view stays pinned to the loopback companion", asy
   );
   assert.match(
     source,
+    /for button in \[\s*retryButton,\s*openButton,\s*\] \{\s*actionRow\.addView\(button, in: \.trailing\)/u,
+  );
+  assert.doesNotMatch(
+    source,
+    /for button in \[\s*retryButton,\s*openButton,\s*openInBrowserButton,/u,
+  );
+  assert.match(
+    source,
     /@objc private func openDashboard\(\) \{[\s\S]*?showDashboardWebView\(dashboardURL\)/u,
   );
   assert.match(
     source,
     /@objc private func openDashboardInBrowser\(\) \{[\s\S]*?NSWorkspace\.shared\.open\(dashboardURL\)/u,
   );
+  // Recovery copy and diagnostics distinguish the host phase without adding
+  // another dashboard lifecycle or retry path.
+  assert.match(source, /private let onFailure: \(LauncherError\) -> Void/u);
+  assert.match(
+    source,
+    /guard viewportPreparationAttempts < 20 else \{[\s\S]*?onFailure\(\.dashboardViewportUnavailable\)/u,
+  );
+  assert.match(
+    source,
+    /guard Date\(\) < deadline else \{[\s\S]*?self\.onFailure\(\.dashboardReadinessTimeout\)/u,
+  );
+  assert.match(
+    source,
+    /func webViewWebContentProcessDidTerminate[\s\S]*?onFailure\(\.dashboardContentProcessTerminated\)/u,
+  );
+  assert.match(
+    source,
+    /private func reportNavigationFailure[\s\S]*?onFailure\(\.dashboardNavigationFailed\)/u,
+  );
+  assert.match(
+    source,
+    /private func dashboardWebViewFailed\(_ failure: LauncherError\) \{[\s\S]*?case \.dashboardReadinessTimeout:[\s\S]*?headline = \.launcherDashboardTakingLonger[\s\S]*?lastFailureCode = failure\.failureCode[\s\S]*?failure\.errorDescription[\s\S]*?failure\.failureCode[\s\S]*?failure\.recoverySuggestion/u,
+  );
+  assert.match(source, /UM_MACOS_DASHBOARD_VIEWPORT_UNAVAILABLE/u);
+  assert.match(source, /UM_MACOS_DASHBOARD_NAVIGATION_FAILED/u);
+  assert.match(source, /UM_MACOS_DASHBOARD_WEB_PROCESS_TERMINATED/u);
+  assert.match(source, /UM_MACOS_DASHBOARD_READY_TIMEOUT/u);
   assert.match(source, /UM_MACOS_DASHBOARD_VIEW_UNAVAILABLE/u);
   assert.match(source, /UM_MACOS_DASHBOARD_DOWNLOAD_FAILED/u);
 });
@@ -1572,7 +1607,7 @@ test("native dashboard launch gates its first refresh on the rendered page", asy
     "private func navigateNativeDashboard(",
   );
   const dashboardFailure = section(
-    "private func dashboardWebViewFailed(code: String)",
+    "private func dashboardWebViewFailed(_ failure: LauncherError)",
     "private func hideDashboardWebView()",
   );
   const dashboardTeardown = section(

--- a/test/macos-localization.test.js
+++ b/test/macos-localization.test.js
@@ -118,6 +118,26 @@ test("native catalogs have complete language parity and preserve placeholders", 
     english.get("settings.updateCheckUnavailableMessage"),
     "TiboTattle couldn't complete the update check. Check your internet connection and try again.",
   );
+  assert.equal(
+    english.get("launcher.dashboardTakingLonger"),
+    "Dashboard is taking longer than expected",
+  );
+  assert.equal(
+    english.get("launcher.errorDashboardReadinessTimeout"),
+    "The local dashboard page loaded, but it did not become ready during the initial wait.",
+  );
+  assert.equal(
+    english.get("launcher.recoveryDashboardWebView"),
+    "Choose Open Dashboard to try the local view again. If it still does not open, choose Retry.",
+  );
+  assert.equal(
+    catalogs.get("es").get("launcher.recoveryDashboardWebView"),
+    "Elige Abrir panel para volver a intentar la vista local. Si aún no se abre, elige Reintentar.",
+  );
+  assert.equal(
+    catalogs.get("zh-Hans").get("launcher.recoveryDashboardWebView"),
+    "请选择“打开仪表板”再次尝试本地视图。如果仍无法打开，请选择“重试”。",
+  );
   assert.match(swiftSource, /LanguagePreference: String, CaseIterable/u);
   assert.match(swiftSource, /UserDefaults\.standard\.set/u);
   assert.match(swiftSource, /Locale\.preferredLanguages/u);


### PR DESCRIPTION
## Summary

- preserve the actual native dashboard failure phase instead of collapsing every WebKit failure into one generic code
- show a truthful “Dashboard is taking longer than expected” message when the local page loads but readiness times out
- keep recovery limited to the existing Retry and Open Dashboard controls, with matching English, Spanish, and Chinese guidance

## Complexity boundary

This adds no dashboard state machine, timers, automatic reloads, WebView replacement, or changes to the recent boot-state and primary-readiness behavior from #59 and #60.

## Validation

- `npm run test:macos:source`
- `npm run test:macos:smoke`
- `git diff --check`