### PR TITLE
fix(codex): fail closed on orphaned inline forks and guard the legacy collector

### DIFF
--- a/src/passive-collector.js
+++ b/src/passive-collector.js
@@ -131,6 +131,8 @@ const DIAGNOSTIC_COUNT_FIELDS = Object.freeze([
   "tierSettingEvents",
   "tierSettingOmissions",
   "malformedTierSettingEvents",
+  "forkReplayEventsSkipped",
+  "forkReplayToolCallsSkipped",
 ]);
 const COLLECTOR_RESOURCE_LIMIT_CODES = Object.freeze({
   directory_entries: "collector_resource_directory_entries_limit_exceeded",
@@ -222,6 +224,8 @@ function emptyCheckpoint(nowIso, backfill, backfillSinceAt = null) {
       tierSettingEvents: 0,
       tierSettingOmissions: 0,
       malformedTierSettingEvents: 0,
+      forkReplayEventsSkipped: 0,
+      forkReplayToolCallsSkipped: 0,
       tierSettingCounts: {},
     },
   };
@@ -725,12 +729,20 @@ function rolloutRecord({ record, state, receivedAt, checkpoint }) {
     ? "provisional_fresh_app_server_marker"
     : "unavailable_no_fresh_contemporaneous_marker";
   if (record.type === "turn_context") {
+    // Any own turn_context ends an inline fork's replayed prefix: Codex
+    // writes the inherited history before the child's first genuine turn.
+    state.ownTurnContextSeen = true;
     if (typeof record.payload?.model === "string") state.currentModel = record.payload.model;
     return null;
   }
   if (record.type === "response_item") {
     const type = record.payload?.type;
     if (type !== "function_call" && type !== "custom_tool_call") return null;
+    if (state.isInlineFork === true && state.ownTurnContextSeen !== true) {
+      checkpoint.diagnostics.forkReplayToolCallsSkipped
+        = (checkpoint.diagnostics.forkReplayToolCallsSkipped ?? 0) + 1;
+      return null;
+    }
     const safe = {
       schemaVersion: RECORD_SCHEMA_VERSION,
       kind: "codex_tool_class_event",
@@ -754,6 +766,17 @@ function rolloutRecord({ record, state, receivedAt, checkpoint }) {
   const last = normalizeTokenUsage(info?.last_token_usage);
   if ((info?.total_token_usage && !total) || (info?.last_token_usage && !last)) {
     checkpoint.diagnostics.malformedUsageRecords += 1;
+  }
+  if (state.isInlineFork === true && state.ownTurnContextSeen !== true) {
+    // Replayed parent turns inside an inline fork are not new spend, and
+    // their rate-limit windows carry rewritten timestamps. A skipped row
+    // still rebases the cumulative baseline — without that, the first
+    // genuine post-fork turn would be charged the entire inherited total as
+    // one enormous delta.
+    if (total) state.previousTotals = total;
+    checkpoint.diagnostics.forkReplayEventsSkipped
+      = (checkpoint.diagnostics.forkReplayEventsSkipped ?? 0) + 1;
+    return null;
   }
   let usage = null;
   if (total) {
@@ -972,6 +995,11 @@ export async function ingestRolloutUpdates({
         tailSeeded: initializeAtEnd || boundedRecentTail,
         surfaceClassification: lineage.surfaceClassification,
         lineageDisposition: lineage.surfaceClassification?.lineageDisposition ?? "standalone",
+        isInlineFork: lineage.isInlineFork === true,
+        // Codex writes an inline fork's replayed parent history before the
+        // child's first own `turn_context`; a prelude that already carries a
+        // model therefore proves the fork boundary is behind this cursor.
+        ownTurnContextSeen: seed.currentModel !== null,
       };
       if (boundedRecentTail) {
         const seedLatestMs = Date.parse(seed.latestRelevantAt);
@@ -1014,6 +1042,9 @@ export async function ingestRolloutUpdates({
       const effectiveOffset = file.metadata.size < state.offset ? 0 : state.offset;
       const mainRead = Math.max(0, file.metadata.size - effectiveOffset);
       const lineageRead = state.surfaceClassification
+          && (state.isInlineFork !== undefined
+            || state.lineageDisposition === "standalone"
+            || state.lineageDisposition === "parent_linked")
         ? 0
         : Math.min(file.metadata.size, maximumLineagePrefixBytes);
       const seedRead = state.currentModel === null
@@ -1024,12 +1055,36 @@ export async function ingestRolloutUpdates({
         : 0;
       if (!reserveSourceBytes(mainRead + lineageRead + seedRead)) break;
     }
-    if (!state.surfaceClassification) {
+    if (state.isInlineFork === undefined
+        && (state.lineageDisposition === "standalone"
+          || state.lineageDisposition === "parent_linked")) {
+      // A persisted non-forked disposition already proves this is not an
+      // inline fork, so the pre-upgrade migration costs no I/O here. Without
+      // this, the first post-upgrade run would reserve min(size, 1 MiB) of
+      // budget per tracked file and bounded-pause a large corpus before its
+      // newest — live — files were reached. Only "forked" dispositions need
+      // the re-read below to split inline forks from paginated continuations.
+      state.isInlineFork = false;
+      if (state.ownTurnContextSeen === undefined) {
+        state.ownTurnContextSeen = state.currentModel !== null;
+      }
+      markChanged();
+    }
+    if (!state.surfaceClassification || state.isInlineFork === undefined) {
       const lineage = await readRolloutLineage(file.path, {
         maximumTotalBytes: maximumLineagePrefixBytes,
       });
       state.surfaceClassification = lineage.surfaceClassification;
       state.lineageDisposition = lineage.surfaceClassification?.lineageDisposition ?? "standalone";
+      state.isInlineFork = lineage.isInlineFork === true;
+      if (state.ownTurnContextSeen === undefined) {
+        // A checkpoint from before this field: the cursor has already
+        // consumed some prefix. A known model means at least one own or
+        // replayed turn was seen; treating it as past-the-boundary matches
+        // the tail-seed rule and only ever errs toward counting, for a file
+        // whose replay damage predates the guard anyway.
+        state.ownTurnContextSeen = state.currentModel !== null;
+      }
       markChanged();
     }
     if (file.metadata.size < state.offset) {
@@ -1038,6 +1093,10 @@ export async function ingestRolloutUpdates({
       state.currentModel = null;
       state.tierState = null;
       state.tailSeeded = false;
+      // The rescan walks the replayed fork prefix again from byte zero, so
+      // the boundary must be re-derived — a stale true here would disable
+      // both fork guards for the whole rewritten file.
+      state.ownTurnContextSeen = false;
       checkpoint.diagnostics.filesTruncated += 1;
       markChanged();
     }
@@ -1046,6 +1105,12 @@ export async function ingestRolloutUpdates({
       state.currentModel = seed.currentModel;
       if (state.previousTotals === null) state.previousTotals = seed.previousTotals;
       if (state.tierState === null) state.tierState = seed.tierState;
+      // A model in the prelude implies a turn_context behind the cursor, so
+      // the fork boundary is already resolved. The converse is bounded, not
+      // exact: a giant line can push every turn_context out of the prelude
+      // window, in which case at most one in-flight fork turn is withheld
+      // (counted in forkReplayEventsSkipped) until the next turn_context.
+      if (seed.currentModel !== null) state.ownTurnContextSeen = true;
       state.tailSeeded = true;
       markChanged();
     }

--- a/src/providers/codex/log-ingestion.js
+++ b/src/providers/codex/log-ingestion.js
@@ -79,6 +79,7 @@ export function createCodexLogIngestion({
     const diagnostics = {
       filesScanned: rolloutInfos.length,
       lineageParentsMissing: 0,
+      forkRolloutsFailedClosed: 0,
       malformedLines: 0,
       malformedTimestamps: 0,
       malformedAccountingRecords: 0,
@@ -245,7 +246,9 @@ export function createCodexLogIngestion({
           && info.lineage.parentId
         ? snapshotsBySession.get(info.lineage.parentId)
         : null;
-      if (info.lineage.isInlineFork === true && !inheritedSnapshots) {
+      const forkParentUnavailable = info.lineage.isInlineFork === true
+        && !inheritedSnapshots;
+      if (forkParentUnavailable) {
         diagnostics.lineageParentsMissing += 1;
       }
       const rolloutSnapshots = collectOwnSnapshots
@@ -253,6 +256,48 @@ export function createCodexLogIngestion({
         : discardedSnapshots;
       for (const snapshot of historySeed?.snapshots ?? []) {
         rolloutSnapshots.add(snapshot);
+      }
+      if (forkParentUnavailable) {
+        // An inline fork replays its parent's entire history into its own
+        // file, and only the parent's cumulative-snapshot keys can prove
+        // which of this file's records are that replay. Discovery pulls
+        // lineage parents into the batch even when they fall outside the
+        // requested window, so reaching here means the parent rollout is
+        // genuinely unavailable (rotated away, or its group quarantined
+        // without members). The parser's own no-turn-context-yet rule would
+        // still skip the replay shape Codex writes today, but that rule is a
+        // heuristic over the current replay format, and a replay it fails to
+        // recognise is charged as fresh spend at disk speed (measured 92.7x
+        // weekly inflation in a naive count). Accounting fails closed
+        // instead: this rollout contributes no events this scan. Its own
+        // keys are still collected — they include the replayed ancestral
+        // prefix, so a descendant fork scanned in this batch keeps full
+        // replay suppression even though the common ancestor is gone.
+        if (collectOwnSnapshots) {
+          await withRolloutInput(info, async (sourceInput) => {
+            await parser.collectCumulativeSnapshotKeys(
+              sourceInput,
+              rolloutSnapshots,
+              resourceGuard,
+              info.size,
+              signal,
+            );
+          });
+          if (info.lineage.sessionId) {
+            snapshotsBySession.set(info.lineage.sessionId, rolloutSnapshots);
+          }
+        }
+        diagnostics.forkRolloutsFailedClosed += 1;
+        // The skip also withholds this rollout's rate-limit snapshots and
+        // open-task markers. Quota telemetry is redundant across files, but
+        // the experiment harness stops controlled runs on
+        // activeTaskRolloutsAtEnd — so a recently-written orphan fork must
+        // still count as possibly-active, or a preflight would read a busy
+        // machine as idle.
+        if (info.mtimeMs >= activeCutoffMs) {
+          diagnostics.activeTaskRolloutsAtEnd += 1;
+        }
+        continue;
       }
       if (info.lineage.sessionId
           && excludedSessions.has(info.lineage.sessionId)) {

--- a/test/codex-log-scan-privacy.test.js
+++ b/test/codex-log-scan-privacy.test.js
@@ -205,6 +205,17 @@ async function privacyFixture() {
 test("raw Codex scan callbacks and result retain accounting semantics without exposing source content", async () => {
   const fixture = await privacyFixture();
   try {
+    // The fork-parent canary must resolve to a real (content-free) rollout:
+    // an unresolvable inline-fork parent now fails accounting closed by
+    // design, and this test is probing privacy, not orphan-fork semantics.
+    await writeFile(
+      join(fixture.codexHome, "archived_sessions", "rollout-2026-07-30T11-00-00-parent-canary.jsonl"),
+      `${JSON.stringify({
+        timestamp: EVENT_AT,
+        type: "session_meta",
+        payload: { id: RAW_CANARIES.parentId },
+      })}\n`,
+    );
     const usageEvents = [];
     const rateLimitSnapshots = [];
     const toolCalls = [];

--- a/test/normalization.test.js
+++ b/test/normalization.test.js
@@ -561,6 +561,89 @@ test("forked cumulative snapshots are excluded while new fork usage is retained"
   }
 });
 
+test("an inline fork with no reachable parent fails closed instead of charging its replay", async () => {
+  const codexHome = await mkdtemp(join(tmpdir(), "app-usagemonitor-scan-test-"));
+  try {
+    const sessions = join(codexHome, "sessions");
+    await mkdir(sessions, { recursive: true });
+    const usage = (input_tokens, total_tokens = input_tokens) => ({
+      input_tokens,
+      cached_input_tokens: 0,
+      cache_write_input_tokens: 0,
+      output_tokens: 0,
+      reasoning_output_tokens: 0,
+      total_tokens,
+    });
+    const record = (timestamp, total, last) => JSON.stringify({
+      timestamp,
+      type: "event_msg",
+      payload: {
+        type: "token_count",
+        info: { total_token_usage: total, last_token_usage: last },
+      },
+    });
+    const turn = (timestamp) => JSON.stringify({
+      timestamp,
+      type: "turn_context",
+      payload: { model: "gpt-test" },
+    });
+    // The orphan replays an adversarial shape: a turn_context INSIDE the
+    // replayed prefix, which defeats the parser's no-turn-context-yet rule.
+    // With the parent file gone, only failing closed keeps it out of spend.
+    const orphan = [
+      JSON.stringify({ timestamp: "2026-07-23T00:01:00.000Z", type: "session_meta", payload: { id: "orphan-fork", forked_from_id: "vanished-parent" } }),
+      turn("2026-07-23T00:01:00.001Z"),
+      record("2026-07-23T00:01:00.002Z", usage(100), usage(100)),
+      record("2026-07-23T00:01:01.000Z", usage(160), usage(60)),
+    ].join("\n");
+    // The grandchild's parent IS present (the orphan), so it parses normally
+    // — and the orphan's fail-closed pass still collected its own keys,
+    // which include the replayed ancestral prefix. Replay suppression
+    // survives the missing common ancestor.
+    const grandchild = [
+      JSON.stringify({ timestamp: "2026-07-23T00:02:00.000Z", type: "session_meta", payload: { id: "grandchild", forked_from_id: "orphan-fork" } }),
+      turn("2026-07-23T00:02:00.001Z"),
+      record("2026-07-23T00:02:00.002Z", usage(100), usage(100)),
+      record("2026-07-23T00:02:00.003Z", usage(160), usage(60)),
+      record("2026-07-23T00:02:01.000Z", usage(210), usage(50)),
+    ].join("\n");
+    const standalone = [
+      JSON.stringify({ timestamp: "2026-07-23T00:03:00.000Z", type: "session_meta", payload: { id: "standalone" } }),
+      turn("2026-07-23T00:03:00.001Z"),
+      record("2026-07-23T00:03:01.000Z", usage(20), usage(20)),
+    ].join("\n");
+    await writeFile(join(sessions, "rollout-2026-07-23T00-01-00-orphan.jsonl"), `${orphan}\n`);
+    await writeFile(join(sessions, "rollout-2026-07-23T00-02-00-grandchild.jsonl"), `${grandchild}\n`);
+    await writeFile(join(sessions, "rollout-2026-07-23T00-03-00-standalone.jsonl"), `${standalone}\n`);
+    const result = await scanAndPriceCodexLogs({
+      codexHome,
+      startAt: "2026-07-22T23:59:00.000Z",
+      endAt: "2026-07-23T00:04:00.000Z",
+      priceCards: [{
+        schema_version: "0.1",
+        id: "openai:gpt-test:test",
+        provider: "openai",
+        model: "gpt-test",
+        components: [{
+          usage_component: "input_uncached_tokens",
+          unit: "token",
+          price: { amount: "1", currency: "USD", per: "1" },
+        }],
+        source: { name: "test", url: "https://example.invalid/pricing", retrieved_at: "2026-07-23T00:00:00.000Z" },
+      }],
+    });
+    assert.equal(result.diagnostics.lineageParentsMissing, 1);
+    assert.equal(result.diagnostics.forkRolloutsFailedClosed, 1);
+    assert.equal(result.diagnostics.forkReplayEventsSkipped, 2);
+    assert.equal(result.eventCount, 2);
+    assert.equal(result.totalTokens, 70);
+    assert.equal(result.runcost.totalUsd, 70);
+    assert.equal(result.diagnostics.usageBearingRollouts, 2);
+  } finally {
+    await rm(codexHome, { recursive: true });
+  }
+});
+
 test("activity scans can exclude exactly the controller session without exposing its identifier", async () => {
   const codexHome = await mkdtemp(join(tmpdir(), "app-usagemonitor-controller-test-"));
   try {

--- a/test/passive-collector.test.js
+++ b/test/passive-collector.test.js
@@ -2336,3 +2336,164 @@ test("idle reconciliation does not rewrite the full checkpoint every cycle", asy
     await rm(fixture.root, { recursive: true });
   }
 });
+
+
+test("inline fork replay stays out of the ledger and the baseline rebases across a resume", async () => {
+  const fixture = await collectorFixture([
+    tokenRecord("2026-07-23T00:00:01.000Z", usage(10), usage(10), 1),
+  ]);
+  const clock = () => Date.parse("2026-07-23T00:10:00.000Z");
+  const forkFile = join(fixture.sessions, "rollout-2026-07-23T00-05-00-fork.jsonl");
+  const meta = JSON.stringify({
+    timestamp: "2026-07-23T00:05:00.000Z",
+    type: "session_meta",
+    payload: { id: "fork-child", forked_from_id: "vanished-parent" },
+  });
+  const tool = JSON.stringify({
+    timestamp: "2026-07-23T00:05:00.500Z",
+    type: "response_item",
+    payload: { type: "custom_tool_call", name: "replayed-tool", call_id: "replayed-call-1" },
+  });
+  const turn = JSON.stringify({
+    timestamp: "2026-07-23T00:05:02.000Z",
+    type: "turn_context",
+    payload: { model: "gpt-test" },
+  });
+  try {
+    // Run 1 stops mid-replay: the checkpoint must persist the pre-boundary
+    // state so the resume cannot mistake the rest of the replay for spend.
+    await writeFile(forkFile, `${[
+      meta,
+      tokenRecord("2026-07-23T00:05:00.100Z", usage(100), usage(100), 2),
+      tool,
+      tokenRecord("2026-07-23T00:05:01.000Z", usage(300), usage(200), 3),
+    ].join("\n")}\n`);
+    const first = await runCollectorOnce({
+      ...fixture,
+      refreshStale: false,
+      backfill: true,
+      backfillSinceAt: "2026-07-20T00:00:00.000Z",
+      clock,
+    });
+    assert.equal(first.status, "complete");
+    const afterFirst = await readLines(fixture.dataFile);
+    assert.equal(
+      afterFirst.filter((row) => row.kind === "codex_rollout_usage_snapshot"
+        && row.components !== null
+        && row.components.input_uncached_tokens > 10).length,
+      0,
+    );
+
+    // The fork's first genuine turn arrives after a restart. Its delta must
+    // be measured from the replayed baseline (400 - 300 = its own 100), not
+    // charged the whole inherited total.
+    await appendFile(forkFile, `${[
+      turn,
+      tokenRecord("2026-07-23T00:05:03.000Z", usage(400), usage(100), 4),
+    ].join("\n")}\n`);
+    const second = await runCollectorOnce({
+      ...fixture,
+      refreshStale: false,
+      backfill: true,
+      backfillSinceAt: "2026-07-20T00:00:00.000Z",
+      clock,
+    });
+    assert.equal(second.status, "complete");
+
+    const records = await readLines(fixture.dataFile);
+    const usageRecords = records.filter((row) => row.kind === "codex_rollout_usage_snapshot"
+      && row.components !== null);
+    const forkUsage = usageRecords.filter((row) => row.model === "gpt-test");
+    assert.equal(forkUsage.length, 1);
+    assert.equal(forkUsage[0].components.input_uncached_tokens, 100);
+    assert.equal(
+      records.filter((row) => row.kind === "codex_tool_class_event"
+        && row.toolClass !== undefined
+        && row.observedAt === "2026-07-23T00:05:00.500Z").length,
+      0,
+    );
+
+    const checkpoint = JSON.parse(await readFile(fixture.checkpointFile, "utf8"));
+    assert.equal(checkpoint.diagnostics.forkReplayEventsSkipped, 2);
+    assert.equal(checkpoint.diagnostics.forkReplayToolCallsSkipped, 1);
+    const forkState = Object.values(checkpoint.files)
+      .find((state) => state.isInlineFork === true);
+    assert.ok(forkState);
+    assert.equal(forkState.ownTurnContextSeen, true);
+  } finally {
+    await rm(fixture.root, { recursive: true });
+  }
+});
+
+test("a truncated fork file re-arms the replay boundary on rescan", async () => {
+  // Regression for the review finding: the truncation reset cleared every
+  // cursor field except ownTurnContextSeen, so a shrink-in-place rescan of a
+  // fork file walked the replayed prefix with both guards disabled and
+  // charged the inherited history as fresh spend.
+  const fixture = await collectorFixture([
+    tokenRecord("2026-07-23T00:00:01.000Z", usage(10), usage(10), 1),
+  ]);
+  const clock = () => Date.parse("2026-07-23T00:10:00.000Z");
+  const forkFile = join(fixture.sessions, "rollout-2026-07-23T00-05-00-fork.jsonl");
+  const meta = JSON.stringify({
+    timestamp: "2026-07-23T00:05:00.000Z",
+    type: "session_meta",
+    payload: { id: "fork-child", forked_from_id: "vanished-parent" },
+  });
+  const turn = JSON.stringify({
+    timestamp: "2026-07-23T00:05:02.000Z",
+    type: "turn_context",
+    payload: { model: "gpt-test" },
+  });
+  try {
+    await writeFile(forkFile, `${[
+      meta,
+      tokenRecord("2026-07-23T00:05:00.100Z", usage(100), usage(100), 2),
+      tokenRecord("2026-07-23T00:05:01.000Z", usage(300), usage(200), 3),
+      turn,
+      tokenRecord("2026-07-23T00:05:03.000Z", usage(400), usage(100), 4),
+    ].join("\n")}\n`);
+    const first = await runCollectorOnce({
+      ...fixture,
+      refreshStale: false,
+      backfill: true,
+      backfillSinceAt: "2026-07-20T00:00:00.000Z",
+      clock,
+    });
+    assert.equal(first.status, "complete");
+
+    // Shrink in place: same inode, replay-only content shorter than the
+    // consumed cursor. The rescan must re-derive the boundary, not inherit a
+    // stale past-the-boundary flag.
+    await writeFile(forkFile, `${[
+      meta,
+      tokenRecord("2026-07-23T00:05:00.100Z", usage(100), usage(100), 2),
+      tokenRecord("2026-07-23T00:05:01.000Z", usage(300), usage(200), 3),
+    ].join("\n")}\n`);
+    const second = await runCollectorOnce({
+      ...fixture,
+      refreshStale: false,
+      backfill: true,
+      backfillSinceAt: "2026-07-20T00:00:00.000Z",
+      clock,
+    });
+    assert.equal(second.status, "complete");
+
+    const records = await readLines(fixture.dataFile);
+    const forkUsage = records.filter((row) => row.kind === "codex_rollout_usage_snapshot"
+      && row.components !== null
+      && row.components.input_uncached_tokens > 10);
+    assert.equal(forkUsage.length, 1);
+    assert.equal(forkUsage[0].components.input_uncached_tokens, 100);
+
+    const checkpoint = JSON.parse(await readFile(fixture.checkpointFile, "utf8"));
+    assert.equal(checkpoint.diagnostics.filesTruncated, 1);
+    assert.equal(checkpoint.diagnostics.forkReplayEventsSkipped, 4);
+    const forkState = Object.values(checkpoint.files)
+      .find((state) => state.isInlineFork === true);
+    assert.ok(forkState);
+    assert.equal(forkState.ownTurnContextSeen, false);
+  } finally {
+    await rm(fixture.root, { recursive: true });
+  }
+});


### PR DESCRIPTION
Closes the two remaining fork-replay exposures found by the 2026-08-30 allowance audit (measured at up to 92.7× weekly naive-count inflation; the audit's collector-ledger proxy read 3.0×). Current main already handles the common case well — discovery force-includes out-of-window fork parents and the parser carries both suppression rules — so this PR targets exactly what remained.

## 1. Ingestion fails closed on an unresolvable inline-fork parent

Reaching the miss means the parent rollout is *genuinely* unavailable, and the remaining `turn_context` heuristic is defeated by an adversarial replay shape (a `turn_context` inside the replay — covered by a new test using precisely that shape). Instead of parsing with an empty inherited set:

- the rollout contributes **no events** that scan (`forkRolloutsFailedClosed` diagnostic);
- its own cumulative keys are **still collected**, so a descendant fork scanned in the same batch keeps full replay suppression across the missing ancestor (tested);
- a recently-written orphan still counts toward `activeTaskRolloutsAtEnd`, so experiment preflights don't read a busy machine as idle.

**Deliberate trade-off:** an orphan's genuine post-fork work and rate-limit snapshots are withheld while the parent stays missing. The replay damage is permanent in uploads; the undercount is not.

## 2. The legacy passive collector gets a fork guard

It had none, and its dedupe key hashes the replay's rewritten timestamps. Now: per-file `isInlineFork` + `ownTurnContextSeen` persisted in the checkpoint, replayed token_counts and tool calls skipped, and every skipped row **rebases the cumulative baseline** so the first genuine post-fork turn isn't charged the inherited total as one delta. Pre-upgrade checkpoints migrate in place — with zero I/O for provably non-forked dispositions.

## Adversarial review, all findings independently reproduced

Three review lenses, then per-finding refutation attempts (18 agents). 7 claims refuted with evidence; 5 actionable findings confirmed **by end-to-end repro** and fixed in this commit:

| finding | severity | fix |
|---|---|---|
| Truncation reset left `ownTurnContextSeen` stale — a shrink-in-place rescan recharged the whole replay | medium | boundary re-armed in the truncation branch + regression test |
| Legacy-state migration reserved min(size, 1 MiB)/file — bounded-paused large corpora before their newest files | medium | non-forked dispositions migrate with zero I/O; reservation narrowed |
| Bare `+=` turned the new counters NaN→null on pre-upgrade checkpoints | low | `(x ?? 0) + 1`, matching every later-added counter |
| Fail-closed skip blinded the experiment harness's concurrency stop | low | conservative active-count for mtime-recent orphans |
| 32 MiB seed prelude can hide the boundary behind a giant line | low | bounded (≤1 in-flight turn), now documented at both seed sites; late re-seed resolves the boundary it proves |

The three verifier repro scripts were re-run against the fixed tree: truncation no longer recharges, counters survive pre-upgrade checkpoints, legacy migration reserves 0 bytes and processes every file.

## Verification

- 322/322 across sixteen affected suites (one unrelated abort-timing flake in `local-unified-index` passes 3/3 in isolation and is untouched by this diff)
- Architecture boundaries: 365 files, 1426 imports, 0 debt edges
- **R7 receipts:** the two `r7-generated-release-evidence` tests fail on exactly the `workloadCodeSha256` invariant (base passes 2/2) — the standard workload-source pin. Regeneration is owed at merge-fold per the runbook, as with previous folds.

## After merge

The server-side corpus already contains historical duplicates (fresh event ids — not filterable retroactively); the community fits should be refit after cleanup, tracked in the allowance-audit handoff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)