### PR TITLE
Fix homepage community graph alignment

### DIFF
--- a/apps/web/public/styles.css
+++ b/apps/web/public/styles.css
@@ -2912,7 +2912,7 @@ footer p { margin: 0; }
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr));
   gap: clamp(42px, 4.5vw, 68px);
-  align-items: center;
+  align-items: start;
   min-height: min(790px, calc(100vh - 74px));
   padding:
     clamp(62px, 8vw, 104px)

--- a/apps/web/test/community-site.test.mjs
+++ b/apps/web/test/community-site.test.mjs
@@ -908,11 +908,16 @@ test("the installer checksum action copies only a complete SHA-256 digest", asyn
   );
 });
 
-test("the public hero keeps equal columns and a bounded stacked preview", async () => {
+test("the public hero keeps equal top-aligned columns and a bounded stacked preview", async () => {
   const styles = await readFile(new URL("../public/styles.css", import.meta.url), "utf8");
   assert.match(
     styles,
     /grid-template-columns: repeat\(2, minmax\(0, 1fr\)\);/u,
+  );
+  assert.match(
+    styles,
+    /\.community-site \.product-hero \{[\s\S]*?align-items: start;/u,
+    "OS panel height changes must not vertically recenter the community graph",
   );
   assert.match(styles, /@media \(max-width: 1120px\)/u);
   assert.match(styles, /width: min\(100%, 620px\);/u);


### PR DESCRIPTION
Top-aligns the homepage community graph with the headline so changing between OS panels does not move it. Adds a regression assertion for the grid alignment. Validation: product UI 357/357; release-site 33/33; browser QA measured a 0.004px macOS-to-Windows document-position variance.