### PR TITLE
Hide internal tool-history warning from the dashboard

### DIFF
--- a/apps/web/public/data-client.js
+++ b/apps/web/public/data-client.js
@@ -26,6 +26,10 @@ export {
 
 const LOCAL_ROOT = "/api/local";
 const CENTRAL_ROOT = "/api/v1";
+// The dashboard has no tool-activity view. Keep this diagnostic in the raw
+// companion payload and retained snapshots, but omit it from display warnings.
+const INTERNAL_TOOL_HISTORY_WARNING =
+  "Usage accounting is complete, but typed tool history is partial. Tool totals are withheld rather than reported as zero.";
 // Provider quota identifiers are protocol values, not display copy. Keep the
 // normal Codex allowance selection bound to the exact technical identifier so
 // a translated UI label (or another product's weekly-looking window) can never
@@ -5458,7 +5462,9 @@ export function normalizeDashboardPayload(payload = {}, fragments = {}) {
       components: pricing?.components ?? selectedUsage?.components
     }),
     coverage: overview?.coverage ?? {},
-    warnings: array(overview?.warnings).map((warning) => text(warning?.message ?? warning, "")).filter(Boolean),
+    warnings: array(overview?.warnings)
+      .map((warning) => text(warning?.message ?? warning, ""))
+      .filter((warning) => warning && warning !== INTERNAL_TOOL_HISTORY_WARNING),
     collector: {
       status: text(overview?.collector?.status, "unavailable"),
       records: count(overview?.collector?.records, 0),

--- a/apps/web/test/lib.test.mjs
+++ b/apps/web/test/lib.test.mjs
@@ -9202,6 +9202,56 @@ test("a chart says so when its series does not reach back as far as its label", 
 // state wholesale, and its copy and rendering are owned there.
 // ---------------------------------------------------------------------------
 
+test("dashboard warnings omit internal tool history while preserving usage caveats and diagnostics", () => {
+  const toolWarning =
+    "Usage accounting is complete, but typed tool history is partial. Tool totals are withheld rather than reported as zero.";
+  const usageWarning = "Some usage events name an unrecognized model and remain unpriced rather than being assigned a guessed price.";
+  const historyWarning = "The unified local index is unreadable.";
+  const otherToolWarning = "Some tool activity has unpriced usage.";
+  const toolClasses = {
+    status: "unavailable",
+    reason: "typed_tool_history_partial",
+    total: null,
+    counts: Object.fromEntries(
+      ["apply_patch", "local_shell", "other", "subagent", "tool_gateway"]
+        .map((key) => [key, null]),
+    ),
+  };
+  const overview = {
+    warnings: [
+      toolWarning,
+      usageWarning,
+      { message: toolWarning },
+      { message: historyWarning },
+      "",
+      null,
+      {},
+      otherToolWarning,
+    ],
+    activity: { toolEvents: null },
+    pricing: { totalCostUsd: 12.5 },
+    accounting: { toolClasses },
+    timeline: {
+      history: { status: "partial", reason: "typed_tool_history_partial" },
+    },
+  };
+  const original = structuredClone(overview);
+  for (const dashboard of [
+    normalizeDashboardPayload(overview),
+    normalizeDashboardPayload({ overview }),
+    normalizeDashboardPayload({}, { overview }),
+  ]) {
+    assert.deepEqual(dashboard.warnings, [usageWarning, historyWarning, otherToolWarning]);
+    assert.equal(dashboard.pricing.totalCostUsd, 12.5);
+    assert.equal(dashboard.activity.toolEvents, null);
+    assert.deepEqual(dashboard.accounting.toolClasses, toolClasses);
+    assert.equal(dashboard.timeline.history.status, "partial");
+    assert.equal(dashboard.timeline.history.reason, "typed_tool_history_partial");
+  }
+  assert.deepEqual(overview, original, "source diagnostics stay unchanged for retention and inspection");
+  assert.deepEqual(normalizeDashboardPayload({ warnings: [toolWarning] }).warnings, []);
+});
+
 test("self-resolving degraded notes are classed informational and keep the quiet style", async () => {
   const appSource = await readFile(new URL("../public/app.js", import.meta.url), "utf8");
   const styles = await readFile(new URL("../public/styles.css", import.meta.url), "utf8");
@@ -9280,8 +9330,6 @@ test("self-resolving degraded notes are classed informational and keep the quiet
     "Recent cost figures come from the live collector projection until the"
       + " replay-safe cache is refreshed. They may double-count usage that"
       + " forked child sessions inherited.",
-    "Usage accounting is complete, but typed tool history is partial. Tool"
-      + " totals are withheld rather than reported as zero.",
     "Indexed-history totals include ${historyCoverage.indexedSourceCount} of"
       + " ${historyCoverage.sourceCount} verified sources."
       + " ${historyCoverage.skippedSourceCount} sources across"


### PR DESCRIPTION
## What and why

The dashboard shows an incomplete tool-history warning beneath the cost total, although it has no tool-history or tool-count view. The warning makes the cost figure look unreliable without giving the user anything useful to act on.

Hide this exact diagnostic at the browser data boundary for both fresh and retained snapshots. Keep all other warnings, unavailable tool counts, partial-history metadata, and raw companion diagnostics unchanged. The retained-snapshot validator still relies on the original diagnostic, so the backend and persistence contracts are deliberately untouched.

## Verification

- `npm run product:ui:test` — 372 passed.
- `node --test --test-concurrency=1 test/local-authoritative-dashboard-snapshot.test.js test/local-companion-data.test.js` — 47 passed, including incomplete tool-history snapshot persistence.
- `npm run test:preflight` — documentation, guidance, root hygiene, and whitespace checks passed; 17 tests passed.
- `npm run architecture:check` — passed.
- Independent code review — no actionable findings.
- Read-only browser comparison using the same captured real local dashboard responses: the original banner was present before the change and absent afterward; the cost total was unchanged and the unrelated coverage notice remained visible. The temporary preview blocked writes and external requests and was stopped after inspection.

Platform tested: macOS arm64, Node v26.2.0.

## Scope and remaining gates

Only the frontend normalizer and its tests change. The full repository, Worker, and native macOS artifact/release gates were not run for this presentation-only change. No installed app was rebuilt or replaced, and no release or deployment is included.

The change does not alter a documented API, privacy disclosure, or maintained operational contract. No maintained-document updates or generated artifacts are needed.

## Content attestation

This PR, its fixtures, and commit message contain no prompts, model responses, real session paths, raw records, credentials, or private QA captures.
