### PR TITLE
Fix dark-mode contrast in the cache reuse tooltip

### DIFF
--- a/apps/web/public/styles.css
+++ b/apps/web/public/styles.css
@@ -2187,7 +2187,7 @@ tbody tr:last-child td { border-bottom: 0; }
   border: 1px solid var(--green);
   border-radius: var(--radius-sm);
   color: var(--ink);
-  background: rgba(255, 254, 249, .98);
+  background: var(--paper);
   box-shadow: 0 18px 42px rgba(31, 45, 39, .2);
   font-size: .68rem;
   line-height: 1.35;


### PR DESCRIPTION
The cache-reuse hover card on Usage and costs kept a cream background in dark mode while its text followed the dark theme, making the heading and details difficult to read.

Use the existing paper color token for the card background. The background and text now follow the same theme, with no changes to chart data, layout, or interaction behavior.

Validation:

- All 371 web UI tests pass (`npm run product:ui:test`).
- Browser checks with real local data covered dark and light rendering, hover selection, keyboard selection, and dismissal.
- A disposable native macOS WKWebView verified both themes, all six tooltip text rows, and unclipped rendering. Minimum text contrast was 4.86:1 in dark mode and 5.63:1 in light mode.
- `git diff --check` passes.

This is a source CSS fix. Installed-app replacement and release validation are separate and were not performed.
