### PR TITLE
Finalize native dogfood replacement compatibility

### DIFF
--- a/docs/plans/2026-08-30-native-dogfood-integration.md
+++ b/docs/plans/2026-08-30-native-dogfood-integration.md
@@ -30,16 +30,23 @@ must remain untouched by integration.
 | #88 native menu history retained during refresh and popup dismissal | Merged as `41c02dd2`; integrated | Revalidate the signed native artifact, including physical clicks |
 | #87 local cache-drop thread links | Explicitly included; merged as `a864d159` from `ce0aacd6` | Reconcile five-column compact layout, test transient name lookup and native handoff; final integrated R7 remains here |
 | #86 participant self-service deletion retirement | Ready/merged handoff supersedes draft-only exclusion; include `9b121b7d` | Reconcile integrated source and native/consent checks; no hosted deployment or production deletion is authorized here |
-| #75 stacked native popup PR | Native popup already ported into release source | Do not merge excluded Electron ancestry |
+| #75 stacked native popup PR | Merged into the Windows/Electron branch, not main; native functionality already ported by #81 | Verified native parity on `c111fded`; do not merge excluded Electron ancestry |
+| #89 server-computed per-model allowance series | Merged into main as `c111fded` after the first candidate was signed | Include source and rerun the complete Worker gate; hosted activation remains a separate deployment |
+| #90 compact accounting, context-pricing parity and retained R7 evidence | Merged as `d13b19ef` | Preserve completed validation and build the final candidate from the subsequently updated source |
+| #91 purchased-credit research analyzer | Opened after the native freeze; standalone research, not a packaged native dependency | Exclude from this candidate; separate source/privacy review remains necessary |
 | #73, #74, Electron delivery, Linux integration and Claude Code integration | Excluded | No scope expansion without a new decision |
 | Credential-lifetime branch | Unreviewed, uncommitted work remains | Do not silently absorb into this candidate |
 
 Take a fresh PR/main snapshot before freezing. Identify newly included source
 explicitly; do not indefinitely follow unrelated active branches.
 
-The selected source set is now frozen through main's `9b121b7d` (#86), including
-#87 and #88, plus this task's compact-accounting changes. Further unrelated PRs
-are not automatically included in the retained validation run.
+PR #90 closed the initial source freeze through main's `9b121b7d` (#86),
+including #87 and #88 plus this task's compact-accounting changes. The owner's
+subsequent request reopened the freeze to include newly merged #89 at
+`c111fded` and verify #75 parity. The final follow-up also repairs the retained
+replacement validator for the exact already-shipped dogfood artifact; it does
+not change the app's runtime. Further unrelated PRs are not automatically
+included in the retained validation run.
 
 ## Execution and acceptance
 
@@ -150,17 +157,73 @@ remains below the 1,610,612,736-byte ceiling. Record this measurement drift
 without calling it either a proven regression or harmless noise. This is
 internal-dogfood evidence, not stable-release qualification.
 
-Existing Developer ID and notarization configuration authenticated successfully
-without signing or submission. The prior signed 0.1.16 dogfood DMG and receipt
-were located and its checksum matched. A schema-9 preservation copy alone is
-not a working rollback for an old reader that only supports schema 8; do not
-launch that reader against the newer state. Before normal installed launch,
+PR #90 merged as `d13b19ef` with a tree identical to its tested final head.
+The annotated `tibotattle-internal-dogfood-0.1.17-rc1-source-20260831` tag
+identifies that first candidate. Its retained finalizer and independent DMG
+validation both exited zero: Developer ID, hardened runtime, app and DMG
+notarization/stapling, Gatekeeper, and empty-profile checks passed. The artifact
+remains preserved and was not installed. It predates #89 and is not the final
+updated-source candidate.
+
+The subsequent actual replacement check refused the previous 0.1.16 dogfood's
+pre-policy source tag. Its checksum matches the original receipt, and its
+embedded build manifest also predates source seals. The follow-up supports
+only that exact previous artifact through a module-private, expiring capability,
+retaining all native trust and payload checks and leaving candidate/public/signing
+validation strict. Actual artifact validation additionally identified the old
+normalized Keytar binary and two absent Keychain plist identity fields. Both
+compatibility rules are previous-only, with exact historical inventory pins;
+current candidates still require the current inventory and explicit identity.
+The actual 1022-to-1023 replacement gate then passed, including both DMGs and
+their native signature, notarization, Gatekeeper and empty-profile smokes.
+An intervening candidate-mount refusal was resolved by detaching the operator's
+already-mounted test image; no validation rule was relaxed. Neither old receipt
+nor tag was rewritten. Both installed old-app bundles have content- and signature-
+verified private ZIP backups; neither original has been replaced or removed.
+
+On `c111fded`, #89's complete Worker gate exited zero: 429 Worker tests,
+174 script tests, workspace-copy guards, endpoints, generated types,
+TypeScript, and default/staging dry-run bundles passed. Fresh pinned Worker
+dependencies and legitimate no-installer public-site inputs were used. The
+first dependency refresh was sandbox-refused; its authorized unchanged retry
+completed. No Worker deployment or migration occurred. The retained R7
+freshness tests still pass 2/2 because this merge does not change their workload
+closure. Recheck both pinned runtimes after the final repair rather than
+regenerating protected evidence without a source-provenance need.
+
+Read-only #75 parity inspection verified that #81's `91735527` port retained
+the native popup/pace implementation, its native render harness and all three
+locale catalogs. Subsequent #88 changes add refresh retention and dismissal.
+No native implementation port is needed; this is source parity, not the
+remaining physical signed-app interaction check.
+
+The final replacement repair passed all five focused policy/forgery regressions
+and the retained native gate, 67/67 without skips or cancellations. The full
+root repeat reported 3,213 passes, 17 designated skips and one Preview-build
+cancellation, with no failed assertions; it was not a passing root run. The
+macOS power log records a 950-second system sleep during that run. With a
+temporary keep-awake assertion, the unchanged Preview test passed in 136 seconds
+within the retained native gate. No timeout, assertion or test was weakened.
+The final full-suite rerun then exited zero in 441 seconds: 3,214 passes,
+17 designated skips, no failures or cancellations, from 3,231 tests. Both
+pinned-runtime R7 freshness checks passed 2/2 again and all ten receipts remain
+unchanged. The
+private backup, atomic-swap and old-app-retirement guard tests passed 27/27 using
+synthetic directories only; actual installation and retirement have not run.
+Final preflight passed 18/18 and architecture passed with 369 production files,
+1,449 imports and zero approved debt edges. Existing Developer ID availability
+and notarization-profile authentication were checked without changing credentials.
+
+A schema-9 preservation copy alone is not a working rollback for an old reader
+that only supports schema 8; do not launch that reader against the newer state.
+Before normal installed launch,
 check whether existing consent, pairing or a pending sign-in can automatically
 resume contribution. Normal installed launch is held for the owner's direction
 about any automatic pairing or upload; do not alter consent as a workaround.
 Credential-free, empty-profile artifact smokes do not qualify real Keychain or
 normal signed-in operation.
 
-Signing, installation and release publication have not yet been completed for
-this source set. Private state records, comparisons, UI captures and release
-inputs remain local and outside tracked docs.
+Final updated-source tagging, signing, replacement validation, installation
+and physical native checks remain. Public release/updater publication is not
+part of this internal dogfood. Private state records, comparisons, UI captures
+and release inputs remain local and outside tracked docs.

--- a/docs/runbooks/macos-stable-release-runbook.md
+++ b/docs/runbooks/macos-stable-release-runbook.md
@@ -107,6 +107,23 @@ but it cannot read or migrate stable state. The signed same-identity
 the live stable database into Preview, relabel `PRAGMA user_version`, delete the
 index, or reopen a migrated schema-10 or schema-11 index with shipped 0.1.16.
 
+The replacement validator has one closed previous-only exception for the
+pre-policy internal-dogfood `0.1.16` / build `1022` DMG: SHA-256
+`2b32964c8b3bc2912620dbbe078aaf4e2fd49f1725a4e94a62dff184cdc9f8c1`,
+49,341,249 bytes, source `5adaca5fdc8f981c391144e0d29b6f4c764f0f96`
+at `v0.1.16`. Its receipt predates channel-specific tags and its app lacks an
+embedded source seal. Only the checksum-verified previous side of
+`validate-macos-replacement.js` accepts that identity, its exact build digests,
+and the existing channel, updater-key, and signed-release assurances. Native
+signature, notarization, Gatekeeper, and isolated-smoke checks still run. Matching
+previous-only rules cover its exact normalized Keytar binary and its two absent
+Keychain identity plist fields. The old payload is fully verified, never
+rewritten; current candidates still require the current normalization inventory
+and both explicit Keychain identity fields. No compatibility flag is available
+for a candidate, public installer, or signing path.
+Do not rewrite the old receipt or tag. Preserving this artifact does not prove
+state rollback: a schema-9 backup is already newer than its schema-8 reader.
+
 **The failure class to expect after a batch of merges** is a *pin* that was
 never updated: a reviewed public-API list, a pinned action SHA, a byte-identity
 digest, a root-workspace allowlist, or an exact `deepEqual` on an exported

--- a/scripts/macos-release-core.js
+++ b/scripts/macos-release-core.js
@@ -131,6 +131,39 @@ const REQUIRED_SIGNED_RELEASE_ASSURANCES = Object.freeze([
   "dmgNotarizationAccepted",
   "dmgTicketStapled",
 ]);
+// This already-distributed DMG predates channel tags and embedded source seals.
+// It is a previous-artifact exception, never a way to build/publish a candidate.
+const LEGACY_DOGFOOD_PREVIOUS_RELEASE = Object.freeze({
+  artifactSha256:
+    "2b32964c8b3bc2912620dbbe078aaf4e2fd49f1725a4e94a62dff184cdc9f8c1",
+  artifactBytes: 49_341_249,
+  artifactFileName: "TiboTattle-0.1.16-macOS-arm64.dmg",
+  bundleVersion: "1022",
+  shortVersion: "0.1.16",
+  sourceCommit: "5adaca5fdc8f981c391144e0d29b6f4c764f0f96",
+  sourceTag: "v0.1.16",
+  sourceSha256:
+    "ff7f59ec074705f8ecb3d78810177a8e8a4795a1e58c2df24faa9b3e6e26fae7",
+  payloadSha256:
+    "a5740aac152d95b638989462584774c0e3039ecd7db511692bd8fe690d8d37c4",
+  publicEdKeySha256:
+    "77d5717947da768e7e96a1b1e6225d2cae4748a556f109f2a30444a5f41ff3d2",
+  frameworkSha256:
+    "2a43f8c41a29b195982354d7580036c178ed89e3b3e5dc0d8ab295290d91a0ac",
+  keytar: Object.freeze({
+    path: "Contents/Resources/app/node_modules/@github/keytar/prebuilds/darwin-arm64/keytar.node",
+    bytes: 98_544,
+    mode: "555",
+    sha256:
+      "dd24fba62f187f494e86ab5c4d499dcb8cb2c5bd7345079651297aecb9c6f049",
+  }),
+});
+// The Symbol is transport only: a caller-controlled options Proxy can discover
+// it. Authorization requires an opaque object in the module-private WeakSet.
+const VERIFIED_LEGACY_DOGFOOD_PREVIOUS_ARTIFACT = Symbol(
+  "verified legacy dogfood previous artifact",
+);
+const VERIFIED_LEGACY_DOGFOOD_CAPABILITIES = new WeakSet();
 const REQUIRED_NODE_RUNTIME_ENTITLEMENTS = Object.freeze([
   "com.apple.security.cs.allow-jit",
   "com.apple.security.cs.allow-unsigned-executable-memory",
@@ -162,6 +195,17 @@ function fail(message, code = "MACOS_RELEASE_FAILED") {
   const error = new Error(message);
   error.code = code;
   throw error;
+}
+
+function validateLegacyDogfoodPreviousCapability(capability) {
+  if (capability === null) return false;
+  if (!VERIFIED_LEGACY_DOGFOOD_CAPABILITIES.has(capability)) {
+    fail(
+      "Legacy dogfood source compatibility requires a verified previous-artifact capability",
+      "MACOS_LEGACY_SOURCE_COMPATIBILITY_INVALID",
+    );
+  }
+  return true;
 }
 
 function resolveOperationalReleaseChannel(channel = "stable") {
@@ -738,7 +782,14 @@ function validateManifestPayloadPath(path) {
   }
 }
 
-async function verifyMacOSBuildPayload(appPath, manifest) {
+async function verifyMacOSBuildPayload(
+  appPath,
+  manifest,
+  legacyDogfoodPreviousCapability = null,
+) {
+  const legacyDogfoodPrevious = validateLegacyDogfoodPreviousCapability(
+    legacyDogfoodPreviousCapability,
+  );
   const payload = manifest.payload;
   const updaterEnabled = manifest.release?.updater?.enabled === true;
   if (!payload
@@ -765,7 +816,10 @@ async function verifyMacOSBuildPayload(appPath, manifest) {
       );
     }
     previousPath = entry.path;
-    const expectedNormalization = NORMALIZED_MACH_O_PATHS.has(entry.path)
+    const legacyKeytar = legacyDogfoodPrevious
+      && entry.path === LEGACY_DOGFOOD_PREVIOUS_RELEASE.keytar.path;
+    const expectedNormalization = (NORMALIZED_MACH_O_PATHS.has(entry.path)
+        || legacyKeytar)
       ? "mach_o_without_code_signature"
       : "raw";
     if (!Number.isSafeInteger(entry.bytes)
@@ -775,6 +829,8 @@ async function verifyMacOSBuildPayload(appPath, manifest) {
         || typeof entry.sha256 !== "string"
         || !/^[a-f0-9]{64}$/u.test(entry.sha256)
         || entry.normalization !== expectedNormalization
+        || (legacyKeytar && ["bytes", "mode", "sha256"].some((key) =>
+          entry[key] !== LEGACY_DOGFOOD_PREVIOUS_RELEASE.keytar[key]))
         || expected.has(entry.path)
         || [BUILD_MANIFEST_PATH, CODE_RESOURCES_PATH].includes(entry.path)) {
       fail(
@@ -790,7 +846,12 @@ async function verifyMacOSBuildPayload(appPath, manifest) {
       ...SPARKLE_NORMALIZED_MACH_O_PATHS,
     ]
     : BASE_NORMALIZED_MACH_O_PATHS;
-  for (const required of requiredMachOPaths) {
+  for (const required of [
+    ...requiredMachOPaths,
+    ...(legacyDogfoodPrevious
+      ? [LEGACY_DOGFOOD_PREVIOUS_RELEASE.keytar.path]
+      : []),
+  ]) {
     if (!expected.has(required)) {
       fail(
         "Application payload inventory omits required signed code",
@@ -974,7 +1035,18 @@ function hasAppOpenScheme(plist) {
       && entry.CFBundleURLSchemes.includes(APP_OPEN_SCHEME));
 }
 
-function hasExpectedProductBrand(plist) {
+function hasExpectedProductBrand(plist, legacyDogfoodPreviousCapability = null) {
+  const legacyDogfoodPrevious = validateLegacyDogfoodPreviousCapability(
+    legacyDogfoodPreviousCapability,
+  );
+  // The pinned old app used the same identity constants in code, before these
+  // two fields were added to its plist. Do not exempt new candidates or accept
+  // a partially specified/different identity on the historical artifact.
+  const expectedKeychainIdentity = legacyDogfoodPrevious
+    ? !Object.hasOwn(plist, "UsageMonitorKeychainNamespace")
+      && !Object.hasOwn(plist, "UsageMonitorKeychainAccount")
+    : plist.UsageMonitorKeychainNamespace === PRODUCT_BRAND.keychainNamespace
+      && plist.UsageMonitorKeychainAccount === PRODUCT_BRAND.keychainAccount;
   return plist.CFBundleDisplayName === PRODUCT_BRAND.displayName
     && plist.CFBundleName === PRODUCT_BRAND.displayName
     && plist.UsageMonitorAppOpenHost === PRODUCT_BRAND.appOpenHost
@@ -983,10 +1055,7 @@ function hasExpectedProductBrand(plist) {
     && plist.UsageMonitorBundleName === PRODUCT_BRAND.bundleName
     && plist.UsageMonitorStateDirectoryName
       === PRODUCT_BRAND.stateDirectoryName
-    && plist.UsageMonitorKeychainNamespace
-      === PRODUCT_BRAND.keychainNamespace
-    && plist.UsageMonitorKeychainAccount
-      === PRODUCT_BRAND.keychainAccount
+    && expectedKeychainIdentity
     && plist.UsageMonitorMonitoredAppDisplayName
       === PRODUCT_BRAND.monitoredAppDisplayName
     && plist.UsageMonitorMonitoredAppBundleIdentifier
@@ -1085,11 +1154,16 @@ async function validateUpdaterBoundary(appPath, plist, manifest, {
 
 export async function inspectMacOSApp(appPath, {
   allowLegacyUnsealedSource = false,
+  [VERIFIED_LEGACY_DOGFOOD_PREVIOUS_ARTIFACT]: legacyDogfoodPreviousCapability = null,
   channel = "stable",
   requireExternalDistribution = false,
 } = {}) {
+  const legacyDogfoodPrevious = validateLegacyDogfoodPreviousCapability(
+    legacyDogfoodPreviousCapability,
+  );
   if (typeof allowLegacyUnsealedSource !== "boolean"
-      || (allowLegacyUnsealedSource && !requireExternalDistribution)) {
+      || ((allowLegacyUnsealedSource || legacyDogfoodPrevious)
+        && !requireExternalDistribution)) {
     fail(
       "Legacy unsealed source compatibility requires external artifact validation",
       "MACOS_LEGACY_SOURCE_COMPATIBILITY_INVALID",
@@ -1115,14 +1189,14 @@ export async function inspectMacOSApp(appPath, {
       || manifest.application?.bundleIdentifier !== BUNDLE_IDENTIFIER) {
     fail("Application build manifest has an unexpected identity");
   }
-  await verifyMacOSBuildPayload(selected, manifest);
+  await verifyMacOSBuildPayload(selected, manifest, legacyDogfoodPreviousCapability);
   const plistPath = join(selected, "Contents", "Info.plist");
   await regularPath(plistPath);
   const plist = parsePlist(plistPath);
   if (plist.CFBundleIdentifier !== BUNDLE_IDENTIFIER
       || plist.CFBundleExecutable !== PRODUCT_BRAND.executableName
       || !hasAppOpenScheme(plist)
-      || !hasExpectedProductBrand(plist)) {
+      || !hasExpectedProductBrand(plist, legacyDogfoodPreviousCapability)) {
     fail("Application bundle metadata is incomplete");
   }
   await validateUpdaterBoundary(selected, plist, manifest, {
@@ -1148,7 +1222,31 @@ export async function inspectMacOSApp(appPath, {
         "MACOS_LEGACY_SOURCE_COMPATIBILITY_INVALID",
       );
     }
-    sealedSource = exactLegacyUnsealedSource
+    const exactLegacyDogfoodSource = legacyDogfoodPrevious
+      && releaseChannel.name === INTERNAL_DOGFOOD_RELEASE_CHANNEL
+      && plist.CFBundleVersion === LEGACY_DOGFOOD_PREVIOUS_RELEASE.bundleVersion
+      && plist.CFBundleShortVersionString
+        === LEGACY_DOGFOOD_PREVIOUS_RELEASE.shortVersion
+      && manifest.application.bundleVersion
+        === LEGACY_DOGFOOD_PREVIOUS_RELEASE.bundleVersion
+      && manifest.application.shortVersion
+        === LEGACY_DOGFOOD_PREVIOUS_RELEASE.shortVersion
+      && manifest.inputs?.sourceSha256
+        === LEGACY_DOGFOOD_PREVIOUS_RELEASE.sourceSha256
+      && manifest.payload?.payloadSha256
+        === LEGACY_DOGFOOD_PREVIOUS_RELEASE.payloadSha256
+      && manifest.release?.source === undefined
+      && manifest.release?.updater?.publicEdKeySha256
+        === LEGACY_DOGFOOD_PREVIOUS_RELEASE.publicEdKeySha256
+      && manifest.release?.updater?.frameworkSha256
+        === LEGACY_DOGFOOD_PREVIOUS_RELEASE.frameworkSha256;
+    if (legacyDogfoodPrevious && !exactLegacyDogfoodSource) {
+      fail(
+        "Legacy dogfood source compatibility does not match the exact previous build",
+        "MACOS_LEGACY_SOURCE_COMPATIBILITY_INVALID",
+      );
+    }
+    sealedSource = (exactLegacyUnsealedSource || exactLegacyDogfoodSource)
         && manifest.release?.source === undefined
       ? null
       : validateSealedMacOSReleaseSource(
@@ -1460,6 +1558,7 @@ function validateSignedReleaseChannel(manifest, label) {
 
 function validateSignedReleaseManifest(manifest, label, {
   allowLegacyStableMigrationSource = false,
+  allowLegacyDogfoodPreviousSource = false,
 } = {}) {
   if (!manifest || typeof manifest !== "object" || Array.isArray(manifest)
       || manifest.schemaVersion !== RELEASE_MANIFEST_SCHEMA
@@ -1499,6 +1598,15 @@ function validateSignedReleaseManifest(manifest, label, {
   const channelName = manifest.channel === undefined
     ? null
     : validateSignedReleaseChannel(manifest, label);
+  const legacyDogfoodPreviousSource = allowLegacyDogfoodPreviousSource
+    && isExactLegacyDogfoodPreviousRelease(manifest);
+  if (manifest.artifact.sha256 === LEGACY_DOGFOOD_PREVIOUS_RELEASE.artifactSha256
+      && !legacyDogfoodPreviousSource) {
+    fail(
+      "The historical dogfood artifact is allowed only as its exact previous release",
+      "MACOS_LEGACY_SOURCE_COMPATIBILITY_INVALID",
+    );
+  }
   const bundleVersion = manifest.application.bundleVersion;
   const legacyStableMigrationSource =
     allowLegacyStableMigrationSource
@@ -1511,7 +1619,7 @@ function validateSignedReleaseManifest(manifest, label, {
   }
   if (manifest.source !== undefined) {
     validateMacOSReleaseSource(manifest.source, label);
-    if (channelName !== null
+    if (channelName !== null && !legacyDogfoodPreviousSource
         && !isMacOSReleaseSourceTagForChannel(manifest.source.tag, {
           channel: channelName,
           expectedVersion: manifest.application.shortVersion,
@@ -1534,6 +1642,26 @@ function validateSignedReleaseManifest(manifest, label, {
     macOSBundleVersionParts(bundleVersion);
   }
   return manifest;
+}
+
+function isExactLegacyDogfoodPreviousRelease(manifest) {
+  const legacy = LEGACY_DOGFOOD_PREVIOUS_RELEASE;
+  return manifest?.channel?.name === INTERNAL_DOGFOOD_RELEASE_CHANNEL
+    && manifest.application?.bundleIdentifier === BUNDLE_IDENTIFIER
+    && manifest.application?.bundleVersion === legacy.bundleVersion
+    && manifest.application?.shortVersion === legacy.shortVersion
+    && manifest.artifact?.sha256 === legacy.artifactSha256
+    && manifest.artifact?.bytes === legacy.artifactBytes
+    && manifest.artifact?.fileName === legacy.artifactFileName
+    && manifest.source?.repository === PUBLIC_RELEASE_SOURCE_REPOSITORY
+    && manifest.source?.commit === legacy.sourceCommit
+    && manifest.source?.tag === legacy.sourceTag
+    && manifest.build?.sourceSha256 === legacy.sourceSha256
+    && manifest.build?.payloadSha256 === legacy.payloadSha256
+    && manifest.updater?.appcastURL === manifest.channel.sparkle.appcastURL
+    && manifest.updater?.publicEdKeySha256 === legacy.publicEdKeySha256
+    && manifest.updater?.frameworkSha256 === legacy.frameworkSha256
+    && manifest.updater?.verifyBeforeExtraction === true;
 }
 
 function compareCandidateToPreviousBundleVersion(candidate, previous) {
@@ -1723,7 +1851,10 @@ export function validateMacOSSignedReplacementPair({
   const previous = validateSignedReleaseManifest(
     previousManifest,
     "Previous release",
-    { allowLegacyStableMigrationSource: true },
+    {
+      allowLegacyStableMigrationSource: true,
+      allowLegacyDogfoodPreviousSource: true,
+    },
   );
   const candidate = validateSignedReleaseManifest(
     candidateManifest,
@@ -1786,7 +1917,10 @@ export function validateMacOSSignedReplacementPair({
 async function readReplacementReleaseArtifact(
   manifestPath,
   label,
-  { allowLegacyStableMigrationSource = false } = {},
+  {
+    allowLegacyStableMigrationSource = false,
+    allowLegacyDogfoodPreviousSource = false,
+  } = {},
 ) {
   const selectedManifest = resolve(manifestPath);
   await regularPath(selectedManifest);
@@ -1801,6 +1935,7 @@ async function readReplacementReleaseArtifact(
   }
   validateSignedReleaseManifest(manifest, label, {
     allowLegacyStableMigrationSource,
+    allowLegacyDogfoodPreviousSource,
   });
   const artifact = join(dirname(selectedManifest), manifest.artifact.fileName);
   const metadata = await regularPath(artifact);
@@ -1879,7 +2014,10 @@ export async function validateMacOSSignedReplacementArtifacts({
   const previous = await readReplacementReleaseArtifact(
     previousReleaseManifestPath,
     "Previous release",
-    { allowLegacyStableMigrationSource: true },
+    {
+      allowLegacyStableMigrationSource: true,
+      allowLegacyDogfoodPreviousSource: true,
+    },
   );
   const candidate = await readReplacementReleaseArtifact(
     candidateReleaseManifestPath,
@@ -1895,11 +2033,28 @@ export async function validateMacOSSignedReplacementArtifacts({
       === LEGACY_STABLE_MACOS_BUNDLE_VERSION
     && previous.manifest.application.shortVersion
       === LEGACY_STABLE_MACOS_BUNDLE_VERSION;
-  await validateArtifact(previous.artifact, {
-    allowLegacyUnsealedSource: previousIsExactLegacyStable,
-    channel: previous.manifest.channel.name,
-    production: true,
-  });
+  const previousArtifactCapability = isExactLegacyDogfoodPreviousRelease(
+    previous.manifest,
+  ) ? Object.freeze({}) : null;
+  if (previousArtifactCapability !== null) {
+    VERIFIED_LEGACY_DOGFOOD_CAPABILITIES.add(previousArtifactCapability);
+  }
+  try {
+    await validateArtifact(previous.artifact, {
+      allowLegacyUnsealedSource: previousIsExactLegacyStable,
+      ...(previousArtifactCapability !== null ? {
+        [VERIFIED_LEGACY_DOGFOOD_PREVIOUS_ARTIFACT]: previousArtifactCapability,
+      } : {}),
+      channel: previous.manifest.channel.name,
+      production: true,
+    });
+  } finally {
+    // Even an injected validator that captures the token cannot reuse it after
+    // the previous-side await settles (including a failed native validation).
+    if (previousArtifactCapability !== null) {
+      VERIFIED_LEGACY_DOGFOOD_CAPABILITIES.delete(previousArtifactCapability);
+    }
+  }
   await validateArtifact(candidate.artifact, {
     allowLegacyUnsealedSource: false,
     channel: candidate.manifest.channel.name,
@@ -2471,14 +2626,17 @@ function parseMacOSDeveloperIDNativeTrust(signature) {
 
 export async function validateInstalledMacOSApp(appPath, {
   allowLegacyUnsealedSource = false,
+  [VERIFIED_LEGACY_DOGFOOD_PREVIOUS_ARTIFACT]: legacyDogfoodPreviousCapability = null,
   channel = "stable",
   expectedBundleIdentifier = null,
   expectedBundleVersion = null,
   expectedShortVersion = null,
   production = true,
 } = {}) {
+  validateLegacyDogfoodPreviousCapability(legacyDogfoodPreviousCapability);
   const inspected = await inspectMacOSApp(appPath, {
     allowLegacyUnsealedSource,
+    [VERIFIED_LEGACY_DOGFOOD_PREVIOUS_ARTIFACT]: legacyDogfoodPreviousCapability,
     channel,
     requireExternalDistribution: production,
   });
@@ -2590,6 +2748,7 @@ export async function validateInstalledMacOSApp(appPath, {
 
 export async function validateMacOSDMG(path, {
   allowLegacyUnsealedSource = false,
+  [VERIFIED_LEGACY_DOGFOOD_PREVIOUS_ARTIFACT]: legacyDogfoodPreviousCapability = null,
   channel = "stable",
   distribution = null,
   expectedBundleIdentifier = null,
@@ -2597,6 +2756,9 @@ export async function validateMacOSDMG(path, {
   expectedShortVersion = null,
   production = true,
 } = {}) {
+  const legacyDogfoodPrevious = validateLegacyDogfoodPreviousCapability(
+    legacyDogfoodPreviousCapability,
+  );
   const selectedDistribution = distribution ?? (
     production ? DMG_DISTRIBUTIONS.release : DMG_DISTRIBUTIONS.development
   );
@@ -2614,7 +2776,17 @@ export async function validateMacOSDMG(path, {
     ? PREVIEW_PRODUCT_BRAND
     : PRODUCT_BRAND;
   const selected = resolve(path);
-  await regularPath(selected);
+  const metadata = await regularPath(selected);
+  if (legacyDogfoodPrevious
+      && (!production || channel !== INTERNAL_DOGFOOD_RELEASE_CHANNEL
+        || metadata.size !== LEGACY_DOGFOOD_PREVIOUS_RELEASE.artifactBytes
+        || await sha256File(selected)
+          !== LEGACY_DOGFOOD_PREVIOUS_RELEASE.artifactSha256)) {
+    fail(
+      "Legacy dogfood source compatibility requires the exact previous DMG bytes",
+      "MACOS_LEGACY_SOURCE_COMPATIBILITY_INVALID",
+    );
+  }
   runMacOSReleaseCommand("/usr/bin/hdiutil", ["verify", selected], {
     failureMessage: "DMG verification failed",
     timeout: 300_000,
@@ -2690,6 +2862,7 @@ export async function validateMacOSDMG(path, {
     }
     return await validateInstalledMacOSApp(installedApp, {
       allowLegacyUnsealedSource,
+      [VERIFIED_LEGACY_DOGFOOD_PREVIOUS_ARTIFACT]: legacyDogfoodPreviousCapability,
       channel,
       expectedBundleIdentifier,
       expectedBundleVersion,

--- a/scripts/validate-macos-replacement.js
+++ b/scripts/validate-macos-replacement.js
@@ -47,7 +47,9 @@ try {
   );
   console.log(`Update mode: ${result.updateMode}`);
   console.log(`Rollback mode: ${result.rollbackMode}`);
-  console.log("Automatic updater: absent");
+  console.log(
+    `Automatic updater: ${result.automaticUpdaterPresent ? "present" : "absent"}`,
+  );
   console.log("Hosted data mutation: none");
 } catch (error) {
   const code =

--- a/test/macos-app-bundle.test.js
+++ b/test/macos-app-bundle.test.js
@@ -98,7 +98,9 @@ import {
   readMacOSReleaseCredentials,
   readStableReleaseManifest,
   submitToAppleNotary,
+  validateInstalledMacOSApp,
   validateNodeRuntimeEntitlements,
+  validateMacOSSignedReleaseArtifact,
   validateMacOSSignedReplacementArtifacts,
   validateMacOSSignedReplacementPair,
   validateMacOSApplicationsLink,
@@ -5169,6 +5171,139 @@ test("signed updater replacement contract validates upgrade and rollback artifac
       INTERNAL_DOGFOOD_SIGNED_BUNDLE_VERSION,
       2,
     );
+    // Public release metadata for the one pre-channel-tag dogfood artifact.
+    // Tests never read its real DMG, installed app, or private local state.
+    const historicalDogfoodManifest = {
+      ...previousDogfoodManifest,
+      application: {
+        bundleIdentifier: "com.usagemonitor.local",
+        bundleVersion: "1022",
+        shortVersion: "0.1.16",
+      },
+      artifact: {
+        bytes: 49_341_249,
+        fileName: "TiboTattle-0.1.16-macOS-arm64.dmg",
+        sha256:
+          "2b32964c8b3bc2912620dbbe078aaf4e2fd49f1725a4e94a62dff184cdc9f8c1",
+      },
+      build: {
+        sourceSha256:
+          "ff7f59ec074705f8ecb3d78810177a8e8a4795a1e58c2df24faa9b3e6e26fae7",
+        payloadSha256:
+          "a5740aac152d95b638989462584774c0e3039ecd7db511692bd8fe690d8d37c4",
+      },
+      source: {
+        repository: "https://github.com/adamallcock/tibotattle",
+        commit: "5adaca5fdc8f981c391144e0d29b6f4c764f0f96",
+        tag: "v0.1.16",
+      },
+      updater: {
+        ...previousDogfoodManifest.updater,
+        frameworkSha256:
+          "2a43f8c41a29b195982354d7580036c178ed89e3b3e5dc0d8ab295290d91a0ac",
+        publicEdKeySha256:
+          "77d5717947da768e7e96a1b1e6225d2cae4748a556f109f2a30444a5f41ff3d2",
+        verifyBeforeExtraction: true,
+      },
+    };
+    assert.doesNotThrow(() => validateMacOSSignedReplacementPair({
+      previousManifest: historicalDogfoodManifest,
+      candidateManifest: candidateDogfoodManifest,
+    }));
+    for (const [section, key, value] of [
+      ["application", "bundleIdentifier", "com.example.changed"],
+      ["application", "bundleVersion", "1021"],
+      ["application", "shortVersion", "0.1.15"],
+      ["artifact", "bytes", 49_341_248],
+      ["artifact", "fileName", "repacked.dmg"],
+      ["artifact", "sha256", "0".repeat(64)],
+      ["source", "repository", "https://github.com/example/changed"],
+      ["source", "commit", "a".repeat(40)],
+      ["source", "tag", "tibotattle-internal-dogfood-0.1.16-rc1-source-20260827"],
+      ["build", "sourceSha256", "a".repeat(64)],
+      ["build", "payloadSha256", "b".repeat(64)],
+      ["updater", "appcastURL", "https://updates.example/changed.xml"],
+      ["updater", "publicEdKeySha256", "c".repeat(64)],
+      ["updater", "frameworkSha256", "d".repeat(64)],
+      ["updater", "verifyBeforeExtraction", false],
+      ...Object.keys(assurances).map((key) => ["assurances", key, false]),
+    ]) {
+      const altered = structuredClone(historicalDogfoodManifest);
+      altered[section][key] = value;
+      assert.throws(
+        () => validateMacOSSignedReplacementPair({
+          previousManifest: altered,
+          candidateManifest: candidateDogfoodManifest,
+        }),
+        (error) => typeof error.code === "string"
+          && error.code.startsWith("MACOS_"),
+        `the historical exception must refuse changed ${section}.${key}`,
+      );
+    }
+    assert.throws(
+      () => validateMacOSSignedReplacementPair({
+        previousManifest: historicalDogfoodManifest,
+        candidateManifest: {
+          ...candidateDogfoodManifest,
+          application: {
+            ...candidateDogfoodManifest.application,
+            bundleVersion: "1022",
+          },
+        },
+      }),
+      { code: "MACOS_REPLACEMENT_VERSION_NOT_NEWER" },
+    );
+    assert.throws(
+      () => validateMacOSSignedReplacementPair({
+        previousManifest: {
+          ...previousDogfoodManifest,
+          application: {
+            ...previousDogfoodManifest.application,
+            bundleVersion: "1021",
+          },
+        },
+        candidateManifest: historicalDogfoodManifest,
+      }),
+      { code: "MACOS_LEGACY_SOURCE_COMPATIBILITY_INVALID" },
+      "the historical dogfood can never be a candidate",
+    );
+    const historicalManifestPath = join(temporaryRoot, "historical.json");
+    const historicalPublicManifestPath = join(temporaryRoot, "historical-public.json");
+    for (const manifest of [
+      historicalDogfoodManifest,
+      {
+        ...historicalDogfoodManifest,
+        channel: createReleaseChannelProvenance(STABLE_RELEASE_CHANNEL, {
+          publicEdKeySha256: historicalDogfoodManifest.updater.publicEdKeySha256,
+        }),
+      },
+    ]) {
+      await writeFile(historicalPublicManifestPath, JSON.stringify(manifest));
+      await assert.rejects(
+        validateMacOSSignedReleaseArtifact({
+          releaseManifestPath: historicalPublicManifestPath,
+          async validateArtifact() {
+            assert.fail("historical compatibility cannot reach public artifact validation");
+          },
+        }),
+        { code: "MACOS_LEGACY_SOURCE_COMPATIBILITY_INVALID" },
+      );
+    }
+    await writeFile(historicalManifestPath, JSON.stringify(historicalDogfoodManifest));
+    await writeFile(
+      join(temporaryRoot, historicalDogfoodManifest.artifact.fileName),
+      "not-the-historical-dmg",
+    );
+    await assert.rejects(
+      validateMacOSSignedReplacementArtifacts({
+        previousReleaseManifestPath: historicalManifestPath,
+        candidateReleaseManifestPath: candidateManifestPath,
+        async validateArtifact() {
+          assert.fail("the previous DMG bytes must match before native validation");
+        },
+      }),
+      { code: "MACOS_REPLACEMENT_ARTIFACT_INVALID" },
+    );
     assert.doesNotThrow(() => validateMacOSSignedReplacementPair({
       previousManifest: previousDogfoodManifest,
       candidateManifest: candidateDogfoodManifest,
@@ -5519,6 +5654,88 @@ test("signed updater replacement contract validates upgrade and rollback artifac
     );
   } finally {
     await rm(temporaryRoot, { recursive: true, force: true });
+  }
+});
+
+test("legacy dogfood capability rejects Proxy-forged identities before any artifact access", async () => {
+  const structuralFake = new Proxy({}, {
+    get() {
+      assert.fail("capability authorization must not inspect caller-controlled properties");
+    },
+  });
+  for (const forged of [true, false, {}, Object.freeze({}), structuralFake]) {
+    for (const [name, validate] of [
+      ["candidate inspection", inspectMacOSApp],
+      ["installed validation", validateInstalledMacOSApp],
+      ["DMG validation", validateMacOSDMG],
+    ]) {
+      let symbolReads = 0;
+      let observedSymbol;
+      const baseOptions = {
+        allowLegacyUnsealedSource: false,
+        channel: INTERNAL_DOGFOOD_RELEASE_CHANNEL,
+        requireExternalDistribution: true,
+        production: true,
+      };
+      const options = new Proxy(baseOptions, {
+        get(target, key, receiver) {
+          if (typeof key === "symbol") {
+            symbolReads += 1;
+            observedSymbol = key;
+            return forged;
+          }
+          return Reflect.get(target, key, receiver);
+        },
+      });
+      // A null path would fail resolution if authorization reached the FS path.
+      // No fixture, installed application, native tool, or real user state is used.
+      await assert.rejects(
+        validate(null, options),
+        { code: "MACOS_LEGACY_SOURCE_COMPATIBILITY_INVALID" },
+        `${name} must reject a supplied non-member identity before path resolution`,
+      );
+      assert.equal(symbolReads, 1, "the Proxy exercised the private option read");
+      await assert.rejects(
+        validate(null, { ...baseOptions, [observedSymbol]: forged }),
+        { code: "MACOS_LEGACY_SOURCE_COMPATIBILITY_INVALID" },
+        `${name} must also reject a forged value replayed with the captured Symbol`,
+      );
+    }
+  }
+});
+
+test("replacement CLI reports the actual automatic-updater result", async () => {
+  const source = await readFile(
+    join(REPOSITORY_ROOT, "scripts", "validate-macos-replacement.js"),
+    "utf8",
+  );
+  const importStatement = /import \{\s*validateMacOSSignedReplacementArtifacts,\s*\} from "\.\/macos-release-core\.js";/u;
+  assert.match(source, importStatement);
+  const executable = source.replace(/^#![^\n]*\n/u, "")
+    .replace(importStatement, "");
+  for (const automaticUpdaterPresent of [true, false]) {
+    const output = [];
+    const processFixture = {
+      argv: ["node", "validator.js", "--previous", "previous.json", "--candidate", "candidate.json"],
+      exitCode: 0,
+    };
+    await runInNewContext(`(async () => { ${executable}\n })()`, {
+      console: {
+        log: (line) => output.push(line),
+        error: (line) => assert.fail(line),
+      },
+      process: processFixture,
+      validateMacOSSignedReplacementArtifacts: async () => ({
+        bundleIdentifier: "com.usagemonitor.local",
+        previousBundleVersion: "1022",
+        candidateBundleVersion: "1023",
+        automaticUpdaterPresent,
+      }),
+    });
+    assert.equal(processFixture.exitCode, 0);
+    assert.ok(output.includes(
+      `Automatic updater: ${automaticUpdaterPresent ? "present" : "absent"}`,
+    ));
   }
 });
 
@@ -5954,6 +6171,75 @@ test("Developer ID and notary hooks are inside-out, hardened, and credential-min
       inspectMacOSApp(app, { requireExternalDistribution: true }),
       { code: "MACOS_RELEASE_SOURCE_INVALID" },
     );
+    await writeBuildManifest({ includeSource: false });
+    for (const attemptedCompatibility of [
+      {},
+      { allowLegacyDogfoodPreviousSource: true },
+      { [Symbol("verified legacy dogfood previous artifact")]: true },
+    ]) {
+      await assert.rejects(
+        inspectMacOSApp(app, {
+          ...attemptedCompatibility,
+          requireExternalDistribution: true,
+        }),
+        { code: "MACOS_RELEASE_SOURCE_INVALID" },
+        "unsealed candidate builds cannot request historical compatibility",
+      );
+    }
+    await writeBuildManifest();
+
+    const plistPath = join(app, "Contents", "Info.plist");
+    const completePlist = JSON.parse(await readFile(plistPath, "utf8"));
+    for (const missing of [
+      ["UsageMonitorKeychainNamespace", "UsageMonitorKeychainAccount"],
+      ["UsageMonitorKeychainNamespace"],
+      ["UsageMonitorKeychainAccount"],
+    ]) {
+      const incomplete = { ...completePlist };
+      for (const key of missing) delete incomplete[key];
+      await writeFile(plistPath, JSON.stringify(incomplete));
+      await writeBuildManifest();
+      await assert.rejects(
+        inspectMacOSApp(app, {
+          requireExternalDistribution: true,
+          allowLegacyDogfoodPreviousSource: true,
+        }),
+        /Application bundle metadata is incomplete/u,
+        "a candidate must not inherit historical missing-Keychain-field compatibility",
+      );
+    }
+    for (const key of ["UsageMonitorKeychainNamespace", "UsageMonitorKeychainAccount"]) {
+      await writeFile(plistPath, JSON.stringify({ ...completePlist, [key]: "different" }));
+      await writeBuildManifest();
+      await assert.rejects(
+        inspectMacOSApp(app, { requireExternalDistribution: true }),
+        /Application bundle metadata is incomplete/u,
+        "a candidate must declare the exact stable Keychain identity",
+      );
+    }
+    await writeFile(plistPath, JSON.stringify(completePlist));
+    const syntheticLegacyPath = "Contents/Resources/app/node_modules/@github/keytar/prebuilds/darwin-arm64/keytar.node";
+    const syntheticLegacyBinary = join(app, ...syntheticLegacyPath.split("/"));
+    await mkdir(dirname(syntheticLegacyBinary), { recursive: true });
+    await copyFile(syntheticMachO, syntheticLegacyBinary);
+    await chmod(syntheticLegacyBinary, 0o555);
+    await writeBuildManifest();
+    const legacyNormalizationManifest = JSON.parse(await readFile(buildManifestPath, "utf8"));
+    legacyNormalizationManifest.payload.files.find((entry) =>
+      entry.path === syntheticLegacyPath).normalization = "mach_o_without_code_signature";
+    await writeFile(buildManifestPath, JSON.stringify(legacyNormalizationManifest));
+    await assert.rejects(
+      inspectMacOSApp(app, {
+        requireExternalDistribution: true,
+        allowLegacyDogfoodPreviousSource: true,
+      }),
+      {
+        code: "MACOS_PAYLOAD_INTEGRITY_FAILED",
+        message: "Application build manifest contains an invalid payload entry",
+      },
+      "a candidate cannot request the historical Keytar normalization inventory",
+    );
+    await rm(join(resources, "app"), { recursive: true });
     await writeBuildManifest();
 
     const calls = [];


### PR DESCRIPTION
## Scope

Finalize the source for the native macOS 0.1.17 internal dogfood on current main, including #89. #75's native popup is already ported through #81; no Electron or Linux ancestry is added.

The retained upgrade validator could not read the already-distributed 0.1.16 / build1022 internal dogfood because its receipt predates channel-specific source tags and its bundle predates embedded source seals. Add one previous-artifact-only compatibility case pinned to the exact DMG checksum/size, source identity, embedded build digests, updater key/framework/feed, and complete existing assurances. Its old normalized Keytar binary is required at the exact historical path/bytes/mode/digest; only that artifact may omit both Keychain identity plist fields. Current normalization rules and explicit Keychain identity remain mandatory for candidates. Native payload, signature, notarization, Gatekeeper and isolated-smoke checks still run. Candidate, public-installer and signing paths remain strict. Do not rewrite the historical receipt or tag.

The compatibility token uses module-private WeakSet membership, is forwarded unchanged, and is revoked before candidate validation. Independent review caught and fixed a Proxy-forgeable draft marker before integration. Regression tests cover forged values, captured-symbol replay, changed identity/assurances, wrong bytes, candidate/public misuse and version ordering.

Also report the real automatic-updater status in the replacement CLI and update the maintained runbook and integration plan. No delivered app runtime or data schema changes in this follow-up.

## Validation

- Final full root: 3,231 tests, 3,214 passed, 17 designated skips, zero failures/cancellations; exit 0 in 441s.
- Complete Worker gate on #89 main: 429 Worker tests, 174 script tests, workspace-copy/endpoints/types checks, default and staging dry-run bundles; exit0. No deployment or migration.
- UI: 414/414; focused replacement/seal/Proxy/CLI tests: 5/5.
- Retained R7 freshness: 2/2 on each pinned Node 24.14.0 and 26.2.0, with all ten receipts unchanged.
- Documentation/preflight: 18/18; architecture: 369 production files, 1,449 imports, zero debt; installed Codex contract and release-note checks passed.
- Retained native gate: 67/67, no skips/cancellations; exit 0 in 238s.
- Actual previous 1022-to-rc1 candidate 1023 replacement validation: exit 0, including native payload, signature, notarization, Gatekeeper and empty-profile checks for both DMGs. A conflicting operator-owned rc1 mount was detached before the successful unchanged validation.

An earlier full-root repeat was not green: 3,213 passes, 17 skips, one Preview-build timeout cancellation. The power log records a 950-second system sleep during that run. With a temporary keep-awake assertion, the unchanged native gate and final full-root rerun passed. No test, assertion, timeout or exclusion was weakened. Private installation/retirement guards additionally passed 27/27 on synthetic directories only.

## Release boundary

PR90's rc1 source was independently signed, notarized and validated, but not installed. It predates #89 and remains preserved; the final updated-source candidate will use a new annotated dogfood source tag and separate artifact location after merge.

Existing R7 decisions remain `release_open`, with 19 unresolved dimensions each; fresh source provenance does not waive those promotion limits. Copy-first schema recovery and prior-app ZIP preservation are recorded, but a schema9 backup is not a working rollback for the old schema8 reader. Installed-app, real Keychain/Community, physical interaction and any hosted or updater publication remain separate gates. No stable release, hosted deployment, new consent, pairing or upload is performed by this source PR.
