### PR TITLE
Prepare 0.1.17 RC5 dogfood and fix menu popover overflow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,8 +42,14 @@ pull requests, including [PR #80](https://github.com/adamallcock/tibotattle/pull
 [PR #84](https://github.com/adamallcock/tibotattle/pull/84),
 [PR #85](https://github.com/adamallcock/tibotattle/pull/85),
 [PR #86](https://github.com/adamallcock/tibotattle/pull/86),
-[PR #87](https://github.com/adamallcock/tibotattle/pull/87), and
-[PR #88](https://github.com/adamallcock/tibotattle/pull/88).
+[PR #87](https://github.com/adamallcock/tibotattle/pull/87),
+[PR #88](https://github.com/adamallcock/tibotattle/pull/88),
+[PR #89](https://github.com/adamallcock/tibotattle/pull/89),
+[PR #90](https://github.com/adamallcock/tibotattle/pull/90),
+[PR #92](https://github.com/adamallcock/tibotattle/pull/92),
+[PR #94](https://github.com/adamallcock/tibotattle/pull/94),
+[PR #95](https://github.com/adamallcock/tibotattle/pull/95), and
+[PR #96](https://github.com/adamallcock/tibotattle/pull/96).
 PRs #73 and #74 are not part of this native macOS candidate. PR #75
 is not merged wholesale; a native subset of its menu-bar and weekly-pace work
 is ported without its Electron or multi-root changes. Separately, this candidate
@@ -89,13 +95,21 @@ published-release claim.
   planning and status prose from the active tree.
 - Adds a native left-click menu-bar popover with current Five-hour and seven-day
   allowance lanes, fail-closed 7/30-day usage history, and a weekly pace outlook;
-  right-click and Control-click retain the native actions menu (native subset of
+  right-click and Control-click retain the native actions menu. The complete
+  instrument now remains reachable through vertical scrolling when two quota
+  lanes exceed the height available below the status item (native subset of
   [PR #75](https://github.com/adamallcock/tibotattle/pull/75)).
 - Adds transient local thread-name links to both recent cache-drop tables,
   including separate parent and worker links when that relationship is recorded.
   Missing attribution stays unlinked; names and links do not enter persisted
   accounting, exports, diagnostics, or hosted contribution
   ([PR #87](https://github.com/adamallcock/tibotattle/pull/87)).
+- Adds an admin-only **By model** allowance view for Sol, Terra, Luna, and
+  GPT-5.5, using the existing Pro-20x normalization and refusing the model band
+  when identification or percentile evidence is incomplete. This source needs
+  Worker migration 0041, deployment, warming, and real cohort data before the
+  hosted view is operational; installing the desktop app does not activate it
+  ([PR #89](https://github.com/adamallcock/tibotattle/pull/89)).
 
 ### Changed
 
@@ -127,6 +141,17 @@ published-release claim.
 - Aligns full-history headline and timeline input-context pricing with the
   accounting cache's existing compatibility rule, fixing differing API
   equivalents for the same older usage without changing token totals.
+- Keeps current-plan and historical-plan local estimates, history, comparison
+  ranges, forecasts, and share cards on the same selected plan-era population.
+  Missing or conflicting account/plan evidence remains unavailable instead of
+  borrowing another era or claiming account-exact, cross-device, or
+  provider-authoritative billing attribution
+  ([PR #94](https://github.com/adamallcock/tibotattle/pull/94)).
+- Adds the closed telemetry v1.1 account/plan transport and lifecycle as staged
+  source only. Worker migrations 0042-0044, hosted activation, and a new explicit
+  consent are separate gates; a desktop install does not deploy the protocol or
+  alter an existing contribution consent
+  ([PR #94](https://github.com/adamallcock/tibotattle/pull/94)).
 - Replaces self-service hosted-delete controls with confirmed **Disconnect this
   Mac**. Disconnect durably pauses this Mac's contribution delivery without
   deleting hosted history, local analysis, or other devices; signing out is a
@@ -204,6 +229,15 @@ published-release claim.
 - Replaces the unconditional “Headline ready” refresh claim with neutral local
   summary/progress copy, and keeps native and browser polling attached through
   the bounded fresh-index build window.
+- Retries compatible legacy Keychain reads non-interactively up to three times
+  and reserves the explained approval fallback for an explicit Settings action.
+  Automatic launch, refresh, contribution, and migration paths remain
+  prompt-free; an unexpected security prompt blocks release qualification
+  ([PR #95](https://github.com/adamallcock/tibotattle/pull/95)).
+- Recovers the native dashboard when readiness arrives after the initial wait:
+  startup uses the bounded primary projection, fences stale generations, keeps
+  the slow-load page alive, and replaces a prior timeout after the late primary
+  render succeeds ([PR #96](https://github.com/adamallcock/tibotattle/pull/96)).
 - Keeps cancellation and timeout terminal handling from starting another full
   data-store reload, preserves the last published generation, and reclaims only
   old, exactly identified abandoned staging files on a later safe retry.
@@ -247,9 +281,11 @@ published-release claim.
 - Gives Preview its own app, bundle, semantic-open, local-state, Keychain,
   preferences, and Sparkle-feed identities, preventing preview installation or
   updates from replacing stable state.
-- Allocates build 1023 to the 0.1.17 internal-dogfood candidate and build 1024
-  to stable, and requires a clean checkout with exactly one matching annotated
-  channel tag at `HEAD` before signed release tooling can proceed.
+- Records builds 1023, 1023.1, and 1023.2 as earlier 0.1.17 internal dogfoods,
+  allocates build 1023.3 to the integrated RC5 candidate, and retains build 1024
+  for stable. Signed tooling requires a clean checkout with exactly one matching
+  annotated channel tag at `HEAD` before it can proceed. RC4 at build 1023.2 is
+  installed evidence for its frozen source, not proof that RC5 or stable exists.
 - Establishes scoped, machine-checked repository guidance for coding agents and
   the root layout they may extend
   ([PR #77](https://github.com/adamallcock/tibotattle/pull/77)).

--- a/apps/macos/README.md
+++ b/apps/macos/README.md
@@ -422,9 +422,10 @@ a claim that Sparkle has updated the preview client.
 `CFBundleShortVersionString` remains the user-facing package version. The
 Sparkle ordering key, `CFBundleVersion`, is explicitly allocated for signed
 builds that retain the stable bundle identifier. The 0.1.17 internal-dogfood
-build is `1023.2`; the 0.1.17 stable final remains `1024`. This startup-recovery
-candidate orders strictly after RC3 `1023.1`, retained RC2 `1023`, and earlier
-shared-identity dogfood `1022`, while stable orders after the dogfood candidate.
+build is `1023.3`; the 0.1.17 stable final remains `1024`. This final integrated
+candidate orders strictly after startup-recovery RC4 `1023.2`, migration RC3
+`1023.1`, retained RC2 `1023`, and earlier shared-identity dogfood `1022`, while
+stable orders after the dogfood candidate.
 A future signed version/channel must add a reviewed
 monotonic allocation before release tooling will run.
 
@@ -522,7 +523,7 @@ For a later stable release, use `--previous-stable-manifest` in place of
 the release command refuses to guess which continuity policy applies.
 `USAGE_MONITOR_BUNDLE_VERSION` is optional as an operator assertion only; when
 present it must exactly equal the checked-in allocation for the selected
-signed release version and channel (`1023.2` for 0.1.17 internal dogfood,
+signed release version and channel (`1023.3` for 0.1.17 internal dogfood,
 `1024` for 0.1.17 stable).
 
 `config/deployment-endpoints.js` is the reviewed source for the public origin

--- a/apps/macos/Sources/MenuBarPopover.swift
+++ b/apps/macos/Sources/MenuBarPopover.swift
@@ -7,7 +7,16 @@ import Foundation
 struct MenuBarPopoverPresentationContract: Equatable {
     let contentWidth: CGFloat
     let contentHeight: CGFloat
+    let documentHeight: CGFloat
+    let viewportHeight: CGFloat
     let containsScrollView: Bool
+    let verticalScrollingRequired: Bool
+    let horizontalScrollingEnabled: Bool
+    let contentStartsAtTop: Bool
+    let verticalScrollOffset: CGFloat
+    let maximumVerticalScrollOffset: CGFloat
+    let headerVisible: Bool
+    let footerActionsVisible: Bool
     let visibleAllowanceLaneCount: Int
     let weeklyPaceVisible: Bool
     let weeklyPaceState: MenuBarPopoverPaceState?
@@ -39,9 +48,42 @@ private enum MenuBarPopoverMetrics {
     static let width: CGFloat = 400
     static let horizontalInset: CGFloat = 18
     static let verticalInset: CGFloat = 16
+    /// Room for the NSPopover arrow, window chrome and lower screen edge.
+    static let popoverVerticalClearance: CGFloat = 28
     static let sectionSpacing: CGFloat = 13
     static let separatorSpacing: CGFloat = 12
     static let chartHeight: CGFloat = 104
+}
+
+/// One deterministic cap for production status-item geometry and compiled
+/// synthetic geometry. `visibleFrame` excludes the Dock/menu bar; the anchor
+/// further limits the space actually available below the clicked status item.
+func menuBarPopoverMaximumViewportHeight(
+    anchorMinY: CGFloat?,
+    visibleFrame: NSRect
+) -> CGFloat {
+    let screenMaximum = max(
+        1,
+        floor(
+            visibleFrame.height
+                - MenuBarPopoverMetrics.popoverVerticalClearance
+        )
+    )
+    guard let anchorMinY, anchorMinY.isFinite else { return screenMaximum }
+    let anchorMaximum = floor(
+        anchorMinY
+            - visibleFrame.minY
+            - MenuBarPopoverMetrics.popoverVerticalClearance
+    )
+    return min(screenMaximum, max(1, anchorMaximum))
+}
+
+/// AppKit's default document coordinates start at the lower edge. A flipped
+/// document gives this top-to-bottom instrument an unambiguous zero offset,
+/// so every explicit opening can reveal the header while background updates
+/// preserve the user's current vertical position.
+private final class MenuBarPopoverDocumentView: NSView {
+    override var isFlipped: Bool { true }
 }
 
 private enum MenuBarPopoverHistoryState {
@@ -715,6 +757,10 @@ final class MenuBarPopoverViewController: NSViewController {
     private let disclaimerLabel = NSTextField(wrappingLabelWithString: "")
     private let openButton = NSButton()
     private let refreshButton = NSButton()
+    private let scrollView = NSScrollView()
+    private let contentDocumentView = MenuBarPopoverDocumentView()
+    private let contentStack = NSStackView()
+    private var headerView: NSView?
 
     private var currentSnapshot = MenuBarStatusSnapshot()
     private var currentNow = Date()
@@ -723,6 +769,9 @@ final class MenuBarPopoverViewController: NSViewController {
     private var historyState: MenuBarPopoverHistoryState = .unavailable
     private var partialPricingDisclosed = false
     private var pricingState: MenuBarPopoverPricingState = .unavailable
+    private var documentHeightConstraint: NSLayoutConstraint?
+    private var naturalContentHeight: CGFloat = 1
+    private var maximumViewportHeight: CGFloat?
     private var didLoadInterface = false
 
     init(productName: String, brandImage: NSImage?, actions: Actions) {
@@ -749,28 +798,60 @@ final class MenuBarPopoverViewController: NSViewController {
 
         configureTypography()
 
-        let content = NSStackView()
-        content.translatesAutoresizingMaskIntoConstraints = false
-        content.orientation = .vertical
-        content.alignment = .leading
-        content.spacing = MenuBarPopoverMetrics.sectionSpacing
-        root.addSubview(content)
+        scrollView.translatesAutoresizingMaskIntoConstraints = false
+        scrollView.borderType = .noBorder
+        scrollView.hasVerticalScroller = true
+        scrollView.hasHorizontalScroller = false
+        scrollView.autohidesScrollers = true
+        scrollView.drawsBackground = false
+        scrollView.horizontalScrollElasticity = .none
+        scrollView.verticalScrollElasticity = .automatic
+        scrollView.scrollerStyle = .overlay
+        root.addSubview(scrollView)
+
+        contentDocumentView.translatesAutoresizingMaskIntoConstraints = false
+        scrollView.documentView = contentDocumentView
+
+        contentStack.translatesAutoresizingMaskIntoConstraints = false
+        contentStack.orientation = .vertical
+        contentStack.alignment = .leading
+        contentStack.spacing = MenuBarPopoverMetrics.sectionSpacing
+        contentDocumentView.addSubview(contentStack)
+        let documentHeightConstraint = contentDocumentView.heightAnchor.constraint(
+            equalToConstant: 1
+        )
+        self.documentHeightConstraint = documentHeightConstraint
         NSLayoutConstraint.activate([
-            content.leadingAnchor.constraint(
-                equalTo: root.leadingAnchor,
+            scrollView.leadingAnchor.constraint(equalTo: root.leadingAnchor),
+            scrollView.trailingAnchor.constraint(equalTo: root.trailingAnchor),
+            scrollView.topAnchor.constraint(equalTo: root.topAnchor),
+            scrollView.bottomAnchor.constraint(equalTo: root.bottomAnchor),
+            contentDocumentView.leadingAnchor.constraint(
+                equalTo: scrollView.contentView.leadingAnchor
+            ),
+            contentDocumentView.topAnchor.constraint(
+                equalTo: scrollView.contentView.topAnchor
+            ),
+            contentDocumentView.widthAnchor.constraint(
+                equalTo: scrollView.contentView.widthAnchor
+            ),
+            documentHeightConstraint,
+            contentStack.leadingAnchor.constraint(
+                equalTo: contentDocumentView.leadingAnchor,
                 constant: MenuBarPopoverMetrics.horizontalInset
             ),
-            content.trailingAnchor.constraint(
-                equalTo: root.trailingAnchor,
+            contentStack.trailingAnchor.constraint(
+                equalTo: contentDocumentView.trailingAnchor,
                 constant: -MenuBarPopoverMetrics.horizontalInset
             ),
-            content.topAnchor.constraint(
-                equalTo: root.topAnchor,
+            contentStack.topAnchor.constraint(
+                equalTo: contentDocumentView.topAnchor,
                 constant: MenuBarPopoverMetrics.verticalInset
             ),
         ])
 
         let header = makeHeader()
+        headerView = header
         let allowanceSection = makeAllowanceSection()
         let historySection = makeHistorySection()
         let footer = makeFooter()
@@ -786,11 +867,11 @@ final class MenuBarPopoverViewController: NSViewController {
             MenuBarPopoverSeparator(),
             footer,
         ] {
-            content.addArrangedSubview(arranged)
-            arranged.widthAnchor.constraint(equalTo: content.widthAnchor).isActive = true
+            contentStack.addArrangedSubview(arranged)
+            arranged.widthAnchor.constraint(equalTo: contentStack.widthAnchor).isActive = true
         }
 
-        content.setCustomSpacing(
+        contentStack.setCustomSpacing(
             MenuBarPopoverMetrics.separatorSpacing,
             after: header
         )
@@ -858,10 +939,25 @@ final class MenuBarPopoverViewController: NSViewController {
     func nativePresentationContract() -> MenuBarPopoverPresentationContract {
         loadViewIfNeeded()
         view.layoutSubtreeIfNeeded()
+        let viewportHeight = scrollView.contentView.bounds.height
+        let documentHeight = contentDocumentView.bounds.height
+        let verticalOffset = scrollView.contentView.bounds.minY
+        let maximumVerticalOffset = maximumVerticalScrollOffset()
         return MenuBarPopoverPresentationContract(
             contentWidth: view.bounds.width,
             contentHeight: view.bounds.height,
+            documentHeight: documentHeight,
+            viewportHeight: viewportHeight,
             containsScrollView: containsScrollView(view),
+            verticalScrollingRequired: documentHeight > viewportHeight + 0.5,
+            horizontalScrollingEnabled: scrollView.hasHorizontalScroller
+                || scrollView.horizontalScrollElasticity != .none,
+            contentStartsAtTop: abs(verticalOffset) <= 0.5,
+            verticalScrollOffset: verticalOffset,
+            maximumVerticalScrollOffset: maximumVerticalOffset,
+            headerVisible: headerView.map(isFullyVisibleInViewport) ?? false,
+            footerActionsVisible: isFullyVisibleInViewport(openButton)
+                && isFullyVisibleInViewport(refreshButton),
             visibleAllowanceLaneCount: visibleAllowanceLaneCount,
             weeklyPaceVisible: !weeklySection.isHidden,
             weeklyPaceState: weeklySection.isHidden
@@ -879,6 +975,58 @@ final class MenuBarPopoverViewController: NSViewController {
             openActionEnabled: openButton.isEnabled,
             refreshActionEnabled: refreshButton.isEnabled
         )
+    }
+
+    /// Apply the height that can actually fit below the status item. The
+    /// anchor's screen coordinates matter on mixed-size multi-display setups;
+    /// `visibleFrame` also respects the Dock and menu-bar reservations.
+    /// Explicit opening resets to the top, while ordinary `update` calls keep
+    /// the current scroll offset.
+    func prepareForPresentation(from anchor: NSView) {
+        loadViewIfNeeded()
+        let screen = anchor.window?.screen ?? NSScreen.main ?? NSScreen.screens.first
+        maximumViewportHeight = screen.map { screen in
+            let anchorMinY = anchor.window.map { window in
+                let anchorInWindow = anchor.convert(anchor.bounds, to: nil)
+                return window.convertToScreen(anchorInWindow).minY
+            }
+            return menuBarPopoverMaximumViewportHeight(
+                anchorMinY: anchorMinY,
+                visibleFrame: screen.visibleFrame
+            )
+        }
+        updatePreferredContentSize()
+        scrollToTop()
+    }
+
+    /// Deterministic packaged-smoke seam through the exact production cap.
+    @discardableResult
+    func prepareForPresentationForSmokeTest(
+        anchorMinY: CGFloat,
+        visibleFrame: NSRect
+    ) -> CGFloat {
+        loadViewIfNeeded()
+        let cap = menuBarPopoverMaximumViewportHeight(
+            anchorMinY: anchorMinY,
+            visibleFrame: visibleFrame
+        )
+        maximumViewportHeight = cap
+        updatePreferredContentSize()
+        scrollToTop()
+        return cap
+    }
+
+    /// Deterministic packaged-smoke seam that proves polling updates retain a
+    /// user's established scroll position.
+    func scrollToVerticalOffsetForSmokeTest(_ offset: CGFloat) {
+        loadViewIfNeeded()
+        setVerticalScrollOffset(offset)
+    }
+
+    /// Deterministic packaged-smoke seam for the actual bottom scroll extent.
+    func scrollToBottomForSmokeTest() {
+        loadViewIfNeeded()
+        setVerticalScrollOffset(maximumVerticalScrollOffset())
     }
 
     /// Deterministic packaged-smoke seam. The production segmented control and
@@ -1380,19 +1528,64 @@ final class MenuBarPopoverViewController: NSViewController {
     }
 
     private func updatePreferredContentSize() {
-        guard didLoadInterface, let content = view.subviews.first else { return }
+        guard didLoadInterface, let documentHeightConstraint else { return }
+        let previousVerticalOffset = scrollView.contentView.bounds.minY
         view.frame.size.width = MenuBarPopoverMetrics.width
         view.layoutSubtreeIfNeeded()
-        let fittingHeight = ceil(
-            content.fittingSize.height + MenuBarPopoverMetrics.verticalInset * 2
+        naturalContentHeight = max(
+            1,
+            ceil(
+                contentStack.fittingSize.height
+                    + MenuBarPopoverMetrics.verticalInset * 2
+            )
+        )
+        let viewportHeight = min(
+            naturalContentHeight,
+            maximumViewportHeight ?? naturalContentHeight
+        )
+        documentHeightConstraint.constant = max(
+            naturalContentHeight,
+            viewportHeight
         )
         let size = NSSize(
             width: MenuBarPopoverMetrics.width,
-            height: max(1, fittingHeight)
+            height: max(1, viewportHeight)
         )
         view.frame.size = size
         preferredContentSize = size
         view.layoutSubtreeIfNeeded()
+        setVerticalScrollOffset(previousVerticalOffset)
+    }
+
+    private func scrollToTop() {
+        setVerticalScrollOffset(0)
+    }
+
+    private func maximumVerticalScrollOffset() -> CGFloat {
+        max(
+            0,
+            contentDocumentView.bounds.height
+                - scrollView.contentView.bounds.height
+        )
+    }
+
+    private func isFullyVisibleInViewport(_ candidate: NSView) -> Bool {
+        let frameInClipView = scrollView.contentView.convert(
+            candidate.bounds,
+            from: candidate
+        )
+        let visibleBounds = scrollView.contentView.bounds.insetBy(dx: -0.5, dy: -0.5)
+        return !candidate.isHidden
+            && !frameInClipView.isEmpty
+            && visibleBounds.contains(frameInClipView)
+    }
+
+    private func setVerticalScrollOffset(_ requestedOffset: CGFloat) {
+        view.layoutSubtreeIfNeeded()
+        let maximumOffset = maximumVerticalScrollOffset()
+        let offset = min(max(0, requestedOffset), maximumOffset)
+        scrollView.contentView.scroll(to: NSPoint(x: 0, y: offset))
+        scrollView.reflectScrolledClipView(scrollView.contentView)
     }
 
     private func renderableLanes(

--- a/apps/macos/Sources/MenuBarStatus.swift
+++ b/apps/macos/Sources/MenuBarStatus.swift
@@ -1693,6 +1693,7 @@ final class MenuBarStatusController: NSObject, NSMenuDelegate, NSPopoverDelegate
         }
         menu.cancelTracking()
         isMenuTracking = false
+        popoverController.prepareForPresentation(from: sender)
         popoverController.update(snapshot: snapshot)
         popover.show(
             relativeTo: sender.bounds,

--- a/apps/macos/UsageMonitorApp.swift
+++ b/apps/macos/UsageMonitorApp.swift
@@ -11043,6 +11043,41 @@ private enum MenuBarContractSmokeTest {
         )
         popup.update(snapshot: liveSnapshot, now: observedAt)
         let sevenDayPopup = popup.nativePresentationContract()
+        let overflowPopup = MenuBarPopoverViewController(
+            productName: BundledProduct.displayName,
+            brandImage: NSApp.applicationIconImage,
+            actions: MenuBarPopoverViewController.Actions(
+                openTiboTattle: {},
+                refresh: {},
+                showMore: { _ in }
+            )
+        )
+        var oneLaneSnapshot = liveSnapshot
+        oneLaneSnapshot.lanes = [weeklyLane]
+        let syntheticVisibleFrame = NSRect(
+            x: 0,
+            y: 40,
+            width: 1_440,
+            height: 800
+        )
+        let syntheticAnchorMinY: CGFloat = 428
+        overflowPopup.update(snapshot: oneLaneSnapshot, now: observedAt)
+        let oneLaneViewportCap = overflowPopup.prepareForPresentationForSmokeTest(
+            anchorMinY: syntheticAnchorMinY,
+            visibleFrame: syntheticVisibleFrame
+        )
+        let oneLaneOverflowAtTop = overflowPopup.nativePresentationContract()
+        overflowPopup.scrollToVerticalOffsetForSmokeTest(72)
+        let oneLaneOverflowScrolled = overflowPopup.nativePresentationContract()
+        overflowPopup.update(snapshot: liveSnapshot, now: observedAt)
+        let twoLaneOverflowPreserved = overflowPopup.nativePresentationContract()
+        overflowPopup.scrollToBottomForSmokeTest()
+        let twoLaneOverflowAtBottom = overflowPopup.nativePresentationContract()
+        let twoLaneViewportCap = overflowPopup.prepareForPresentationForSmokeTest(
+            anchorMinY: syntheticAnchorMinY,
+            visibleFrame: syntheticVisibleFrame
+        )
+        let twoLaneOverflowAtTop = overflowPopup.nativePresentationContract()
         popup.selectHistoryRangeForSmokeTest(.thirtyDays)
         let thirtyDayPopup = popup.nativePresentationContract()
         popup.update(snapshot: analyzingLiveSnapshot, now: observedAt)
@@ -11114,6 +11149,72 @@ private enum MenuBarContractSmokeTest {
         noCompanionSnapshot.phase = .unavailable
         popup.update(snapshot: noCompanionSnapshot, now: observedAt)
         let noCompanionPopup = popup.nativePresentationContract()
+        let overflowGeometryChecks: [(String, Bool)] = [
+            ("natural-two-lane-fits-without-cap", !sevenDayPopup.verticalScrollingRequired),
+            ("natural-two-lane-starts-at-top", sevenDayPopup.contentStartsAtTop),
+            ("one-lane-count", oneLaneOverflowAtTop.visibleAllowanceLaneCount == 1),
+            ("one-lane-overflows", oneLaneOverflowAtTop.verticalScrollingRequired),
+            ("one-lane-vertical-only", !oneLaneOverflowAtTop.horizontalScrollingEnabled),
+            ("one-lane-starts-at-top", oneLaneOverflowAtTop.contentStartsAtTop),
+            ("one-lane-header-visible", oneLaneOverflowAtTop.headerVisible),
+            ("synthetic-cap-exact", oneLaneViewportCap == 360),
+            (
+                "forced-viewport-height",
+                oneLaneOverflowAtTop.viewportHeight == oneLaneViewportCap
+            ),
+            (
+                "one-lane-document-exceeds-viewport",
+                oneLaneOverflowAtTop.documentHeight > oneLaneOverflowAtTop.viewportHeight
+            ),
+            ("smoke-scroll-moves", !oneLaneOverflowScrolled.contentStartsAtTop),
+            ("smoke-scroll-positive", oneLaneOverflowScrolled.verticalScrollOffset > 0),
+            ("two-lane-count", twoLaneOverflowPreserved.visibleAllowanceLaneCount == 2),
+            ("two-lane-overflows", twoLaneOverflowPreserved.verticalScrollingRequired),
+            ("two-lane-vertical-only", !twoLaneOverflowPreserved.horizontalScrollingEnabled),
+            (
+                "poll-preserves-scroll",
+                abs(
+                    twoLaneOverflowPreserved.verticalScrollOffset
+                        - oneLaneOverflowScrolled.verticalScrollOffset
+                ) <= 0.5
+            ),
+            (
+                "two-lanes-grow-document",
+                twoLaneOverflowPreserved.documentHeight
+                    > oneLaneOverflowAtTop.documentHeight
+            ),
+            (
+                "bottom-offset-reached",
+                abs(
+                    twoLaneOverflowAtBottom.verticalScrollOffset
+                        - twoLaneOverflowAtBottom.maximumVerticalScrollOffset
+                ) <= 0.5
+            ),
+            ("bottom-offset-positive", twoLaneOverflowAtBottom.maximumVerticalScrollOffset > 0),
+            ("bottom-footer-actions-visible", twoLaneOverflowAtBottom.footerActionsVisible),
+            ("bottom-header-hidden", !twoLaneOverflowAtBottom.headerVisible),
+            ("reopen-synthetic-cap-exact", twoLaneViewportCap == 360),
+            ("reopen-two-lane-count", twoLaneOverflowAtTop.visibleAllowanceLaneCount == 2),
+            ("reopen-two-lane-overflows", twoLaneOverflowAtTop.verticalScrollingRequired),
+            ("reopen-two-lane-vertical-only", !twoLaneOverflowAtTop.horizontalScrollingEnabled),
+            ("reopen-starts-at-top", twoLaneOverflowAtTop.contentStartsAtTop),
+            ("reopen-zero-offset", twoLaneOverflowAtTop.verticalScrollOffset == 0),
+            ("reopen-header-visible", twoLaneOverflowAtTop.headerVisible),
+            ("reopen-footer-actions-below-fold", !twoLaneOverflowAtTop.footerActionsVisible),
+        ]
+        if let failed = overflowGeometryChecks.first(where: { !$0.1 }) {
+            FileHandle.standardError.write(Data(
+                ("macOS menu bar overflow smoke failed: \(failed.0) "
+                    + "one_document=\(oneLaneOverflowAtTop.documentHeight) "
+                    + "two_document=\(twoLaneOverflowAtTop.documentHeight) "
+                    + "viewport=\(twoLaneOverflowAtTop.viewportHeight) "
+                    + "one_offset=\(oneLaneOverflowScrolled.verticalScrollOffset) "
+                    + "two_offset=\(twoLaneOverflowPreserved.verticalScrollOffset) "
+                    + "bottom_offset=\(twoLaneOverflowAtBottom.verticalScrollOffset) "
+                    + "maximum_offset=\(twoLaneOverflowAtBottom.maximumVerticalScrollOffset)\n").utf8
+            ))
+            return 1
+        }
         guard starting.informationRowsAreNative,
               starting.informationRowsHaveTitles,
               unavailable.informationRowsAreNative,
@@ -11125,7 +11226,7 @@ private enum MenuBarContractSmokeTest {
               starting.statusItemButtonRoutesClicks,
               starting.popoverIsTransient,
               starting.popoverContentWidth == 400,
-              !starting.popoverContainsScrollView,
+              starting.popoverContainsScrollView,
               starting.escapeDismissalMonitorInstalled,
               starting.sameAppClickAwayMonitorInstalled,
               starting.appDeactivationDismissalObserverInstalled,
@@ -11141,7 +11242,8 @@ private enum MenuBarContractSmokeTest {
               liveSummary == expectedLiveSummary,
               staleSummary == expectedStaleSummary,
               sevenDayPopup.contentWidth == 400,
-              !sevenDayPopup.containsScrollView,
+              sevenDayPopup.containsScrollView,
+              !sevenDayPopup.horizontalScrollingEnabled,
               sevenDayPopup.visibleAllowanceLaneCount == 2,
               sevenDayPopup.weeklyPaceVisible,
               sevenDayPopup.weeklyPaceState == .over,
@@ -11218,6 +11320,7 @@ private enum MenuBarContractSmokeTest {
                 + "pricing=complete,partial,unavailable model=dst,overlap,future,per-lane "
                 + "reset_credits=absent analysis_title=live-fallback "
                 + "history_retention=refresh,failure,source-reset"
+                + " overflow=screen-capped,vertical-only,top-reset,poll-preserved"
         )
         return 0
     }

--- a/apps/worker/test/telemetry-v11.spec.ts
+++ b/apps/worker/test/telemetry-v11.spec.ts
@@ -77,12 +77,16 @@ async function upload(fixture: Awaited<ReturnType<typeof createV11DeviceFixture>
   return api("/api/v1/contributions", { method: "POST", headers: {
     authorization: `Upload ${authorization.uploadAuthorization}`, "content-type": "application/json" }, body: raw });
 }
-function runnerOptions(fixture: Awaited<ReturnType<typeof createV11DeviceFixture>>, count = 1) {
+function runnerOptions(
+  fixture: Awaited<ReturnType<typeof createV11DeviceFixture>>,
+  count = 1,
+  syncDay = day,
+) {
   return {
     serverBaseUrl: "https://example.test", deviceAuthorization: fixture.authorization,
-    consent: telemetryV11RequiredConsent(), days: [day],
-    readDay: async (selectedDay: string) => makeV11Day(selectedDay, { usage: selectedDay === day
-      ? Array.from({ length: count }, (_, index) => v11UsageRecord(day, "a", { eventId: "event:v2:" + index.toString(16).padStart(64, "0") }))
+    consent: telemetryV11RequiredConsent(), days: [syncDay],
+    readDay: async (selectedDay: string) => makeV11Day(selectedDay, { usage: selectedDay === syncDay
+      ? Array.from({ length: count }, (_, index) => v11UsageRecord(syncDay, "a", { eventId: "event:v2:" + index.toString(16).padStart(64, "0") }))
       : [] }),
     createEnvelope: encrypted,
     fetchImpl: async (url: URL, options: RequestInit) => {
@@ -230,7 +234,8 @@ describe("staged attribution transport and enrollment floor", () => {
 
   it("the real HTTP runner resumes a bounded partial day and activates only its complete comparison domain", async () => {
     const fixture = await createV11DeviceFixture(db(), { grant: true });
-    const options = runnerOptions(fixture, 201);
+    const syncDay = new Date(fixture.nowEpoch).toISOString().slice(0, 10);
+    const options = runnerOptions(fixture, 201, syncDay);
     const partial = await runTelemetryV11Sync({ ...options, maxChunks: 1 });
     expect(partial.failure).toBeNull();
     expect(partial).toMatchObject({ status: "partial", chunksUploaded: 1, daysSynced: 0, acknowledgedThroughDay: null });

--- a/docs/current-status.md
+++ b/docs/current-status.md
@@ -1,10 +1,10 @@
 ---
 title: Current product and release status
-date: 2026-08-27
+date: 2026-08-31
 type: status
 status: current
-source_commit: 52399658f28303f6af00259f921c2c46a881978f
-observation_date: 2026-08-27
+source_commit: 3b0f2d23775c0ca1f092fe3eb48f0c3166c8461a
+observation_date: 2026-08-31
 ---
 
 # Current product and release status
@@ -18,8 +18,9 @@ using this page for a later release or operational decision.
 
 | Boundary | Verified state |
 |---|---|
-| Documentation/source review | `origin/main` commit `52399658f28303f6af00259f921c2c46a881978f`, reviewed 2026-08-27 |
-| Public service | Read-only `GET https://tibotattle.com/api/health`, observed 2026-08-27 |
+| Documentation/source review | Release-preparation base `origin/main` commit `3b0f2d23775c0ca1f092fe3eb48f0c3166c8461a`, reviewed 2026-08-31; final source freeze is pending |
+| Installed internal dogfood | Signed and notarized RC4 source `735a59ce2ec01df0e381fb1aa878c5c7a39edcd8`, build `1023.2`, installed 2026-08-31; excludes PR #94 and is not current main or stable |
+| Public service | Read-only `GET https://tibotattle.com/api/health`, HTTP 200, deployment source `304f3d736b6f9451d32a616bf3046ea628e828a3`, observed 2026-08-31 |
 | Public updater | Read-only `GET https://updates.tibotattle.com/appcast.xml`, observed 2026-08-27 |
 | Published release | GitHub release API for `adamallcock/tibotattle`, observed 2026-08-27 |
 
@@ -36,7 +37,7 @@ and command contracts are indexed in [the documentation index](./README.md).
 The source tree at the reviewed commit is ahead of the live Worker reported
 below. Source merge therefore does not prove public deployment.
 
-### Source-only amendment, 2026-08-30
+### Source-only amendments through 2026-08-31
 
 The [approved self-service deletion retirement](./decisions/2026-08-30-self-service-deletion-retirement.md)
 retires `DELETE /api/v1/me` as `404 NOT_FOUND` without D1 access or participant
@@ -45,21 +46,46 @@ preserving hosted/local history, and retains private owner erasure through
 admin maintenance. The source health contract is `participantDeletion: false`
 with `deletionSafeRestoreReplay: true`. No migration or retention change is
 part of that retirement. This amendment does not refresh or supersede the
-2026-08-27 live-service, installed-artifact, release, or updater observations
-below; deployment and release remain separate unproven gates.
+independent live-service, installed-artifact, release, or updater observations
+below; deployment and release remain separate gates.
+
+[PR #89](https://github.com/adamallcock/tibotattle/pull/89) adds a hosted
+admin-only per-model allowance series and **By model** view. Migration 0041,
+Worker deployment, warming, and real cohort evidence remain separate; desktop
+installation does not activate it.
+
+[PR #94](https://github.com/adamallcock/tibotattle/pull/94) adds local plan-era
+attribution plus a staged telemetry v1.1 transport and device-continuity repair.
+Local estimates, history, ranges, forecasts, and share cards use one compatible
+selected population; missing or conflicting identity remains unavailable.
+Migrations 0042-0044, stronger-format hosted activation, and new explicit
+consent are not supplied by installing the desktop app.
+
+[PR #95](https://github.com/adamallcock/tibotattle/pull/95) makes compatible
+Keychain migration bounded and non-interactive, with an explained approval
+fallback available only through a deliberate Settings action. Automatic
+security prompts are release-blocking.
+
+[PR #96](https://github.com/adamallcock/tibotattle/pull/96) makes native startup
+use the bounded primary projection and recover from readiness that arrives after
+the initial wait without retaining a stale timeout page. These entries describe
+merged source at the release-preparation base; they are not installed-artifact,
+hosted-deployment, updater, or stable-release evidence.
 
 ## Public service
 
-At the observation time, `/api/health` returned `status: ok`, open enrollment,
-operational collection controls, healthy D1/deletion-ledger/object-store checks,
-and deployment source commit
-`826b1b89cf86b436713b42bee2707be85c61b550`. It reported the v1.0 incremental
-contribution contract as implementation-ready and externally authorized; the
-v0.2 account-scoped contract remained implementation-disabled.
+At the observation time, `/api/health` returned HTTP 200 and deployment source
+commit `304f3d736b6f9451d32a616bf3046ea628e828a3`. That deployment predates PR
+#94's device-continuity protocol. It can treat replay of one pairing identifier
+idempotently, but does not establish the fresh-pairing recovery protocol needed
+for an already registered local device.
 
-The live Worker commit is behind this document’s reviewed source commit. Do not
-describe post-`826b1b89` source changes as deployed until the live health
-identity advances and the affected route is checked directly.
+The live Worker commit is behind this document's reviewed source commit. Do not
+describe PR #89 or PR #94 Worker behavior as deployed until the live health
+identity advances and the affected migration and route are checked directly.
+Read-only production migration-ledger inspection was unavailable to the current
+operator credentials, so remote migration state remains unknown rather than
+assumed current.
 
 ## Published macOS release and updater
 
@@ -87,13 +113,33 @@ The complete qualification matrix and rules for changing these claims are in
 
 - The checked-out source contains unreleased changes after `v0.1.16`; the
   [changelog](../CHANGELOG.md) records them without claiming they shipped.
-- Protected R7 receipts are valid only for the exact source and environment
-  named in each receipt. A changed workload source makes them historical until
-  the protected dual-runtime workflow is deliberately regenerated.
+- The installed RC4 proves only frozen source `735a59ce`, build `1023.2`. It
+  excludes PR #94. The integrated RC5 allocation is `1023.3`, but no signed,
+  notarized, or installed RC5 artifact is established by this snapshot.
+- The current RC5 R7 workload-source closure has fresh protected dual-runtime
+  receipts for 359 files / workload SHA-256
+  `4c3058b3453bda2696e946952d18e81310f26eb0187074d410c730e44162f1d6`.
+  Both decisions remain honestly `release_open`; a later workload change would
+  make these receipts historical again. Native UI and build-allocation files are
+  outside that R7 closure and require their separate macOS source, smoke,
+  signed-artifact, and installed-artifact gates.
 - The public service and release feed are remote state. Their health and
   availability can change after this snapshot.
 - Public health is not proof that every admin, identity, contribution, deletion,
   or updater path works end to end.
+- Before RC5 dogfood sign-off or 0.1.17 stable qualification, PR #94 still needs
+  the fixed real-corpus before/after coverage, diagnostic-distribution, and
+  resource review. Current APIs cannot emit the complete named fit-rejection
+  reconciliation, so that gate remains open rather than inferred green. The
+  exact integrated native artifact must also pass signing, notarization,
+  state-preserving installation, updater, and physical native checks. Pairing
+  continuity needs compatible hosted Worker migrations/deployment before the
+  repaired desktop flow can be validated end to end.
+- An owner-only fixed-window attempt on 2026-08-31 failed closed before comparison:
+  the strict pre-PR scan reported `codex_rollout_content_invalid`. The supported
+  resource benchmark independently stopped at `benchmark_cold_rebuild_incomplete`
+  on both exact PR #94 revisions. No empirical comparison receipt was produced,
+  no source was excluded, and this remains an open RC5/stable gate.
 
 ## How to refresh this page
 

--- a/docs/decisions/2026-08-27-local-state-schema-and-release-channel-isolation.md
+++ b/docs/decisions/2026-08-27-local-state-schema-and-release-channel-isolation.md
@@ -138,6 +138,15 @@ dogfood build `1022`; the stable final also orders after the dogfood candidate.
 Release tooling refuses a signed version/channel without an owner-reviewed
 allocation, and an environment value can only assert the exact allocation.
 
+#### Allocation amendment, 2026-08-31
+
+The `1023` paragraph above records the first 0.1.17 dogfood allocation. RC2 used
+build `1023`, RC3 used `1023.1`, and the signed, notarized, installed
+startup-recovery RC4 used `1023.2`. The integrated RC5 allocation is now
+`1023.3`; stable remains reserved at `1024`. Each increment retains the same
+production bundle identity and therefore must be monotonic. RC4 evidence applies
+only to its frozen source and is not inherited by RC5 or stable.
+
 The separately identified Preview app uses the deterministic migration epoch
 `(2000 + major).minor.patch`, so preview package `0.1.17` maps to
 `2000.1.17`. That keeps local preview builds deterministic and valid within

--- a/docs/decisions/2026-08-31-silent-keychain-migration.md
+++ b/docs/decisions/2026-08-31-silent-keychain-migration.md
@@ -277,3 +277,18 @@ authorized old-to-new installation check and complete native visual/interaction
 QA. No real TiboTattle Keychain item, installed app, application history, consent,
 or hosted deployment has been changed by these implementation and synthetic
 qualification steps. No release is established by this decision.
+
+## Later dogfood amendment: 2026-08-31
+
+The `1023.1` sentence above records the allocation at that checkpoint. PR #95
+subsequently merged as `a3c850360bc83c0e27bef2171aeb4a302b72f472`, and the
+startup-recovery RC4 used build `1023.2`. RC4 source
+`735a59ce2ec01df0e381fb1aa878c5c7a39edcd8` was signed, notarized, and installed;
+that artifact excludes later PR #94 and does not qualify current main or stable.
+
+The next integrated dogfood allocation is RC5 build `1023.3`, strictly after
+RC4 and before reserved stable build `1024`. It has not yet been built or
+qualified. The prompt-avoidance contract is unchanged: automatic Keychain reads
+remain bounded to three non-interactive attempts, and only the explained,
+deliberate Settings recovery action may request approval. An unexpected prompt
+in an automatic flow remains release-blocking.

--- a/docs/plans/2026-08-30-account-plan-attribution-implementation.md
+++ b/docs/plans/2026-08-30-account-plan-attribution-implementation.md
@@ -2,7 +2,7 @@
 title: Account and plan attribution implementation after red-team review
 date: 2026-08-30
 type: plan
-status: implemented-pending-coordinated-merge
+status: implemented-merged-pending-qualification
 ---
 
 # Account and plan attribution implementation
@@ -19,8 +19,10 @@ untouched in the original checkout. Implementation is committed on the isolated
 `codex/account-plan-attribution` branch: `f57dab81` contains the product changes;
 `be8e8f5d` adds the test-only cancellation-observer correction described below.
 The implementation-checkpoint documentation records those results without
-changing product code. The subsequent source-PR preparation is recorded below;
-its merge and release qualification are coordinated separately.
+changing product code. PR #94 later merged into `main` as
+`20f449ff5c222989029fe343f219f02b497ae1d4`; source merge does not close the
+empirical, protected-R7, installed-artifact, migration, consent, deployment, or
+release gates recorded below.
 
 This document owns the implementation decisions and progress. It is not a
 deployment, installed-artifact, privacy-erasure, or release receipt. Local tests
@@ -383,16 +385,20 @@ also drove the preserved-history, actual-client and artifact-closure fixes above
   selected-versus-diagnostic distribution and resource review remains required
   before hosted methodology activation or dogfood sign-off. No acceptable-loss
   percentage is invented to bypass it.
-- **R7:** retained receipts need the protected, environment-specific regeneration
-  workflow after source freeze. Stale receipts are not waived or hand-edited.
+- **R7:** the current RC5 R7 workload-source closure completed the protected
+  dual-runtime regeneration after its source freeze. All ten receipts validate
+  against 359 files / workload SHA-256
+  `4c3058b3453bda2696e946952d18e81310f26eb0187074d410c730e44162f1d6`;
+  the reconstructed decision remains `release_open` and is not promoted by hand.
+  Native UI and allocation files are outside that closure and use separate gates.
 - **Hosted cutover:** 0042–0044 are source migrations, not remote receipts.
   Stronger-format writes remain staged and require explicit new consent; existing
   v0.2 history is deliberately preserved behind an upgrade refusal until a
   compatible replacement adapter is reviewed.
-- **Delivery:** source validation and local ad-hoc test bundles do not establish
-  CI, merge, deployment, a signed/notarized release, updater availability, or an
-  installed and manually verified dogfood. None of those protected outcomes has
-  been performed as part of this implementation.
+- **Delivery:** source validation, passing PR workflows, and the later PR #94
+  merge do not establish deployment, a signed/notarized integrated release,
+  updater availability, or an installed and manually verified integrated
+  dogfood. Those protected outcomes remain separate from this implementation.
 - **Large/continuously changing histories:** the immutable domain limits are
   4,096 days, 30,000 chunks and 6,000,000 records. A prefix that changes faster
   than it can be revalidated within repeated foreground budgets can remain
@@ -419,3 +425,42 @@ the full root gate or final frozen-source R7 qualification.
 The before/after real-corpus coverage review, native installed-artifact checks,
 and hosted migration/activation boundaries above remain unchanged. Source-PR
 readiness is not permission to upload real data or activate the new transport.
+
+### Merge receipt and current boundary: 2026-08-31
+
+After the held installed-generation handoff, PR #94 merged into `main` as
+`20f449ff5c222989029fe343f219f02b497ae1d4`. The current release-preparation
+base `3b0f2d23775c0ca1f092fe3eb48f0c3166c8461a` includes that merge together
+with the prompt-free Keychain and startup-recovery follow-ups. The earlier hold
+and validation record above remain historical evidence for the reviewed PR
+head; they are no longer a statement that PR #94 is unmerged.
+
+The current RC5 R7 workload-source closure subsequently regenerated all ten
+protected receipts on 2026-08-31. Its closure is 359 files with workload
+SHA-256 `4c3058b3453bda2696e946952d18e81310f26eb0187074d410c730e44162f1d6`;
+the retained receipt test passes, and the reconstructed decision remains
+honestly `release_open` rather than release-ready. Native UI/allocation changes
+are outside this closure and retain separate source, smoke, and artifact gates.
+The fixed real-corpus
+before/after coverage, selected-versus-diagnostic distribution, and resource
+review remain open before PR #94 methodology sign-off or hosted activation.
+Current APIs cannot emit a complete named fit-rejection reconciliation, so no
+green empirical receipt or same-login workspace-identity proof is claimed.
+
+An owner-only diagnostic attempt on 2026-08-31 pinned the PR first parent
+`a3c850360bc83c0e27bef2171aeb4a302b72f472`, merge result
+`20f449ff5c222989029fe343f219f02b497ae1d4`, and fixed window
+`2025-08-31T00:00:00.000Z` through `2026-08-31T00:00:00.000Z`. It failed closed
+before comparison when the strict baseline scan reported
+`codex_rollout_content_invalid`. The supported resource benchmark separately
+stopped at `benchmark_cold_rebuild_incomplete` on both revisions. No aggregate
+comparison receipt was produced, no invalid source was silently excluded, and
+the empirical gate remains open.
+
+The live Worker observed read-only on 2026-08-31 reported deployment source
+`304f3d736b6f9451d32a616bf3046ea628e828a3`, which predates PR #94's
+device-continuity protocol. Migrations 0042-0044, telemetry v1.1 activation, and
+new consent remain undeployed and separately authorized. The signed, notarized,
+installed RC4 at source `735a59ce2ec01df0e381fb1aa878c5c7a39edcd8`, build
+`1023.2`, also predates PR #94. It cannot qualify this integrated source or the
+planned RC5 build `1023.3`.

--- a/docs/plans/2026-08-30-native-dogfood-integration.md
+++ b/docs/plans/2026-08-30-native-dogfood-integration.md
@@ -13,12 +13,15 @@ Electron release, or new signed-Preview workflow. Source integration, tests,
 state migration, signing, installation, and native verification are separate
 gates; none is complete merely because an earlier gate passed.
 
-The installed RC2 source is `3d9055fc` (PR #92). The owner's subsequent
-prompt-free Keychain follow-up, its approved reset boundary, and current
-qualification are recorded in the
+The installed RC4 source is `735a59ce`, build `1023.2`. Its prompt-free Keychain
+foundation, approved recovery boundary, and qualification are recorded in the
 [silent-migration decision](../decisions/2026-08-31-silent-keychain-migration.md).
-That candidate remains frozen while the separate account/plan-attribution PR
-is prepared for a later 0.1.17 dogfood; do not combine their R7 evidence.
+RC4 is signed, notarized, and installed, but it was intentionally frozen before
+account/plan PR #94 and therefore does not qualify current main or stable. The
+integrated release-preparation base is `origin/main` at `3b0f2d23` (PR #96).
+Its current R7 workload-source closure now has fresh protected receipts, whose
+decision remains `release_open`; native/allocation source review and RC5 artifact
+evidence are outside that closure and remain separate and pending.
 
 ## Source boundary
 
@@ -35,14 +38,16 @@ must remain untouched by integration.
 | #85 internal tool-history warning | In current main | Include and verify dashboard state |
 | Compact accounting headings, five-column cache table, quieter partial-coverage copy | Local task changes | Review, test, commit, PR and merge |
 | #88 native menu history retained during refresh and popup dismissal | Merged as `41c02dd2`; integrated | Revalidate the signed native artifact, including physical clicks |
-| #87 local cache-drop thread links | Explicitly included; merged as `a864d159` from `ce0aacd6` | Reconcile five-column compact layout, test transient name lookup and native handoff; final integrated R7 remains here |
+| #87 local cache-drop thread links | Explicitly included; merged as `a864d159` from `ce0aacd6` | Reconcile five-column compact layout, test transient name lookup and native handoff; revalidate against the fresh R7 workload receipts |
 | #86 participant self-service deletion retirement | Ready/merged handoff supersedes draft-only exclusion; include `9b121b7d` | Reconcile integrated source and native/consent checks; no hosted deployment or production deletion is authorized here |
 | #75 stacked native popup PR | Merged into the Windows/Electron branch, not main; native functionality already ported by #81 | Verified native parity on `c111fded`; do not merge excluded Electron ancestry |
 | #89 server-computed per-model allowance series | Merged into main as `c111fded` after the first candidate was signed | Include source and rerun the complete Worker gate; hosted activation remains a separate deployment |
 | #90 compact accounting, context-pricing parity and retained R7 evidence | Merged as `d13b19ef` | Preserve completed validation and build the final candidate from the subsequently updated source |
 | #91 purchased-credit research analyzer | Opened after the native freeze; standalone research, not a packaged native dependency | Exclude from this candidate; separate source/privacy review remains necessary |
+| #94 local plan-era attribution, staged telemetry v1.1 and device continuity | Merged as `20f449ff`; not present in installed RC4 | Include in RC5; the R7 workload closure is fresh, while empirical coverage/resource review and installed artifact gates remain open. Hosted migrations, activation and new consent remain separate |
+| #95 prompt-free Keychain migration | Merged as `a3c85036`; foundation of RC4 and current main | Retain the bounded three-attempt automatic path and Settings-only explained fallback; unexpected prompts block release |
+| #96 late native startup recovery | Merged as `3b0f2d23`; current release-preparation base | Include in RC5 and revalidate delayed readiness on the exact installed artifact |
 | #73, #74, Electron delivery, Linux integration and Claude Code integration | Excluded | No scope expansion without a new decision |
-| Credential-lifetime branch | Unreviewed, uncommitted work remains | Do not silently absorb into this candidate |
 
 Take a fresh PR/main snapshot before freezing. Identify newly included source
 explicitly; do not indefinitely follow unrelated active branches.
@@ -50,10 +55,11 @@ explicitly; do not indefinitely follow unrelated active branches.
 PR #90 closed the initial source freeze through main's `9b121b7d` (#86),
 including #87 and #88 plus this task's compact-accounting changes. The owner's
 subsequent request reopened the freeze to include newly merged #89 at
-`c111fded` and verify #75 parity. The final follow-up also repairs the retained
-replacement validator for the exact already-shipped dogfood artifact; it does
-not change the app's runtime. Further unrelated PRs are not automatically
-included in the retained validation run.
+`c111fded` and verify #75 parity. PR #92 supplied the retained replacement
+validator; PR #95 supplied prompt-free migration; frozen RC4 then added startup
+recovery without PR #94. The final integrated freeze is reopened only through
+merged PR #94 and PR #96 at base `3b0f2d23`. Further unrelated PRs are not
+automatically included in the retained validation run.
 
 ## Execution and acceptance
 
@@ -73,8 +79,8 @@ included in the retained validation run.
 5. Commit and merge the reviewed result, then create one exact annotated
    `tibotattle-internal-dogfood-0.1.17-rcN-source-YYYYMMDD` tag. Use the reviewed
    channel allocation from `scripts/macos-bundle-version.js`, clean source and
-   retained release finalizer. RC1/RC2 use `1023`; the approved Keychain-migration
-   follow-up uses `1023.1`.
+   retained release finalizer. Earlier candidates used `1023`, `1023.1`, and
+   `1023.2`; the integrated RC5 uses `1023.3`. Stable remains `1024`.
    Signing and notarization are authorized; public updater/release publication
    and hosted deployment are not part of this task.
 6. Install only the verified signed artifact with a recoverable prior-app and
@@ -236,3 +242,39 @@ Final updated-source tagging, signing, replacement validation, installation
 and physical native checks remain. Public release/updater publication is not
 part of this internal dogfood. Private state records, comparisons, UI captures
 and release inputs remain local and outside tracked docs.
+
+## RC4 handoff and integrated RC5 boundary
+
+Frozen RC4 source `735a59ce2ec01df0e381fb1aa878c5c7a39edcd8`, build
+`1023.2`, was subsequently signed, notarized, and installed. That artifact is
+valid evidence for its exact source only. It excludes PR #94 and cannot qualify
+the current release-preparation base `3b0f2d23775c0ca1f092fe3eb48f0c3166c8461a`
+or stable 0.1.17.
+
+The integrated current-main candidate is RC5 build `1023.3`. It includes merged
+PRs #94, #95, and #96. Its current R7 workload-source closure regenerated and
+validated all ten protected receipts on 2026-08-31 against 359 files / workload
+SHA-256 `4c3058b3453bda2696e946952d18e81310f26eb0187074d410c730e44162f1d6`.
+The reconstructed R7 decision remains honestly `release_open`, and PR #94's
+fixed-corpus empirical review remains open. RC5 has not yet been frozen, tagged,
+built, signed, notarized, installed, or physically qualified; root/Worker/native
+gates and clean source review still apply. The native UI and allocation files are
+outside the R7 closure and rely on those separate gates. Stable build `1024`, the `v0.1.17`
+tag, GitHub release, appcast, updater, and public artifacts remain separate later
+gates.
+
+The owner-only fixed-window PR #94 diagnostic attempted on 2026-08-31 failed
+closed before comparison with `codex_rollout_content_invalid` in the strict
+baseline scan. Its supported resource benchmark independently stopped at
+`benchmark_cold_rebuild_incomplete` on both exact revisions. No empirical
+comparison receipt exists, and RC5 may be built only as an explicitly open-gate
+test candidate rather than an empirically signed-off or stable-ready artifact.
+
+A read-only service observation on 2026-08-31 returned HTTP 200 from deployment
+source `304f3d736b6f9451d32a616bf3046ea628e828a3`. That Worker predates PR #94's
+device-continuity protocol, so an already registered Mac can fail a fresh
+three-step pairing attempt even though its prior local binding remains valid.
+The current source repair requires both the newer desktop path and compatible
+hosted Worker behavior. Worker migrations/deployment, telemetry v1.1 activation,
+and new consent are protected operations outside this internal artifact build;
+desktop installation alone cannot establish end-to-end pairing repair.

--- a/docs/plans/2026-08-31-native-startup-recovery.md
+++ b/docs/plans/2026-08-31-native-startup-recovery.md
@@ -2,16 +2,17 @@
 title: Native dogfood startup recovery
 date: 2026-08-31
 type: plan
-status: in-progress
+status: implemented-pending-integrated-candidate
 ---
 
 # Boundary
 
-Finish the current native 0.1.17 dogfood before adding account/plan PR #94 to
-an installed candidate. The owner merged #94 into main at `20f449ff` during
-qualification; this corrective candidate remains based on `a3c85036` plus only
-the startup fix. Carry the fix to newer main separately without silently
-changing this artifact's source.
+The corrective RC4 was intentionally frozen before account/plan PR #94. The
+owner later merged #94 into main at `20f449ff`, and PR #96 carried the startup
+fix to newer main as merge `3b0f2d23`. Preserve the artifact boundary: installed
+RC4 source `735a59ce` is based on `a3c85036` plus only the startup fix; it does
+not contain or qualify PR #94. The integrated current-main candidate is a new
+RC5, not a relabel of RC4.
 The signed PR #95 candidate reproduced `UM_MACOS_DASHBOARD_READY_TIMEOUT` on
 normal launch with existing schema-11 history. A replacement companion later
 reported a ready snapshot and returned the overview in 51 ms; the native window
@@ -36,8 +37,11 @@ or public release is part of this correction.
   callback and optional-service regressions. Keep every existing safety gate.
 - [x] Validate the combined corrective source and retained R7 freshness. Allocate
   its monotonic native build and freeze the source separately from newer main.
-- [ ] Sign/notarize, preserve state and the prior app, install and verify real
-  native startup, refresh, restart and prompt-free behavior.
+- [x] Sign, notarize, preserve state and the prior app, and install frozen RC4
+  build `1023.2`. This qualifies only source `735a59ce`.
+- [ ] Re-run exact-source artifact gates and verify native startup, refresh,
+  restart, pairing repair, and prompt-free behavior on integrated RC5 build
+  `1023.3`.
 
 ## Acceptance
 
@@ -85,9 +89,10 @@ not to the later main integration described below.
   discovery retains its existing local queue-bookkeeping semantics; it does
   not itself upload. A primary read that never settles still reaches the
   native hard deadline rather than being presented as successful.
-- Exact-source hosted checks, signing, notarization, state-preserving replacement
-  and installed native interaction
-  remain separate pending steps. Browser QA is not native qualification.
+- RC4 signing, notarization, state-preserving replacement, and installation were
+  completed later for this exact frozen source. That evidence is not inherited
+  by the integrated PR #94 tree or stable release. Browser QA remains distinct
+  from physical native qualification.
 
 ## Source-only main integration
 
@@ -105,5 +110,25 @@ Both protected R7 freshness checks fail on the current workload digest and file
 count. The integrated workload provenance was recomputed from every main Git
 blob and matches this tree exactly; all ten retained receipts also match main
 byte-for-byte. These failures are inherited from main, not introduced by the
-startup fix. No protected receipt was edited or regenerated. Main-source merge
-remains review-gated, separately from the RC4 signed-artifact qualification.
+startup fix. No protected receipt was edited or regenerated. At the time of
+this checkpoint, main-source merge remained review-gated, separately from the
+RC4 signed-artifact qualification.
+
+## Merge and integrated-candidate amendment
+
+PR #96 subsequently merged the source-only startup correction into `main` as
+`3b0f2d23775c0ca1f092fe3eb48f0c3166c8461a`. That release-preparation base
+includes PR #94 and PR #95. The earlier stale-R7 statement remains the accurate
+checkpoint for that pre-merge review. The current RC5 R7 workload-source closure
+subsequently regenerated and validated all ten protected receipts on 2026-08-31
+against 359 files / workload SHA-256
+`4c3058b3453bda2696e946952d18e81310f26eb0187074d410c730e44162f1d6`.
+The reconstructed decision remains `release_open`; this is current evidence,
+not a claim that R7's standing promotion ceilings or PR #94's empirical gate are
+closed. The native startup and RC5 allocation files are outside that workload
+closure and remain subject to their separate native and artifact gates.
+
+Installed RC4 source `735a59ce2ec01df0e381fb1aa878c5c7a39edcd8`, build
+`1023.2`, is signed and notarized but excludes PR #94. The next integrated
+dogfood therefore uses monotonic RC5 build `1023.3`; it has not yet been built,
+signed, notarized, or installed. Stable build `1024` remains separately reserved.

--- a/docs/runbooks/macos-stable-release-runbook.md
+++ b/docs/runbooks/macos-stable-release-runbook.md
@@ -241,8 +241,9 @@ node scripts/release-macos-app.js \
 
 For the 0.1.17 stable release, `CFBundleShortVersionString` remains `0.1.17`
 and the owner-reviewed signed `CFBundleVersion` is exactly `1024`. It follows
-the internal-dogfood 0.1.17 startup-recovery allocation `1023.2`, migration RC3
-`1023.1`, retained RC2 `1023`, and earlier shared-identity dogfood `1022`. The
+the final integrated internal-dogfood 0.1.17 allocation `1023.3`,
+startup-recovery RC4 `1023.2`, migration RC3 `1023.1`, retained RC2 `1023`,
+and earlier shared-identity dogfood `1022`. The
 checked-in allocation is authoritative; the
 `USAGE_MONITOR_BUNDLE_VERSION` value above is only an exact assertion and
 cannot select or override a different build. A future stable version must add

--- a/generated/r7-release-decision-node24.14.0-v0.1.json
+++ b/generated/r7-release-decision-node24.14.0-v0.1.json
@@ -481,8 +481,8 @@
     "resourcePolicySourceSha256": "d9748895468534062e9c8c436db75cbf5acf4ccf54f84319db37e88197627870",
     "resourcePolicyValuesSha256": "3cbe7853c8f75e96912885f64ba4ad1aeb13aff8a22e4ffbd51806b27c73b418",
     "schemaModuleSha256": "594d035e641e87b29db4027dca35157f8225fd5621816d67d5d9f25825468bbf",
-    "workloadCodeFileCount": 335,
-    "workloadCodeSha256": "8be3813e1f9cc787652bf6c718715d91e245e90df6f5eff1bcef5ad1cd16832a"
+    "workloadCodeFileCount": 359,
+    "workloadCodeSha256": "4c3058b3453bda2696e946952d18e81310f26eb0187074d410c730e44162f1d6"
   },
   "determinism": {
     "comparisons": {
@@ -849,7 +849,7 @@
         "decision": "unresolved",
         "dimension": "source_bytes",
         "exactBoundaryValue": "not_identified",
-        "realHistoryValue": 26380548633,
+        "realHistoryValue": 26380587616,
         "selectionBasis": "not_identified",
         "unit": "bytes"
       },
@@ -939,7 +939,7 @@
         "decision": "unresolved",
         "dimension": "export_set_encoded_bytes",
         "exactBoundaryValue": "not_identified",
-        "realHistoryValue": 29090311,
+        "realHistoryValue": 29090523,
         "selectionBasis": "not_identified",
         "unit": "bytes"
       },
@@ -989,7 +989,7 @@
         "decision": "unresolved",
         "dimension": "elapsed_time",
         "exactBoundaryValue": "not_identified",
-        "realHistoryValue": 320624,
+        "realHistoryValue": 382845,
         "selectionBasis": "not_identified",
         "unit": "milliseconds"
       },
@@ -999,7 +999,7 @@
         "decision": "unresolved",
         "dimension": "rss",
         "exactBoundaryValue": "not_identified",
-        "realHistoryValue": 1254391808,
+        "realHistoryValue": 1489780736,
         "selectionBasis": "not_identified",
         "unit": "bytes"
       }
@@ -1007,20 +1007,20 @@
     "headroomBasisPoints": 2000,
     "inputReceipts": {
       "materializedBoundaries": {
-        "node24Sha256": "9f90cc89b2a678adcec1fb30313b3fa5acf6e5e052be51c41617acb85311005c",
-        "node26Sha256": "bc488011baaeaf46ad51c9fabc87eb6ec88ea4cf096c7863d21a71a1530260b6"
+        "node24Sha256": "bff844d9d4d4d1699e975416c914cfecc31c34dfb626ba106882f7de1659c5ed",
+        "node26Sha256": "7bda1b915961762c8e961fd60b6fffc2eead86bfadd356b659b8c71f4bd12818"
       },
       "realLocalHistory": {
-        "node24Sha256": "b3b68972f3e419879ee2f8f9f71666152683c2e6365f0fbd833ef2c370426cfa",
-        "node26Sha256": "0ba728cf2ccbf02fc171126e4a92848fbc02e5de108b7fa1ee3f985ac70419ba"
+        "node24Sha256": "4582408f1f578e1e23b705b9a44464cb989831c6528ece05415e268043336968",
+        "node26Sha256": "d2a7d60d12aedbb65811d4096ef5e3c04f13bd8855ae66897f4f994c138974c4"
       },
       "syntheticPressure": {
-        "node24Sha256": "9d47731bc8060b743ca43ac514d014d5a53df049bbf6fe668afe8f326bdb6c87",
-        "node26Sha256": "566312174be959efe01d904097ad0a62adb491dca0c996a3e7ffd1fb15bcb38c"
+        "node24Sha256": "03341e66a24566b1f876bf0cec71b49fa530d273401a614584aac20954041a70",
+        "node26Sha256": "a10d939d59620e56b64c54a51371da30cdce7adaa5ab0832888825ee88c95c51"
       },
       "syntheticSemantics": {
-        "node24Sha256": "8a64ac37941429fd98011836c46710b7aacd33f4439300bdd3b4bc8289fb71f6",
-        "node26Sha256": "ad7bbaabe5de8a1fa683fbbfcda51f893225732bee47fb167207820802f39d64"
+        "node24Sha256": "4ddfe56b735cf44241ef3cd5119cdccb3490d17bc13e6ba44d1668c859b694a4",
+        "node26Sha256": "4e90b8b3bdd596f5eb5694c33f534417ce64dbca642013b7d14b4a644cbc75cc"
       }
     },
     "kind": "release_decision",
@@ -1039,7 +1039,7 @@
     "singleMachineLimitation": true
   },
   "protocolVersion": "g1-r7-release-evidence-v0.1",
-  "receiptSha256": "38f1a931561a486738c697bff1a93d6ae938dc2e1077f12d47362c91a163a94d",
+  "receiptSha256": "1b890470afb709cd3455a59306bd37cb95091a132e066382d73b7934271243da",
   "runtimeProvenance": {
     "architecture": "arm64",
     "elapsedClock": "parent_monotonic",

--- a/generated/r7-release-decision-node26.2.0-v0.1.json
+++ b/generated/r7-release-decision-node26.2.0-v0.1.json
@@ -481,8 +481,8 @@
     "resourcePolicySourceSha256": "d9748895468534062e9c8c436db75cbf5acf4ccf54f84319db37e88197627870",
     "resourcePolicyValuesSha256": "3cbe7853c8f75e96912885f64ba4ad1aeb13aff8a22e4ffbd51806b27c73b418",
     "schemaModuleSha256": "594d035e641e87b29db4027dca35157f8225fd5621816d67d5d9f25825468bbf",
-    "workloadCodeFileCount": 335,
-    "workloadCodeSha256": "8be3813e1f9cc787652bf6c718715d91e245e90df6f5eff1bcef5ad1cd16832a"
+    "workloadCodeFileCount": 359,
+    "workloadCodeSha256": "4c3058b3453bda2696e946952d18e81310f26eb0187074d410c730e44162f1d6"
   },
   "determinism": {
     "comparisons": {
@@ -849,7 +849,7 @@
         "decision": "unresolved",
         "dimension": "source_bytes",
         "exactBoundaryValue": "not_identified",
-        "realHistoryValue": 26380548633,
+        "realHistoryValue": 26380587616,
         "selectionBasis": "not_identified",
         "unit": "bytes"
       },
@@ -939,7 +939,7 @@
         "decision": "unresolved",
         "dimension": "export_set_encoded_bytes",
         "exactBoundaryValue": "not_identified",
-        "realHistoryValue": 29090311,
+        "realHistoryValue": 29090523,
         "selectionBasis": "not_identified",
         "unit": "bytes"
       },
@@ -989,7 +989,7 @@
         "decision": "unresolved",
         "dimension": "elapsed_time",
         "exactBoundaryValue": "not_identified",
-        "realHistoryValue": 320624,
+        "realHistoryValue": 382845,
         "selectionBasis": "not_identified",
         "unit": "milliseconds"
       },
@@ -999,7 +999,7 @@
         "decision": "unresolved",
         "dimension": "rss",
         "exactBoundaryValue": "not_identified",
-        "realHistoryValue": 1254391808,
+        "realHistoryValue": 1489780736,
         "selectionBasis": "not_identified",
         "unit": "bytes"
       }
@@ -1007,20 +1007,20 @@
     "headroomBasisPoints": 2000,
     "inputReceipts": {
       "materializedBoundaries": {
-        "node24Sha256": "9f90cc89b2a678adcec1fb30313b3fa5acf6e5e052be51c41617acb85311005c",
-        "node26Sha256": "bc488011baaeaf46ad51c9fabc87eb6ec88ea4cf096c7863d21a71a1530260b6"
+        "node24Sha256": "bff844d9d4d4d1699e975416c914cfecc31c34dfb626ba106882f7de1659c5ed",
+        "node26Sha256": "7bda1b915961762c8e961fd60b6fffc2eead86bfadd356b659b8c71f4bd12818"
       },
       "realLocalHistory": {
-        "node24Sha256": "b3b68972f3e419879ee2f8f9f71666152683c2e6365f0fbd833ef2c370426cfa",
-        "node26Sha256": "0ba728cf2ccbf02fc171126e4a92848fbc02e5de108b7fa1ee3f985ac70419ba"
+        "node24Sha256": "4582408f1f578e1e23b705b9a44464cb989831c6528ece05415e268043336968",
+        "node26Sha256": "d2a7d60d12aedbb65811d4096ef5e3c04f13bd8855ae66897f4f994c138974c4"
       },
       "syntheticPressure": {
-        "node24Sha256": "9d47731bc8060b743ca43ac514d014d5a53df049bbf6fe668afe8f326bdb6c87",
-        "node26Sha256": "566312174be959efe01d904097ad0a62adb491dca0c996a3e7ffd1fb15bcb38c"
+        "node24Sha256": "03341e66a24566b1f876bf0cec71b49fa530d273401a614584aac20954041a70",
+        "node26Sha256": "a10d939d59620e56b64c54a51371da30cdce7adaa5ab0832888825ee88c95c51"
       },
       "syntheticSemantics": {
-        "node24Sha256": "8a64ac37941429fd98011836c46710b7aacd33f4439300bdd3b4bc8289fb71f6",
-        "node26Sha256": "ad7bbaabe5de8a1fa683fbbfcda51f893225732bee47fb167207820802f39d64"
+        "node24Sha256": "4ddfe56b735cf44241ef3cd5119cdccb3490d17bc13e6ba44d1668c859b694a4",
+        "node26Sha256": "4e90b8b3bdd596f5eb5694c33f534417ce64dbca642013b7d14b4a644cbc75cc"
       }
     },
     "kind": "release_decision",
@@ -1039,7 +1039,7 @@
     "singleMachineLimitation": true
   },
   "protocolVersion": "g1-r7-release-evidence-v0.1",
-  "receiptSha256": "bfae1aa4bbe56945890f1e14da426b1bf74199f17ca3178910830b98c2f628c4",
+  "receiptSha256": "33ebe20838a63301eaf50b892ea31bce4f31af0c50d11f23d7753fef01138a9b",
   "runtimeProvenance": {
     "architecture": "arm64",
     "elapsedClock": "parent_monotonic",

--- a/generated/r7-release-materialized-boundaries-node24.14.0-v0.1.json
+++ b/generated/r7-release-materialized-boundaries-node24.14.0-v0.1.json
@@ -481,8 +481,8 @@
     "resourcePolicySourceSha256": "d9748895468534062e9c8c436db75cbf5acf4ccf54f84319db37e88197627870",
     "resourcePolicyValuesSha256": "3cbe7853c8f75e96912885f64ba4ad1aeb13aff8a22e4ffbd51806b27c73b418",
     "schemaModuleSha256": "594d035e641e87b29db4027dca35157f8225fd5621816d67d5d9f25825468bbf",
-    "workloadCodeFileCount": 335,
-    "workloadCodeSha256": "8be3813e1f9cc787652bf6c718715d91e245e90df6f5eff1bcef5ad1cd16832a"
+    "workloadCodeFileCount": 359,
+    "workloadCodeSha256": "4c3058b3453bda2696e946952d18e81310f26eb0187074d410c730e44162f1d6"
   },
   "determinism": {
     "comparisons": {
@@ -500,8 +500,8 @@
     "projectionVersion": "g1-r7-release-deterministic-projection-v0.1",
     "runCount": 2,
     "runProjectionSha256es": [
-      "32547d1d22aa4ae8691ddec0e6547e3794353fcf9b4185a77c41136a04ff577b",
-      "32547d1d22aa4ae8691ddec0e6547e3794353fcf9b4185a77c41136a04ff577b"
+      "34780cd156643c6c62a33e7ce2dffb5c4b1fb66ae4eea4d4b5b0a6186c58c6c5",
+      "34780cd156643c6c62a33e7ce2dffb5c4b1fb66ae4eea4d4b5b0a6186c58c6c5"
     ],
     "status": "partial"
   },
@@ -822,16 +822,16 @@
       "decodedBytes": 0,
       "durablePeakRssBytes": 0,
       "encodedBytes": 0,
-      "externalPeakRssBytes": 329367552,
-      "externalRssSampleCount": 69,
-      "externalRssSampleFailureCount": 0,
+      "externalPeakRssBytes": 324698112,
+      "externalRssSampleCount": 64,
+      "externalRssSampleFailureCount": 1,
       "filesystem": {
         "afterBytes": 0,
         "beforeBytes": 0,
-        "sampledHighWaterBytes": 30808835
+        "sampledHighWaterBytes": 30807688
       },
       "outputRecords": 0,
-      "parentElapsedMs": 3831,
+      "parentElapsedMs": 3365,
       "runCount": 2,
       "sourceBytes": 0,
       "sourceFiles": 0,
@@ -894,7 +894,7 @@
     }
   },
   "protocolVersion": "g1-r7-release-evidence-v0.1",
-  "receiptSha256": "9f90cc89b2a678adcec1fb30313b3fa5acf6e5e052be51c41617acb85311005c",
+  "receiptSha256": "bff844d9d4d4d1699e975416c914cfecc31c34dfb626ba106882f7de1659c5ed",
   "runtimeProvenance": {
     "architecture": "arm64",
     "elapsedClock": "parent_monotonic",

--- a/generated/r7-release-materialized-boundaries-node26.2.0-v0.1.json
+++ b/generated/r7-release-materialized-boundaries-node26.2.0-v0.1.json
@@ -481,8 +481,8 @@
     "resourcePolicySourceSha256": "d9748895468534062e9c8c436db75cbf5acf4ccf54f84319db37e88197627870",
     "resourcePolicyValuesSha256": "3cbe7853c8f75e96912885f64ba4ad1aeb13aff8a22e4ffbd51806b27c73b418",
     "schemaModuleSha256": "594d035e641e87b29db4027dca35157f8225fd5621816d67d5d9f25825468bbf",
-    "workloadCodeFileCount": 335,
-    "workloadCodeSha256": "8be3813e1f9cc787652bf6c718715d91e245e90df6f5eff1bcef5ad1cd16832a"
+    "workloadCodeFileCount": 359,
+    "workloadCodeSha256": "4c3058b3453bda2696e946952d18e81310f26eb0187074d410c730e44162f1d6"
   },
   "determinism": {
     "comparisons": {
@@ -500,8 +500,8 @@
     "projectionVersion": "g1-r7-release-deterministic-projection-v0.1",
     "runCount": 2,
     "runProjectionSha256es": [
-      "f6ae6015bfc0b78dee000969f789834b2884897881f07a07c84392e305817129",
-      "f6ae6015bfc0b78dee000969f789834b2884897881f07a07c84392e305817129"
+      "3786d4747f7bc24e4ebb58388f8a8b33c8dc721b47975e3e517ee484f8acaed8",
+      "3786d4747f7bc24e4ebb58388f8a8b33c8dc721b47975e3e517ee484f8acaed8"
     ],
     "status": "partial"
   },
@@ -822,16 +822,16 @@
       "decodedBytes": 0,
       "durablePeakRssBytes": 0,
       "encodedBytes": 0,
-      "externalPeakRssBytes": 345341952,
-      "externalRssSampleCount": 62,
+      "externalPeakRssBytes": 345669632,
+      "externalRssSampleCount": 154,
       "externalRssSampleFailureCount": 0,
       "filesystem": {
         "afterBytes": 0,
         "beforeBytes": 0,
-        "sampledHighWaterBytes": 30808253
+        "sampledHighWaterBytes": 30868184
       },
       "outputRecords": 0,
-      "parentElapsedMs": 3142,
+      "parentElapsedMs": 8423,
       "runCount": 2,
       "sourceBytes": 0,
       "sourceFiles": 0,
@@ -894,7 +894,7 @@
     }
   },
   "protocolVersion": "g1-r7-release-evidence-v0.1",
-  "receiptSha256": "bc488011baaeaf46ad51c9fabc87eb6ec88ea4cf096c7863d21a71a1530260b6",
+  "receiptSha256": "7bda1b915961762c8e961fd60b6fffc2eead86bfadd356b659b8c71f4bd12818",
   "runtimeProvenance": {
     "architecture": "arm64",
     "elapsedClock": "parent_monotonic",

--- a/generated/r7-release-real-local-history-node24.14.0-v0.1.json
+++ b/generated/r7-release-real-local-history-node24.14.0-v0.1.json
@@ -481,8 +481,8 @@
     "resourcePolicySourceSha256": "d9748895468534062e9c8c436db75cbf5acf4ccf54f84319db37e88197627870",
     "resourcePolicyValuesSha256": "3cbe7853c8f75e96912885f64ba4ad1aeb13aff8a22e4ffbd51806b27c73b418",
     "schemaModuleSha256": "594d035e641e87b29db4027dca35157f8225fd5621816d67d5d9f25825468bbf",
-    "workloadCodeFileCount": 335,
-    "workloadCodeSha256": "8be3813e1f9cc787652bf6c718715d91e245e90df6f5eff1bcef5ad1cd16832a"
+    "workloadCodeFileCount": 359,
+    "workloadCodeSha256": "4c3058b3453bda2696e946952d18e81310f26eb0187074d410c730e44162f1d6"
   },
   "determinism": {
     "comparisons": {
@@ -500,8 +500,8 @@
     "projectionVersion": "g1-r7-release-deterministic-projection-v0.1",
     "runCount": 2,
     "runProjectionSha256es": [
-      "3e420a85870b76c99f8e3331e6f018c068c3fa2c446ca8c072d6062c1ab4be27",
-      "3e420a85870b76c99f8e3331e6f018c068c3fa2c446ca8c072d6062c1ab4be27"
+      "4d202dd385b105ead21c63d82e1af1bbb3966432f4d7c471b37840481a15bbe6",
+      "4d202dd385b105ead21c63d82e1af1bbb3966432f4d7c471b37840481a15bbe6"
     ],
     "status": "passed"
   },
@@ -514,23 +514,23 @@
     {
       "failureCode": "none",
       "metrics": {
-        "childCpuMs": 298822,
-        "childMaxRssBytes": 1170735104,
+        "childCpuMs": 326060,
+        "childMaxRssBytes": 1489780736,
         "decodedBytes": 0,
-        "durablePeakRssBytes": 1170735104,
+        "durablePeakRssBytes": 1489780736,
         "encodedBytes": 0,
-        "externalPeakRssBytes": 1161953280,
-        "externalRssSampleCount": 5583,
+        "externalPeakRssBytes": 1488781312,
+        "externalRssSampleCount": 6704,
         "externalRssSampleFailureCount": 0,
         "filesystem": {
-          "afterBytes": 1141719040,
+          "afterBytes": 1141571584,
           "beforeBytes": 0,
-          "sampledHighWaterBytes": 1141719151
+          "sampledHighWaterBytes": 1141742203
         },
         "outputRecords": 436557,
-        "parentElapsedMs": 286181,
+        "parentElapsedMs": 382845,
         "runCount": 2,
-        "sourceBytes": 26380548633,
+        "sourceBytes": 26380587616,
         "sourceFiles": 3123,
         "stderrBytes": 169,
         "stdoutBytes": 1172
@@ -570,49 +570,49 @@
     {
       "failureCode": "none",
       "metrics": {
-        "childCpuMs": 31575,
-        "childMaxRssBytes": 831602688,
+        "childCpuMs": 32136,
+        "childMaxRssBytes": 836780032,
         "decodedBytes": 518442273,
-        "durablePeakRssBytes": 1170735104,
-        "encodedBytes": 29090311,
-        "externalPeakRssBytes": 807452672,
-        "externalRssSampleCount": 585,
-        "externalRssSampleFailureCount": 0,
+        "durablePeakRssBytes": 1489780736,
+        "encodedBytes": 29090523,
+        "externalPeakRssBytes": 821166080,
+        "externalRssSampleCount": 596,
+        "externalRssSampleFailureCount": 1,
         "filesystem": {
-          "afterBytes": 1170944407,
-          "beforeBytes": 1141719040,
-          "sampledHighWaterBytes": 1170945096
+          "afterBytes": 1170797163,
+          "beforeBytes": 1141571584,
+          "sampledHighWaterBytes": 1170797852
         },
         "outputRecords": 436557,
-        "parentElapsedMs": 29810,
+        "parentElapsedMs": 30819,
         "runCount": 2,
-        "sourceBytes": 26380548633,
+        "sourceBytes": 26380587616,
         "sourceFiles": 3123,
         "stderrBytes": 169,
         "stdoutBytes": 1261
       },
       "name": "export_set_materialize",
-      "projectionSha256": "174add87a3219e81ce39826e46b684cb840f2d39d286ca87523868444ed1ab4f",
+      "projectionSha256": "7bc786d8c45d113bdc32cb2d9d8a7ef8f7fbec6d156f39b3831040cff7f05c16",
       "status": "completed"
     },
     {
       "failureCode": "none",
       "metrics": {
-        "childCpuMs": 25112,
-        "childMaxRssBytes": 1061126144,
+        "childCpuMs": 25319,
+        "childMaxRssBytes": 1063550976,
         "decodedBytes": 518442273,
         "durablePeakRssBytes": 0,
-        "encodedBytes": 29090311,
-        "externalPeakRssBytes": 992542720,
-        "externalRssSampleCount": 505,
+        "encodedBytes": 29090523,
+        "externalPeakRssBytes": 1029996544,
+        "externalRssSampleCount": 509,
         "externalRssSampleFailureCount": 0,
         "filesystem": {
-          "afterBytes": 1170944407,
-          "beforeBytes": 1170944407,
-          "sampledHighWaterBytes": 1268520839
+          "afterBytes": 1170797163,
+          "beforeBytes": 1170797163,
+          "sampledHighWaterBytes": 1268713427
         },
         "outputRecords": 436557,
-        "parentElapsedMs": 25694,
+        "parentElapsedMs": 25897,
         "runCount": 2,
         "sourceBytes": 0,
         "sourceFiles": 0,
@@ -620,35 +620,35 @@
         "stdoutBytes": 1017
       },
       "name": "export_set_verify",
-      "projectionSha256": "6d78662bf64fe30b601fbc77bd0ddb1d0093160965d0264f9ee88091c757e5cb",
+      "projectionSha256": "c4e85ff4a4f70b1088aace276fbbd5d77c39158090a3c391ad55a7ac89d1353b",
       "status": "completed"
     },
     {
       "failureCode": "none",
       "metrics": {
-        "childCpuMs": 80567,
-        "childMaxRssBytes": 1109934080,
+        "childCpuMs": 89643,
+        "childMaxRssBytes": 1076101120,
         "decodedBytes": 0,
         "durablePeakRssBytes": 0,
         "encodedBytes": 0,
-        "externalPeakRssBytes": 1055539200,
-        "externalRssSampleCount": 1615,
+        "externalPeakRssBytes": 1076101120,
+        "externalRssSampleCount": 2085,
         "externalRssSampleFailureCount": 0,
         "filesystem": {
           "afterBytes": 461,
-          "beforeBytes": 1170944407,
-          "sampledHighWaterBytes": 1170968609
+          "beforeBytes": 1170797163,
+          "sampledHighWaterBytes": 1170810501
         },
         "outputRecords": 0,
-        "parentElapsedMs": 82291,
+        "parentElapsedMs": 126934,
         "runCount": 2,
         "sourceBytes": 0,
         "sourceFiles": 0,
         "stderrBytes": 169,
-        "stdoutBytes": 1009
+        "stdoutBytes": 1010
       },
       "name": "complete_set_delete",
-      "projectionSha256": "1bc8385314f579180128d593016ef1fcf10314abe5574c9c0efa163928b65565",
+      "projectionSha256": "de0fcb7d2693432989fecabedafdafd19823c669fa559f8dfd9b099b7a5f4b88",
       "status": "completed"
     },
     {
@@ -816,8 +816,8 @@
   "profile": "release_real_local_history",
   "profileEvidence": {
     "claude": {
-      "completeLinePrefixBytes": 1468857524,
-      "sourceBytes": 1468857524,
+      "completeLinePrefixBytes": 1468896507,
+      "sourceBytes": 1468896507,
       "sourceFiles": 1654
     },
     "codex": {
@@ -832,7 +832,7 @@
     "rawDurableCopyCreated": false
   },
   "protocolVersion": "g1-r7-release-evidence-v0.1",
-  "receiptSha256": "b3b68972f3e419879ee2f8f9f71666152683c2e6365f0fbd833ef2c370426cfa",
+  "receiptSha256": "4582408f1f578e1e23b705b9a44464cb989831c6528ece05415e268043336968",
   "runtimeProvenance": {
     "architecture": "arm64",
     "elapsedClock": "parent_monotonic",

--- a/generated/r7-release-real-local-history-node26.2.0-v0.1.json
+++ b/generated/r7-release-real-local-history-node26.2.0-v0.1.json
@@ -481,8 +481,8 @@
     "resourcePolicySourceSha256": "d9748895468534062e9c8c436db75cbf5acf4ccf54f84319db37e88197627870",
     "resourcePolicyValuesSha256": "3cbe7853c8f75e96912885f64ba4ad1aeb13aff8a22e4ffbd51806b27c73b418",
     "schemaModuleSha256": "594d035e641e87b29db4027dca35157f8225fd5621816d67d5d9f25825468bbf",
-    "workloadCodeFileCount": 335,
-    "workloadCodeSha256": "8be3813e1f9cc787652bf6c718715d91e245e90df6f5eff1bcef5ad1cd16832a"
+    "workloadCodeFileCount": 359,
+    "workloadCodeSha256": "4c3058b3453bda2696e946952d18e81310f26eb0187074d410c730e44162f1d6"
   },
   "determinism": {
     "comparisons": {
@@ -500,8 +500,8 @@
     "projectionVersion": "g1-r7-release-deterministic-projection-v0.1",
     "runCount": 2,
     "runProjectionSha256es": [
-      "f38bac8c91731bc1824f21ef1c20c2c5714590f9b784d6953b497aad9f6570c8",
-      "f38bac8c91731bc1824f21ef1c20c2c5714590f9b784d6953b497aad9f6570c8"
+      "59ef4e3ca58306cbc02fb981dcfe3d0b859b3148da313f73a9f2636e719ab2aa",
+      "59ef4e3ca58306cbc02fb981dcfe3d0b859b3148da313f73a9f2636e719ab2aa"
     ],
     "status": "passed"
   },
@@ -514,23 +514,23 @@
     {
       "failureCode": "none",
       "metrics": {
-        "childCpuMs": 334830,
-        "childMaxRssBytes": 1254391808,
+        "childCpuMs": 347543,
+        "childMaxRssBytes": 1325400064,
         "decodedBytes": 0,
-        "durablePeakRssBytes": 1254391808,
+        "durablePeakRssBytes": 1325400064,
         "encodedBytes": 0,
-        "externalPeakRssBytes": 1248444416,
-        "externalRssSampleCount": 6277,
+        "externalPeakRssBytes": 1322483712,
+        "externalRssSampleCount": 6762,
         "externalRssSampleFailureCount": 0,
         "filesystem": {
-          "afterBytes": 1141719040,
+          "afterBytes": 1141571584,
           "beforeBytes": 0,
-          "sampledHighWaterBytes": 1142337903
+          "sampledHighWaterBytes": 1143910791
         },
         "outputRecords": 436557,
-        "parentElapsedMs": 320624,
+        "parentElapsedMs": 348310,
         "runCount": 2,
-        "sourceBytes": 26380548633,
+        "sourceBytes": 26380587616,
         "sourceFiles": 3123,
         "stderrBytes": 0,
         "stdoutBytes": 1172
@@ -570,49 +570,49 @@
     {
       "failureCode": "none",
       "metrics": {
-        "childCpuMs": 28598,
-        "childMaxRssBytes": 918634496,
+        "childCpuMs": 29090,
+        "childMaxRssBytes": 921960448,
         "decodedBytes": 518442273,
-        "durablePeakRssBytes": 1254391808,
-        "encodedBytes": 29090311,
-        "externalPeakRssBytes": 918568960,
-        "externalRssSampleCount": 540,
+        "durablePeakRssBytes": 1325400064,
+        "encodedBytes": 29090523,
+        "externalPeakRssBytes": 921894912,
+        "externalRssSampleCount": 546,
         "externalRssSampleFailureCount": 0,
         "filesystem": {
-          "afterBytes": 1170944406,
-          "beforeBytes": 1141719040,
-          "sampledHighWaterBytes": 1170944516
+          "afterBytes": 1170797162,
+          "beforeBytes": 1141571584,
+          "sampledHighWaterBytes": 1170797162
         },
         "outputRecords": 436557,
-        "parentElapsedMs": 27496,
+        "parentElapsedMs": 27797,
         "runCount": 2,
-        "sourceBytes": 26380548633,
+        "sourceBytes": 26380587616,
         "sourceFiles": 3123,
         "stderrBytes": 0,
         "stdoutBytes": 1261
       },
       "name": "export_set_materialize",
-      "projectionSha256": "174add87a3219e81ce39826e46b684cb840f2d39d286ca87523868444ed1ab4f",
+      "projectionSha256": "7bc786d8c45d113bdc32cb2d9d8a7ef8f7fbec6d156f39b3831040cff7f05c16",
       "status": "completed"
     },
     {
       "failureCode": "none",
       "metrics": {
-        "childCpuMs": 23192,
-        "childMaxRssBytes": 723812352,
+        "childCpuMs": 24856,
+        "childMaxRssBytes": 729219072,
         "decodedBytes": 518442273,
         "durablePeakRssBytes": 0,
-        "encodedBytes": 29090311,
-        "externalPeakRssBytes": 722550784,
-        "externalRssSampleCount": 468,
+        "encodedBytes": 29090523,
+        "externalPeakRssBytes": 727302144,
+        "externalRssSampleCount": 545,
         "externalRssSampleFailureCount": 0,
         "filesystem": {
-          "afterBytes": 1170944406,
-          "beforeBytes": 1170944406,
-          "sampledHighWaterBytes": 1267903822
+          "afterBytes": 1170797162,
+          "beforeBytes": 1170797162,
+          "sampledHighWaterBytes": 1267586610
         },
         "outputRecords": 436557,
-        "parentElapsedMs": 23817,
+        "parentElapsedMs": 31522,
         "runCount": 2,
         "sourceBytes": 0,
         "sourceFiles": 0,
@@ -620,35 +620,35 @@
         "stdoutBytes": 1016
       },
       "name": "export_set_verify",
-      "projectionSha256": "6d78662bf64fe30b601fbc77bd0ddb1d0093160965d0264f9ee88091c757e5cb",
+      "projectionSha256": "c4e85ff4a4f70b1088aace276fbbd5d77c39158090a3c391ad55a7ac89d1353b",
       "status": "completed"
     },
     {
       "failureCode": "none",
       "metrics": {
-        "childCpuMs": 74578,
-        "childMaxRssBytes": 943816704,
+        "childCpuMs": 79158,
+        "childMaxRssBytes": 804700160,
         "decodedBytes": 0,
         "durablePeakRssBytes": 0,
         "encodedBytes": 0,
-        "externalPeakRssBytes": 910213120,
-        "externalRssSampleCount": 1494,
+        "externalPeakRssBytes": 804061184,
+        "externalRssSampleCount": 1902,
         "externalRssSampleFailureCount": 0,
         "filesystem": {
           "afterBytes": 461,
-          "beforeBytes": 1170944406,
-          "sampledHighWaterBytes": 1170956562
+          "beforeBytes": 1170797162,
+          "sampledHighWaterBytes": 1170809318
         },
         "outputRecords": 0,
-        "parentElapsedMs": 76170,
+        "parentElapsedMs": 102676,
         "runCount": 2,
         "sourceBytes": 0,
         "sourceFiles": 0,
         "stderrBytes": 0,
-        "stdoutBytes": 1008
+        "stdoutBytes": 1009
       },
       "name": "complete_set_delete",
-      "projectionSha256": "d8e2c49777e7afd4f4b159c21e54d4034dfe6641521fa17d67a1aa87845ca6fc",
+      "projectionSha256": "2b22e67a5730cb11919b8d8788db1a6b871c47af2fbf2378250f1a1ee76b278b",
       "status": "completed"
     },
     {
@@ -816,8 +816,8 @@
   "profile": "release_real_local_history",
   "profileEvidence": {
     "claude": {
-      "completeLinePrefixBytes": 1468857524,
-      "sourceBytes": 1468857524,
+      "completeLinePrefixBytes": 1468896507,
+      "sourceBytes": 1468896507,
       "sourceFiles": 1654
     },
     "codex": {
@@ -832,7 +832,7 @@
     "rawDurableCopyCreated": false
   },
   "protocolVersion": "g1-r7-release-evidence-v0.1",
-  "receiptSha256": "0ba728cf2ccbf02fc171126e4a92848fbc02e5de108b7fa1ee3f985ac70419ba",
+  "receiptSha256": "d2a7d60d12aedbb65811d4096ef5e3c04f13bd8855ae66897f4f994c138974c4",
   "runtimeProvenance": {
     "architecture": "arm64",
     "elapsedClock": "parent_monotonic",

--- a/generated/r7-release-synthetic-pressure-node24.14.0-v0.1.json
+++ b/generated/r7-release-synthetic-pressure-node24.14.0-v0.1.json
@@ -481,8 +481,8 @@
     "resourcePolicySourceSha256": "d9748895468534062e9c8c436db75cbf5acf4ccf54f84319db37e88197627870",
     "resourcePolicyValuesSha256": "3cbe7853c8f75e96912885f64ba4ad1aeb13aff8a22e4ffbd51806b27c73b418",
     "schemaModuleSha256": "594d035e641e87b29db4027dca35157f8225fd5621816d67d5d9f25825468bbf",
-    "workloadCodeFileCount": 335,
-    "workloadCodeSha256": "8be3813e1f9cc787652bf6c718715d91e245e90df6f5eff1bcef5ad1cd16832a"
+    "workloadCodeFileCount": 359,
+    "workloadCodeSha256": "4c3058b3453bda2696e946952d18e81310f26eb0187074d410c730e44162f1d6"
   },
   "determinism": {
     "comparisons": {
@@ -500,8 +500,8 @@
     "projectionVersion": "g1-r7-release-deterministic-projection-v0.1",
     "runCount": 2,
     "runProjectionSha256es": [
-      "98de178921afdae106bd3daeb8c0a8630eb29344763b94143b735b709e448cd4",
-      "98de178921afdae106bd3daeb8c0a8630eb29344763b94143b735b709e448cd4"
+      "1fca4155225420de75bd10bd4e9a724e465c2eac815b5e7f6c71e0ead6206e99",
+      "1fca4155225420de75bd10bd4e9a724e465c2eac815b5e7f6c71e0ead6206e99"
     ],
     "status": "passed"
   },
@@ -514,26 +514,26 @@
     {
       "failureCode": "none",
       "metrics": {
-        "childCpuMs": 16346,
-        "childMaxRssBytes": 687882240,
+        "childCpuMs": 17594,
+        "childMaxRssBytes": 689242112,
         "decodedBytes": 0,
-        "durablePeakRssBytes": 682967040,
+        "durablePeakRssBytes": 685473792,
         "encodedBytes": 0,
-        "externalPeakRssBytes": 685326336,
-        "externalRssSampleCount": 230,
+        "externalPeakRssBytes": 682000384,
+        "externalRssSampleCount": 243,
         "externalRssSampleFailureCount": 0,
         "filesystem": {
-          "afterBytes": 96981152,
+          "afterBytes": 96927904,
           "beforeBytes": 160,
-          "sampledHighWaterBytes": 96981263
+          "sampledHighWaterBytes": 97088623
         },
         "outputRecords": 29108,
-        "parentElapsedMs": 11699,
+        "parentElapsedMs": 12337,
         "runCount": 2,
         "sourceBytes": 47637907,
         "sourceFiles": 4096,
         "stderrBytes": 169,
-        "stdoutBytes": 1098
+        "stdoutBytes": 1099
       },
       "name": "source_scan",
       "projectionSha256": "c70ea4b8c4d71a9ee8b2a1cd72023877e32391e1f2b8fd7bfb355374b28f2395",
@@ -542,26 +542,26 @@
     {
       "failureCode": "none",
       "metrics": {
-        "childCpuMs": 10645,
-        "childMaxRssBytes": 493682688,
+        "childCpuMs": 10219,
+        "childMaxRssBytes": 682573824,
         "decodedBytes": 0,
-        "durablePeakRssBytes": 750272512,
+        "durablePeakRssBytes": 785268736,
         "encodedBytes": 0,
-        "externalPeakRssBytes": 493682688,
-        "externalRssSampleCount": 181,
+        "externalPeakRssBytes": 682573824,
+        "externalRssSampleCount": 187,
         "externalRssSampleFailureCount": 0,
         "filesystem": {
-          "afterBytes": 193962144,
-          "beforeBytes": 127090848,
-          "sampledHighWaterBytes": 193962144
+          "afterBytes": 193855648,
+          "beforeBytes": 127037600,
+          "sampledHighWaterBytes": 194016367
         },
         "outputRecords": 29108,
-        "parentElapsedMs": 9244,
+        "parentElapsedMs": 9464,
         "runCount": 2,
         "sourceBytes": 47637907,
         "sourceFiles": 4096,
         "stderrBytes": 169,
-        "stdoutBytes": 1102
+        "stdoutBytes": 1103
       },
       "name": "checkpoint_resume",
       "projectionSha256": "c70ea4b8c4d71a9ee8b2a1cd72023877e32391e1f2b8fd7bfb355374b28f2395",
@@ -570,49 +570,49 @@
     {
       "failureCode": "none",
       "metrics": {
-        "childCpuMs": 4063,
-        "childMaxRssBytes": 263569408,
+        "childCpuMs": 4092,
+        "childMaxRssBytes": 265273344,
         "decodedBytes": 46019365,
-        "durablePeakRssBytes": 682967040,
-        "encodedBytes": 2072928,
-        "externalPeakRssBytes": 262455296,
-        "externalRssSampleCount": 178,
+        "durablePeakRssBytes": 685473792,
+        "encodedBytes": 2072942,
+        "externalPeakRssBytes": 265240576,
+        "externalRssSampleCount": 180,
         "externalRssSampleFailureCount": 0,
         "filesystem": {
-          "afterBytes": 197069782,
-          "beforeBytes": 193962144,
-          "sampledHighWaterBytes": 197070472
+          "afterBytes": 196963300,
+          "beforeBytes": 193855648,
+          "sampledHighWaterBytes": 196963990
         },
         "outputRecords": 29108,
-        "parentElapsedMs": 8993,
+        "parentElapsedMs": 9178,
         "runCount": 2,
         "sourceBytes": 47637907,
         "sourceFiles": 4096,
         "stderrBytes": 169,
-        "stdoutBytes": 1250
+        "stdoutBytes": 1251
       },
       "name": "export_set_materialize",
-      "projectionSha256": "dd38bb8754184c19dcc19cec83d8af64a4fc5a4fdf698955cb5403372612cfba",
+      "projectionSha256": "d07ab8525b6edf84955d1c50eab884cdc158534953150969217fcf90a6967949",
       "status": "completed"
     },
     {
       "failureCode": "none",
       "metrics": {
-        "childCpuMs": 1715,
-        "childMaxRssBytes": 272498688,
+        "childCpuMs": 1784,
+        "childMaxRssBytes": 277544960,
         "decodedBytes": 46019365,
         "durablePeakRssBytes": 0,
-        "encodedBytes": 2072928,
-        "externalPeakRssBytes": 272105472,
+        "encodedBytes": 2072942,
+        "externalPeakRssBytes": 276037632,
         "externalRssSampleCount": 36,
         "externalRssSampleFailureCount": 0,
         "filesystem": {
-          "afterBytes": 197069782,
-          "beforeBytes": 197069782,
-          "sampledHighWaterBytes": 205033942
+          "afterBytes": 196963300,
+          "beforeBytes": 196963300,
+          "sampledHighWaterBytes": 203959852
         },
         "outputRecords": 29108,
-        "parentElapsedMs": 1771,
+        "parentElapsedMs": 1814,
         "runCount": 2,
         "sourceBytes": 0,
         "sourceFiles": 0,
@@ -620,27 +620,27 @@
         "stdoutBytes": 1011
       },
       "name": "export_set_verify",
-      "projectionSha256": "a6a388562999ab4ef0bc8df02bdba7fbab19810edf40f9fbed0af2f3f030bef6",
+      "projectionSha256": "41418659b080f75d258c95880ab31fe3cca71aba516c02bcefdaa3700a1b6401",
       "status": "completed"
     },
     {
       "failureCode": "none",
       "metrics": {
-        "childCpuMs": 6223,
-        "childMaxRssBytes": 325419008,
+        "childCpuMs": 6626,
+        "childMaxRssBytes": 320110592,
         "decodedBytes": 0,
         "durablePeakRssBytes": 0,
         "encodedBytes": 0,
-        "externalPeakRssBytes": 325402624,
-        "externalRssSampleCount": 155,
+        "externalPeakRssBytes": 320110592,
+        "externalRssSampleCount": 177,
         "externalRssSampleFailureCount": 0,
         "filesystem": {
-          "afterBytes": 96983684,
-          "beforeBytes": 197071853,
-          "sampledHighWaterBytes": 197152514
+          "afterBytes": 96930436,
+          "beforeBytes": 196965371,
+          "sampledHighWaterBytes": 197046032
         },
         "outputRecords": 0,
-        "parentElapsedMs": 7869,
+        "parentElapsedMs": 9814,
         "runCount": 2,
         "sourceBytes": 0,
         "sourceFiles": 0,
@@ -648,27 +648,27 @@
         "stdoutBytes": 1004
       },
       "name": "complete_set_delete",
-      "projectionSha256": "f1816a82854af324c41cae87d317139e10977697bc206bdf97d4f2523f6cfd3c",
+      "projectionSha256": "d4e2a4622bb6a44d55ebe591694f5b173e74f49b8f1d8804a9817e41681f91e6",
       "status": "completed"
     },
     {
       "failureCode": "interruption_injected",
       "metrics": {
-        "childCpuMs": 371,
-        "childMaxRssBytes": 126238720,
+        "childCpuMs": 404,
+        "childMaxRssBytes": 130056192,
         "decodedBytes": 0,
         "durablePeakRssBytes": 0,
         "encodedBytes": 0,
-        "externalPeakRssBytes": 126074880,
-        "externalRssSampleCount": 48,
+        "externalPeakRssBytes": 130056192,
+        "externalRssSampleCount": 58,
         "externalRssSampleFailureCount": 0,
         "filesystem": {
-          "afterBytes": 197071853,
-          "beforeBytes": 297240572,
-          "sampledHighWaterBytes": 297240572
+          "afterBytes": 196965371,
+          "beforeBytes": 297080856,
+          "sampledHighWaterBytes": 297080856
         },
         "outputRecords": 0,
-        "parentElapsedMs": 2365,
+        "parentElapsedMs": 3472,
         "runCount": 2,
         "sourceBytes": 0,
         "sourceFiles": 0,
@@ -676,27 +676,27 @@
         "stdoutBytes": 1012
       },
       "name": "complete_set_delete_recovery",
-      "projectionSha256": "f1816a82854af324c41cae87d317139e10977697bc206bdf97d4f2523f6cfd3c",
+      "projectionSha256": "d4e2a4622bb6a44d55ebe591694f5b173e74f49b8f1d8804a9817e41681f91e6",
       "status": "interrupted_recovered"
     },
     {
       "failureCode": "none",
       "metrics": {
-        "childCpuMs": 139,
-        "childMaxRssBytes": 117080064,
+        "childCpuMs": 142,
+        "childMaxRssBytes": 117243904,
         "decodedBytes": 0,
         "durablePeakRssBytes": 0,
         "encodedBytes": 0,
-        "externalPeakRssBytes": 117080064,
+        "externalPeakRssBytes": 117096448,
         "externalRssSampleCount": 8,
         "externalRssSampleFailureCount": 0,
         "filesystem": {
-          "afterBytes": 197070317,
-          "beforeBytes": 227179478,
-          "sampledHighWaterBytes": 227180821
+          "afterBytes": 196963835,
+          "beforeBytes": 227072996,
+          "sampledHighWaterBytes": 227073107
         },
         "outputRecords": 0,
-        "parentElapsedMs": 322,
+        "parentElapsedMs": 339,
         "runCount": 2,
         "sourceBytes": 0,
         "sourceFiles": 0,
@@ -710,21 +710,21 @@
     {
       "failureCode": "interruption_injected",
       "metrics": {
-        "childCpuMs": 95,
-        "childMaxRssBytes": 117063680,
+        "childCpuMs": 92,
+        "childMaxRssBytes": 117047296,
         "decodedBytes": 0,
         "durablePeakRssBytes": 0,
         "encodedBytes": 0,
-        "externalPeakRssBytes": 116703232,
+        "externalPeakRssBytes": 116965376,
         "externalRssSampleCount": 6,
         "externalRssSampleFailureCount": 0,
         "filesystem": {
-          "afterBytes": 197070852,
-          "beforeBytes": 227181245,
-          "sampledHighWaterBytes": 257291052
+          "afterBytes": 196964370,
+          "beforeBytes": 227074763,
+          "sampledHighWaterBytes": 257184570
         },
         "outputRecords": 0,
-        "parentElapsedMs": 268,
+        "parentElapsedMs": 271,
         "runCount": 2,
         "sourceBytes": 0,
         "sourceFiles": 0,
@@ -739,20 +739,20 @@
       "failureCode": "none",
       "metrics": {
         "childCpuMs": 5,
-        "childMaxRssBytes": 111575040,
+        "childMaxRssBytes": 111607808,
         "decodedBytes": 0,
         "durablePeakRssBytes": 0,
         "encodedBytes": 0,
-        "externalPeakRssBytes": 94781440,
+        "externalPeakRssBytes": 94011392,
         "externalRssSampleCount": 4,
         "externalRssSampleFailureCount": 0,
         "filesystem": {
-          "afterBytes": 197071122,
-          "beforeBytes": 197071301,
-          "sampledHighWaterBytes": 197071301
+          "afterBytes": 196964640,
+          "beforeBytes": 196964819,
+          "sampledHighWaterBytes": 196964819
         },
         "outputRecords": 0,
-        "parentElapsedMs": 168,
+        "parentElapsedMs": 172,
         "runCount": 2,
         "sourceBytes": 0,
         "sourceFiles": 0,
@@ -766,21 +766,21 @@
     {
       "failureCode": "interruption_injected",
       "metrics": {
-        "childCpuMs": 5,
-        "childMaxRssBytes": 109527040,
+        "childCpuMs": 6,
+        "childMaxRssBytes": 111099904,
         "decodedBytes": 0,
         "durablePeakRssBytes": 0,
         "encodedBytes": 0,
-        "externalPeakRssBytes": 93061120,
+        "externalPeakRssBytes": 99483648,
         "externalRssSampleCount": 4,
         "externalRssSampleFailureCount": 0,
         "filesystem": {
-          "afterBytes": 197071392,
-          "beforeBytes": 197071580,
-          "sampledHighWaterBytes": 197071580
+          "afterBytes": 196964910,
+          "beforeBytes": 196965098,
+          "sampledHighWaterBytes": 196965098
         },
         "outputRecords": 0,
-        "parentElapsedMs": 161,
+        "parentElapsedMs": 165,
         "runCount": 2,
         "sourceBytes": 0,
         "sourceFiles": 0,
@@ -827,7 +827,7 @@
     "targetChunks": 128
   },
   "protocolVersion": "g1-r7-release-evidence-v0.1",
-  "receiptSha256": "9d47731bc8060b743ca43ac514d014d5a53df049bbf6fe668afe8f326bdb6c87",
+  "receiptSha256": "03341e66a24566b1f876bf0cec71b49fa530d273401a614584aac20954041a70",
   "runtimeProvenance": {
     "architecture": "arm64",
     "elapsedClock": "parent_monotonic",

--- a/generated/r7-release-synthetic-pressure-node26.2.0-v0.1.json
+++ b/generated/r7-release-synthetic-pressure-node26.2.0-v0.1.json
@@ -481,8 +481,8 @@
     "resourcePolicySourceSha256": "d9748895468534062e9c8c436db75cbf5acf4ccf54f84319db37e88197627870",
     "resourcePolicyValuesSha256": "3cbe7853c8f75e96912885f64ba4ad1aeb13aff8a22e4ffbd51806b27c73b418",
     "schemaModuleSha256": "594d035e641e87b29db4027dca35157f8225fd5621816d67d5d9f25825468bbf",
-    "workloadCodeFileCount": 335,
-    "workloadCodeSha256": "8be3813e1f9cc787652bf6c718715d91e245e90df6f5eff1bcef5ad1cd16832a"
+    "workloadCodeFileCount": 359,
+    "workloadCodeSha256": "4c3058b3453bda2696e946952d18e81310f26eb0187074d410c730e44162f1d6"
   },
   "determinism": {
     "comparisons": {
@@ -500,8 +500,8 @@
     "projectionVersion": "g1-r7-release-deterministic-projection-v0.1",
     "runCount": 2,
     "runProjectionSha256es": [
-      "3d5ec2ea0d9c0d5f7c41bbfb567be89c117fee822b8f04a2b2e5ecd089086855",
-      "3d5ec2ea0d9c0d5f7c41bbfb567be89c117fee822b8f04a2b2e5ecd089086855"
+      "a54551a8d3154107c6a9d0583e073a8fd294f16d16ce5cff1b330a8ac1541ae3",
+      "a54551a8d3154107c6a9d0583e073a8fd294f16d16ce5cff1b330a8ac1541ae3"
     ],
     "status": "passed"
   },
@@ -514,26 +514,26 @@
     {
       "failureCode": "none",
       "metrics": {
-        "childCpuMs": 16739,
-        "childMaxRssBytes": 1063600128,
+        "childCpuMs": 19185,
+        "childMaxRssBytes": 711868416,
         "decodedBytes": 0,
-        "durablePeakRssBytes": 990707712,
+        "durablePeakRssBytes": 711770112,
         "encodedBytes": 0,
-        "externalPeakRssBytes": 990707712,
-        "externalRssSampleCount": 273,
+        "externalPeakRssBytes": 711770112,
+        "externalRssSampleCount": 280,
         "externalRssSampleFailureCount": 0,
         "filesystem": {
-          "afterBytes": 96948384,
+          "afterBytes": 96919712,
           "beforeBytes": 160,
-          "sampledHighWaterBytes": 96948384
+          "sampledHighWaterBytes": 96919712
         },
         "outputRecords": 29108,
-        "parentElapsedMs": 13854,
+        "parentElapsedMs": 14218,
         "runCount": 2,
         "sourceBytes": 47637907,
         "sourceFiles": 4096,
         "stderrBytes": 0,
-        "stdoutBytes": 1099
+        "stdoutBytes": 1098
       },
       "name": "source_scan",
       "projectionSha256": "c70ea4b8c4d71a9ee8b2a1cd72023877e32391e1f2b8fd7bfb355374b28f2395",
@@ -542,21 +542,21 @@
     {
       "failureCode": "none",
       "metrics": {
-        "childCpuMs": 11180,
-        "childMaxRssBytes": 654409728,
+        "childCpuMs": 12414,
+        "childMaxRssBytes": 456818688,
         "decodedBytes": 0,
-        "durablePeakRssBytes": 654409728,
+        "durablePeakRssBytes": 596475904,
         "encodedBytes": 0,
-        "externalPeakRssBytes": 649363456,
-        "externalRssSampleCount": 206,
+        "externalPeakRssBytes": 454115328,
+        "externalRssSampleCount": 211,
         "externalRssSampleFailureCount": 0,
         "filesystem": {
-          "afterBytes": 193896608,
-          "beforeBytes": 127058080,
-          "sampledHighWaterBytes": 193896608
+          "afterBytes": 193839264,
+          "beforeBytes": 127029408,
+          "sampledHighWaterBytes": 193848143
         },
         "outputRecords": 29108,
-        "parentElapsedMs": 10444,
+        "parentElapsedMs": 10741,
         "runCount": 2,
         "sourceBytes": 47637907,
         "sourceFiles": 4096,
@@ -570,21 +570,21 @@
     {
       "failureCode": "none",
       "metrics": {
-        "childCpuMs": 3682,
-        "childMaxRssBytes": 212221952,
+        "childCpuMs": 3724,
+        "childMaxRssBytes": 219578368,
         "decodedBytes": 46019365,
-        "durablePeakRssBytes": 990707712,
-        "encodedBytes": 2072950,
-        "externalPeakRssBytes": 211484672,
+        "durablePeakRssBytes": 711770112,
+        "encodedBytes": 2072942,
+        "externalPeakRssBytes": 219201536,
         "externalRssSampleCount": 173,
         "externalRssSampleFailureCount": 0,
         "filesystem": {
-          "afterBytes": 197004267,
-          "beforeBytes": 193896608,
-          "sampledHighWaterBytes": 197004957
+          "afterBytes": 196946915,
+          "beforeBytes": 193839264,
+          "sampledHighWaterBytes": 196948184
         },
         "outputRecords": 29108,
-        "parentElapsedMs": 8730,
+        "parentElapsedMs": 8808,
         "runCount": 2,
         "sourceBytes": 47637907,
         "sourceFiles": 4096,
@@ -592,27 +592,27 @@
         "stdoutBytes": 1250
       },
       "name": "export_set_materialize",
-      "projectionSha256": "d09658ff4e68c6134f1210c14badf9bc23fdda66fa82f0f54cb0fafe02ba8130",
+      "projectionSha256": "1be88270834d7fb3a810e42d80b0f08ba8443792ee6b8ebd7bc65f25099aa548",
       "status": "completed"
     },
     {
       "failureCode": "none",
       "metrics": {
-        "childCpuMs": 1589,
-        "childMaxRssBytes": 240222208,
+        "childCpuMs": 1636,
+        "childMaxRssBytes": 239845376,
         "decodedBytes": 46019365,
         "durablePeakRssBytes": 0,
-        "encodedBytes": 2072950,
-        "externalPeakRssBytes": 239665152,
-        "externalRssSampleCount": 32,
+        "encodedBytes": 2072942,
+        "externalPeakRssBytes": 239714304,
+        "externalRssSampleCount": 33,
         "externalRssSampleFailureCount": 0,
         "filesystem": {
-          "afterBytes": 197004267,
-          "beforeBytes": 197004267,
-          "sampledHighWaterBytes": 204550251
+          "afterBytes": 196946915,
+          "beforeBytes": 196946915,
+          "sampledHighWaterBytes": 204788323
         },
         "outputRecords": 29108,
-        "parentElapsedMs": 1615,
+        "parentElapsedMs": 1681,
         "runCount": 2,
         "sourceBytes": 0,
         "sourceFiles": 0,
@@ -620,55 +620,55 @@
         "stdoutBytes": 1011
       },
       "name": "export_set_verify",
-      "projectionSha256": "c410a6ab3b05e8d1e62c095497f78f75639d61f147cab1fb3e86afd42e2799e0",
+      "projectionSha256": "41418659b080f75d258c95880ab31fe3cca71aba516c02bcefdaa3700a1b6401",
       "status": "completed"
     },
     {
       "failureCode": "none",
       "metrics": {
-        "childCpuMs": 5685,
-        "childMaxRssBytes": 267288576,
+        "childCpuMs": 7026,
+        "childMaxRssBytes": 267173888,
         "decodedBytes": 0,
         "durablePeakRssBytes": 0,
         "encodedBytes": 0,
-        "externalPeakRssBytes": 266797056,
-        "externalRssSampleCount": 143,
-        "externalRssSampleFailureCount": 1,
+        "externalPeakRssBytes": 267173888,
+        "externalRssSampleCount": 234,
+        "externalRssSampleFailureCount": 0,
         "filesystem": {
-          "afterBytes": 96950916,
-          "beforeBytes": 197006338,
-          "sampledHighWaterBytes": 197088181
+          "afterBytes": 96922244,
+          "beforeBytes": 196948986,
+          "sampledHighWaterBytes": 197030238
         },
         "outputRecords": 0,
-        "parentElapsedMs": 7279,
+        "parentElapsedMs": 16269,
         "runCount": 2,
         "sourceBytes": 0,
         "sourceFiles": 0,
         "stderrBytes": 0,
-        "stdoutBytes": 1004
+        "stdoutBytes": 1006
       },
       "name": "complete_set_delete",
-      "projectionSha256": "9d66a2b4205022531ac542075c3b1465d8b915683f1d4c68ccae764b66168c31",
+      "projectionSha256": "08024d5b1fa645ccb58d91e724d1262a468585f9700d754119c53bf5b7af46b6",
       "status": "completed"
     },
     {
       "failureCode": "interruption_injected",
       "metrics": {
-        "childCpuMs": 383,
-        "childMaxRssBytes": 138248192,
+        "childCpuMs": 450,
+        "childMaxRssBytes": 141099008,
         "decodedBytes": 0,
         "durablePeakRssBytes": 0,
         "encodedBytes": 0,
-        "externalPeakRssBytes": 138248192,
-        "externalRssSampleCount": 48,
+        "externalPeakRssBytes": 140886016,
+        "externalRssSampleCount": 66,
         "externalRssSampleFailureCount": 0,
         "filesystem": {
-          "afterBytes": 197006338,
-          "beforeBytes": 297142310,
-          "sampledHighWaterBytes": 297142310
+          "afterBytes": 196948986,
+          "beforeBytes": 297056278,
+          "sampledHighWaterBytes": 297056278
         },
         "outputRecords": 0,
-        "parentElapsedMs": 2384,
+        "parentElapsedMs": 4260,
         "runCount": 2,
         "sourceBytes": 0,
         "sourceFiles": 0,
@@ -676,27 +676,27 @@
         "stdoutBytes": 1012
       },
       "name": "complete_set_delete_recovery",
-      "projectionSha256": "9d66a2b4205022531ac542075c3b1465d8b915683f1d4c68ccae764b66168c31",
+      "projectionSha256": "08024d5b1fa645ccb58d91e724d1262a468585f9700d754119c53bf5b7af46b6",
       "status": "interrupted_recovered"
     },
     {
       "failureCode": "none",
       "metrics": {
-        "childCpuMs": 143,
-        "childMaxRssBytes": 123158528,
+        "childCpuMs": 146,
+        "childMaxRssBytes": 125206528,
         "decodedBytes": 0,
         "durablePeakRssBytes": 0,
         "encodedBytes": 0,
-        "externalPeakRssBytes": 123158528,
+        "externalPeakRssBytes": 125059072,
         "externalRssSampleCount": 8,
         "externalRssSampleFailureCount": 0,
         "filesystem": {
-          "afterBytes": 197004802,
-          "beforeBytes": 227113963,
-          "sampledHighWaterBytes": 227115306
+          "afterBytes": 196947450,
+          "beforeBytes": 227056611,
+          "sampledHighWaterBytes": 227056722
         },
         "outputRecords": 0,
-        "parentElapsedMs": 326,
+        "parentElapsedMs": 334,
         "runCount": 2,
         "sourceBytes": 0,
         "sourceFiles": 0,
@@ -710,21 +710,21 @@
     {
       "failureCode": "interruption_injected",
       "metrics": {
-        "childCpuMs": 96,
-        "childMaxRssBytes": 122437632,
+        "childCpuMs": 98,
+        "childMaxRssBytes": 124452864,
         "decodedBytes": 0,
         "durablePeakRssBytes": 0,
         "encodedBytes": 0,
-        "externalPeakRssBytes": 121913344,
-        "externalRssSampleCount": 6,
+        "externalPeakRssBytes": 124452864,
+        "externalRssSampleCount": 7,
         "externalRssSampleFailureCount": 0,
         "filesystem": {
-          "afterBytes": 197005337,
-          "beforeBytes": 227115730,
-          "sampledHighWaterBytes": 257225537
+          "afterBytes": 196947985,
+          "beforeBytes": 227058378,
+          "sampledHighWaterBytes": 257168185
         },
         "outputRecords": 0,
-        "parentElapsedMs": 268,
+        "parentElapsedMs": 313,
         "runCount": 2,
         "sourceBytes": 0,
         "sourceFiles": 0,
@@ -738,21 +738,21 @@
     {
       "failureCode": "none",
       "metrics": {
-        "childCpuMs": 5,
-        "childMaxRssBytes": 116867072,
+        "childCpuMs": 6,
+        "childMaxRssBytes": 118996992,
         "decodedBytes": 0,
         "durablePeakRssBytes": 0,
         "encodedBytes": 0,
-        "externalPeakRssBytes": 105431040,
+        "externalPeakRssBytes": 104595456,
         "externalRssSampleCount": 4,
         "externalRssSampleFailureCount": 0,
         "filesystem": {
-          "afterBytes": 197005607,
-          "beforeBytes": 197005786,
-          "sampledHighWaterBytes": 197005786
+          "afterBytes": 196948255,
+          "beforeBytes": 196948434,
+          "sampledHighWaterBytes": 196948434
         },
         "outputRecords": 0,
-        "parentElapsedMs": 170,
+        "parentElapsedMs": 172,
         "runCount": 2,
         "sourceBytes": 0,
         "sourceFiles": 0,
@@ -767,7 +767,7 @@
       "failureCode": "interruption_injected",
       "metrics": {
         "childCpuMs": 5,
-        "childMaxRssBytes": 117014528,
+        "childMaxRssBytes": 118407168,
         "decodedBytes": 0,
         "durablePeakRssBytes": 0,
         "encodedBytes": 0,
@@ -775,12 +775,12 @@
         "externalRssSampleCount": 4,
         "externalRssSampleFailureCount": 0,
         "filesystem": {
-          "afterBytes": 197005877,
-          "beforeBytes": 197006065,
-          "sampledHighWaterBytes": 197006065
+          "afterBytes": 196948525,
+          "beforeBytes": 196948713,
+          "sampledHighWaterBytes": 196948713
         },
         "outputRecords": 0,
-        "parentElapsedMs": 159,
+        "parentElapsedMs": 162,
         "runCount": 2,
         "sourceBytes": 0,
         "sourceFiles": 0,
@@ -827,7 +827,7 @@
     "targetChunks": 128
   },
   "protocolVersion": "g1-r7-release-evidence-v0.1",
-  "receiptSha256": "566312174be959efe01d904097ad0a62adb491dca0c996a3e7ffd1fb15bcb38c",
+  "receiptSha256": "a10d939d59620e56b64c54a51371da30cdce7adaa5ab0832888825ee88c95c51",
   "runtimeProvenance": {
     "architecture": "arm64",
     "elapsedClock": "parent_monotonic",

--- a/generated/r7-release-synthetic-semantics-node24.14.0-v0.1.json
+++ b/generated/r7-release-synthetic-semantics-node24.14.0-v0.1.json
@@ -481,8 +481,8 @@
     "resourcePolicySourceSha256": "d9748895468534062e9c8c436db75cbf5acf4ccf54f84319db37e88197627870",
     "resourcePolicyValuesSha256": "3cbe7853c8f75e96912885f64ba4ad1aeb13aff8a22e4ffbd51806b27c73b418",
     "schemaModuleSha256": "594d035e641e87b29db4027dca35157f8225fd5621816d67d5d9f25825468bbf",
-    "workloadCodeFileCount": 335,
-    "workloadCodeSha256": "8be3813e1f9cc787652bf6c718715d91e245e90df6f5eff1bcef5ad1cd16832a"
+    "workloadCodeFileCount": 359,
+    "workloadCodeSha256": "4c3058b3453bda2696e946952d18e81310f26eb0187074d410c730e44162f1d6"
   },
   "determinism": {
     "comparisons": {
@@ -500,8 +500,8 @@
     "projectionVersion": "g1-r7-release-deterministic-projection-v0.1",
     "runCount": 2,
     "runProjectionSha256es": [
-      "9a8c3740c02a307d7ba46d3d6c023d98f513a4fe09854fd95372e231fc4af5e8",
-      "9a8c3740c02a307d7ba46d3d6c023d98f513a4fe09854fd95372e231fc4af5e8"
+      "9ac7325be54ac2b04d51f620fab54ceec1fdd26a37b8ba2e0547e449f4cc735e",
+      "9ac7325be54ac2b04d51f620fab54ceec1fdd26a37b8ba2e0547e449f4cc735e"
     ],
     "status": "passed"
   },
@@ -515,20 +515,20 @@
       "failureCode": "none",
       "metrics": {
         "childCpuMs": 71,
-        "childMaxRssBytes": 122044416,
+        "childMaxRssBytes": 122503168,
         "decodedBytes": 0,
-        "durablePeakRssBytes": 121995264,
+        "durablePeakRssBytes": 122503168,
         "encodedBytes": 0,
-        "externalPeakRssBytes": 121978880,
-        "externalRssSampleCount": 5,
-        "externalRssSampleFailureCount": 1,
+        "externalPeakRssBytes": 122519552,
+        "externalRssSampleCount": 6,
+        "externalRssSampleFailureCount": 0,
         "filesystem": {
           "afterBytes": 200864,
           "beforeBytes": 160,
-          "sampledHighWaterBytes": 200975
+          "sampledHighWaterBytes": 200864
         },
         "outputRecords": 27,
-        "parentElapsedMs": 214,
+        "parentElapsedMs": 210,
         "runCount": 2,
         "sourceBytes": 154645,
         "sourceFiles": 14,
@@ -542,12 +542,12 @@
     {
       "failureCode": "none",
       "metrics": {
-        "childCpuMs": 49,
-        "childMaxRssBytes": 120176640,
+        "childCpuMs": 48,
+        "childMaxRssBytes": 120324096,
         "decodedBytes": 0,
-        "durablePeakRssBytes": 160333824,
+        "durablePeakRssBytes": 162381824,
         "encodedBytes": 0,
-        "externalPeakRssBytes": 100564992,
+        "externalPeakRssBytes": 97435648,
         "externalRssSampleCount": 4,
         "externalRssSampleFailureCount": 0,
         "filesystem": {
@@ -556,7 +556,7 @@
           "sampledHighWaterBytes": 401568
         },
         "outputRecords": 27,
-        "parentElapsedMs": 179,
+        "parentElapsedMs": 180,
         "runCount": 2,
         "sourceBytes": 154645,
         "sourceFiles": 14,
@@ -571,20 +571,20 @@
       "failureCode": "none",
       "metrics": {
         "childCpuMs": 201,
-        "childMaxRssBytes": 131203072,
+        "childMaxRssBytes": 131317760,
         "decodedBytes": 109963,
-        "durablePeakRssBytes": 131088384,
-        "encodedBytes": 32467,
-        "externalPeakRssBytes": 131088384,
+        "durablePeakRssBytes": 131235840,
+        "encodedBytes": 32465,
+        "externalPeakRssBytes": 130957312,
         "externalRssSampleCount": 19,
-        "externalRssSampleFailureCount": 1,
+        "externalRssSampleFailureCount": 0,
         "filesystem": {
-          "afterBytes": 554637,
+          "afterBytes": 554635,
           "beforeBytes": 401568,
-          "sampledHighWaterBytes": 555326
+          "sampledHighWaterBytes": 555902
         },
         "outputRecords": 27,
-        "parentElapsedMs": 952,
+        "parentElapsedMs": 957,
         "runCount": 2,
         "sourceBytes": 154645,
         "sourceFiles": 14,
@@ -592,27 +592,27 @@
         "stdoutBytes": 1223
       },
       "name": "export_set_materialize",
-      "projectionSha256": "159d2f4522dace218404538b1581c17dc79badefb9b9b22fe2dc38b18a062adf",
+      "projectionSha256": "5944426c3bba1db00f51fb699c78207922f06671e526ee390a76d401a58adeff",
       "status": "completed"
     },
     {
       "failureCode": "none",
       "metrics": {
-        "childCpuMs": 41,
-        "childMaxRssBytes": 123404288,
+        "childCpuMs": 46,
+        "childMaxRssBytes": 124289024,
         "decodedBytes": 109963,
         "durablePeakRssBytes": 0,
-        "encodedBytes": 32467,
-        "externalPeakRssBytes": 90210304,
+        "encodedBytes": 32465,
+        "externalPeakRssBytes": 92733440,
         "externalRssSampleCount": 4,
         "externalRssSampleFailureCount": 0,
         "filesystem": {
-          "afterBytes": 554637,
-          "beforeBytes": 554637,
-          "sampledHighWaterBytes": 554637
+          "afterBytes": 554635,
+          "beforeBytes": 554635,
+          "sampledHighWaterBytes": 554635
         },
         "outputRecords": 27,
-        "parentElapsedMs": 173,
+        "parentElapsedMs": 180,
         "runCount": 2,
         "sourceBytes": 0,
         "sourceFiles": 0,
@@ -620,27 +620,27 @@
         "stdoutBytes": 997
       },
       "name": "export_set_verify",
-      "projectionSha256": "c6753e2d41b2ad9de7298861a30425cda11a9a7e62d9f831e050af36992ffed3",
+      "projectionSha256": "2839288640255af62cb6bc1795aa861729379bda98d141bf0909aeabf4336c58",
       "status": "completed"
     },
     {
       "failureCode": "none",
       "metrics": {
-        "childCpuMs": 143,
-        "childMaxRssBytes": 135823360,
+        "childCpuMs": 142,
+        "childMaxRssBytes": 138035200,
         "decodedBytes": 0,
         "durablePeakRssBytes": 0,
         "encodedBytes": 0,
-        "externalPeakRssBytes": 135708672,
+        "externalPeakRssBytes": 137854976,
         "externalRssSampleCount": 12,
         "externalRssSampleFailureCount": 0,
         "filesystem": {
           "afterBytes": 203384,
-          "beforeBytes": 556700,
-          "sampledHighWaterBytes": 556811
+          "beforeBytes": 556698,
+          "sampledHighWaterBytes": 556809
         },
         "outputRecords": 0,
-        "parentElapsedMs": 557,
+        "parentElapsedMs": 561,
         "runCount": 2,
         "sourceBytes": 0,
         "sourceFiles": 0,
@@ -648,27 +648,27 @@
         "stdoutBytes": 996
       },
       "name": "complete_set_delete",
-      "projectionSha256": "0e9adc5c8d7a7011ebfdff7a5128af3ef66d6bc42339a45234f24df7a88edd45",
+      "projectionSha256": "e744484b9c219eea32283dd229742e4f71e76573c1baebde450e4474c616a91f",
       "status": "completed"
     },
     {
       "failureCode": "interruption_injected",
       "metrics": {
         "childCpuMs": 38,
-        "childMaxRssBytes": 114638848,
+        "childMaxRssBytes": 115032064,
         "decodedBytes": 0,
         "durablePeakRssBytes": 0,
         "encodedBytes": 0,
-        "externalPeakRssBytes": 114606080,
+        "externalPeakRssBytes": 114982912,
         "externalRssSampleCount": 10,
         "externalRssSampleFailureCount": 0,
         "filesystem": {
-          "afterBytes": 556700,
-          "beforeBytes": 920788,
-          "sampledHighWaterBytes": 920788
+          "afterBytes": 556698,
+          "beforeBytes": 920784,
+          "sampledHighWaterBytes": 920784
         },
         "outputRecords": 0,
-        "parentElapsedMs": 425,
+        "parentElapsedMs": 435,
         "runCount": 2,
         "sourceBytes": 0,
         "sourceFiles": 0,
@@ -676,27 +676,27 @@
         "stdoutBytes": 1005
       },
       "name": "complete_set_delete_recovery",
-      "projectionSha256": "0e9adc5c8d7a7011ebfdff7a5128af3ef66d6bc42339a45234f24df7a88edd45",
+      "projectionSha256": "e744484b9c219eea32283dd229742e4f71e76573c1baebde450e4474c616a91f",
       "status": "interrupted_recovered"
     },
     {
       "failureCode": "none",
       "metrics": {
-        "childCpuMs": 16,
-        "childMaxRssBytes": 115081216,
+        "childCpuMs": 17,
+        "childMaxRssBytes": 115392512,
         "decodedBytes": 0,
         "durablePeakRssBytes": 0,
         "encodedBytes": 0,
-        "externalPeakRssBytes": 97648640,
-        "externalRssSampleCount": 4,
+        "externalPeakRssBytes": 115195904,
+        "externalRssSampleCount": 5,
         "externalRssSampleFailureCount": 0,
         "filesystem": {
-          "afterBytes": 555170,
-          "beforeBytes": 722573,
-          "sampledHighWaterBytes": 722573
+          "afterBytes": 555168,
+          "beforeBytes": 722571,
+          "sampledHighWaterBytes": 722571
         },
         "outputRecords": 0,
-        "parentElapsedMs": 196,
+        "parentElapsedMs": 216,
         "runCount": 2,
         "sourceBytes": 0,
         "sourceFiles": 0,
@@ -711,20 +711,20 @@
       "failureCode": "interruption_injected",
       "metrics": {
         "childCpuMs": 13,
-        "childMaxRssBytes": 114540544,
+        "childMaxRssBytes": 114573312,
         "decodedBytes": 0,
         "durablePeakRssBytes": 0,
         "encodedBytes": 0,
-        "externalPeakRssBytes": 94601216,
+        "externalPeakRssBytes": 94633984,
         "externalRssSampleCount": 4,
         "externalRssSampleFailureCount": 0,
         "filesystem": {
-          "afterBytes": 555703,
-          "beforeBytes": 724334,
-          "sampledHighWaterBytes": 724334
+          "afterBytes": 555701,
+          "beforeBytes": 724332,
+          "sampledHighWaterBytes": 724332
         },
         "outputRecords": 0,
-        "parentElapsedMs": 189,
+        "parentElapsedMs": 191,
         "runCount": 2,
         "sourceBytes": 0,
         "sourceFiles": 0,
@@ -739,20 +739,20 @@
       "failureCode": "none",
       "metrics": {
         "childCpuMs": 6,
-        "childMaxRssBytes": 111656960,
+        "childMaxRssBytes": 112082944,
         "decodedBytes": 0,
         "durablePeakRssBytes": 0,
         "encodedBytes": 0,
-        "externalPeakRssBytes": 94404608,
+        "externalPeakRssBytes": 93011968,
         "externalRssSampleCount": 4,
         "externalRssSampleFailureCount": 0,
         "filesystem": {
-          "afterBytes": 555973,
-          "beforeBytes": 556152,
-          "sampledHighWaterBytes": 556152
+          "afterBytes": 555971,
+          "beforeBytes": 556150,
+          "sampledHighWaterBytes": 556150
         },
         "outputRecords": 0,
-        "parentElapsedMs": 169,
+        "parentElapsedMs": 171,
         "runCount": 2,
         "sourceBytes": 0,
         "sourceFiles": 0,
@@ -767,20 +767,20 @@
       "failureCode": "interruption_injected",
       "metrics": {
         "childCpuMs": 5,
-        "childMaxRssBytes": 111624192,
+        "childMaxRssBytes": 111591424,
         "decodedBytes": 0,
         "durablePeakRssBytes": 0,
         "encodedBytes": 0,
-        "externalPeakRssBytes": 94355456,
+        "externalPeakRssBytes": 92782592,
         "externalRssSampleCount": 4,
         "externalRssSampleFailureCount": 0,
         "filesystem": {
-          "afterBytes": 556243,
-          "beforeBytes": 556431,
-          "sampledHighWaterBytes": 556431
+          "afterBytes": 556241,
+          "beforeBytes": 556429,
+          "sampledHighWaterBytes": 556429
         },
         "outputRecords": 0,
-        "parentElapsedMs": 161,
+        "parentElapsedMs": 165,
         "runCount": 2,
         "sourceBytes": 0,
         "sourceFiles": 0,
@@ -836,7 +836,7 @@
     "kind": "release_synthetic_semantics"
   },
   "protocolVersion": "g1-r7-release-evidence-v0.1",
-  "receiptSha256": "8a64ac37941429fd98011836c46710b7aacd33f4439300bdd3b4bc8289fb71f6",
+  "receiptSha256": "4ddfe56b735cf44241ef3cd5119cdccb3490d17bc13e6ba44d1668c859b694a4",
   "runtimeProvenance": {
     "architecture": "arm64",
     "elapsedClock": "parent_monotonic",

--- a/generated/r7-release-synthetic-semantics-node26.2.0-v0.1.json
+++ b/generated/r7-release-synthetic-semantics-node26.2.0-v0.1.json
@@ -481,8 +481,8 @@
     "resourcePolicySourceSha256": "d9748895468534062e9c8c436db75cbf5acf4ccf54f84319db37e88197627870",
     "resourcePolicyValuesSha256": "3cbe7853c8f75e96912885f64ba4ad1aeb13aff8a22e4ffbd51806b27c73b418",
     "schemaModuleSha256": "594d035e641e87b29db4027dca35157f8225fd5621816d67d5d9f25825468bbf",
-    "workloadCodeFileCount": 335,
-    "workloadCodeSha256": "8be3813e1f9cc787652bf6c718715d91e245e90df6f5eff1bcef5ad1cd16832a"
+    "workloadCodeFileCount": 359,
+    "workloadCodeSha256": "4c3058b3453bda2696e946952d18e81310f26eb0187074d410c730e44162f1d6"
   },
   "determinism": {
     "comparisons": {
@@ -500,8 +500,8 @@
     "projectionVersion": "g1-r7-release-deterministic-projection-v0.1",
     "runCount": 2,
     "runProjectionSha256es": [
-      "850fb82636e252b551589e992fe3275148d6696dfbb6f91543686f358fe84169",
-      "850fb82636e252b551589e992fe3275148d6696dfbb6f91543686f358fe84169"
+      "541414ca938c50980d496589a0dd63e37b33f3aba5b3d361d467d2f770607ed2",
+      "541414ca938c50980d496589a0dd63e37b33f3aba5b3d361d467d2f770607ed2"
     ],
     "status": "passed"
   },
@@ -514,26 +514,26 @@
     {
       "failureCode": "none",
       "metrics": {
-        "childCpuMs": 77,
-        "childMaxRssBytes": 129695744,
+        "childCpuMs": 74,
+        "childMaxRssBytes": 131891200,
         "decodedBytes": 0,
-        "durablePeakRssBytes": 129662976,
+        "durablePeakRssBytes": 131858432,
         "encodedBytes": 0,
-        "externalPeakRssBytes": 129007616,
+        "externalPeakRssBytes": 128598016,
         "externalRssSampleCount": 6,
         "externalRssSampleFailureCount": 0,
         "filesystem": {
           "afterBytes": 200864,
           "beforeBytes": 160,
-          "sampledHighWaterBytes": 200975
+          "sampledHighWaterBytes": 200864
         },
         "outputRecords": 27,
-        "parentElapsedMs": 263,
+        "parentElapsedMs": 237,
         "runCount": 2,
         "sourceBytes": 154645,
         "sourceFiles": 14,
         "stderrBytes": 0,
-        "stdoutBytes": 1072
+        "stdoutBytes": 1071
       },
       "name": "source_scan",
       "projectionSha256": "9a32d3d160adf2c4f0f900f4583abf8c4b37c5460377fcdd74447945cfa9acd7",
@@ -542,12 +542,12 @@
     {
       "failureCode": "none",
       "metrics": {
-        "childCpuMs": 48,
-        "childMaxRssBytes": 126631936,
+        "childCpuMs": 49,
+        "childMaxRssBytes": 128712704,
         "decodedBytes": 0,
-        "durablePeakRssBytes": 166756352,
+        "durablePeakRssBytes": 167313408,
         "encodedBytes": 0,
-        "externalPeakRssBytes": 106299392,
+        "externalPeakRssBytes": 106790912,
         "externalRssSampleCount": 4,
         "externalRssSampleFailureCount": 0,
         "filesystem": {
@@ -556,7 +556,7 @@
           "sampledHighWaterBytes": 401568
         },
         "outputRecords": 27,
-        "parentElapsedMs": 186,
+        "parentElapsedMs": 183,
         "runCount": 2,
         "sourceBytes": 154645,
         "sourceFiles": 14,
@@ -570,21 +570,21 @@
     {
       "failureCode": "none",
       "metrics": {
-        "childCpuMs": 209,
-        "childMaxRssBytes": 138084352,
+        "childCpuMs": 205,
+        "childMaxRssBytes": 140115968,
         "decodedBytes": 109963,
-        "durablePeakRssBytes": 138067968,
-        "encodedBytes": 32467,
-        "externalPeakRssBytes": 138100736,
-        "externalRssSampleCount": 19,
+        "durablePeakRssBytes": 140099584,
+        "encodedBytes": 32431,
+        "externalPeakRssBytes": 140165120,
+        "externalRssSampleCount": 20,
         "externalRssSampleFailureCount": 0,
         "filesystem": {
-          "afterBytes": 554636,
+          "afterBytes": 554600,
           "beforeBytes": 401568,
-          "sampledHighWaterBytes": 554636
+          "sampledHighWaterBytes": 555488
         },
         "outputRecords": 27,
-        "parentElapsedMs": 931,
+        "parentElapsedMs": 950,
         "runCount": 2,
         "sourceBytes": 154645,
         "sourceFiles": 14,
@@ -592,27 +592,27 @@
         "stdoutBytes": 1223
       },
       "name": "export_set_materialize",
-      "projectionSha256": "5d4c3f5f971ace41564876ee804b47b25c316b3ed7d4b3a7e8c6e6a7cc8a0a80",
+      "projectionSha256": "6a12d5a201d85e88a0a8486a1a346cb22e67c67373ecbe0107b242d9abc9c3f4",
       "status": "completed"
     },
     {
       "failureCode": "none",
       "metrics": {
-        "childCpuMs": 41,
-        "childMaxRssBytes": 131186688,
+        "childCpuMs": 42,
+        "childMaxRssBytes": 134397952,
         "decodedBytes": 109963,
         "durablePeakRssBytes": 0,
-        "encodedBytes": 32467,
-        "externalPeakRssBytes": 98222080,
+        "encodedBytes": 32431,
+        "externalPeakRssBytes": 98025472,
         "externalRssSampleCount": 4,
         "externalRssSampleFailureCount": 0,
         "filesystem": {
-          "afterBytes": 554636,
-          "beforeBytes": 554636,
-          "sampledHighWaterBytes": 554636
+          "afterBytes": 554600,
+          "beforeBytes": 554600,
+          "sampledHighWaterBytes": 554600
         },
         "outputRecords": 27,
-        "parentElapsedMs": 171,
+        "parentElapsedMs": 179,
         "runCount": 2,
         "sourceBytes": 0,
         "sourceFiles": 0,
@@ -620,55 +620,55 @@
         "stdoutBytes": 997
       },
       "name": "export_set_verify",
-      "projectionSha256": "c6753e2d41b2ad9de7298861a30425cda11a9a7e62d9f831e050af36992ffed3",
+      "projectionSha256": "3273ab99840aa9026615572e61d9b4b877ea7b024da7a0ea11dc975f3510953e",
       "status": "completed"
     },
     {
       "failureCode": "none",
       "metrics": {
-        "childCpuMs": 146,
-        "childMaxRssBytes": 144375808,
+        "childCpuMs": 145,
+        "childMaxRssBytes": 145358848,
         "decodedBytes": 0,
         "durablePeakRssBytes": 0,
         "encodedBytes": 0,
-        "externalPeakRssBytes": 144244736,
+        "externalPeakRssBytes": 145063936,
         "externalRssSampleCount": 12,
         "externalRssSampleFailureCount": 0,
         "filesystem": {
           "afterBytes": 203384,
-          "beforeBytes": 556699,
-          "sampledHighWaterBytes": 556810
+          "beforeBytes": 556663,
+          "sampledHighWaterBytes": 556774
         },
         "outputRecords": 0,
-        "parentElapsedMs": 557,
+        "parentElapsedMs": 560,
         "runCount": 2,
         "sourceBytes": 0,
         "sourceFiles": 0,
         "stderrBytes": 0,
-        "stdoutBytes": 997
+        "stdoutBytes": 996
       },
       "name": "complete_set_delete",
-      "projectionSha256": "4b4842193c778ab4ab18c92c4cd6ca8c58e7e4e15c7f280e9a3606d3e1cd33a5",
+      "projectionSha256": "3e165319d4b31f383f0e155b3a07725087d0665b31cb61ee2f9299f72c4498d0",
       "status": "completed"
     },
     {
       "failureCode": "interruption_injected",
       "metrics": {
-        "childCpuMs": 38,
-        "childMaxRssBytes": 119259136,
+        "childCpuMs": 37,
+        "childMaxRssBytes": 122044416,
         "decodedBytes": 0,
         "durablePeakRssBytes": 0,
         "encodedBytes": 0,
-        "externalPeakRssBytes": 119259136,
+        "externalPeakRssBytes": 121995264,
         "externalRssSampleCount": 10,
         "externalRssSampleFailureCount": 0,
         "filesystem": {
-          "afterBytes": 556699,
-          "beforeBytes": 920786,
-          "sampledHighWaterBytes": 920786
+          "afterBytes": 556663,
+          "beforeBytes": 920714,
+          "sampledHighWaterBytes": 920714
         },
         "outputRecords": 0,
-        "parentElapsedMs": 427,
+        "parentElapsedMs": 425,
         "runCount": 2,
         "sourceBytes": 0,
         "sourceFiles": 0,
@@ -676,27 +676,27 @@
         "stdoutBytes": 1005
       },
       "name": "complete_set_delete_recovery",
-      "projectionSha256": "4b4842193c778ab4ab18c92c4cd6ca8c58e7e4e15c7f280e9a3606d3e1cd33a5",
+      "projectionSha256": "3e165319d4b31f383f0e155b3a07725087d0665b31cb61ee2f9299f72c4498d0",
       "status": "interrupted_recovered"
     },
     {
       "failureCode": "none",
       "metrics": {
-        "childCpuMs": 17,
-        "childMaxRssBytes": 121274368,
+        "childCpuMs": 16,
+        "childMaxRssBytes": 123371520,
         "decodedBytes": 0,
         "durablePeakRssBytes": 0,
         "encodedBytes": 0,
-        "externalPeakRssBytes": 107003904,
+        "externalPeakRssBytes": 106872832,
         "externalRssSampleCount": 4,
-        "externalRssSampleFailureCount": 0,
+        "externalRssSampleFailureCount": 1,
         "filesystem": {
-          "afterBytes": 555169,
-          "beforeBytes": 722572,
-          "sampledHighWaterBytes": 722572
+          "afterBytes": 555133,
+          "beforeBytes": 722536,
+          "sampledHighWaterBytes": 722536
         },
         "outputRecords": 0,
-        "parentElapsedMs": 199,
+        "parentElapsedMs": 204,
         "runCount": 2,
         "sourceBytes": 0,
         "sourceFiles": 0,
@@ -711,20 +711,20 @@
       "failureCode": "interruption_injected",
       "metrics": {
         "childCpuMs": 12,
-        "childMaxRssBytes": 120487936,
+        "childMaxRssBytes": 121913344,
         "decodedBytes": 0,
         "durablePeakRssBytes": 0,
         "encodedBytes": 0,
-        "externalPeakRssBytes": 106463232,
+        "externalPeakRssBytes": 106741760,
         "externalRssSampleCount": 4,
         "externalRssSampleFailureCount": 0,
         "filesystem": {
-          "afterBytes": 555702,
-          "beforeBytes": 724333,
-          "sampledHighWaterBytes": 724333
+          "afterBytes": 555666,
+          "beforeBytes": 724297,
+          "sampledHighWaterBytes": 724297
         },
         "outputRecords": 0,
-        "parentElapsedMs": 189,
+        "parentElapsedMs": 190,
         "runCount": 2,
         "sourceBytes": 0,
         "sourceFiles": 0,
@@ -739,20 +739,20 @@
       "failureCode": "none",
       "metrics": {
         "childCpuMs": 5,
-        "childMaxRssBytes": 117014528,
+        "childMaxRssBytes": 118390784,
         "decodedBytes": 0,
         "durablePeakRssBytes": 0,
         "encodedBytes": 0,
-        "externalPeakRssBytes": 105611264,
+        "externalPeakRssBytes": 103202816,
         "externalRssSampleCount": 4,
         "externalRssSampleFailureCount": 0,
         "filesystem": {
-          "afterBytes": 555972,
-          "beforeBytes": 556151,
-          "sampledHighWaterBytes": 556151
+          "afterBytes": 555936,
+          "beforeBytes": 556115,
+          "sampledHighWaterBytes": 556115
         },
         "outputRecords": 0,
-        "parentElapsedMs": 195,
+        "parentElapsedMs": 176,
         "runCount": 2,
         "sourceBytes": 0,
         "sourceFiles": 0,
@@ -767,17 +767,17 @@
       "failureCode": "interruption_injected",
       "metrics": {
         "childCpuMs": 5,
-        "childMaxRssBytes": 116506624,
+        "childMaxRssBytes": 118571008,
         "decodedBytes": 0,
         "durablePeakRssBytes": 0,
         "encodedBytes": 0,
-        "externalPeakRssBytes": 103219200,
+        "externalPeakRssBytes": 101777408,
         "externalRssSampleCount": 4,
         "externalRssSampleFailureCount": 0,
         "filesystem": {
-          "afterBytes": 556242,
-          "beforeBytes": 556430,
-          "sampledHighWaterBytes": 556430
+          "afterBytes": 556206,
+          "beforeBytes": 556394,
+          "sampledHighWaterBytes": 556394
         },
         "outputRecords": 0,
         "parentElapsedMs": 161,
@@ -836,7 +836,7 @@
     "kind": "release_synthetic_semantics"
   },
   "protocolVersion": "g1-r7-release-evidence-v0.1",
-  "receiptSha256": "ad7bbaabe5de8a1fa683fbbfcda51f893225732bee47fb167207820802f39d64",
+  "receiptSha256": "4e90b8b3bdd596f5eb5694c33f534417ce64dbca642013b7d14b4a644cbc75cc",
   "runtimeProvenance": {
     "architecture": "arm64",
     "elapsedClock": "parent_monotonic",

--- a/release-notes/0.1.17.md
+++ b/release-notes/0.1.17.md
@@ -1,8 +1,10 @@
 # TiboTattle 0.1.17
 
-**Status:** Candidate source notes for native dogfood. No stable `v0.1.17` tag,
-GitHub release, signed or notarized artifact, published appcast, or installed
-0.1.17 validation is claimed yet.
+**Status:** Candidate source notes for native dogfood. Frozen RC4 source
+`735a59ce2ec01df0e381fb1aa878c5c7a39edcd8` produced a signed, notarized, and
+installed build `1023.2`, but that artifact excludes PR #94 and does not qualify
+the current integrated source or stable 0.1.17. No stable `v0.1.17` tag, GitHub
+release, published appcast, or integrated RC5 artifact is claimed yet.
 
 The native Mac app is easier to recover, clearer while it starts, and ready for
 the newer Codex history, plan, and quota formats already appearing in current
@@ -16,7 +18,10 @@ local data, stable Keychain identity, and anything already contributed.
 The dashboard now explains what it is doing while the local service starts and
 while a large history is being analysed. It opens as soon as the primary view is
 ready instead of waiting for every secondary load, and startup failures name the
-phase that failed so the suggested recovery step is relevant.
+phase that failed so the suggested recovery step is relevant. If primary
+readiness arrives after the initial wait, the native app now keeps observing the
+same fenced document generation, refreshes once, and replaces the timeout page
+after the late primary result succeeds rather than requiring a manual reload.
 
 A collapsed sidebar can always be reopened from the toolbar, the View menu, or
 the keyboard. The native window also stops offering unused tab controls, its
@@ -30,10 +35,12 @@ usage and cost history, and a weekly pace outlook when matching evidence is
 available. Right-click and Control-click retain the native actions menu. The
 popover keeps the latest measured allowance visible during a refresh and can
 retain compatible, previously validated usage history with a clear retained-data
-label. It hides history or pace when the supporting evidence is unavailable; it
-never presents retained history as fresh or fills a gap with zero or a guessed
-forecast. An offline update check is also distinguished from broken update
-infrastructure.
+label. When both Five-hour and seven-day lanes make the instrument taller than
+the space below the status item, it opens at the top and scrolls vertically so
+neither the first lane nor the lower history and actions are clipped. It hides
+history or pace when the supporting evidence is unavailable; it never presents
+retained history as fresh or fills a gap with zero or a guessed forecast. An
+offline update check is also distinguished from broken update infrastructure.
 
 ## Codex history keeps moving
 
@@ -70,6 +77,21 @@ Sparse or windowless quota updates are accepted when they are valid. A malformed
 window is withheld with a diagnostic, so missing evidence cannot turn into a
 confident zero or corrupt the allowance history; valid usage, tool, and other
 quota facts from the same rollout remain available.
+
+## Local history follows the selected plan era
+
+Current and historical plan evidence now stays attached to its compatible era.
+The selected estimate, history, comparison range, forecast, and share card all
+use the same selected population instead of borrowing a more complete-looking
+result from a different plan. Useful retained history survives when account
+identity is missing, while conflicting or unsupported attribution remains
+explicitly unavailable.
+
+This is conditional local attribution, not proof of an account-exact billing
+identity, workspace identity, cross-device equivalence, provider-authoritative
+quota formula, or bill. The local SQLite schema remains version 11; the change
+reanalyses derived accounting evidence without wiping the retained ledger or raw
+history.
 
 ## Large-history and retained-data honesty
 
@@ -191,19 +213,30 @@ and Preview never opts into automatic updates.
 
 Internal dogfood is deliberately different: it keeps the stable bundle and
 local-state identity so it can test an in-place upgrade, while using its own
-update channel. The 0.1.17 release tooling allocates build **1023** to that
-dogfood candidate and **1024** to the stable final, keeping stable ordered after
-the candidate. Signed tooling also requires a clean checkout and exactly one
+update channel. Earlier 0.1.17 internal candidates used builds **1023**,
+**1023.1**, and **1023.2**. The integrated RC5 allocation is **1023.3**, while
+**1024** remains reserved for the stable final, keeping stable ordered after the
+candidate. Signed tooling also requires a clean checkout and exactly one
 matching annotated source tag at `HEAD`: `v0.1.17` for stable, or the strict
 `tibotattle-internal-dogfood-0.1.17-rcN-source-YYYYMMDD` form for a dated
 candidate.
 
-These are source and release-tooling readiness changes. They do not by
-themselves mean that 0.1.17 has been signed, notarized, installed, published, or
-made available through an updater. The signed candidate still needs native
-popover interaction and actual thread-link handoff to Codex checked on the
-installed app; browser rendering and compiled native tests do not prove those
-interactions.
+RC4 build `1023.2` is signed, notarized, and installed evidence only for its
+frozen source; it predates the PR #94 merge. The integrated RC5 source still
+needs exact-source gates, signing, notarization, state-preserving replacement,
+and installed native checks. No 0.1.17 artifact has been published or made
+available through an updater. Browser rendering and compiled native tests do
+not prove physical popover interaction or thread-link handoff to Codex.
+
+## Prompt-free credential upgrades
+
+Automatic launch, refresh, contribution, and credential-migration paths now
+forbid Keychain interaction prompts. A compatible legacy credential is retried
+non-interactively up to three times. If macOS still refuses access, the app keeps
+local analysis available and offers an explained, deliberate recovery action in
+Settings; only that user-initiated fallback may request approval. It does not
+grant a blanket ACL, store a secret outside Keychain, or silently reset identity.
+An unexpected automatic Keychain prompt remains a release blocker.
 
 ## Disconnect this Mac without deleting history
 
@@ -239,6 +272,17 @@ The public community page can show the merged measured allowance across plans,
 and its compact platform selector states which downloads are actually
 available. The graph stays aligned with its explanation when the page changes
 shape.
+
+The hosted admin source also adds a **By model** view for Sol, Terra, Luna, and
+GPT-5.5 with the existing Pro-20x normalization and identification gates. It is
+not activated by this desktop release: Worker migration 0041, deployment,
+warming, and real cohort data remain separate operational gates.
+
+PR #94 also includes a closed telemetry v1.1 account/plan transport and
+lifecycle, but it remains staged source. Worker migrations 0042-0044, hosted
+activation, and a new explicit consent are separate operations. Installing the
+desktop app neither deploys that protocol nor changes an existing contribution
+consent.
 
 ## Known limitations
 

--- a/scripts/macos-bundle-version.js
+++ b/scripts/macos-bundle-version.js
@@ -14,15 +14,16 @@ export const LEGACY_STABLE_MACOS_BUNDLE_VERSION = "0.1.16";
 export const MACOS_BUNDLE_VERSION_EPOCH = 2_000;
 
 // Signed releases keep the production bundle identifier, so their build
-// numbers must advance from the last shared-identity dogfood build (1023.1).
+// numbers must advance from the last shared-identity dogfood build (1023.2).
 // Freeze the owner-reviewed allocations per marketing version and channel;
 // adding a future release is an explicit policy change, never an implicit
 // timestamp or environment-controlled counter.
-// The 0.1.17 RC2 used 1023 and RC3 used 1023.1. The startup-recovery RC4
-// uses 1023.2, preserving the allocated stable 1024 and monotonic upgrades.
+// The 0.1.17 RC2 used 1023, RC3 used 1023.1, and the installed
+// startup-recovery RC4 used 1023.2. The integrated RC5 uses 1023.3,
+// preserving the allocated stable 1024 and monotonic upgrades.
 export const SIGNED_MACOS_BUNDLE_VERSION_PLAN = Object.freeze({
   "0.1.17": Object.freeze({
-    "internal-dogfood": "1023.2",
+    "internal-dogfood": "1023.3",
     stable: "1024",
   }),
 });

--- a/test/macos-app-bundle.test.js
+++ b/test/macos-app-bundle.test.js
@@ -2890,6 +2890,39 @@ test("menu-bar status item degrades honestly and never invents allowance evidenc
     /func menuBarStatusActivationIntent\([\s\S]*?eventType == \.rightMouseUp[\s\S]*?modifierFlags\.contains\(\.control\)/u,
   );
   assert.match(source, /popover\.show\([\s\S]*?preferredEdge: \.minY/u);
+  assert.match(
+    source,
+    /popoverController\.prepareForPresentation\(from: sender\)\s*\n\s*popoverController\.update\(snapshot: snapshot\)\s*\n\s*popover\.show/u,
+  );
+  assert.match(popupSource, /private let scrollView = NSScrollView\(\)/u);
+  assert.match(popupSource, /scrollView\.hasVerticalScroller = true/u);
+  assert.match(popupSource, /scrollView\.hasHorizontalScroller = false/u);
+  assert.match(popupSource, /scrollView\.horizontalScrollElasticity = \.none/u);
+  assert.match(
+    popupSource,
+    /func menuBarPopoverMaximumViewportHeight\([\s\S]*?anchorMinY[\s\S]*?- visibleFrame\.minY[\s\S]*?- MenuBarPopoverMetrics\.popoverVerticalClearance[\s\S]*?return min\(screenMaximum, max\(1, anchorMaximum\)\)/u,
+  );
+  assert.equal(
+    popupSource.match(/menuBarPopoverMaximumViewportHeight\(/gu)?.length,
+    3,
+    "one cap helper definition must serve production and the compiled smoke seam",
+  );
+  assert.match(
+    popupSource,
+    /let previousVerticalOffset = scrollView\.contentView\.bounds\.minY[\s\S]*?setVerticalScrollOffset\(previousVerticalOffset\)/u,
+  );
+  assert.match(
+    popupSource,
+    /func prepareForPresentation\(from anchor: NSView\)[\s\S]*?updatePreferredContentSize\(\)\s*\n\s*scrollToTop\(\)/u,
+  );
+  assert.match(
+    popupSource,
+    /func isFullyVisibleInViewport\(_ candidate: NSView\)[\s\S]*?scrollView\.contentView\.convert\([\s\S]*?visibleBounds\.contains\(frameInClipView\)/u,
+  );
+  assert.match(
+    popupSource,
+    /func scrollToBottomForSmokeTest\(\)[\s\S]*?setVerticalScrollOffset\(maximumVerticalScrollOffset\(\)\)/u,
+  );
   assert.match(source, /menu\.popUp\(positioning: nil, at: screenPoint, in: nil\)/u);
   assert.match(source, /func popoverDidClose\(_ notification: Notification\)/u);
   const showActionMenu = source.match(
@@ -3135,11 +3168,13 @@ test("menu-bar status item degrades honestly and never invents allowance evidenc
     /weeklyPaceOutlook: snapshot\.weeklyPaceOutlook,/u,
   );
 
-  // The rich popup is a real AppKit surface with fixed width, no scroll view,
-  // two native history ranges, and the companion-projected weekly pace states.
+  // The rich popup is a real AppKit surface with fixed width, vertical-only
+  // overflow, two native history ranges, and companion-projected pace states.
   assert.match(popupSource, /final class MenuBarPopoverViewController: NSViewController/u);
   assert.match(popupSource, /static let width: CGFloat = 400/u);
-  assert.doesNotMatch(popupSource, /NSScrollView\s*\(/u);
+  assert.match(popupSource, /private let scrollView = NSScrollView\(\)/u);
+  assert.match(popupSource, /scrollView\.hasVerticalScroller = true/u);
+  assert.match(popupSource, /scrollView\.hasHorizontalScroller = false/u);
   assert.match(popupSource, /let rangeControl = NSSegmentedControl\(\)/u);
   assert.match(modelSource, /case sevenDays = "7d"/u);
   assert.match(modelSource, /case thirtyDays = "30d"/u);
@@ -4264,11 +4299,11 @@ test("development and preview builds treat the release-channel policy as optiona
 
 test("macOS release metadata validates versions, production mode, and Keychain references", async () => {
   assert.equal(normalizeMacOSBundleVersion(), DERIVED_MACOS_BUNDLE_VERSION);
-  assert.equal(INTERNAL_DOGFOOD_SIGNED_BUNDLE_VERSION, "1023.2");
+  assert.equal(INTERNAL_DOGFOOD_SIGNED_BUNDLE_VERSION, "1023.3");
   assert.equal(STABLE_SIGNED_BUNDLE_VERSION, "1024");
   assert.equal(
     normalizeMacOSBundleVersion(INTERNAL_DOGFOOD_SIGNED_BUNDLE_VERSION),
-    "1023.2",
+    "1023.3",
   );
   assert.equal(
     compareMacOSBundleVersions(
@@ -4288,19 +4323,24 @@ test("macOS release metadata validates versions, production mode, and Keychain r
     "the corrective dogfood must be strictly newer than the installed RC3",
   );
   assert.equal(
+    compareMacOSBundleVersions("1023.2", INTERNAL_DOGFOOD_SIGNED_BUNDLE_VERSION),
+    -1,
+    "the final integrated dogfood must be strictly newer than startup-recovery RC4",
+  );
+  assert.equal(
     compareMacOSBundleVersions(
       STABLE_SIGNED_BUNDLE_VERSION,
       INTERNAL_DOGFOOD_SIGNED_BUNDLE_VERSION,
     ) > 0,
     true,
   );
-  for (const unallocated of ["1023", "1023.0", "1023.1", "1023.1.0", "1023.2.0", "1024", "2000.1.17"]) {
+  for (const unallocated of ["1023", "1023.0", "1023.1", "1023.1.0", "1023.2", "1023.2.0", "1023.3.0", "1024", "2000.1.17"]) {
     assert.throws(
       () => readMacOSReleaseBuildConfiguration({
         USAGE_MONITOR_BUNDLE_VERSION: unallocated,
       }, INTERNAL_DOGFOOD_RELEASE_CHANNEL),
       { code: "MACOS_BUNDLE_VERSION_MISMATCH" },
-      "operator overrides cannot reuse RC2/RC3, alias the allocation, or consume stable/preview builds",
+      "operator overrides cannot reuse an earlier RC, alias the allocation, or consume stable/preview builds",
     );
   }
   assert.equal(
@@ -7883,7 +7923,7 @@ macOSArtifactTest("reproducible ad-hoc-signed app passes orderly and launcher-SI
     );
     assert.match(
       menuBarSmoke.stdout,
-      /^USAGE_MONITOR_MACOS_MENU_BAR_CONTRACT popover=true width=400 bars=7,30 pace=canonical-outlook native_actions=true states=live,starting,unavailable shortcuts=cmd-r,cmd-comma,cmd-q routing=left-popover,right-menu,control-menu dismissal=escape,transient,same-app,outside,deactivation weekly_position=factual-menu-only pace_outlook=collecting,under,on,over,critical,fail-closed history=authoritative,coverage-named,fail-closed pricing=complete,partial,unavailable model=dst,overlap,future,per-lane reset_credits=absent analysis_title=live-fallback history_retention=refresh,failure,source-reset$/mu,
+      /^USAGE_MONITOR_MACOS_MENU_BAR_CONTRACT popover=true width=400 bars=7,30 pace=canonical-outlook native_actions=true states=live,starting,unavailable shortcuts=cmd-r,cmd-comma,cmd-q routing=left-popover,right-menu,control-menu dismissal=escape,transient,same-app,outside,deactivation weekly_position=factual-menu-only pace_outlook=collecting,under,on,over,critical,fail-closed history=authoritative,coverage-named,fail-closed pricing=complete,partial,unavailable model=dst,overlap,future,per-lane reset_credits=absent analysis_title=live-fallback history_retention=refresh,failure,source-reset overflow=screen-capped,vertical-only,top-reset,poll-preserved$/mu,
     );
     const analysisProgressSmoke = spawnSync(
       join(outputA, "Contents", "MacOS", "TiboTattle"),


### PR DESCRIPTION
## Summary

- cap the native menu-bar popover to the clicked screen and make the full two-limit view vertically scrollable
- preserve scroll position during polling, reopen at the top, and keep the footer reachable without horizontal scrolling
- allocate internal dogfood build 1023.3 while reserving stable build 1024
- make the Worker telemetry replay integration test derive its day from the fixture clock
- regenerate the protected dual-runtime R7 receipts for the current 359-file workload-source closure and update release boundaries

## Validation

- exact root suite: 3465 tests, 3444 passed, 21 declared platform skips, 0 failed
- Worker gate: 179 operational tests and 524 functional tests passed; production and safe-unprovisioned staging dry bundles passed
- UI and local-companion owning gates passed; local companion 295/295
- macOS source lane: 78 passed, 3 intended artifact exclusions
- macOS smoke lane: 1/1
- macOS artifact lane: 81/81 app and migration tests plus 8/8 updater tests
- aggregate macOS product gate: 89/89
- preflight, architecture, release-documentation, installed Codex contract, and retained R7 receipt verification passed
- independent final patch audit found no blocker

## Explicit open boundaries

- R7 remains release_open; its freshness applies only to the declared 359-file workload closure. Native UI and build allocation use separate macOS and artifact gates.
- The PR 94 fixed-real-corpus comparison failed closed before producing a receipt, and both supported resource benchmarks stopped incomplete. This is an internal test candidate, not empirically signed off or stable-ready.
- No Worker deployment, migrations 0042-0044, telemetry v1.1 activation, hosted pairing test, public updater publication, stable tag, GitHub Release, website, or Homebrew change is included.
- Signed and notarized RC5 artifact generation, state-preserving RC4 replacement, and installed native verification remain post-merge protected gates.
