### PR TITLE
fix(macos): retain menu-bar history and dismiss outside clicks

### DIFF
--- a/apps/macos/README.md
+++ b/apps/macos/README.md
@@ -66,12 +66,23 @@ that compatibility backend.
    The bars use
    observed tokens; dollar figures are explicitly Standard API-price
    equivalents, not a subscription bill, and disappear when pricing evidence
-   cannot support them. Missing evidence is a named gap, never a zero. The
+   cannot support them. During refresh the last completed usage analysis stays
+   visible with an explicit retained-history label, including both chart ranges
+   and their original coverage. A transient read failure also keeps that
+   labelled history, while current quota and forecast claims are cleared.
+   Companion restart or source replacement clears all previous in-memory
+   evidence; first-run or invalid history is never fabricated. Missing evidence
+   is a named gap, never a zero. The
    popover forecast is an ephemeral, strict projection from the companion's
    narrow read-only weekly-pace endpoint. Request-time geometry is recalculated
    from the retained strict forecast without rerunning accounting; it is never
    stored, logged, exported, or added to community data. It contains no account
    identity, plan claim, purchase flow, reset credits, or redemption action.
+   Clicking outside the popover dismisses it even if another app was already
+   active when it opened. Its outside mouse listener exists only while the
+   popover is open; it does not record event content, monitor global keys, or
+   consume clicks destined for other apps. Popover controls and a second click
+   on its status icon retain their normal control and toggle behavior.
    Right-click or Control-click opens the native action menu with **Open
    TiboTattle**, state-aware **Analyze/Update Local
    Usage**, Settings, About, update checks when available, and **Quit
@@ -555,6 +566,16 @@ backup before launching the previous version unless that exact existing-state
 rollback has been rehearsed.
 
 ## Automated validation
+
+For menu-bar refresh changes, start with `npm run test:macos:source` and
+`npm run test:macos:smoke`. The latter compiles a development-only app and checks
+retained history through both the companion's projection and the native view,
+including both ranges, read failure, and source reset. Its development-only
+`--menu-bar-overview-render-smoke-test <derived-overview.json> <output-directory>`
+mode renders ready, updating, and read-failure states without starting a
+companion or altering installed app state. Automated fixtures must remain
+synthetic; local real-data visual QA is separate from those tests and from an
+installed or signed-artifact gate.
 
 Run the focused suite:
 

--- a/apps/macos/Resources/en.lproj/Localizable.strings
+++ b/apps/macos/Resources/en.lproj/Localizable.strings
@@ -231,6 +231,7 @@
 "menuBarPopup.notSubscriptionBill" = "Not a subscription bill";
 "menuBarPopup.accountingUnavailableTitle" = "Local usage history is not available yet";
 "menuBarPopup.accountingUnavailableBody" = "Run a local analysis to build 7-day and 30-day API-price-equivalent history from this Mac.";
+"menuBarPopup.retainedHistory" = "Showing the last completed analysis.";
 "menuBarPopup.noUsageObserved" = "No local usage observed in %@.";
 "menuBarPopup.startingTitle" = "Preparing local usage";
 "menuBarPopup.startingBody" = "TiboTattle will show values only after a fresh local observation.";

--- a/apps/macos/Resources/es.lproj/Localizable.strings
+++ b/apps/macos/Resources/es.lproj/Localizable.strings
@@ -129,6 +129,7 @@
 "menuBarPopup.notSubscriptionBill" = "No es una factura de suscripción";
 "menuBarPopup.accountingUnavailableTitle" = "El historial de uso local aún no está disponible";
 "menuBarPopup.accountingUnavailableBody" = "Ejecuta un análisis local para crear un historial de equivalencia de precios de la API de 7 y 30 días a partir de este Mac.";
+"menuBarPopup.retainedHistory" = "Se muestra el último análisis completado.";
 "menuBarPopup.noUsageObserved" = "No se ha observado uso local en %@.";
 "menuBarPopup.startingTitle" = "Preparando el uso local";
 "menuBarPopup.startingBody" = "TiboTattle mostrará valores solo después de una observación local reciente.";

--- a/apps/macos/Resources/zh-Hans.lproj/Localizable.strings
+++ b/apps/macos/Resources/zh-Hans.lproj/Localizable.strings
@@ -129,6 +129,7 @@
 "menuBarPopup.notSubscriptionBill" = "并非订阅账单";
 "menuBarPopup.accountingUnavailableTitle" = "本地用量历史尚不可用";
 "menuBarPopup.accountingUnavailableBody" = "运行本地分析，以根据这台 Mac 上的数据生成过去 7 天和 30 天的 API 价格等值历史。";
+"menuBarPopup.retainedHistory" = "正在显示上次完成的分析。";
 "menuBarPopup.noUsageObserved" = "在%@内未观测到本地用量。";
 "menuBarPopup.startingTitle" = "正在准备本地用量";
 "menuBarPopup.startingBody" = "仅在获得新的本地观测后，TiboTattle 才会显示数值。";

--- a/apps/macos/Sources/Localization.swift
+++ b/apps/macos/Sources/Localization.swift
@@ -298,6 +298,7 @@ enum TiboTattleLocalization {
         case menuBarPopupNotSubscriptionBill = "menuBarPopup.notSubscriptionBill"
         case menuBarPopupAccountingUnavailableTitle = "menuBarPopup.accountingUnavailableTitle"
         case menuBarPopupAccountingUnavailableBody = "menuBarPopup.accountingUnavailableBody"
+        case menuBarPopupRetainedHistory = "menuBarPopup.retainedHistory"
         case menuBarPopupNoUsageObserved = "menuBarPopup.noUsageObserved"
         case menuBarPopupStartingTitle = "menuBarPopup.startingTitle"
         case menuBarPopupStartingBody = "menuBarPopup.startingBody"
@@ -888,6 +889,8 @@ enum TiboTattleLocalization {
                 "Local usage history is not available yet"
             case .menuBarPopupAccountingUnavailableBody:
                 "Run a local analysis to build 7-day and 30-day API-price-equivalent history from this Mac."
+            case .menuBarPopupRetainedHistory:
+                "Showing the last completed analysis."
             case .menuBarPopupNoUsageObserved:
                 "No local usage observed in %@."
             case .menuBarPopupStartingTitle:

--- a/apps/macos/Sources/MenuBarPopover.swift
+++ b/apps/macos/Sources/MenuBarPopover.swift
@@ -14,6 +14,7 @@ struct MenuBarPopoverPresentationContract: Equatable {
     let selectedHistoryRange: MenuBarHistoryRange
     let dailyBarCount: Int
     let historyVisible: Bool
+    let retainedHistoryDisclosed: Bool
     let partialPricingDisclosed: Bool
     let pricingState: MenuBarPopoverPricingState
     let historyCoverageState: MenuBarPopoverHistoryCoverageState
@@ -704,6 +705,7 @@ final class MenuBarPopoverViewController: NSViewController {
     private let historyTokenLabel = NSTextField(labelWithString: "")
     private let historyEventsLabel = NSTextField(labelWithString: "")
     private let historyPriceLabel = NSTextField(wrappingLabelWithString: "")
+    private let historyFreshnessLabel = NSTextField(wrappingLabelWithString: "")
     private let historyChart = MenuBarDailyTokenBarsView()
     private let historyCoverageLabel = NSTextField(wrappingLabelWithString: "")
     private let historyAvailableStack = NSStackView()
@@ -868,6 +870,8 @@ final class MenuBarPopoverViewController: NSViewController {
             selectedHistoryRange: selectedRange,
             dailyBarCount: historyChart.days.count,
             historyVisible: historyState == .available,
+            retainedHistoryDisclosed: !historyFreshnessLabel.isHidden
+                && !historyFreshnessLabel.stringValue.isEmpty,
             partialPricingDisclosed: partialPricingDisclosed,
             pricingState: pricingState,
             historyCoverageState: historyChart.coverageState,
@@ -953,6 +957,9 @@ final class MenuBarPopoverViewController: NSViewController {
         historyPriceLabel.font = .systemFont(ofSize: 10.5)
         historyPriceLabel.textColor = .secondaryLabelColor
         historyPriceLabel.maximumNumberOfLines = 2
+        historyFreshnessLabel.font = .systemFont(ofSize: 10.5)
+        historyFreshnessLabel.textColor = .secondaryLabelColor
+        historyFreshnessLabel.maximumNumberOfLines = 2
         historyCoverageLabel.font = .systemFont(ofSize: 9.5)
         historyCoverageLabel.textColor = .secondaryLabelColor
         historyCoverageLabel.maximumNumberOfLines = 2
@@ -1086,6 +1093,7 @@ final class MenuBarPopoverViewController: NSViewController {
         historyAvailableStack.alignment = .leading
         historyAvailableStack.spacing = 4
         for child in [
+            historyFreshnessLabel,
             historyHeadlineLabel,
             metrics,
             historyPriceLabel,
@@ -1095,6 +1103,7 @@ final class MenuBarPopoverViewController: NSViewController {
             historyAvailableStack.addArrangedSubview(child)
         }
         for child in [
+            historyFreshnessLabel,
             historyHeadlineLabel,
             metrics,
             historyPriceLabel,
@@ -1250,7 +1259,9 @@ final class MenuBarPopoverViewController: NSViewController {
 
     private func renderHistory(_ history: MenuBarHistorySnapshot) {
         rangeControl.selectedSegment = selectedRange == .sevenDays ? 0 : 1
-        guard history.accountingStatus == .current,
+        historyFreshnessLabel.stringValue = ""
+        historyFreshnessLabel.isHidden = true
+        guard history.accountingStatus != .unavailable,
               let period = history.period(for: selectedRange)
         else {
             historyState = .unavailable
@@ -1281,6 +1292,16 @@ final class MenuBarPopoverViewController: NSViewController {
         historyState = .available
         historyAvailableStack.isHidden = false
         historyUnavailableStack.isHidden = true
+        if history.accountingStatus == .retained
+            || currentSnapshot.phase == .analyzing {
+            historyFreshnessLabel.stringValue = TiboTattleLocalization.string(
+                .menuBarPopupRetainedHistory
+            )
+            historyFreshnessLabel.isHidden = false
+            historyFreshnessLabel.setAccessibilityLabel(
+                historyFreshnessLabel.stringValue
+            )
+        }
         let periodLabel = selectedRange == .sevenDays
             ? TiboTattleLocalization.string(.menuBarPopupPeriodLastSevenDays)
             : TiboTattleLocalization.string(.menuBarPopupPeriodLastThirtyDays)

--- a/apps/macos/Sources/MenuBarPopupModel.swift
+++ b/apps/macos/Sources/MenuBarPopupModel.swift
@@ -85,6 +85,9 @@ struct MenuBarHistoryDay: Equatable {
 struct MenuBarHistorySnapshot: Equatable {
     enum AccountingStatus: Equatable {
         case current
+        /// Validated figures from an earlier completed analysis, never a
+        /// current-generation claim. Quota freshness remains independent.
+        case retained
         case unavailable
     }
 
@@ -124,6 +127,20 @@ struct MenuBarHistorySnapshot: Equatable {
             return thirtyDayHistory
         }
     }
+
+    /// Retain only an already validated snapshot after a same-companion read
+    /// failure. This cannot turn a first-run/invalid response into evidence.
+    func retainingLastVerified() -> MenuBarHistorySnapshot {
+        guard accountingStatus != .unavailable else { return self }
+        return MenuBarHistorySnapshot(
+            accountingStatus: .retained,
+            last24Hours: last24Hours,
+            lastSevenDays: lastSevenDays,
+            lastThirtyDays: lastThirtyDays,
+            sevenDayHistory: sevenDayHistory,
+            thirtyDayHistory: thirtyDayHistory
+        )
+    }
 }
 
 /// Pure, fail-closed projection of the accounting and timeline fields already
@@ -136,10 +153,14 @@ enum MenuBarHistoryProjection {
         now: Date,
         calendar: Calendar
     ) -> MenuBarHistorySnapshot {
-        let dayWindows = civilDayWindows(now: now, calendar: calendar)
+        let state = accountingState(root, now: now)
+        // A retained rolling period and its civil-day bars keep the original
+        // analysis date, including across midnight or daylight-saving changes.
+        let snapshotDate = state?.snapshotDate ?? now
+        let dayWindows = civilDayWindows(now: snapshotDate, calendar: calendar)
         let unavailableHistory = unavailableHistories(dayWindows)
 
-        guard accountingIsAuthoritative(root),
+        guard let state,
               let periods = decodePeriods(root)
         else {
             return MenuBarHistorySnapshot(
@@ -154,7 +175,7 @@ enum MenuBarHistoryProjection {
 
         guard let history = decodeHistory(
             root: root,
-            now: now,
+            now: snapshotDate,
             dayWindows: dayWindows
         ) else {
             // Current rolling totals do not make a malformed or unavailable
@@ -171,7 +192,7 @@ enum MenuBarHistoryProjection {
             )
         }
         return MenuBarHistorySnapshot(
-            accountingStatus: .current,
+            accountingStatus: state.status,
             last24Hours: periods[.last24Hours],
             lastSevenDays: periods[.lastSevenDays],
             lastThirtyDays: periods[.lastThirtyDays],
@@ -233,24 +254,49 @@ enum MenuBarHistoryProjection {
 
     private static let maximumJSONSafeInteger = 9_007_199_254_740_991.0
 
-    private static func accountingIsAuthoritative(
-        _ root: [String: Any]
-    ) -> Bool {
-        guard let freshness = root["freshness"] as? [String: Any],
-              freshness["accountingStatus"] as? String == "available",
-              let accounting = root["accounting"] as? [String: Any],
+    private static func accountingState(
+        _ root: [String: Any],
+        now: Date
+    ) -> (status: MenuBarHistorySnapshot.AccountingStatus, snapshotDate: Date)? {
+        guard let accounting = root["accounting"] as? [String: Any],
               let sourceMode = accounting["sourceMode"] as? String,
               ["legacy", "unified"].contains(sourceMode)
         else {
-            return false
+            return nil
         }
 
-        // The data store can retain the previous complete figures while a new
-        // unified generation is being built. Its period rows remain populated,
-        // but `generationMatched` deliberately stays false. That state is not a
-        // current numeric accounting claim for this compact surface.
-        return sourceMode != "unified"
-            || exactBoolean(accounting["generationMatched"]) == true
+        if let value = accounting["projection"] {
+            guard let projection = value as? [String: Any] else { return nil }
+            if projection["status"] as? String == "retained" {
+                // The companion explicitly attests that these are previous
+                // verified figures. A generation mismatch alone is NOT enough:
+                // placeholders or an unlabelled/malformed payload stay hidden.
+                let parser = TimestampParser()
+                guard sourceMode == "unified",
+                      exactBoolean(accounting["generationMatched"]) == false,
+                      exactBoolean(projection["terminal"]) != nil,
+                      let retainedAt = parser.date(projection["retainedAt"]),
+                      let coverage = projection["coveredAt"] as? [String: Any],
+                      let startAt = parser.date(coverage["startAt"]),
+                      let endAt = parser.date(coverage["endAt"]),
+                      startAt < endAt,
+                      endAt <= retainedAt,
+                      retainedAt <= now
+                else { return nil }
+                return (.retained, retainedAt)
+            }
+            guard projection["status"] as? String == "available",
+                  projection["reason"] is NSNull,
+                  exactBoolean(projection["terminal"]) == false
+            else { return nil }
+        }
+
+        guard let freshness = root["freshness"] as? [String: Any],
+              freshness["accountingStatus"] as? String == "available",
+              sourceMode != "unified"
+                || exactBoolean(accounting["generationMatched"]) == true
+        else { return nil }
+        return (.current, now)
     }
 
     private static func decodePeriods(

--- a/apps/macos/Sources/MenuBarStatus.swift
+++ b/apps/macos/Sources/MenuBarStatus.swift
@@ -9,11 +9,13 @@ import Foundation
 // own evidence plus the two actions a background monitor needs at hand.
 //
 // Honesty rules encoded here:
-//   * no number is ever synthesised, interpolated, or carried forward;
+//   * no quota number is ever synthesised, interpolated, or carried forward;
 //   * a number is shown in the menu bar only while the companion itself
 //     reports live evidence inside its own freshness window;
 //   * stale or absent evidence collapses to a neutral placeholder and the
-//     menu explains, in words, why there is no number.
+//     menu explains, in words, why there is no number;
+//   * previous verified history may remain visible with an explicit retained
+//     label, independently of current allowance and forecast authority.
 
 /// One quota lane the local companion actually observed. The menu deliberately
 /// knows only the safe display category, remaining percentage, and reset time;
@@ -341,10 +343,12 @@ struct NativeMenuPresentationContract: Equatable {
     let usesNativeStatusItemMenu: Bool
     let statusItemButtonRoutesClicks: Bool
     let popoverIsTransient: Bool
+    let popoverIsShown: Bool
     let popoverContentWidth: CGFloat
     let popoverContainsScrollView: Bool
     let escapeDismissalMonitorInstalled: Bool
     let sameAppClickAwayMonitorInstalled: Bool
+    let outsideClickAwayMonitorInstalled: Bool
     let appDeactivationDismissalObserverInstalled: Bool
 }
 
@@ -387,6 +391,19 @@ struct MenuBarStatusSnapshot: Equatable {
     /// local-analysis action. An unavailable surface with no companion must
     /// not present a button that silently does nothing.
     var analysisAvailable = false
+
+    /// Current quota/forecast claims cannot survive an unreadable response.
+    /// Historical usage may survive a transient read failure within this
+    /// companion generation, but is explicitly downgraded to retained data.
+    /// Lifecycle/source changes use the default and discard every old value.
+    mutating func invalidateObservedEvidence(keepingHistory: Bool = false) {
+        lanes = []
+        observedAt = nil
+        evidence = .none
+        history = keepingHistory ? history.retainingLastVerified() : .unavailable
+        weeklyPaceOutlook = nil
+        staleAfterSeconds = nil
+    }
 
     /// Mirrors the dashboard's primary selection across the normal Codex
     /// allowance track. Other provider products are rejected while decoding,
@@ -719,6 +736,31 @@ func menuBarShouldDismissForEscape(
     isPopoverShown: Bool
 ) -> Bool {
     keyCode == 53 && (isMenuTracking || isPopoverShown)
+}
+
+enum MenuBarMouseTarget: Equatable, CaseIterable {
+    case popover
+    case statusItem
+    case applicationWindow
+    case outside
+}
+
+/// Popover controls and the status button own their normal actions. Native
+/// menu windows also keep their own tracking; unknown/windowless mouse events
+/// dismiss only the popover, not a separately tracking action menu.
+func menuBarShouldDismissForMouse(
+    target: MenuBarMouseTarget,
+    isMenuTracking: Bool,
+    isPopoverShown: Bool
+) -> Bool {
+    switch target {
+    case .popover, .statusItem:
+        return false
+    case .applicationWindow:
+        return isMenuTracking || isPopoverShown
+    case .outside:
+        return isPopoverShown
+    }
 }
 
 /// Pure projection of the companion's overview payload. Kept free of AppKit so
@@ -1351,6 +1393,7 @@ final class MenuBarStatusController: NSObject, NSMenuDelegate, NSPopoverDelegate
     private var renderedLaneLabels: [String] = []
     private var escapeMonitor: Any?
     private var localMouseMonitor: Any?
+    private var outsideMouseMonitor: Any?
     private var appDeactivationObserver: NSObjectProtocol?
     private var stopped = false
 
@@ -1609,13 +1652,23 @@ final class MenuBarStatusController: NSObject, NSMenuDelegate, NSPopoverDelegate
                 statusItem.button?.target === self
                     && statusItem.button?.action == #selector(statusItemActivated),
             popoverIsTransient: popover.behavior == .transient,
+            popoverIsShown: popover.isShown,
             popoverContentWidth: popup.contentWidth,
             popoverContainsScrollView: popup.containsScrollView,
             escapeDismissalMonitorInstalled: escapeMonitor != nil,
             sameAppClickAwayMonitorInstalled: localMouseMonitor != nil,
+            outsideClickAwayMonitorInstalled: outsideMouseMonitor != nil,
             appDeactivationDismissalObserverInstalled:
                 appDeactivationObserver != nil
         )
+    }
+
+    /// Packaged native-test seam: show the same popover from the same status
+    /// button without posting synthetic input or starting a companion.
+    func showPopoverForSmokeTest() -> Bool {
+        guard !stopped, let button = statusItem.button else { return false }
+        if !popover.isShown { statusItemActivated(button) }
+        return popover.isShown
     }
 
     /// Left-click is the glanceable instrument; right-click and Control-click
@@ -1646,6 +1699,7 @@ final class MenuBarStatusController: NSObject, NSMenuDelegate, NSPopoverDelegate
             of: sender,
             preferredEdge: .minY
         )
+        startOutsideClickMonitoring()
         sender.highlight(true)
         pollNow()
     }
@@ -1660,6 +1714,7 @@ final class MenuBarStatusController: NSObject, NSMenuDelegate, NSPopoverDelegate
             to: nil
         )
         let screenPoint = anchor.window?.convertPoint(toScreen: windowPoint)
+        stopOutsideClickMonitoring()
         defersPopoverRefreshUntilMenuCloses = popover.isShown
         popover.performClose(nil)
         statusItem.button?.highlight(true)
@@ -1675,7 +1730,12 @@ final class MenuBarStatusController: NSObject, NSMenuDelegate, NSPopoverDelegate
         }
     }
 
+    func popoverDidShow(_ notification: Notification) {
+        startOutsideClickMonitoring()
+    }
+
     func popoverDidClose(_ notification: Notification) {
+        stopOutsideClickMonitoring()
         statusItem.button?.highlight(false)
         guard !stopped else { return }
         if suppressesNextPopoverCloseRefresh {
@@ -1711,21 +1771,35 @@ final class MenuBarStatusController: NSObject, NSMenuDelegate, NSPopoverDelegate
         localMouseMonitor = NSEvent.addLocalMonitorForEvents(
             matching: [.leftMouseDown, .rightMouseDown, .otherMouseDown]
         ) { [weak self] event in
-            guard let self,
-                  self.isMenuTracking || self.popover.isShown,
-                  let eventWindow = event.window,
-                  NSApp.windows.contains(where: { $0 === eventWindow })
+            guard let self, !self.stopped,
+                  self.isMenuTracking || self.popover.isShown
             else {
                 return event
             }
-            if self.popover.isShown,
+            let target: MenuBarMouseTarget
+            if let eventWindow = event.window,
                eventWindow === self.popover.contentViewController?.view.window {
-                return event
+                target = .popover
+            } else if let button = self.statusItem.button,
+                      let eventWindow = event.window,
+                      eventWindow === button.window,
+                      button.bounds.contains(button.convert(event.locationInWindow, from: nil)) {
+                // Do not close on mouse-down and reopen on the button's
+                // mouse-up. Its own action retains toggle/context-menu routing.
+                target = .statusItem
+            } else if let eventWindow = event.window,
+                      NSApp.windows.contains(where: { $0 === eventWindow }) {
+                target = .applicationWindow
+            } else {
+                target = .outside
             }
-            // The menu's own window is not an application window, so native
-            // menu-item clicks continue through AppKit. A click in any of the
-            // app's windows is an unambiguous same-app click-away.
-            self.dismissSurfaces()
+            if menuBarShouldDismissForMouse(
+                target: target,
+                isMenuTracking: self.isMenuTracking,
+                isPopoverShown: self.popover.isShown
+            ) {
+                self.dismissSurfaces()
+            }
             return event
         }
         appDeactivationObserver = NotificationCenter.default.addObserver(
@@ -1739,7 +1813,32 @@ final class MenuBarStatusController: NSObject, NSMenuDelegate, NSPopoverDelegate
         }
     }
 
+    /// A status-item popover can open while the app is already inactive, so
+    /// another application's click need not cause didResignActive. Observe
+    /// mouse-down only while open, ignoring all event content and never
+    /// consuming another application's event or monitoring global keystrokes.
+    private func startOutsideClickMonitoring() {
+        guard !stopped, popover.isShown, outsideMouseMonitor == nil else { return }
+        outsideMouseMonitor = NSEvent.addGlobalMonitorForEvents(
+            matching: [.leftMouseDown, .rightMouseDown, .otherMouseDown]
+        ) { [weak self] _ in
+            // AppKit delivers event-monitor callbacks on the main thread.
+            MainActor.assumeIsolated {
+                guard let self, !self.stopped, self.popover.isShown else { return }
+                self.dismissSurfaces()
+            }
+        }
+    }
+
+    private func stopOutsideClickMonitoring() {
+        if let outsideMouseMonitor {
+            NSEvent.removeMonitor(outsideMouseMonitor)
+            self.outsideMouseMonitor = nil
+        }
+    }
+
     private func removeInteractionMonitoring() {
+        stopOutsideClickMonitoring()
         if let localMouseMonitor {
             NSEvent.removeMonitor(localMouseMonitor)
             self.localMouseMonitor = nil
@@ -1764,6 +1863,7 @@ final class MenuBarStatusController: NSObject, NSMenuDelegate, NSPopoverDelegate
             suppressesNextMenuCloseRefresh = isMenuTracking
             suppressesNextPopoverCloseRefresh = popover.isShown
         }
+        stopOutsideClickMonitoring()
         menu.cancelTracking()
         isMenuTracking = false
         popover.performClose(nil)
@@ -1839,7 +1939,7 @@ final class MenuBarStatusController: NSObject, NSMenuDelegate, NSPopoverDelegate
                     : .ready
             case .unreachable:
                 self.overviewResponseHealthy = false
-                self.invalidateObservedEvidence()
+                self.invalidateObservedEvidence(keepingHistory: true)
                 self.snapshot.phase = .unavailable
                 self.snapshot.failureSummary =
                     TiboTattleLocalization.string(
@@ -1925,11 +2025,11 @@ final class MenuBarStatusController: NSObject, NSMenuDelegate, NSPopoverDelegate
                 return
             }
             guard let overview else {
-                // An unreadable response cannot support the previous number.
-                // Clear it immediately and leave a retryable unavailable state
-                // rather than silently retaining live-looking evidence.
+                // An unreadable response cannot support a current quota or
+                // forecast. Keep prior verified history explicitly labelled
+                // as retained while this same companion remains retryable.
                 self.overviewResponseHealthy = false
-                self.invalidateObservedEvidence()
+                self.invalidateObservedEvidence(keepingHistory: true)
                 self.snapshot.phase = .unavailable
                 self.snapshot.failureSummary =
                     TiboTattleLocalization.string(
@@ -2070,15 +2170,10 @@ final class MenuBarStatusController: NSObject, NSMenuDelegate, NSPopoverDelegate
         )
     }
 
-    private func invalidateObservedEvidence() {
+    private func invalidateObservedEvidence(keepingHistory: Bool = false) {
         evidenceExpiryWorkItem?.cancel()
         evidenceExpiryWorkItem = nil
-        snapshot.lanes = []
-        snapshot.observedAt = nil
-        snapshot.evidence = .none
-        snapshot.history = .unavailable
-        snapshot.weeklyPaceOutlook = nil
-        snapshot.staleAfterSeconds = nil
+        snapshot.invalidateObservedEvidence(keepingHistory: keepingHistory)
         observedEvidenceExpiresAt = nil
     }
 
@@ -2479,7 +2574,7 @@ final class MenuBarStatusController: NSObject, NSMenuDelegate, NSPopoverDelegate
             case .unreachable:
                 self.automaticRefreshSuppressed = true
                 self.overviewResponseHealthy = false
-                self.invalidateObservedEvidence()
+                self.invalidateObservedEvidence(keepingHistory: true)
                 self.snapshot.phase = .unavailable
                 self.snapshot.failureSummary =
                     TiboTattleLocalization.string(

--- a/apps/macos/UsageMonitorApp.swift
+++ b/apps/macos/UsageMonitorApp.swift
@@ -9416,6 +9416,157 @@ private enum MenuBarContractSmokeTest {
         )
     }
 
+    private static func retainedHistoryProjectionContract() -> Bool {
+        var calendar = Calendar(identifier: .gregorian)
+        guard let timeZone = TimeZone(identifier: "America/Los_Angeles") else {
+            return false
+        }
+        calendar.timeZone = timeZone
+        let parser = ISO8601DateFormatter()
+        // Re-read two days later, across both midnight and the spring DST
+        // transition. Retained rolling periods must keep their original bars.
+        guard let retainedAt = parser.date(from: "2026-03-08T08:10:00Z"),
+              let now = parser.date(from: "2026-03-10T19:00:00Z")
+        else { return false }
+        var bucket = timelineBucket(
+            startAt: retainedAt.addingTimeInterval(-70 * 60),
+            endAt: retainedAt.addingTimeInterval(-55 * 60)
+        )
+        let coverage = pricingCoverage(fully: 1, partially: 1, unpriced: 1)
+        bucket["usageEvents"] = 3
+        bucket["totalTokens"] = 3_000
+        bucket["apiPriceEquivalentUsd"] = 0.50
+        bucket["pricingCoverage"] = coverage
+        var previous = overviewFixture(
+            now: retainedAt,
+            calendar: calendar,
+            accountingSource: "unified",
+            timelineUsage: [bucket]
+        )
+        guard var accounting = previous["accounting"] as? [String: Any],
+              let timeline = previous["timeline"] as? [String: Any]
+        else { return false }
+        accounting["periods"] = ["24h", "7d", "30d"].map { identifier in
+            var row = periodRow(identifier)
+            row["events"] = 3
+            row["totalTokens"] = 3_000
+            row["apiPriceEquivalentUsd"] = 0.50
+            row["pricingCoverage"] = coverage
+            return row
+        }
+        previous["accounting"] = accounting
+        guard let verified = decodeOverview(
+            previous, now: retainedAt, calendar: calendar
+        ), verified.history.accountingStatus == .current else { return false }
+
+        var retained = previous
+        retained["freshness"] = ["accountingStatus": "unavailable"]
+        accounting["generationMatched"] = false
+        let projection: [String: Any] = [
+            "status": "retained",
+            "reason": "local_unified_index_deferred",
+            "terminal": false,
+            "retainedAt": iso8601(retainedAt),
+            "coveredAt": timeline["coveredAt"]!,
+        ]
+        accounting["projection"] = projection
+        retained["accounting"] = accounting
+        let expected = verified.history.retainingLastVerified()
+        guard let held = decodeOverview(retained, now: now, calendar: calendar),
+              held.history == expected,
+              held.history.lastSevenDays?.totalTokens == 3_000,
+              held.history.lastThirtyDays?.knownAPIPriceEquivalentUSD == 0.50,
+              held.history.lastSevenDays?.pricingCoverage.isComplete == false,
+              held.history.sevenDayHistory.contains(where: {
+                $0.totalTokens == 3_000
+              })
+        else { return false }
+
+        func withProjection(_ value: Any) -> [String: Any] {
+            var root = retained
+            var valueAccounting = accounting
+            valueAccounting["projection"] = value
+            root["accounting"] = valueAccounting
+            return root
+        }
+        var terminal = projection
+        terminal["terminal"] = true
+        guard decodeOverview(
+            withProjection(terminal), now: now, calendar: calendar
+        )?.history == expected else { return false }
+
+        // A marker never overrides malformed provenance, chronology, periods,
+        // or timeline coverage. No generation mismatch alone admits history.
+        var invalidRoots = [withProjection(NSNull())]
+        let invalidFields: [(String, Any)] = [
+            ("status", "unavailable"),
+            ("terminal", "false"),
+            ("terminal", 1),
+            ("retainedAt", NSNull()),
+            ("retainedAt", "not-a-date"),
+            ("retainedAt", iso8601(now.addingTimeInterval(60))),
+            ("coveredAt", ["startAt": NSNull(), "endAt": NSNull()]),
+            ("coveredAt", [
+                "startAt": iso8601(retainedAt),
+                "endAt": iso8601(retainedAt.addingTimeInterval(60)),
+            ]),
+            ("coveredAt", [
+                "startAt": iso8601(retainedAt),
+                "endAt": iso8601(retainedAt.addingTimeInterval(-60)),
+            ]),
+        ]
+        for (key, value) in invalidFields {
+            var invalid = projection
+            invalid[key] = value
+            invalidRoots.append(withProjection(invalid))
+        }
+        for (key, value) in [
+            ("generationMatched", true as Any),
+            ("generationMatched", "false" as Any),
+            ("sourceMode", "legacy" as Any),
+            ("periods", [periodRow("24h")] as Any),
+        ] {
+            var invalid = retained
+            var invalidAccounting = accounting
+            invalidAccounting[key] = value
+            invalid["accounting"] = invalidAccounting
+            invalidRoots.append(invalid)
+        }
+        var missingTimelineCoverage = retained
+        var invalidTimeline = timeline
+        invalidTimeline["coveredAt"] = ["startAt": NSNull(), "endAt": NSNull()]
+        missingTimelineCoverage["timeline"] = invalidTimeline
+        invalidRoots.append(missingTimelineCoverage)
+        return invalidRoots.allSatisfy { root in
+            guard let decoded = decodeOverview(root, now: now, calendar: calendar)
+            else { return false }
+            return decoded.history.accountingStatus == .unavailable
+                && decoded.history.lastSevenDays == nil
+                && decoded.history.lastThirtyDays == nil
+        }
+    }
+
+    private static func mouseDismissalContract() -> Bool {
+        let targets: [MenuBarMouseTarget] = [
+            .popover, .statusItem, .applicationWindow, .outside,
+        ]
+        let cases: [(menu: Bool, popover: Bool, expected: [Bool])] = [
+            (false, false, [false, false, false, false]),
+            (true, false, [false, false, true, false]),
+            (false, true, [false, false, true, true]),
+            (true, true, [false, false, true, true]),
+        ]
+        return cases.allSatisfy { state in
+            zip(targets, state.expected).allSatisfy { target, expected in
+                menuBarShouldDismissForMouse(
+                    target: target,
+                    isMenuTracking: state.menu,
+                    isPopoverShown: state.popover
+                ) == expected
+            }
+        }
+    }
+
     private static func semanticProjectionContract() -> Bool {
         var calendar = Calendar(identifier: .gregorian)
         guard let timeZone = TimeZone(identifier: "America/Los_Angeles") else {
@@ -9924,7 +10075,36 @@ private enum MenuBarContractSmokeTest {
             summary: "The local companion is unavailable for this smoke test."
         )
         let unavailable = controller.nativePresentationContract()
+        // The normal app runs its event loop before any status-button click.
+        // This synchronous smoke must let AppKit attach the real status item
+        // first; a missing or unshowable item still fails the bounded check.
+        application.finishLaunching()
+        let openDeadline = Date().addingTimeInterval(2)
+        var didShowPopover = controller.showPopoverForSmokeTest()
+        while !didShowPopover && Date() < openDeadline {
+            RunLoop.main.run(until: Date().addingTimeInterval(0.02))
+            didShowPopover = controller.showPopoverForSmokeTest()
+        }
+        let shown = controller.nativePresentationContract()
         controller.shutDown()
+        let stopped = controller.nativePresentationContract()
+        let reopenedAfterShutdown = controller.showPopoverForSmokeTest()
+        let dismissalLifecycleChecks = [
+            ("initial-monitor-absent", !starting.outsideClickAwayMonitorInstalled),
+            ("popover-opened", didShowPopover && shown.popoverIsShown),
+            ("open-monitor-installed", shown.outsideClickAwayMonitorInstalled),
+            ("shutdown-outside-monitor-removed", !stopped.outsideClickAwayMonitorInstalled),
+            ("shutdown-local-monitor-removed", !stopped.sameAppClickAwayMonitorInstalled),
+            ("shutdown-escape-monitor-removed", !stopped.escapeDismissalMonitorInstalled),
+            ("shutdown-observer-removed", !stopped.appDeactivationDismissalObserverInstalled),
+            ("shutdown-cannot-reopen", !reopenedAfterShutdown),
+        ]
+        if let failed = dismissalLifecycleChecks.first(where: { !$0.1 }) {
+            FileHandle.standardError.write(Data(
+                "macOS menu bar dismissal smoke failed: \(failed.0)\n".utf8
+            ))
+            return 1
+        }
         let popup = MenuBarPopoverViewController(
             productName: BundledProduct.displayName,
             brandImage: NSApp.applicationIconImage,
@@ -9938,6 +10118,27 @@ private enum MenuBarContractSmokeTest {
         let sevenDayPopup = popup.nativePresentationContract()
         popup.selectHistoryRangeForSmokeTest(.thirtyDays)
         let thirtyDayPopup = popup.nativePresentationContract()
+        popup.update(snapshot: analyzingLiveSnapshot, now: observedAt)
+        let updatingThirtyDayPopup = popup.nativePresentationContract()
+        popup.selectHistoryRangeForSmokeTest(.sevenDays)
+        let updatingSevenDayPopup = popup.nativePresentationContract()
+        popup.selectHistoryRangeForSmokeTest(.thirtyDays)
+        var readFailureSnapshot = liveSnapshot
+        readFailureSnapshot.invalidateObservedEvidence(keepingHistory: true)
+        readFailureSnapshot.phase = .unavailable
+        popup.update(snapshot: readFailureSnapshot, now: observedAt)
+        let readFailurePopup = popup.nativePresentationContract()
+        let retainedHistory = readFailureSnapshot.history
+        readFailureSnapshot.invalidateObservedEvidence(keepingHistory: true)
+        let repeatedFailurePreservesHistory = readFailureSnapshot.history == retainedHistory
+        popup.update(snapshot: liveSnapshot, now: observedAt)
+        let recoveredPopup = popup.nativePresentationContract()
+        var restartedSnapshot = liveSnapshot
+        restartedSnapshot.invalidateObservedEvidence()
+        popup.update(snapshot: restartedSnapshot, now: observedAt)
+        let restartedPopup = popup.nativePresentationContract()
+        var failedFirstRunSnapshot = MenuBarStatusSnapshot()
+        failedFirstRunSnapshot.invalidateObservedEvidence(keepingHistory: true)
         func historyWithSevenDayCoverage(
             _ coverage: MenuBarPricingCoverage,
             knownCost: Double
@@ -10023,6 +10224,36 @@ private enum MenuBarContractSmokeTest {
               thirtyDayPopup.selectedHistoryRange == .thirtyDays,
               thirtyDayPopup.dailyBarCount == 30,
               thirtyDayPopup.historyVisible,
+              !sevenDayPopup.retainedHistoryDisclosed,
+              updatingThirtyDayPopup.selectedHistoryRange == .thirtyDays,
+              updatingThirtyDayPopup.dailyBarCount == 30,
+              updatingThirtyDayPopup.historyVisible,
+              updatingThirtyDayPopup.retainedHistoryDisclosed,
+              !updatingThirtyDayPopup.refreshActionEnabled,
+              updatingSevenDayPopup.dailyBarCount == 7,
+              updatingSevenDayPopup.historyVisible,
+              updatingSevenDayPopup.retainedHistoryDisclosed,
+              readFailurePopup.selectedHistoryRange == .thirtyDays,
+              readFailurePopup.dailyBarCount == 30,
+              readFailurePopup.historyVisible,
+              readFailurePopup.retainedHistoryDisclosed,
+              readFailurePopup.visibleAllowanceLaneCount == 0,
+              !readFailurePopup.weeklyPaceVisible,
+              readFailurePopup.refreshActionEnabled,
+              retainedHistory == liveSnapshot.history.retainingLastVerified(),
+              readFailureSnapshot.lanes.isEmpty,
+              readFailureSnapshot.observedAt == nil,
+              readFailureSnapshot.evidence == .none,
+              readFailureSnapshot.weeklyPaceOutlook == nil,
+              readFailureSnapshot.staleAfterSeconds == nil,
+              repeatedFailurePreservesHistory,
+              recoveredPopup.selectedHistoryRange == .thirtyDays,
+              recoveredPopup.historyVisible,
+              !recoveredPopup.retainedHistoryDisclosed,
+              restartedSnapshot.history == .unavailable,
+              !restartedPopup.historyVisible,
+              !restartedPopup.retainedHistoryDisclosed,
+              failedFirstRunSnapshot.history == .unavailable,
               sevenDayPopup.pricingState == .completeEquivalent,
               sevenDayPopup.historyCoverageState == .mixed,
               sevenDayPopup.historyCoverageNamed,
@@ -10038,7 +10269,9 @@ private enum MenuBarContractSmokeTest {
                   now: observedAt,
                   weeklyLane: weeklyLane
               ),
-              semanticProjectionContract()
+              semanticProjectionContract(),
+              retainedHistoryProjectionContract(),
+              mouseDismissalContract()
         else {
             FileHandle.standardError.write(
                 Data("macOS menu bar contract smoke failed\\n".utf8)
@@ -10051,14 +10284,163 @@ private enum MenuBarContractSmokeTest {
                 + "native_actions=true states=live,starting,unavailable "
                 + "shortcuts=cmd-r,cmd-comma,cmd-q "
                 + "routing=left-popover,right-menu,control-menu "
-                + "dismissal=escape,transient,same-app,deactivation "
+                + "dismissal=escape,transient,same-app,outside,deactivation "
                 + "weekly_position=factual-menu-only "
                 + "pace_outlook=collecting,under,on,over,critical,fail-closed "
                 + "history=authoritative,coverage-named,fail-closed "
                 + "pricing=complete,partial,unavailable model=dst,overlap,future,per-lane "
-                + "reset_credits=absent analysis_title=live-fallback"
+                + "reset_credits=absent analysis_title=live-fallback "
+                + "history_retention=refresh,failure,source-reset"
         )
         return 0
+    }
+
+    @MainActor
+    private final class InteractionHarnessActions: NSObject {
+        let controller: MenuBarStatusController
+
+        init(controller: MenuBarStatusController) { self.controller = controller }
+
+        @objc func showPopover(_ sender: Any?) {
+            _ = controller.showPopoverForSmokeTest()
+        }
+    }
+
+    /// Data-free, development-only interactive QA. No app delegate, companion,
+    /// user defaults, source files, credentials, or refresh are initialized.
+    static func runInteractionHarness() -> Int32 {
+        let application = NSApplication.shared
+        application.setActivationPolicy(.accessory)
+        let controller = MenuBarStatusController(
+            productName: "Menu-bar dismissal test",
+            actions: .init(
+                openTiboTattle: {}, showSettings: {}, showAbout: {},
+                quit: { application.terminate(nil) }
+            )
+        )
+        let target = InteractionHarnessActions(controller: controller)
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 480, height: 180),
+            styleMask: [.titled], backing: .buffered, defer: false
+        )
+        window.title = "Menu-bar dismissal test — no live data"
+        let showButton = NSButton(
+            title: "Open test popover", target: target,
+            action: #selector(InteractionHarnessActions.showPopover(_:))
+        )
+        let exitButton = NSButton(
+            title: "Finish test", target: application,
+            action: #selector(NSApplication.terminate(_:))
+        )
+        let content = NSStackView(views: [
+            NSTextField(labelWithString: "Temporary native test. No companion or usage data."),
+            showButton, exitButton,
+        ])
+        content.orientation = .vertical
+        content.spacing = 18
+        content.translatesAutoresizingMaskIntoConstraints = false
+        if let root = window.contentView {
+            root.addSubview(content)
+            NSLayoutConstraint.activate([
+                content.centerXAnchor.constraint(equalTo: root.centerXAnchor),
+                content.centerYAnchor.constraint(equalTo: root.centerYAnchor),
+            ])
+        }
+        window.center()
+        window.orderFrontRegardless()
+        var previous: String?
+        let deadline = Date().addingTimeInterval(180)
+        let timer = Timer.scheduledTimer(withTimeInterval: 0.1, repeats: true) { _ in
+            MainActor.assumeIsolated {
+                let state = controller.nativePresentationContract()
+                let line = "MENU_BAR_INTERACTION shown=\(state.popoverIsShown) outside_monitor=\(state.outsideClickAwayMonitorInstalled) active=\(application.isActive)"
+                if line != previous {
+                    FileHandle.standardOutput.write(Data("\(line)\n".utf8))
+                    previous = line
+                }
+                if Date() >= deadline {
+                    controller.shutDown()
+                    window.orderOut(nil)
+                    application.terminate(nil)
+                }
+            }
+        }
+        DispatchQueue.main.asyncAfter(deadline: .now() + 2) {
+            _ = controller.showPopoverForSmokeTest()
+        }
+        application.run()
+        timer.invalidate()
+        controller.shutDown()
+        window.orderOut(nil)
+        withExtendedLifetime(target) {}
+        return 0
+    }
+
+    /// Development-only, read-only handoff from the companion projection to
+    /// the actual native view. The input is a derived overview, never raw logs;
+    /// stdout reports layout/state facts rather than any private usage values.
+    static func renderOverview(inputPath: String, outputDirectory: String) -> Int32 {
+        let application = NSApplication.shared
+        application.setActivationPolicy(.accessory)
+        do {
+            let input = try FileHandle(forReadingFrom: URL(fileURLWithPath: inputPath))
+            defer { try? input.close() }
+            let maximumBytes = 8 * 1_024 * 1_024
+            let now = Date()
+            guard let data = try input.read(upToCount: maximumBytes + 1),
+                  data.count <= maximumBytes,
+                  let overview = LocalCompanionOverviewProjection.decode(data, now: now),
+                  overview.history.accountingStatus != .unavailable
+            else { return 1 }
+            let output = URL(fileURLWithPath: outputDirectory, isDirectory: true)
+            try FileManager.default.createDirectory(at: output, withIntermediateDirectories: true)
+            var snapshot = MenuBarStatusSnapshot()
+            snapshot.evidence = LocalCompanionOverviewProjection.evidence(for: overview, now: now)
+            snapshot.lanes = overview.lanes
+            snapshot.observedAt = overview.observedAt
+            snapshot.staleAfterSeconds = overview.staleAfterSeconds
+            snapshot.history = overview.history
+            snapshot.analysisAvailable = true
+            let popup = MenuBarPopoverViewController(
+                productName: BundledProduct.displayName,
+                brandImage: NSApp.applicationIconImage,
+                actions: MenuBarPopoverViewController.Actions(
+                    openTiboTattle: {}, refresh: {}, showMore: { _ in }
+                )
+            )
+            for (phase, name) in [
+                (MenuBarStatusSnapshot.Phase.ready, "ready"),
+                (.analyzing, "updating"),
+                (.unavailable, "read-failure"),
+            ] {
+                snapshot.phase = phase
+                if phase == .unavailable {
+                    snapshot.invalidateObservedEvidence(keepingHistory: true)
+                }
+                popup.update(snapshot: snapshot, now: now)
+                for range in MenuBarHistoryRange.allCases {
+                    popup.selectHistoryRangeForSmokeTest(range)
+                    let presentation = popup.nativePresentationContract()
+                    guard presentation.historyVisible,
+                          presentation.dailyBarCount == range.dayCount,
+                          presentation.retainedHistoryDisclosed
+                            == (phase != .ready || snapshot.history.accountingStatus == .retained),
+                          phase != .unavailable || presentation.visibleAllowanceLaneCount == 0,
+                          snapshot.history.period(for: range) == overview.history.period(for: range),
+                          snapshot.history.history(for: range) == overview.history.history(for: range)
+                    else { return 1 }
+                    try popup.renderPNG(
+                        to: output.appendingPathComponent("\(name)-\(range.rawValue).png"),
+                        appearance: .aqua
+                    )
+                }
+            }
+            print("USAGE_MONITOR_MACOS_MENU_BAR_OVERVIEW_RENDER ranges=7d,30d states=ready,updating,read-failure history=preserved freshness=labelled current_quota=cleared-on-failure")
+            return 0
+        } catch {
+            FileHandle.standardError.write(Data("macOS menu bar overview render failed\n".utf8))
+            return 1
+        }
     }
 
     static func render(outputDirectory: String) -> Int32 {
@@ -10222,6 +10604,28 @@ private enum MenuBarContractSmokeTest {
                             appearance: appearance
                         )
                     }
+                    var updatingSnapshot = snapshot
+                    updatingSnapshot.phase = .analyzing
+                    updatingSnapshot.history = snapshot.history.retainingLastVerified()
+                    popup.update(snapshot: updatingSnapshot, now: observedAt)
+                    for range in [MenuBarHistoryRange.sevenDays, .thirtyDays] {
+                        popup.selectHistoryRangeForSmokeTest(range)
+                        try popup.renderPNG(
+                            to: output.appendingPathComponent(
+                                "menu-bar-popover-en-updating-\(range.rawValue)-light.png"
+                            ),
+                            appearance: .aqua
+                        )
+                    }
+                    updatingSnapshot.invalidateObservedEvidence(keepingHistory: true)
+                    updatingSnapshot.phase = .unavailable
+                    popup.update(snapshot: updatingSnapshot, now: observedAt)
+                    try popup.renderPNG(
+                        to: output.appendingPathComponent(
+                            "menu-bar-popover-en-read-failure-30d-light.png"
+                        ),
+                        appearance: .aqua
+                    )
                 }
             }
 
@@ -10372,7 +10776,8 @@ private enum MenuBarContractSmokeTest {
                 + "locales=en,es,zh-Hans appearances=light,dark "
                 + "ranges=7d,30d "
                 + "states=live,pace-collecting,pace-under,pace-on,"
-                + "pace-over,pace-critical,partial-pricing,unpriced,unavailable "
+                + "pace-over,pace-critical,partial-pricing,unpriced,unavailable,"
+                + "updating-7d,updating-30d,read-failure-30d "
                 + "width=400 source=synthetic-content-free"
         )
         return 0
@@ -11826,6 +12231,25 @@ private struct UsageMonitorMain {
         if arguments.contains("--menu-bar-contract-smoke-test") {
             exit(MainActor.assumeIsolated {
                 MenuBarContractSmokeTest.run()
+            })
+        }
+        if arguments.contains("--menu-bar-interaction-smoke-test") {
+            guard BundledProduct.buildChannel == "development" else { exit(2) }
+            exit(MainActor.assumeIsolated {
+                MenuBarContractSmokeTest.runInteractionHarness()
+            })
+        }
+        if let overviewRenderIndex = arguments.firstIndex(
+            of: "--menu-bar-overview-render-smoke-test"
+        ) {
+            guard overviewRenderIndex + 2 < arguments.count,
+                  BundledProduct.buildChannel == "development"
+            else { exit(2) }
+            exit(MainActor.assumeIsolated {
+                MenuBarContractSmokeTest.renderOverview(
+                    inputPath: arguments[overviewRenderIndex + 1],
+                    outputDirectory: arguments[overviewRenderIndex + 2]
+                )
             })
         }
         if let renderIndex = arguments.firstIndex(

--- a/src/local-companion-data.js
+++ b/src/local-companion-data.js
@@ -3632,7 +3632,16 @@ const PROJECTION_SURFACES = Object.freeze([
     preserveIncomingKeys: Object.freeze(["paceForecast", "paceOutlook"]),
   },
   { path: Object.freeze(["overview", "usage"]), rows: usagePeriodRows },
-  { path: Object.freeze(["overview", "timeline", "usage"]), rows: arrayRows },
+  {
+    path: Object.freeze(["overview", "timeline", "usage"]),
+    rows: arrayRows,
+    // Coverage and encoding describe these exact usage rows. Keeping rows
+    // with the deferred build's empty coverage makes native consumers reject
+    // the retained history. Carry only their metadata, not fresh quota lanes.
+    retainSiblingKeys: Object.freeze([
+      "source", "coveredAt", "bucketMinutes", "history", "allowanceWeightingEncoding",
+    ]),
+  },
   { path: Object.freeze(["overview", "timeline", "sparkUsage"]), rows: arrayRows },
   {
     path: Object.freeze(["overview", "timeline", "calibrationUsage"]),
@@ -3898,7 +3907,7 @@ export class LocalCompanionDataStore {
     const retained = this.#snapshot;
     if (retained === null) return next;
     let usageEvidenceRetained = false;
-    for (const { path, rows, preserveIncomingKeys = [] }
+    for (const { path, rows, preserveIncomingKeys = [], retainSiblingKeys = [] }
       of PROJECTION_SURFACES) {
       const key = path[path.length - 1];
       const nextParent = surfaceParent(next, path);
@@ -3917,6 +3926,15 @@ export class LocalCompanionDataStore {
           }
         }
         nextParent[key] = replacement;
+        for (const siblingKey of retainSiblingKeys) {
+          if (Object.hasOwn(retainedParent, siblingKey)) {
+            nextParent[siblingKey] = structuredClone(retainedParent[siblingKey]);
+          } else {
+            // A missing old metadata field must not borrow the incoming
+            // projection's coverage or encoding for unrelated retained rows.
+            delete nextParent[siblingKey];
+          }
+        }
         if (path.length === 2 && path[0] === "overview" && path[1] === "usage") {
           usageEvidenceRetained = true;
         }

--- a/test/local-companion-data.test.js
+++ b/test/local-companion-data.test.js
@@ -2632,6 +2632,174 @@ test("a deferred quick reload keeps the usage figures and both usage timelines",
   })();
 });
 
+test("usage timeline retention keeps its matching metadata without retaining current quota lanes", async (t) => {
+  const metadataKeys = [
+    "source", "coveredAt", "bucketMinutes", "history", "allowanceWeightingEncoding",
+  ];
+  const snapshot = ({ generation, matched, populated }) => {
+    const generatedAt = generation === 1
+      ? "2026-08-28T12:00:00.000Z"
+      : "2026-08-28T12:15:00.000Z";
+    const coveredAt = populated
+      ? { startAt: "2026-08-28T00:00:00.000Z", endAt: generatedAt }
+      : { startAt: null, endAt: null };
+    return {
+      schemaVersion: LOCAL_COMPANION_SCHEMA_VERSION,
+      mode: "real_local_evidence",
+      generatedAt,
+      overview: {
+        quota: { observedAt: generatedAt, windows: [{ remainingPercent: 90 - generation }] },
+        accounting: {
+          sourceMode: "unified",
+          generation,
+          generationMatched: matched,
+          generationFingerprint: `synthetic-generation-${generation}`,
+          accountingCacheStatus: matched ? "available" : "unavailable",
+          generatedAt,
+          coveredAt,
+          events: populated ? generation : 0,
+          projection: {
+            status: matched ? "current" : "loading",
+            reason: matched ? null : "unified_index_deferred",
+            terminal: matched,
+          },
+        },
+        usage: [{ id: "7d", events: populated ? generation : 0 }],
+        timeline: {
+          source: populated ? "unified_local_index" : "insufficient_evidence",
+          coveredAt,
+          bucketMinutes: generation === 1 ? 15 : 30,
+          history: { status: populated ? "complete" : "loading", coveredAt, generatedAt },
+          allowanceWeightingEncoding: {
+            schemaVersion: "quota-weighted-timeline-v0.1",
+            scenarioOrder: generation === 1
+              ? ["unresolved_as_standard", "unresolved_as_fast"]
+              : ["unresolved_as_fast", "unresolved_as_standard"],
+            selectedScenario: "unresolved_as_standard",
+          },
+          usage: populated ? [{ at: generatedAt, totalTokens: generation * 100 }] : [],
+          quota: [{ at: generatedAt, usedPercent: generation }],
+          sparkQuota: [{ at: generatedAt, usedPercent: generation * 2 }],
+          sparkUsage: [{ at: generatedAt, totalTokens: generation * 10 }],
+          calibrationUsage: [{ at: generatedAt, totalTokens: generation * 20 }],
+          allowanceCapacity: { status: "available", marker: generation },
+          marker: generation,
+        },
+      },
+      gradient: { datasets: {} },
+      weekly: { datasets: {} },
+      quality: {},
+    };
+  };
+  const storeWith = (snapshots) => {
+    let call = 0;
+    return new LocalCompanionDataStore({
+      builder: async () => snapshots[Math.min(call++, snapshots.length - 1)],
+    });
+  };
+
+  for (const purpose of ["startup", "quick", "full"]) {
+    await t.test(`${purpose} retains usage and metadata as one projection`, async () => {
+      const previous = snapshot({ generation: 1, matched: true, populated: true });
+      const incoming = snapshot({ generation: 2, matched: false, populated: false });
+      const unmodified = structuredClone([previous, incoming]);
+      const store = storeWith([previous, incoming]);
+      await store.reload({ purpose: "full" });
+      await store.reload({ purpose });
+      const held = store.getOverview();
+      const expectedTimeline = { ...incoming.overview.timeline, usage: previous.overview.timeline.usage };
+      for (const key of metadataKeys) expectedTimeline[key] = previous.overview.timeline[key];
+      assert.deepEqual(held.timeline, expectedTimeline,
+        "retained usage needs its old metadata; quota, Spark, and other incoming lanes stay fresh");
+      assert.deepEqual(held.quota, incoming.overview.quota);
+      assert.equal(held.generatedAt, incoming.generatedAt);
+      assert.equal(held.accounting.generation, 2);
+      assert.equal(held.accounting.generationMatched, false);
+      assert.equal(held.accounting.generationFingerprint, "synthetic-generation-2");
+      assert.equal(held.accounting.accountingCacheStatus, "unavailable");
+      assert.deepEqual(held.accounting.projection, {
+        ...incoming.overview.accounting.projection,
+        status: "retained",
+        retainedAt: previous.generatedAt,
+        coveredAt: previous.overview.accounting.coveredAt,
+      });
+      assert.deepEqual([previous, incoming], unmodified, "retention must not mutate builder snapshots");
+    });
+  }
+
+  await t.test("missing old metadata is not borrowed from the incoming projection", async () => {
+    const previous = snapshot({ generation: 1, matched: true, populated: true });
+    for (const key of metadataKeys) delete previous.overview.timeline[key];
+    const incoming = snapshot({ generation: 2, matched: false, populated: false });
+    const store = storeWith([previous, incoming]);
+    await store.reload({ purpose: "full" });
+    await store.reload({ purpose: "quick" });
+    const held = store.getOverview();
+    assert.deepEqual(held.timeline.usage, previous.overview.timeline.usage);
+    for (const key of metadataKeys) {
+      assert.equal(Object.hasOwn(held.timeline, key), false, `${key} cannot be invented for old rows`);
+    }
+    assert.deepEqual(held.timeline.quota, incoming.overview.timeline.quota);
+  });
+
+  await t.test("malformed old coverage stays unavailable rather than being repaired from accounting dates", async () => {
+    const previous = snapshot({ generation: 1, matched: true, populated: true });
+    const malformedMetadata = {
+      source: null,
+      coveredAt: { startAt: "not-a-date", endAt: null },
+      bucketMinutes: -1,
+      history: null,
+      allowanceWeightingEncoding: null,
+    };
+    Object.assign(previous.overview.timeline, malformedMetadata);
+    const incoming = snapshot({ generation: 2, matched: false, populated: false });
+    const store = storeWith([previous, incoming]);
+    await store.reload({ purpose: "full" });
+    await store.reload({ purpose: "full" });
+    const held = store.getOverview();
+    assert.deepEqual(held.timeline.usage, previous.overview.timeline.usage);
+    for (const key of metadataKeys) assert.deepEqual(held.timeline[key], malformedMetadata[key]);
+    assert.deepEqual(held.accounting.projection.coveredAt, previous.overview.accounting.coveredAt);
+    assert.notDeepEqual(held.timeline.coveredAt, held.accounting.projection.coveredAt);
+  });
+
+  for (const [name, matched, populated] of [
+    ["authoritative empty", true, false],
+    ["authoritative populated", true, true],
+    ["non-authoritative populated", false, true],
+  ]) {
+    await t.test(`${name} replaces both usage and its metadata`, async () => {
+      const previous = snapshot({ generation: 1, matched: true, populated: true });
+      const incoming = snapshot({ generation: 2, matched, populated });
+      const store = storeWith([previous, incoming]);
+      await store.reload({ purpose: "full" });
+      await store.reload({ purpose: "full" });
+      assert.deepEqual(store.getOverview().timeline, incoming.overview.timeline);
+      assert.deepEqual(store.getOverview().accounting, incoming.overview.accounting);
+    });
+  }
+
+  await t.test("an omitted usage surface does not trigger metadata retention", async () => {
+    const previous = snapshot({ generation: 1, matched: true, populated: true });
+    const incoming = snapshot({ generation: 2, matched: false, populated: false });
+    delete incoming.overview.timeline.usage;
+    const store = storeWith([previous, incoming]);
+    await store.reload({ purpose: "full" });
+    await store.reload({ purpose: "quick" });
+    assert.deepEqual(store.getOverview().timeline, incoming.overview.timeline);
+  });
+
+  await t.test("a first refresh without previous usage cannot manufacture timeline metadata", async () => {
+    const previous = snapshot({ generation: 1, matched: true, populated: false });
+    const incoming = snapshot({ generation: 2, matched: false, populated: false });
+    const store = storeWith([previous, incoming]);
+    await store.reload({ purpose: "startup" });
+    assert.deepEqual(store.getOverview().timeline, previous.overview.timeline);
+    await store.reload({ purpose: "quick" });
+    assert.deepEqual(store.getOverview().timeline, incoming.overview.timeline);
+  });
+});
+
 test("a non-authoritative FULL build keeps the evidence it could not rebuild", async () => {
   // Reproduced 2026-08-21 against the owner's real index (repro-blank.mjs):
   // a full-mode snapshot built while the generation row is not ready — the
@@ -2972,9 +3140,10 @@ test("every surface a withheld projection empties is registered for retention", 
   // values, so enumerating its substitution sites enumerates the class.
   //
   // Two of the eight sites yield real data surfaces as bare empty arrays and
-  // one yields the zeroed placeholder periods; the remaining five yield a
-  // coverage window or a source LABEL, which carry no rows and are meant to
-  // change on a deferred pass. If a new evidence-bearing substitution appears,
+  // one yields the zeroed placeholder periods; the remaining five yield
+  // metadata rather than rows. Usage coverage/source metadata is retained with
+  // the exact usage rows it describes; accounting truth fields remain current.
+  // If a new evidence-bearing substitution appears,
   // this fails until it is registered in PROJECTION_SURFACES — which is the
   // point, because reviewing the retention list is not something anyone
   // remembers to do when adding a surface.

--- a/test/macos-app-bundle.test.js
+++ b/test/macos-app-bundle.test.js
@@ -1564,20 +1564,41 @@ test("native launcher keeps the requested foreground-only lifecycle", async () =
     /func applicationWillTerminate[\s\S]*menuBarStatus\?\.shutDown\(\)/u,
   );
   // The shipped app must never become a menu-bar-only surface. Accessory
-  // activation is confined to the non-launching AppKit smoke modes.
+  // activation is confined to isolated AppKit smoke modes, including the
+  // development-only, data-free interaction harness below.
   assert.match(
     source,
     /private enum MenuBarContractSmokeTest \{[\s\S]*?application\.setActivationPolicy\(\.accessory\)/u,
   );
   assert.equal(
     source.match(/setActivationPolicy\(\.accessory\)/gu)?.length,
-    6,
+    8,
     "only isolated AppKit smoke modes may use accessory activation",
   );
   assert.match(
     source,
     /static func render\(outputDirectory: String\) -> Int32 \{[\s\S]*?application\.setActivationPolicy\(\.accessory\)/u,
   );
+  assert.match(
+    source,
+    /static func renderOverview\(inputPath: String, outputDirectory: String\) -> Int32 \{[\s\S]*?application\.setActivationPolicy\(\.accessory\)/u,
+  );
+  const menuBarSmokeSource = source.match(
+    /private enum MenuBarContractSmokeTest \{[\s\S]*?(?=\nprivate enum NativeSettingsLayout)/u,
+  )?.[0] ?? "";
+  const interactionHarness = menuBarSmokeSource.match(
+    /static func runInteractionHarness\(\) -> Int32 \{[\s\S]*?\n    \}/u,
+  )?.[0] ?? "";
+  assert.match(interactionHarness, /application\.setActivationPolicy\(\.accessory\)/u);
+  assert.match(interactionHarness, /MenuBarStatusController\(/u);
+  assert.doesNotMatch(interactionHarness,
+    /CompanionProcess|CompanionResources|\bProcess\(|companionReady\(|startCompanion\(|openDashboard\(/u);
+  const interactionEntry = source.match(
+    /if arguments\.contains\("--menu-bar-interaction-smoke-test"\) \{[\s\S]*?\n        \}/u,
+  )?.[0] ?? "";
+  assert.match(interactionEntry,
+    /guard BundledProduct\.buildChannel == "development"[\s\S]*?else \{\s*exit\(2\)/u);
+  assert.match(interactionEntry, /MenuBarContractSmokeTest\.runInteractionHarness\(\)/u);
   // The sidebar-recovery and interaction-safety smokes build real AppKit or
   // WebKit objects in windows they never bring forward.
   assert.match(
@@ -2744,7 +2765,7 @@ test("menu-bar status item degrades honestly and never invents allowance evidenc
   assert.match(source, /menu\.popUp\(positioning: nil, at: screenPoint, in: nil\)/u);
   assert.match(source, /func popoverDidClose\(_ notification: Notification\)/u);
   const showActionMenu = source.match(
-    /private func showActionMenu\(from anchor: NSView\)[\s\S]*?(?=\n    func popoverDidClose)/u,
+    /private func showActionMenu\(from anchor: NSView\)[\s\S]*?(?=\n    func popoverDidShow)/u,
   )?.[0] ?? "";
   const popoverDidClose = source.match(
     /func popoverDidClose\(_ notification: Notification\)[\s\S]*?(?=\n    \/\/\/ AppKit normally)/u,
@@ -2802,13 +2823,16 @@ test("menu-bar status item degrades honestly and never invents allowance evidenc
     /func shutDown\(\) \{[\s\S]*?stopped = true\s*\n\s*dismissSurfaces\(\)/u,
   );
 
-  // Restart/failure/read errors clear numeric evidence before rendering. A
-  // callback from an older URL or start cannot cross the generation boundary.
+  // Restart/source replacement clears all evidence. Same-source read failures
+  // clear current quota and forecast, but retain explicitly labelled history.
+  // A callback from an older URL/start cannot cross the generation boundary.
   assert.match(source, /private var companionGeneration: UInt64 = 0/u);
-  assert.match(source, /private func invalidateObservedEvidence\(\) \{[\s\S]*?snapshot\.lanes = \[\][\s\S]*?snapshot\.observedAt = nil[\s\S]*?snapshot\.evidence = \.none/u);
+  assert.match(source, /mutating func invalidateObservedEvidence\(keepingHistory: Bool = false\) \{\s*lanes = \[\]\s*observedAt = nil\s*evidence = \.none\s*history = keepingHistory \? history\.retainingLastVerified\(\) : \.unavailable\s*weeklyPaceOutlook = nil\s*staleAfterSeconds = nil/u);
+  assert.match(source, /private func invalidateObservedEvidence\(keepingHistory: Bool = false\) \{[\s\S]*?snapshot\.invalidateObservedEvidence\(keepingHistory: keepingHistory\)/u);
+  assert.match(source, /func companionReady\(dashboardURL: URL\) \{[\s\S]*?invalidateObservedEvidence\(\)/u);
   assert.match(source, /func companionStarting\(\) \{[\s\S]*?invalidateObservedEvidence\(\)/u);
   assert.match(source, /func companionUnavailable\(summary: String\?\) \{[\s\S]*?invalidateObservedEvidence\(\)/u);
-  assert.match(source, /guard let overview else \{[\s\S]*?invalidateObservedEvidence\(\)[\s\S]*?snapshot\.phase = \.unavailable/u);
+  assert.match(source, /guard let overview else \{[\s\S]*?invalidateObservedEvidence\(keepingHistory: true\)[\s\S]*?snapshot\.phase = \.unavailable/u);
   assert.match(source, /self\.companionGeneration == generation/u);
   assert.match(source, /self\.dashboardURL == dashboardURL/u);
 
@@ -3025,15 +3049,18 @@ test("menu-bar status item degrades honestly and never invents allowance evidenc
   assert.match(popupSource, /menuBarPopupCoverageMixed/u);
   assert.match(popupSource, /menuBarPopupCoverageAccessible/u);
   assert.match(popupSource, /historyCoverageLabel\.isHidden = historyChart\.coverageState == \.complete/u);
+  assert.match(popupSource, /history\.accountingStatus == \.retained[\s\S]*?currentSnapshot\.phase == \.analyzing[\s\S]*?menuBarPopupRetainedHistory/u);
   assert.match(popupSource, /refreshButton\.isEnabled = snapshot\.analysisAvailable/u);
   assert.match(popupSource, /selectHistoryRangeForSmokeTest/u);
   assert.match(popupSource, /renderPNG\(to url: URL, appearance: NSAppearance\.Name\)/u);
+  assert.match(appSource, /of: "--menu-bar-overview-render-smoke-test"[\s\S]*?BundledProduct\.buildChannel == "development"[\s\S]*?MenuBarContractSmokeTest\.renderOverview/u);
 
   // Accounting is independently fail-closed. Calendar-day aggregation uses
   // Calendar arithmetic for DST, preserves gaps, and admits authoritative
   // zeros only inside complete coverage.
   assert.match(modelSource, /freshness\["accountingStatus"\] as\? String == "available"/u);
   assert.match(modelSource, /sourceMode != "unified"[\s\S]*?generationMatched/u);
+  assert.match(modelSource, /projection\["status"\] as\? String == "retained"[\s\S]*?sourceMode == "unified"[\s\S]*?exactBoolean\(accounting\["generationMatched"\]\) == false[\s\S]*?startAt < endAt[\s\S]*?endAt <= retainedAt[\s\S]*?retainedAt <= now/u);
   assert.match(modelSource, /enum Evidence: Equatable \{[\s\S]*?case available[\s\S]*?case partial[\s\S]*?case unavailable/u);
   assert.match(modelSource, /calendar\.date\([\s\S]*?byAdding: \.day/u);
   assert.match(modelSource, /let fullCivilDayCovered/u);
@@ -3133,6 +3160,75 @@ test("menu-bar status item degrades honestly and never invents allowance evidenc
   ]) {
     assert.equal(source.includes(forbidden), false, forbidden);
   }
+});
+
+test("menu-bar click-away monitoring is mouse-only, popover-scoped, and preserves status-button routing", async () => {
+  const source = await readFile(MENU_BAR_STATUS_SOURCE, "utf8");
+  const method = (name) => {
+    const body = source.match(new RegExp(
+      `func ${name}\\([^)]*\\)[\\s\\S]*?\\n    \\}`,
+      "u",
+    ))?.[0];
+    assert.ok(body, `${name} must remain an explicit lifecycle boundary`);
+    return body;
+  };
+  const mouseDecision = source.match(
+    /func menuBarShouldDismissForMouse\([\s\S]*?\n\}/u,
+  )?.[0] ?? "";
+  const mouseTargets = source.match(
+    /enum MenuBarMouseTarget[^\n]*\{[\s\S]*?\n\}/u,
+  )?.[0] ?? "";
+  assert.match(mouseTargets, /enum MenuBarMouseTarget: Equatable, CaseIterable \{\s*case popover\s*case statusItem\s*case applicationWindow\s*case outside\s*\}/u);
+  assert.match(mouseDecision, /case \.popover, \.statusItem:\s*return false/u);
+  assert.match(mouseDecision, /case \.applicationWindow:\s*return isMenuTracking \|\| isPopoverShown/u);
+  assert.match(mouseDecision, /case \.outside:\s*return isPopoverShown/u);
+
+  const interactionMonitoring = method("installInteractionMonitoring");
+  const localMouseMonitor = interactionMonitoring.match(
+    /localMouseMonitor = NSEvent\.addLocalMonitorForEvents\([\s\S]*?(?=\n        appDeactivationObserver =)/u,
+  )?.[0] ?? "";
+  assert.match(localMouseMonitor,
+    /matching: \[\.leftMouseDown, \.rightMouseDown, \.otherMouseDown\]/u);
+  assert.match(localMouseMonitor,
+    /guard let self, !self\.stopped,\s*self\.isMenuTracking \|\| self\.popover\.isShown/u);
+  assert.match(localMouseMonitor,
+    /eventWindow === self\.popover\.contentViewController\?\.view\.window \{\s*target = \.popover/u);
+  assert.match(localMouseMonitor,
+    /let button = self\.statusItem\.button,[\s\S]*?eventWindow === button\.window,\s*button\.bounds\.contains\(button\.convert\(event\.locationInWindow, from: nil\)\) \{[\s\S]*?target = \.statusItem/u);
+  assert.match(localMouseMonitor,
+    /NSApp\.windows\.contains\(where: \{ \$0 === eventWindow \}\) \{\s*target = \.applicationWindow\s*\} else \{\s*target = \.outside/u);
+  assert.match(localMouseMonitor,
+    /menuBarShouldDismissForMouse\(\s*target: target,\s*isMenuTracking: self\.isMenuTracking,\s*isPopoverShown: self\.popover\.isShown\s*\) \{\s*self\.dismissSurfaces\(\)\s*\}\s*return event/u);
+  assert.doesNotMatch(localMouseMonitor, /return nil|\.characters|\.keyCode/u);
+  assert.doesNotMatch(interactionMonitoring, /addGlobalMonitorForEvents|startOutsideClickMonitoring/u);
+
+  const outsideMonitoring = method("startOutsideClickMonitoring");
+  assert.equal(source.match(/NSEvent\.addGlobalMonitorForEvents/gu)?.length, 1,
+    "the sole global monitor must stay in the popover-only mouse listener");
+  assert.match(outsideMonitoring,
+    /guard !stopped, popover\.isShown, outsideMouseMonitor == nil else \{ return \}/u);
+  assert.match(outsideMonitoring,
+    /outsideMouseMonitor = NSEvent\.addGlobalMonitorForEvents\(\s*matching: \[\.leftMouseDown, \.rightMouseDown, \.otherMouseDown\]\s*\) \{ \[weak self\] _ in/u);
+  assert.match(outsideMonitoring,
+    /MainActor\.assumeIsolated \{\s*guard let self, !self\.stopped, self\.popover\.isShown else \{ return \}\s*self\.dismissSurfaces\(\)/u);
+  assert.doesNotMatch(outsideMonitoring,
+    /\.keyDown|\.keyUp|\.flagsChanged|\.mouseMoved|\.scrollWheel|\.characters|\.keyCode|\bevent\.|print\(|FileHandle/u);
+  assert.match(method("stopOutsideClickMonitoring"),
+    /if let outsideMouseMonitor \{\s*NSEvent\.removeMonitor\(outsideMouseMonitor\)\s*self\.outsideMouseMonitor = nil/u);
+  assert.match(method("statusItemActivated"),
+    /popover\.show\([\s\S]*?preferredEdge: \.minY\s*\)\s*startOutsideClickMonitoring\(\)/u);
+  assert.match(method("popoverDidShow"), /startOutsideClickMonitoring\(\)/u);
+  assert.match(method("popoverDidClose"),
+    /stopOutsideClickMonitoring\(\)[\s\S]*?guard !stopped/u);
+  assert.match(method("showActionMenu"),
+    /stopOutsideClickMonitoring\(\)[\s\S]*?popover\.performClose\(nil\)/u);
+  assert.match(method("dismissSurfaces"),
+    /stopOutsideClickMonitoring\(\)\s*menu\.cancelTracking\(\)[\s\S]*?popover\.performClose\(nil\)/u);
+  assert.match(method("removeInteractionMonitoring"), /stopOutsideClickMonitoring\(\)/u);
+  assert.match(method("shutDown"),
+    /stopped = true\s*dismissSurfaces\(\)[\s\S]*?removeInteractionMonitoring\(\)/u);
+  assert.match(source, /popoverIsShown: popover\.isShown/u);
+  assert.match(source, /outsideClickAwayMonitorInstalled: outsideMouseMonitor != nil/u);
 });
 
 test("native quota duration and reset scheduling stay bounded and provider-aware", async () => {
@@ -7217,7 +7313,7 @@ macOSArtifactTest("reproducible ad-hoc-signed app passes orderly and launcher-SI
     );
     assert.match(
       menuBarSmoke.stdout,
-      /^USAGE_MONITOR_MACOS_MENU_BAR_CONTRACT popover=true width=400 bars=7,30 pace=canonical-outlook native_actions=true states=live,starting,unavailable shortcuts=cmd-r,cmd-comma,cmd-q routing=left-popover,right-menu,control-menu dismissal=escape,transient,same-app,deactivation weekly_position=factual-menu-only pace_outlook=collecting,under,on,over,critical,fail-closed history=authoritative,coverage-named,fail-closed pricing=complete,partial,unavailable model=dst,overlap,future,per-lane reset_credits=absent analysis_title=live-fallback$/mu,
+      /^USAGE_MONITOR_MACOS_MENU_BAR_CONTRACT popover=true width=400 bars=7,30 pace=canonical-outlook native_actions=true states=live,starting,unavailable shortcuts=cmd-r,cmd-comma,cmd-q routing=left-popover,right-menu,control-menu dismissal=escape,transient,same-app,outside,deactivation weekly_position=factual-menu-only pace_outlook=collecting,under,on,over,critical,fail-closed history=authoritative,coverage-named,fail-closed pricing=complete,partial,unavailable model=dst,overlap,future,per-lane reset_credits=absent analysis_title=live-fallback history_retention=refresh,failure,source-reset$/mu,
     );
     const analysisProgressSmoke = spawnSync(
       join(outputA, "Contents", "MacOS", "TiboTattle"),
@@ -7246,10 +7342,13 @@ macOSArtifactTest("reproducible ad-hoc-signed app passes orderly and launcher-SI
     );
     assert.match(
       popupRenderSmoke.stdout,
-      /^USAGE_MONITOR_MACOS_MENU_BAR_POPOVER_RENDER locales=en,es,zh-Hans appearances=light,dark ranges=7d,30d states=live,pace-collecting,pace-under,pace-on,pace-over,pace-critical,partial-pricing,unpriced,unavailable width=400 source=synthetic-content-free$/mu,
+      /^USAGE_MONITOR_MACOS_MENU_BAR_POPOVER_RENDER locales=en,es,zh-Hans appearances=light,dark ranges=7d,30d states=live,pace-collecting,pace-under,pace-on,pace-over,pace-critical,partial-pricing,unpriced,unavailable,updating-7d,updating-30d,read-failure-30d width=400 source=synthetic-content-free$/mu,
     );
     const popupRenders = (await readdir(popupRenderDirectory)).sort();
-    assert.equal(popupRenders.length, 15);
+    assert.equal(popupRenders.length, 18);
+    for (const state of ["updating-7d", "updating-30d", "read-failure-30d"]) {
+      assert.equal(popupRenders.includes(`menu-bar-popover-en-${state}-light.png`), true);
+    }
     assert.equal(
       popupRenders.includes("menu-bar-popover-en-30d-light.png"),
       true,
@@ -7293,7 +7392,7 @@ macOSArtifactTest("reproducible ad-hoc-signed app passes orderly and launcher-SI
       assert.equal(renderBytes.readUInt32BE(16), 800, popupRender);
       const pixelHeight = renderBytes.readUInt32BE(20);
       assert.ok(pixelHeight >= 600, popupRender);
-      if (!popupRender.includes("unavailable")) {
+      if (!popupRender.includes("unavailable") && !popupRender.includes("read-failure")) {
         assert.ok(pixelHeight >= 1_000, popupRender);
       }
       popupRenderDigests.set(

--- a/test/macos-test-build.test.mjs
+++ b/test/macos-test-build.test.mjs
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import { spawnSync } from "node:child_process";
-import { mkdtemp, realpath, rm, writeFile } from "node:fs/promises";
+import { mkdtemp, readdir, realpath, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import test from "node:test";
@@ -81,6 +81,70 @@ async function currentWeeklyPaceFixture() {
   return { weekly: { paceOutlook } };
 }
 
+async function retainedMenuBarOverviewFixture() {
+  const nowMs = Date.now() - 1_000;
+  const generatedAt = new Date(nowMs - 60_000).toISOString();
+  const coveredAt = {
+    startAt: new Date(nowMs - 30 * 24 * 60 * 60_000).toISOString(),
+    endAt: generatedAt,
+  };
+  const pricingCoverage = { fullyPricedEvents: 2, partiallyPricedEvents: 1, unpricedEvents: 1 };
+  const periods = ["24h", "7d", "30d"].map((periodId) => ({
+    periodId, events: 4, totalTokens: 1_000, apiPriceEquivalentUsd: .2, pricingCoverage,
+  }));
+  const bucketEndMs = Math.floor((nowMs - 60_000) / 900_000) * 900_000;
+  let candidate = {
+    schemaVersion: LOCAL_COMPANION_SCHEMA_VERSION,
+    mode: "real_local_evidence",
+    generatedAt,
+    overview: {
+      evidenceStatus: "available",
+      freshness: { status: "live", accountingStatus: "available", staleAfterSeconds: 600 },
+      quotaWindows: [{
+        limitId: "codex", slot: "primary", durationMinutes: 10_080,
+        remainingPercent: 80, usedPercent: 20, observedAt: generatedAt,
+        resetAt: new Date(nowMs + 6 * 24 * 60 * 60_000).toISOString(),
+      }],
+      accounting: {
+        sourceMode: "unified", generation: 1, generationMatched: true,
+        generatedAt, coveredAt, events: 4, periods,
+        projection: { status: "available", reason: null, terminal: false },
+      },
+      usage: periods.map(({ periodId, ...period }) => ({ id: periodId, ...period })),
+      timeline: {
+        source: "unified_local_index", coveredAt, bucketMinutes: 15,
+        history: { status: "complete", coveredAt, generatedAt },
+        usage: [{
+          startAt: new Date(bucketEndMs - 900_000).toISOString(),
+          endAt: new Date(bucketEndMs).toISOString(),
+          usageEvents: 4, totalTokens: 1_000, apiPriceEquivalentUsd: .2, pricingCoverage,
+        }],
+      },
+    },
+    gradient: {}, weekly: {}, quality: {},
+  };
+  const store = new LocalCompanionDataStore({ builder: async () => candidate });
+  await store.reload({ purpose: "full" });
+  candidate = structuredClone(candidate);
+  candidate.generatedAt = new Date(nowMs).toISOString();
+  candidate.overview.freshness.accountingStatus = "unavailable";
+  Object.assign(candidate.overview.quotaWindows[0], {
+    observedAt: candidate.generatedAt, remainingPercent: 75, usedPercent: 25,
+  });
+  Object.assign(candidate.overview.accounting, {
+    generation: 2, generationMatched: false, events: 0, periods: [],
+    generatedAt: candidate.generatedAt, coveredAt: { startAt: null, endAt: null },
+    projection: { status: "unavailable", reason: "local_unified_index_deferred", terminal: false },
+  });
+  candidate.overview.usage = [];
+  Object.assign(candidate.overview.timeline, {
+    source: "insufficient_evidence", coveredAt: { startAt: null, endAt: null },
+    history: { status: "loading" }, usage: [],
+  });
+  await store.reload({ purpose: "quick" });
+  return store.getOverview();
+}
+
 test("test compiler profile builds a development-only launcher that runs", {
   skip: BUILD_SUPPORTED ? false : "requires pinned macOS arm64 Node v26.2.0 builder",
   timeout: 90_000,
@@ -129,6 +193,45 @@ test("test compiler profile builds a development-only launcher that runs", {
       progressSmoke.stdout,
       /phases=allowlisted[\s\S]*unified=scanning[\s\S]*accounting=calculating[\s\S]*counts=bounded[\s\S]*quick_result=evidence-gated[\s\S]*unknown=generic[\s\S]*free_text=ignored/u,
     );
+    const menuBarSmoke = spawnSync(
+      launcher,
+      ["--menu-bar-contract-smoke-test"],
+      { encoding: "utf8", timeout: 10_000 },
+    );
+    assert.equal(
+      menuBarSmoke.status,
+      0,
+      menuBarSmoke.error?.message ?? menuBarSmoke.stderr,
+    );
+    assert.match(
+      menuBarSmoke.stdout,
+      /history=authoritative,coverage-named,fail-closed[\s\S]*history_retention=refresh,failure,source-reset/u,
+    );
+    assert.match(
+      menuBarSmoke.stdout,
+      /dismissal=escape,transient,same-app,outside,deactivation/u,
+    );
+    const retainedOverviewFixture = join(temporaryRoot, "retained-menu-bar-overview.json");
+    const retainedOverview = await retainedMenuBarOverviewFixture();
+    assert.equal(retainedOverview.accounting.projection.status, "retained");
+    assert.equal(retainedOverview.accounting.generationMatched, false);
+    const overviewRenderDirectory = join(temporaryRoot, "retained-menu-bar-render");
+    await writeFile(retainedOverviewFixture, `${JSON.stringify(retainedOverview)}\n`, {
+      encoding: "utf8", mode: 0o600,
+    });
+    const overviewRenderSmoke = spawnSync(launcher, [
+      "--menu-bar-overview-render-smoke-test", retainedOverviewFixture, overviewRenderDirectory,
+    ], { encoding: "utf8", timeout: 10_000 });
+    assert.equal(
+      overviewRenderSmoke.status, 0,
+      overviewRenderSmoke.error?.message ?? overviewRenderSmoke.stderr,
+    );
+    assert.match(overviewRenderSmoke.stdout,
+      /USAGE_MONITOR_MACOS_MENU_BAR_OVERVIEW_RENDER ranges=7d,30d states=ready,updating,read-failure history=preserved freshness=labelled current_quota=cleared-on-failure/u);
+    assert.deepEqual((await readdir(overviewRenderDirectory)).sort(),
+      ["ready", "updating", "read-failure"].flatMap((state) => (
+        ["7d", "30d"].map((range) => `${state}-${range}.png`)
+      )).sort());
     const weeklyPaceFixture = join(temporaryRoot, "weekly-pace-outlook.json");
     await writeFile(
       weeklyPaceFixture,


### PR DESCRIPTION
## Summary

- Preserve the last verified 7-day/30-day menu-bar usage analysis through refresh and transient companion reads, explicitly labelled as retained; clear current quota/forecast on failure and retained history on companion replacement.
- Retain usage timeline rows together with their original coverage/encoding metadata without retaining incoming quota lanes or inventing missing evidence.
- Dismiss the native popover on outside clicks even when TiboTattle was already inactive. Keep mouse observation scoped to an open popover, ignore event content, preserve inside/status-button actions, and remove monitors on every close/shutdown path.
- Add focused synthetic regressions and development-only native QA modes. No schema change, Electron/Claude feature work, compact-accounting web edits, installation, or release publication.

## Validation

- Companion data/refresh and loopback-server regressions: 184 passed.
- Native source: 53 passed; 6 localization and 17 documentation checks passed. Three artifact-only tests remain excluded by the existing source-only lane.
- Compiled native smoke: passed on macOS arm64 / Node.js 26.2.0, including retained-history projection/rendering and real AppKit popover open/monitor/shutdown checks.
- Architecture, root hygiene, and preflight: passed.
- Independent read-only dismissal review: no concrete concerns.

## Release handoff

Source-only change for the coordinated 0.1.17 native dogfood. Integrated R7
receipt freshness/regeneration is intentionally deferred to the final combined
source gate; no receipt has been rewritten here. Signed build and installation
remain with the release coordinator.

Physical mouse click-through remains a signed-candidate check: the desktop-control
helper failed its mouse-action transport, so this PR does not claim that manual
interaction gate passed. A data-free native test window and compiled AppKit
lifecycle checks were used without exposing private usage or replacing any app.
