### PR TITLE
Customizable menu bar allowance display

### DIFF
--- a/apps/macos/Resources/en.lproj/Localizable.strings
+++ b/apps/macos/Resources/en.lproj/Localizable.strings
@@ -24,6 +24,10 @@
 "settings.appearancePickerHint" = "Choose how TiboTattle looks.";
 "settings.appearanceSummary" = "Uses your Mac appearance by default.";
 "settings.appearanceSystem" = "System";
+"settings.menuBarAllowance" = "Menu bar allowance";
+"settings.menuBarAllowanceDetail" = "Choose which fresh allowance percentage appears beside the menu-bar icon.";
+"settings.menuBarAllowanceFiveHour" = "5-hour only";
+"settings.menuBarAllowanceBoth" = "Both 5-hour and 7-day";
 "settings.automaticUpdates" = "Automatic updates";
 "settings.automaticUpdatesOff" = "Automatic downloads are off.";
 "settings.automaticUpdatesOn" = "Automatic downloads are on.";
@@ -151,12 +155,14 @@
 "menuBar.analyzeLocalUsage" = "Analyze Local Usage";
 "menuBar.analyzingLocalUsage" = "Analyzing Local Usage…";
 "menuBar.allowanceTitle" = "%@ · %@ allowance";
+"menuBar.compactAllowance" = "%@ %@";
 "menuBar.companionNotRunning" = "The local companion is not running.";
 "menuBar.companionStarting" = "Starting the local companion…";
 "menuBar.currentEvidence" = "Observed locally · verified current evidence";
 "menuBar.currentEvidenceWithAge" = "Observed %@ · verified current evidence";
 "menuBar.daysAgo" = "%d days ago";
 "menuBar.fiveHourAllowance" = "Five-hour allowance";
+"menuBar.fiveHourShort" = "5h";
 "menuBar.hoursAgo" = "%d hours ago";
 "menuBar.justNow" = "just now";
 "menuBar.lastObservationNotCurrent" = "Quota lanes were last observed, but are not current";
@@ -178,6 +184,7 @@
 "menuBar.resetMinutes" = "in %dm";
 "menuBar.retryLocalAnalysis" = "Retry Local Analysis";
 "menuBar.sevenDayAllowance" = "Seven-day allowance";
+"menuBar.sevenDayShort" = "7d";
 "menuBar.staleEvidenceHidden" = "Allowance values and reset countdowns are hidden.";
 "menuBar.updateLocalUsage" = "Update Local Usage";
 "menuBar.verifiedAllowanceMany" = "%d verified Codex allowances";

--- a/apps/macos/Resources/en.lproj/Localizable.strings
+++ b/apps/macos/Resources/en.lproj/Localizable.strings
@@ -26,8 +26,10 @@
 "settings.appearanceSystem" = "System";
 "settings.menuBarAllowance" = "Menu bar allowance";
 "settings.menuBarAllowanceDetail" = "Choose which fresh allowance percentage appears beside the menu-bar icon.";
-"settings.menuBarAllowanceFiveHour" = "5-hour only";
-"settings.menuBarAllowanceBoth" = "Both 5-hour and 7-day";
+"settings.menuBarAllowanceFiveHour" = "5-hour";
+"settings.menuBarAllowanceWeekly" = "Week";
+"settings.menuBarAllowanceBoth" = "5-hour + week";
+"settings.menuBarAllowanceOff" = "Off";
 "settings.automaticUpdates" = "Automatic updates";
 "settings.automaticUpdatesOff" = "Automatic downloads are off.";
 "settings.automaticUpdatesOn" = "Automatic downloads are on.";

--- a/apps/macos/Resources/es.lproj/Localizable.strings
+++ b/apps/macos/Resources/es.lproj/Localizable.strings
@@ -46,12 +46,14 @@
 "menuBar.analyzeLocalUsage" = "Analizar uso local";
 "menuBar.analyzingLocalUsage" = "Analizando uso local…";
 "menuBar.allowanceTitle" = "%@ · %@ de límite";
+"menuBar.compactAllowance" = "%@ %@";
 "menuBar.companionNotRunning" = "El acompañante local no se está ejecutando.";
 "menuBar.companionStarting" = "Iniciando el acompañante local…";
 "menuBar.currentEvidence" = "Observado localmente · evidencia actual verificada";
 "menuBar.currentEvidenceWithAge" = "Observado hace %@ · evidencia actual verificada";
 "menuBar.daysAgo" = "Hace %d días";
 "menuBar.fiveHourAllowance" = "Límite de cinco horas";
+"menuBar.fiveHourShort" = "5 h";
 "menuBar.hoursAgo" = "Hace %d horas";
 "menuBar.justNow" = "ahora mismo";
 "menuBar.lastObservationNotCurrent" = "Las ventanas de límite se observaron antes, pero no son actuales";
@@ -73,6 +75,7 @@
 "menuBar.resetMinutes" = "en %d min";
 "menuBar.retryLocalAnalysis" = "Reintentar análisis local";
 "menuBar.sevenDayAllowance" = "Límite de siete días";
+"menuBar.sevenDayShort" = "7 d";
 "menuBar.staleEvidenceHidden" = "Se ocultan los valores de límite y las cuentas atrás de reinicio.";
 "menuBar.updateLocalUsage" = "Actualizar uso local";
 "menuBar.verifiedAllowanceMany" = "%d límites de Codex verificados";
@@ -87,6 +90,10 @@
 "settings.appearancePickerHint" = "Elige cómo se ve TiboTattle.";
 "settings.appearanceSummary" = "Usa la apariencia de tu Mac de forma predeterminada.";
 "settings.appearanceSystem" = "Sistema";
+"settings.menuBarAllowance" = "Límite de la barra de menús";
+"settings.menuBarAllowanceDetail" = "Elige qué porcentaje de límite reciente aparece junto al icono de la barra de menús.";
+"settings.menuBarAllowanceFiveHour" = "Solo 5 horas";
+"settings.menuBarAllowanceBoth" = "5 horas y 7 días";
 "settings.automaticUpdates" = "Actualizaciones automáticas";
 "settings.automaticUpdatesOff" = "Las descargas automáticas están desactivadas.";
 "settings.automaticUpdatesOn" = "Las descargas automáticas están activadas.";

--- a/apps/macos/Resources/es.lproj/Localizable.strings
+++ b/apps/macos/Resources/es.lproj/Localizable.strings
@@ -92,8 +92,10 @@
 "settings.appearanceSystem" = "Sistema";
 "settings.menuBarAllowance" = "Límite de la barra de menús";
 "settings.menuBarAllowanceDetail" = "Elige qué porcentaje de límite reciente aparece junto al icono de la barra de menús.";
-"settings.menuBarAllowanceFiveHour" = "Solo 5 horas";
-"settings.menuBarAllowanceBoth" = "5 horas y 7 días";
+"settings.menuBarAllowanceFiveHour" = "5 horas";
+"settings.menuBarAllowanceWeekly" = "Semana";
+"settings.menuBarAllowanceBoth" = "5 horas + semana";
+"settings.menuBarAllowanceOff" = "Desactivado";
 "settings.automaticUpdates" = "Actualizaciones automáticas";
 "settings.automaticUpdatesOff" = "Las descargas automáticas están desactivadas.";
 "settings.automaticUpdatesOn" = "Las descargas automáticas están activadas.";

--- a/apps/macos/Resources/zh-Hans.lproj/Localizable.strings
+++ b/apps/macos/Resources/zh-Hans.lproj/Localizable.strings
@@ -92,8 +92,10 @@
 "settings.appearanceSystem" = "跟随系统";
 "settings.menuBarAllowance" = "菜单栏额度";
 "settings.menuBarAllowanceDetail" = "选择菜单栏图标旁显示哪个最新额度百分比。";
-"settings.menuBarAllowanceFiveHour" = "仅五小时";
-"settings.menuBarAllowanceBoth" = "五小时和七天";
+"settings.menuBarAllowanceFiveHour" = "五小时";
+"settings.menuBarAllowanceWeekly" = "每周";
+"settings.menuBarAllowanceBoth" = "五小时 + 每周";
+"settings.menuBarAllowanceOff" = "关闭";
 "settings.automaticUpdates" = "自动更新";
 "settings.automaticUpdatesOff" = "自动下载已关闭。";
 "settings.automaticUpdatesOn" = "自动下载已开启。";

--- a/apps/macos/Resources/zh-Hans.lproj/Localizable.strings
+++ b/apps/macos/Resources/zh-Hans.lproj/Localizable.strings
@@ -46,12 +46,14 @@
 "menuBar.analyzeLocalUsage" = "分析本地使用情况";
 "menuBar.analyzingLocalUsage" = "正在分析本地使用情况…";
 "menuBar.allowanceTitle" = "%@ · %@ 额度";
+"menuBar.compactAllowance" = "%@ %@";
 "menuBar.companionNotRunning" = "本地伴随程序没有运行。";
 "menuBar.companionStarting" = "正在启动本地伴随程序…";
 "menuBar.currentEvidence" = "已在本机观测 · 已验证的当前证据";
 "menuBar.currentEvidenceWithAge" = "%@前在本机观测 · 已验证的当前证据";
 "menuBar.daysAgo" = "%d 天前";
 "menuBar.fiveHourAllowance" = "五小时额度";
+"menuBar.fiveHourShort" = "5小时";
 "menuBar.hoursAgo" = "%d 小时前";
 "menuBar.justNow" = "刚刚";
 "menuBar.lastObservationNotCurrent" = "额度窗口曾被观测到，但不再是当前状态";
@@ -73,6 +75,7 @@
 "menuBar.resetMinutes" = "%d 分钟后";
 "menuBar.retryLocalAnalysis" = "重试本地分析";
 "menuBar.sevenDayAllowance" = "七天额度";
+"menuBar.sevenDayShort" = "7天";
 "menuBar.staleEvidenceHidden" = "额度数值和重置倒计时已隐藏。";
 "menuBar.updateLocalUsage" = "更新本地使用情况";
 "menuBar.verifiedAllowanceMany" = "%d 个已验证的 Codex 额度";
@@ -87,6 +90,10 @@
 "settings.appearancePickerHint" = "选择 TiboTattle 的外观。";
 "settings.appearanceSummary" = "默认使用这台 Mac 的外观。";
 "settings.appearanceSystem" = "跟随系统";
+"settings.menuBarAllowance" = "菜单栏额度";
+"settings.menuBarAllowanceDetail" = "选择菜单栏图标旁显示哪个最新额度百分比。";
+"settings.menuBarAllowanceFiveHour" = "仅五小时";
+"settings.menuBarAllowanceBoth" = "五小时和七天";
 "settings.automaticUpdates" = "自动更新";
 "settings.automaticUpdatesOff" = "自动下载已关闭。";
 "settings.automaticUpdatesOn" = "自动下载已开启。";

--- a/apps/macos/Sources/Localization.swift
+++ b/apps/macos/Sources/Localization.swift
@@ -214,12 +214,14 @@ enum TiboTattleLocalization {
         case menuBarAnalysisRequestRejected = "menuBar.analysisRequestRejected"
         case menuBarAnalyzingLocalUsage = "menuBar.analyzingLocalUsage"
         case menuBarAllowanceTitle = "menuBar.allowanceTitle"
+        case menuBarCompactAllowance = "menuBar.compactAllowance"
         case menuBarCompanionNotRunning = "menuBar.companionNotRunning"
         case menuBarCompanionStarting = "menuBar.companionStarting"
         case menuBarCurrentEvidence = "menuBar.currentEvidence"
         case menuBarCurrentEvidenceWithAge = "menuBar.currentEvidenceWithAge"
         case menuBarDaysAgo = "menuBar.daysAgo"
         case menuBarFiveHourAllowance = "menuBar.fiveHourAllowance"
+        case menuBarFiveHourShort = "menuBar.fiveHourShort"
         case menuBarFailureRecovery = "menuBar.failureRecovery"
         case menuBarHoursAgo = "menuBar.hoursAgo"
         case menuBarJustNow = "menuBar.justNow"
@@ -242,6 +244,7 @@ enum TiboTattleLocalization {
         case menuBarResetMinutes = "menuBar.resetMinutes"
         case menuBarRetryLocalAnalysis = "menuBar.retryLocalAnalysis"
         case menuBarSevenDayAllowance = "menuBar.sevenDayAllowance"
+        case menuBarSevenDayShort = "menuBar.sevenDayShort"
         case menuBarStaleEvidenceHidden = "menuBar.staleEvidenceHidden"
         case menuBarUpdateLocalUsage = "menuBar.updateLocalUsage"
         case menuBarVerifiedAllowanceMany = "menuBar.verifiedAllowanceMany"
@@ -263,6 +266,10 @@ enum TiboTattleLocalization {
         case settingsAppearancePickerHint = "settings.appearancePickerHint"
         case settingsAppearanceSummary = "settings.appearanceSummary"
         case settingsAppearanceSystem = "settings.appearanceSystem"
+        case settingsMenuBarAllowance = "settings.menuBarAllowance"
+        case settingsMenuBarAllowanceDetail = "settings.menuBarAllowanceDetail"
+        case settingsMenuBarAllowanceFiveHour = "settings.menuBarAllowanceFiveHour"
+        case settingsMenuBarAllowanceBoth = "settings.menuBarAllowanceBoth"
         case settingsAutomaticUpdates = "settings.automaticUpdates"
         case settingsAutomaticUpdatesOff = "settings.automaticUpdatesOff"
         case settingsAutomaticUpdatesOn = "settings.automaticUpdatesOn"
@@ -657,6 +664,8 @@ enum TiboTattleLocalization {
                 "Analyzing Local Usage…"
             case .menuBarAllowanceTitle:
                 "%@ · %@ allowance"
+            case .menuBarCompactAllowance:
+                "%@ %@"
             case .menuBarCompanionNotRunning:
                 "The local companion is not running."
             case .menuBarCompanionStarting:
@@ -669,6 +678,8 @@ enum TiboTattleLocalization {
                 "%d days ago"
             case .menuBarFiveHourAllowance:
                 "Five-hour allowance"
+            case .menuBarFiveHourShort:
+                "5h"
             case .menuBarFailureRecovery:
                 "Not running: %@. Open the window for the recovery step."
             case .menuBarHoursAgo:
@@ -713,6 +724,8 @@ enum TiboTattleLocalization {
                 "Retry Local Analysis"
             case .menuBarSevenDayAllowance:
                 "Seven-day allowance"
+            case .menuBarSevenDayShort:
+                "7d"
             case .menuBarStaleEvidenceHidden:
                 "Allowance values and reset countdowns are hidden."
             case .menuBarUpdateLocalUsage:
@@ -755,6 +768,14 @@ enum TiboTattleLocalization {
                 "Uses your Mac appearance by default."
             case .settingsAppearanceSystem:
                 "System"
+            case .settingsMenuBarAllowance:
+                "Menu bar allowance"
+            case .settingsMenuBarAllowanceDetail:
+                "Choose which fresh allowance percentage appears beside the menu-bar icon."
+            case .settingsMenuBarAllowanceFiveHour:
+                "5-hour only"
+            case .settingsMenuBarAllowanceBoth:
+                "Both 5-hour and 7-day"
             case .settingsAutomaticUpdates:
                 "Automatic updates"
             case .settingsAutomaticUpdatesOff:

--- a/apps/macos/Sources/Localization.swift
+++ b/apps/macos/Sources/Localization.swift
@@ -269,7 +269,9 @@ enum TiboTattleLocalization {
         case settingsMenuBarAllowance = "settings.menuBarAllowance"
         case settingsMenuBarAllowanceDetail = "settings.menuBarAllowanceDetail"
         case settingsMenuBarAllowanceFiveHour = "settings.menuBarAllowanceFiveHour"
+        case settingsMenuBarAllowanceWeekly = "settings.menuBarAllowanceWeekly"
         case settingsMenuBarAllowanceBoth = "settings.menuBarAllowanceBoth"
+        case settingsMenuBarAllowanceOff = "settings.menuBarAllowanceOff"
         case settingsAutomaticUpdates = "settings.automaticUpdates"
         case settingsAutomaticUpdatesOff = "settings.automaticUpdatesOff"
         case settingsAutomaticUpdatesOn = "settings.automaticUpdatesOn"
@@ -773,9 +775,13 @@ enum TiboTattleLocalization {
             case .settingsMenuBarAllowanceDetail:
                 "Choose which fresh allowance percentage appears beside the menu-bar icon."
             case .settingsMenuBarAllowanceFiveHour:
-                "5-hour only"
+                "5-hour"
+            case .settingsMenuBarAllowanceWeekly:
+                "Week"
             case .settingsMenuBarAllowanceBoth:
-                "Both 5-hour and 7-day"
+                "5-hour + week"
+            case .settingsMenuBarAllowanceOff:
+                "Off"
             case .settingsAutomaticUpdates:
                 "Automatic updates"
             case .settingsAutomaticUpdatesOff:

--- a/apps/macos/Sources/MenuBarStatus.swift
+++ b/apps/macos/Sources/MenuBarStatus.swift
@@ -285,6 +285,37 @@ private enum StatusGlyphState: Equatable {
     case unavailable
 }
 
+/// Which provider-reported Codex allowance appears in the compact status-item
+/// title. The drop-down menu continues to show every observed lane; this
+/// preference only controls the always-visible title beside the app mark.
+enum NativeMenuBarAllowanceDisplayPreference: String, CaseIterable {
+    case fiveHour = "five-hour"
+    case both
+
+    static let defaultsKey = "tibotattle.menu-bar-allowance.v1"
+    static let defaultPreference: Self = .fiveHour
+
+    static var current: Self {
+        current(in: .standard)
+    }
+
+    static func current(in defaults: UserDefaults) -> Self {
+        guard let rawValue = defaults.string(forKey: defaultsKey),
+              let preference = Self(rawValue: rawValue)
+        else {
+            return defaultPreference
+        }
+        return preference
+    }
+
+    static func set(
+        _ preference: Self,
+        in defaults: UserDefaults = .standard
+    ) {
+        defaults.set(preference.rawValue, forKey: defaultsKey)
+    }
+}
+
 /// A deliberately small observable contract for the native menu smoke test.
 /// It contains presentation facts only, never evidence values or an account
 /// identifier, so the packaged launcher can prove this surface without
@@ -329,12 +360,42 @@ struct MenuBarStatusSnapshot: Equatable {
     var lanes: [ObservedQuotaLane] = []
     var observedAt: Date?
     var failureSummary: String?
+    var allowanceDisplayPreference =
+        NativeMenuBarAllowanceDisplayPreference.defaultPreference
 
     /// Mirrors the dashboard's primary selection across the normal Codex
     /// allowance track. Other provider products are rejected while decoding,
     /// so they cannot become a fallback for the compact title.
     var primaryLane: ObservedQuotaLane? {
         lanes.first(where: \.isPrimary) ?? lanes.first
+    }
+
+    /// The compact title is intentionally limited to the normal Codex
+    /// five-hour and seven-day windows. A selected five-hour display never
+    /// falls back to the weekly lane when the five-hour observation is absent.
+    var compactDisplayLanes: [ObservedQuotaLane] {
+        switch allowanceDisplayPreference {
+        case .fiveHour:
+            return lanes.filter {
+                $0.durationMinutes == fiveHourWindowDurationMinutes
+            }
+        case .both:
+            return [
+                lanes.first {
+                    $0.durationMinutes == fiveHourWindowDurationMinutes
+                },
+                lanes.first {
+                    $0.durationMinutes == weeklyWindowDurationMinutes
+                },
+            ].compactMap { $0 }
+        }
+    }
+
+    /// The icon meter follows the most relevant compact lane. With both lanes
+    /// selected, the five-hour meter stays primary because it is the first
+    /// number shown in the title.
+    var primaryDisplayLane: ObservedQuotaLane? {
+        compactDisplayLanes.first
     }
 
     /// True only when the companion has published a loopback dashboard.
@@ -350,10 +411,19 @@ struct MenuBarStatusSnapshot: Equatable {
     var title: String {
         if companionReachable,
            evidence == .live,
-           let lane = primaryLane {
-            return TiboTattleLocalization.percentString(
-                lane.roundedRemainingPercent
-            )
+           !compactDisplayLanes.isEmpty {
+            return compactDisplayLanes.map { lane in
+                let label = lane.durationMinutes == fiveHourWindowDurationMinutes
+                    ? TiboTattleLocalization.string(.menuBarFiveHourShort)
+                    : TiboTattleLocalization.string(.menuBarSevenDayShort)
+                return TiboTattleLocalization.format(
+                    .menuBarCompactAllowance,
+                    label,
+                    TiboTattleLocalization.percentString(
+                        lane.roundedRemainingPercent
+                    )
+                )
+            }.joined(separator: " · ")
         }
         return phase == .analyzing
             ? analyzingPlaceholder
@@ -1061,6 +1131,8 @@ final class MenuBarStatusController: NSObject, NSMenuDelegate {
         self.productName = productName
         self.actions = actions
         self.brandBirdTemplate = Self.makeBrandBirdTemplate()
+        snapshot.allowanceDisplayPreference =
+            NativeMenuBarAllowanceDisplayPreference.current
         // Constructing the item touches only in-memory AppKit state: no
         // network, no disk, and no waiting. Every evidence read below is
         // asynchronous with a main-queue completion.
@@ -1245,6 +1317,16 @@ final class MenuBarStatusController: NSObject, NSMenuDelegate {
             .menuQuitProduct,
             productName
         )
+        render()
+    }
+
+    /// Applies the persisted compact-title preference without touching the
+    /// companion, its evidence, or the menu's quota rows.
+    func setAllowanceDisplayPreference(
+        _ preference: NativeMenuBarAllowanceDisplayPreference
+    ) {
+        guard !stopped else { return }
+        snapshot.allowanceDisplayPreference = preference
         render()
     }
 
@@ -1698,7 +1780,7 @@ final class MenuBarStatusController: NSObject, NSMenuDelegate {
         if snapshot.phase == .analyzing { return .analyzing }
         guard snapshot.phase == .ready else { return .unavailable }
         guard snapshot.evidence == .live,
-              let lane = snapshot.primaryLane
+              let lane = snapshot.primaryDisplayLane
         else {
             return snapshot.evidence == .stale ? .stale : .unavailable
         }

--- a/apps/macos/Sources/MenuBarStatus.swift
+++ b/apps/macos/Sources/MenuBarStatus.swift
@@ -283,6 +283,7 @@ private enum StatusGlyphState: Equatable {
     case stale
     case analyzing
     case unavailable
+    case off
 }
 
 /// Which provider-reported Codex allowance appears in the compact status-item
@@ -290,7 +291,9 @@ private enum StatusGlyphState: Equatable {
 /// preference only controls the always-visible title beside the app mark.
 enum NativeMenuBarAllowanceDisplayPreference: String, CaseIterable {
     case fiveHour = "five-hour"
+    case weekly = "weekly"
     case both
+    case off
 
     static let defaultsKey = "tibotattle.menu-bar-allowance.v1"
     static let defaultPreference: Self = .fiveHour
@@ -371,13 +374,17 @@ struct MenuBarStatusSnapshot: Equatable {
     }
 
     /// The compact title is intentionally limited to the normal Codex
-    /// five-hour and seven-day windows. A selected five-hour display never
-    /// falls back to the weekly lane when the five-hour observation is absent.
+    /// five-hour and seven-day windows. A selected lane never falls back to
+    /// another window, and `off` removes the compact percentage entirely.
     var compactDisplayLanes: [ObservedQuotaLane] {
         switch allowanceDisplayPreference {
         case .fiveHour:
             return lanes.filter {
                 $0.durationMinutes == fiveHourWindowDurationMinutes
+            }
+        case .weekly:
+            return lanes.filter {
+                $0.durationMinutes == weeklyWindowDurationMinutes
             }
         case .both:
             return [
@@ -388,12 +395,15 @@ struct MenuBarStatusSnapshot: Equatable {
                     $0.durationMinutes == weeklyWindowDurationMinutes
                 },
             ].compactMap { $0 }
+        case .off:
+            return []
         }
     }
 
     /// The icon meter follows the most relevant compact lane. With both lanes
     /// selected, the five-hour meter stays primary because it is the first
-    /// number shown in the title.
+    /// number shown in the title. With the display off, no allowance meter is
+    /// drawn.
     var primaryDisplayLane: ObservedQuotaLane? {
         compactDisplayLanes.first
     }
@@ -407,12 +417,26 @@ struct MenuBarStatusSnapshot: Equatable {
     /// an explicit pass checks for newer evidence, so analysis state does not
     /// replace it. `…` means "a pass is running without a live number"; `–`
     /// means "no number can be shown honestly right now" and the menu explains
-    /// which case applies.
+    /// which case applies. A single-window preference uses only the percentage
+    /// to keep the status item narrow; combined mode keeps its short labels so
+    /// each value remains identifiable if one observation is temporarily
+    /// unavailable.
     var title: String {
+        if allowanceDisplayPreference == .off {
+            return ""
+        }
         if companionReachable,
            evidence == .live,
            !compactDisplayLanes.isEmpty {
-            return compactDisplayLanes.map { lane in
+            let displayLanes = compactDisplayLanes
+            if allowanceDisplayPreference != .both,
+               displayLanes.count == 1,
+               let lane = displayLanes.first {
+                return TiboTattleLocalization.percentString(
+                    lane.roundedRemainingPercent
+                )
+            }
+            return displayLanes.map { lane in
                 let label = lane.durationMinutes == fiveHourWindowDurationMinutes
                     ? TiboTattleLocalization.string(.menuBarFiveHourShort)
                     : TiboTattleLocalization.string(.menuBarSevenDayShort)
@@ -1759,6 +1783,8 @@ final class MenuBarStatusController: NSObject, NSMenuDelegate {
             0.58
         case .unavailable:
             0.42
+        case .off:
+            1
         }
         base.draw(
             in: birdRect,
@@ -1777,6 +1803,9 @@ final class MenuBarStatusController: NSObject, NSMenuDelegate {
     private static func glyphState(
         for snapshot: MenuBarStatusSnapshot
     ) -> StatusGlyphState {
+        if snapshot.allowanceDisplayPreference == .off {
+            return .off
+        }
         if snapshot.phase == .analyzing { return .analyzing }
         guard snapshot.phase == .ready else { return .unavailable }
         guard snapshot.evidence == .live,
@@ -1960,6 +1989,8 @@ final class MenuBarStatusController: NSObject, NSMenuDelegate {
             NSColor.black.withAlphaComponent(0.42).setStroke()
             track.lineWidth = 0.8
             track.stroke()
+        case .off:
+            break
         }
     }
 

--- a/apps/macos/UsageMonitorApp.swift
+++ b/apps/macos/UsageMonitorApp.swift
@@ -3670,6 +3670,7 @@ private final class AppDelegate: NSObject, NSApplicationDelegate,
     private weak var settingsQuotaNotificationThresholds: NSSegmentedControl?
     private weak var settingsQuotaNotificationStatusLabel: NSTextField?
     private weak var settingsAppearancePicker: NSPopUpButton?
+    private weak var settingsMenuBarAllowancePicker: NSPopUpButton?
     private weak var settingsRefreshIntervalPicker: NSPopUpButton?
     private let nativeEvidenceReader = LocalCompanionEvidenceReader()
     private var quotaNotificationCoordinator: QuotaNotificationCoordinator?
@@ -5779,6 +5780,16 @@ private final class AppDelegate: NSObject, NSApplicationDelegate,
         }
     }
 
+    private func updateMenuBarAllowanceSettingsControl() {
+        guard let picker = settingsMenuBarAllowancePicker else { return }
+        let preference = NativeMenuBarAllowanceDisplayPreference.current
+        if let index = picker.itemArray.firstIndex(where: {
+            ($0.representedObject as? String) == preference.rawValue
+        }) {
+            picker.selectItem(at: index)
+        }
+    }
+
     private func applyAppearancePreference(
         notifyDashboard: Bool = true
     ) {
@@ -6189,6 +6200,23 @@ private final class AppDelegate: NSObject, NSApplicationDelegate,
         applyAppearancePreference()
     }
 
+    @objc private func selectMenuBarAllowancePreference(
+        _ sender: NSPopUpButton
+    ) {
+        guard let rawPreference = sender.selectedItem?.representedObject
+            as? String,
+              let preference = NativeMenuBarAllowanceDisplayPreference(
+                  rawValue: rawPreference
+              )
+        else {
+            updateMenuBarAllowanceSettingsControl()
+            return
+        }
+        NativeMenuBarAllowanceDisplayPreference.set(preference)
+        menuBarStatus?.setAllowanceDisplayPreference(preference)
+        updateMenuBarAllowanceSettingsControl()
+    }
+
     @objc private func selectLanguagePreference(_ sender: NSPopUpButton) {
         guard let rawPreference = sender.selectedItem?.representedObject
             as? String,
@@ -6261,6 +6289,7 @@ private final class AppDelegate: NSObject, NSApplicationDelegate,
         settingsAboutAutomaticUpdatesDetailLabel = nil
         settingsCheckForUpdatesButton = nil
         settingsAppearancePicker = nil
+        settingsMenuBarAllowancePicker = nil
         settingsRefreshIntervalPicker = nil
         if shouldRestoreSettings {
             showSettings(selecting: selectedSettingsTab)
@@ -6298,6 +6327,7 @@ private final class AppDelegate: NSObject, NSApplicationDelegate,
             updateSettingsCodexHomeSummary()
             updateAutomaticUpdatesSettingsControl()
             updateAppearanceSettingsControl()
+            updateMenuBarAllowanceSettingsControl()
             updateRefreshIntervalSettingsControl()
             updateStartAtLoginSettingsControl()
             quotaNotificationCoordinator?.refreshAuthorization()
@@ -6363,6 +6393,52 @@ private final class AppDelegate: NSObject, NSApplicationDelegate,
                 appearanceRow,
                 settingsLabel(
                     TiboTattleLocalization.string(.settingsAppearanceSummary),
+                    font: .systemFont(ofSize: 12),
+                    color: .secondaryLabelColor
+                ),
+            ]
+        )
+        let menuBarAllowancePicker = NSPopUpButton(
+            frame: .zero,
+            pullsDown: false
+        )
+        let menuBarAllowanceChoices: [(
+            NativeMenuBarAllowanceDisplayPreference,
+            TiboTattleLocalization.Key
+        )] = [
+            (.fiveHour, .settingsMenuBarAllowanceFiveHour),
+            (.both, .settingsMenuBarAllowanceBoth),
+        ]
+        for (preference, key) in menuBarAllowanceChoices {
+            menuBarAllowancePicker.addItem(
+                withTitle: TiboTattleLocalization.string(key)
+            )
+            menuBarAllowancePicker.lastItem?.representedObject =
+                preference.rawValue
+        }
+        menuBarAllowancePicker.target = self
+        menuBarAllowancePicker.action =
+            #selector(selectMenuBarAllowancePreference(_:))
+        menuBarAllowancePicker.toolTip = TiboTattleLocalization.string(
+            .settingsMenuBarAllowanceDetail
+        )
+        menuBarAllowancePicker.setAccessibilityLabel(
+            TiboTattleLocalization.string(.settingsMenuBarAllowance)
+        )
+        settingsMenuBarAllowancePicker = menuBarAllowancePicker
+        updateMenuBarAllowanceSettingsControl()
+        let menuBarAllowanceRow = NSStackView(views: [menuBarAllowancePicker])
+        menuBarAllowanceRow.orientation = .horizontal
+        menuBarAllowanceRow.alignment = .centerY
+        let menuBarAllowanceSection = settingsGroup(
+            title: TiboTattleLocalization.string(.settingsMenuBarAllowance),
+            symbolName: "chart.bar",
+            views: [
+                menuBarAllowanceRow,
+                settingsLabel(
+                    TiboTattleLocalization.string(
+                        .settingsMenuBarAllowanceDetail
+                    ),
                     font: .systemFont(ofSize: 12),
                     color: .secondaryLabelColor
                 ),
@@ -6662,6 +6738,7 @@ private final class AppDelegate: NSObject, NSApplicationDelegate,
             summary: TiboTattleLocalization.string(.settingsGeneralSummary),
             views: [
                 appearanceSection,
+                menuBarAllowanceSection,
                 languageSection,
                 sourceSection,
                 refreshIntervalSection,
@@ -8568,12 +8645,24 @@ private enum MenuBarContractSmokeTest {
             observedAt: observedAt,
             isPrimary: true
         )
+        let fiveHourLane = ObservedQuotaLane(
+            label: TiboTattleLocalization.string(.menuBarFiveHourAllowance),
+            remainingPercent: 63,
+            durationMinutes: CodexQuotaWindowDuration.fiveHourMinutes,
+            resetAt: resetAt,
+            observedAt: observedAt,
+            isPrimary: false
+        )
         let weeklyPosition = weeklyWindowPosition(weeklyLane)
         var liveSnapshot = MenuBarStatusSnapshot()
         liveSnapshot.phase = .ready
         liveSnapshot.evidence = .live
-        liveSnapshot.lanes = [weeklyLane]
+        liveSnapshot.lanes = [weeklyLane, fiveHourLane]
         liveSnapshot.observedAt = observedAt
+        var bothLiveSnapshot = liveSnapshot
+        bothLiveSnapshot.allowanceDisplayPreference = .both
+        var weeklyOnlySnapshot = liveSnapshot
+        weeklyOnlySnapshot.lanes = [weeklyLane]
         let liveSummary = liveSnapshot.laneSummary(
             weeklyLane,
             now: observedAt
@@ -8591,7 +8680,23 @@ private enum MenuBarContractSmokeTest {
         var unavailableLiveSnapshot = liveSnapshot
         unavailableLiveSnapshot.phase = .unavailable
         let reset = resetCountdown(resetAt, now: observedAt)
-        let expectedLiveTitle = TiboTattleLocalization.percentString(71)
+        let expectedLiveTitle = TiboTattleLocalization.format(
+            .menuBarCompactAllowance,
+            TiboTattleLocalization.string(.menuBarFiveHourShort),
+            TiboTattleLocalization.percentString(63)
+        )
+        let expectedBothLiveTitle = [
+            TiboTattleLocalization.format(
+                .menuBarCompactAllowance,
+                TiboTattleLocalization.string(.menuBarFiveHourShort),
+                TiboTattleLocalization.percentString(63)
+            ),
+            TiboTattleLocalization.format(
+                .menuBarCompactAllowance,
+                TiboTattleLocalization.string(.menuBarSevenDayShort),
+                TiboTattleLocalization.percentString(71)
+            ),
+        ].joined(separator: " · ")
         let expectedLiveSummary = reset.map {
             TiboTattleLocalization.format(
                 .menuBarQuotaWeeklyPositionResets,
@@ -8635,7 +8740,10 @@ private enum MenuBarContractSmokeTest {
                   elapsedPercent: 24,
                   usedPercent: 29
               ),
+              liveSnapshot.allowanceDisplayPreference == .fiveHour,
               liveSnapshot.title == expectedLiveTitle,
+              bothLiveSnapshot.title == expectedBothLiveTitle,
+              weeklyOnlySnapshot.title == "–",
               analyzingLiveSnapshot.title == expectedLiveTitle,
               analyzingWithoutLiveEvidence.title == "…",
               staleSnapshot.title == "–",
@@ -8654,6 +8762,7 @@ private enum MenuBarContractSmokeTest {
                 + "shortcuts=cmd-r,cmd-comma,cmd-q "
                 + "dismissal=native,escape,same-app,deactivation "
                 + "weekly_position=fresh-only "
+                + "compact_allowance=five-hour-or-both "
                 + "analysis_title=live-fallback"
         )
         return 0

--- a/apps/macos/UsageMonitorApp.swift
+++ b/apps/macos/UsageMonitorApp.swift
@@ -6407,7 +6407,9 @@ private final class AppDelegate: NSObject, NSApplicationDelegate,
             TiboTattleLocalization.Key
         )] = [
             (.fiveHour, .settingsMenuBarAllowanceFiveHour),
+            (.weekly, .settingsMenuBarAllowanceWeekly),
             (.both, .settingsMenuBarAllowanceBoth),
+            (.off, .settingsMenuBarAllowanceOff),
         ]
         for (preference, key) in menuBarAllowanceChoices {
             menuBarAllowancePicker.addItem(
@@ -8659,8 +8661,15 @@ private enum MenuBarContractSmokeTest {
         liveSnapshot.evidence = .live
         liveSnapshot.lanes = [weeklyLane, fiveHourLane]
         liveSnapshot.observedAt = observedAt
+        var weeklyDisplaySnapshot = liveSnapshot
+        weeklyDisplaySnapshot.allowanceDisplayPreference = .weekly
         var bothLiveSnapshot = liveSnapshot
         bothLiveSnapshot.allowanceDisplayPreference = .both
+        var bothWeeklyOnlySnapshot = liveSnapshot
+        bothWeeklyOnlySnapshot.lanes = [weeklyLane]
+        bothWeeklyOnlySnapshot.allowanceDisplayPreference = .both
+        var offDisplaySnapshot = liveSnapshot
+        offDisplaySnapshot.allowanceDisplayPreference = .off
         var weeklyOnlySnapshot = liveSnapshot
         weeklyOnlySnapshot.lanes = [weeklyLane]
         let liveSummary = liveSnapshot.laneSummary(
@@ -8680,10 +8689,8 @@ private enum MenuBarContractSmokeTest {
         var unavailableLiveSnapshot = liveSnapshot
         unavailableLiveSnapshot.phase = .unavailable
         let reset = resetCountdown(resetAt, now: observedAt)
-        let expectedLiveTitle = TiboTattleLocalization.format(
-            .menuBarCompactAllowance,
-            TiboTattleLocalization.string(.menuBarFiveHourShort),
-            TiboTattleLocalization.percentString(63)
+        let expectedLiveTitle = TiboTattleLocalization.percentString(
+            63
         )
         let expectedBothLiveTitle = [
             TiboTattleLocalization.format(
@@ -8697,6 +8704,9 @@ private enum MenuBarContractSmokeTest {
                 TiboTattleLocalization.percentString(71)
             ),
         ].joined(separator: " · ")
+        let expectedWeeklyLiveTitle = TiboTattleLocalization.percentString(
+            71
+        )
         let expectedLiveSummary = reset.map {
             TiboTattleLocalization.format(
                 .menuBarQuotaWeeklyPositionResets,
@@ -8742,7 +8752,14 @@ private enum MenuBarContractSmokeTest {
               ),
               liveSnapshot.allowanceDisplayPreference == .fiveHour,
               liveSnapshot.title == expectedLiveTitle,
+              weeklyDisplaySnapshot.title == expectedWeeklyLiveTitle,
               bothLiveSnapshot.title == expectedBothLiveTitle,
+              bothWeeklyOnlySnapshot.title == TiboTattleLocalization.format(
+                  .menuBarCompactAllowance,
+                  TiboTattleLocalization.string(.menuBarSevenDayShort),
+                  TiboTattleLocalization.percentString(71)
+              ),
+              offDisplaySnapshot.title.isEmpty,
               weeklyOnlySnapshot.title == "–",
               analyzingLiveSnapshot.title == expectedLiveTitle,
               analyzingWithoutLiveEvidence.title == "…",
@@ -8762,7 +8779,7 @@ private enum MenuBarContractSmokeTest {
                 + "shortcuts=cmd-r,cmd-comma,cmd-q "
                 + "dismissal=native,escape,same-app,deactivation "
                 + "weekly_position=fresh-only "
-                + "compact_allowance=five-hour-or-both "
+                + "compact_allowance=five-hour,weekly,both,off "
                 + "analysis_title=live-fallback"
         )
         return 0

--- a/test/macos-app-bundle.test.js
+++ b/test/macos-app-bundle.test.js
@@ -978,7 +978,7 @@ test("native launcher keeps the requested foreground-only lifecycle", async () =
   assert.ok(generalSettings, "general settings page wiring should be present");
   assert.match(
     generalSettings,
-    /appearanceSection[\s\S]*languageSection[\s\S]*sourceSection[\s\S]*refreshIntervalSection[\s\S]*startAtLoginSection/u,
+    /appearanceSection[\s\S]*menuBarAllowanceSection[\s\S]*languageSection[\s\S]*sourceSection[\s\S]*refreshIntervalSection[\s\S]*startAtLoginSection/u,
   );
   assert.doesNotMatch(generalSettings, /quotaNotificationsSection/u);
   assert.doesNotMatch(
@@ -1034,6 +1034,16 @@ test("native launcher keeps the requested foreground-only lifecycle", async () =
   assert.match(settingsSource, /symbolName: "circle\.lefthalf\.filled"/u);
   assert.match(settingsSource, /symbolName: "folder"/u);
   assert.match(settingsSource, /symbolName: "clock"/u);
+  assert.match(settingsSource, /symbolName: "chart\.bar"/u);
+  assert.match(settingsSource, /settingsMenuBarAllowancePicker/u);
+  assert.match(
+    settingsSource,
+    /NativeMenuBarAllowanceDisplayPreference[\s\S]*?\.fiveHour[\s\S]*?\.settingsMenuBarAllowanceFiveHour[\s\S]*?\.both[\s\S]*?\.settingsMenuBarAllowanceBoth/u,
+  );
+  assert.match(
+    source,
+    /NativeMenuBarAllowanceDisplayPreference\.set\(preference\)[\s\S]*?menuBarStatus\?\.setAllowanceDisplayPreference\(preference\)/u,
+  );
   assert.match(source, /settingsOpenNotifications/u);
   assert.match(source, /x-apple\.systempreferences:com\.apple\.Notifications-Settings\.extension/u);
   assert.match(source, /case \.unverified:[\s\S]*?settingsCheckForUpdates/u);
@@ -2316,8 +2326,16 @@ test("menu-bar status item degrades honestly and never invents allowance evidenc
   // available; stale, absent, starting, and failed states remain non-numeric.
   assert.match(
     source,
-    /if companionReachable,\s*evidence == \.live,\s*let lane = primaryLane \{\s*return TiboTattleLocalization\.percentString\(\s*lane\.roundedRemainingPercent\s*\)/u,
+    /if companionReachable,\s*evidence == \.live,\s*!compactDisplayLanes\.isEmpty/u,
   );
+  assert.match(
+    source,
+    /enum NativeMenuBarAllowanceDisplayPreference: String, CaseIterable/u,
+  );
+  assert.match(source, /static let defaultsKey = "tibotattle\.menu-bar-allowance\.v1"/u);
+  assert.match(source, /static let defaultPreference: Self = \.fiveHour/u);
+  assert.match(source, /case fiveHour = "five-hour"[\s\S]*?case both/u);
+  assert.match(source, /let lane = snapshot\.primaryDisplayLane/u);
   assert.match(
     source,
     /return phase == \.analyzing\s*\? analyzingPlaceholder\s*:\s*unknownPlaceholder/u,

--- a/test/macos-app-bundle.test.js
+++ b/test/macos-app-bundle.test.js
@@ -1038,7 +1038,7 @@ test("native launcher keeps the requested foreground-only lifecycle", async () =
   assert.match(settingsSource, /settingsMenuBarAllowancePicker/u);
   assert.match(
     settingsSource,
-    /NativeMenuBarAllowanceDisplayPreference[\s\S]*?\.fiveHour[\s\S]*?\.settingsMenuBarAllowanceFiveHour[\s\S]*?\.both[\s\S]*?\.settingsMenuBarAllowanceBoth/u,
+    /NativeMenuBarAllowanceDisplayPreference[\s\S]*?\.fiveHour[\s\S]*?\.settingsMenuBarAllowanceFiveHour[\s\S]*?\.weekly[\s\S]*?\.settingsMenuBarAllowanceWeekly[\s\S]*?\.both[\s\S]*?\.settingsMenuBarAllowanceBoth[\s\S]*?\.off[\s\S]*?\.settingsMenuBarAllowanceOff/u,
   );
   assert.match(
     source,
@@ -2334,7 +2334,10 @@ test("menu-bar status item degrades honestly and never invents allowance evidenc
   );
   assert.match(source, /static let defaultsKey = "tibotattle\.menu-bar-allowance\.v1"/u);
   assert.match(source, /static let defaultPreference: Self = \.fiveHour/u);
-  assert.match(source, /case fiveHour = "five-hour"[\s\S]*?case both/u);
+  assert.match(
+    source,
+    /case fiveHour = "five-hour"[\s\S]*?case weekly = "weekly"[\s\S]*?case both[\s\S]*?case off/u,
+  );
   assert.match(source, /let lane = snapshot\.primaryDisplayLane/u);
   assert.match(
     source,


### PR DESCRIPTION
## Summary

Adds a compact, user-selectable menu bar allowance display for Codex usage.

## Display choices

- 5-hour: percentage only, for example 63%
- Week: percentage only, for example 94%
- 5-hour + week: 5h 63% · 7d 94%
- Off: hides the allowance title while keeping the app menu available

Single-window mode intentionally omits the window label to keep the menu bar narrow. Combined mode keeps short labels so the two percentages remain distinguishable. Missing evidence is not replaced with an invented value.

## Verification

- Native source lane: 49 passed, 3 skipped, 0 failed
- Swift typecheck passed
- Local app bundle built and launched successfully
- Local preview displayed companion-reported allowance data
- No companion data-fetching behavior was changed