### PR TITLE
Complete cold accounting refreshes for 0.1.17 RC6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -281,11 +281,14 @@ published-release claim.
 - Gives Preview its own app, bundle, semantic-open, local-state, Keychain,
   preferences, and Sparkle-feed identities, preventing preview installation or
   updates from replacing stable state.
-- Records builds 1023, 1023.1, and 1023.2 as earlier 0.1.17 internal dogfoods,
-  allocates build 1023.3 to the integrated RC5 candidate, and retains build 1024
-  for stable. Signed tooling requires a clean checkout with exactly one matching
-  annotated channel tag at `HEAD` before it can proceed. RC4 at build 1023.2 is
-  installed evidence for its frozen source, not proof that RC5 or stable exists.
+- Records builds 1023, 1023.1, 1023.2, and 1023.3 as earlier 0.1.17 internal
+  dogfoods, allocates build 1023.4 to RC6, and retains build 1024 for stable.
+  Signed tooling requires a clean checkout with exactly one matching annotated
+  channel tag at `HEAD` before it can proceed. RC5 build 1023.3 is signed,
+  notarized, and installed evidence for its frozen source, but physical testing
+  found that its ordinary five-minute refresh deadline stopped a legitimate
+  full accounting-cache rebuild. RC6 still requires exact-source gates,
+  protected R7 regeneration, signing, installation, and physical verification.
 - Establishes scoped, machine-checked repository guidance for coding agents and
   the root layout they may extend
   ([PR #77](https://github.com/adamallcock/tibotattle/pull/77)).

--- a/apps/local/README.md
+++ b/apps/local/README.md
@@ -152,11 +152,18 @@ seven-day index and deeper replay-safe accounting complete. The refresh status
 exposes `quickResultAt` and the `quick_result` phase. Internal
 `bounded_pause` results continue automatically under the same user action, with
 a fixed ceiling of exactly two automatic continuations after the initial pass.
-Each accepted pass receives a six-minute browser polling window around the
-server's five-minute pass ceiling, so one click has a finite roughly 18-minute
-UI budget. If more work remains, the dashboard says **Deep analysis paused
-after two bounded continuations**, retains the headline and verified state, and
-offers an explicit later resume; it is not presented as a crash.
+Ordinary cache-hit work retains the server's five-minute pass ceiling. A fresh
+index, or the exact point at which the companion has authoritatively selected a
+full accounting-cache rebuild, can instead use a four-hour total cold-work
+ceiling measured from that refresh's start. Each accepted pass receives a
+241-minute browser polling window so progress and **Cancel** remain attached to
+either server bound; the browser window does not extend the companion deadline.
+The fixed maximum remains two automatic continuations after the initial pass,
+so the absolute UI attachment bound is three 241-minute windows even though
+ordinary passes normally settle within five minutes. If more work remains, the
+dashboard says **Deep analysis paused after two bounded continuations**, retains
+the headline and verified state, and offers an explicit later resume; it is not
+presented as a crash.
 
 A user can cancel through the same-origin loopback API at any time. Cancellation
 preserves the last verified dashboard, safe quick result, and durable

--- a/apps/macos/README.md
+++ b/apps/macos/README.md
@@ -422,10 +422,10 @@ a claim that Sparkle has updated the preview client.
 `CFBundleShortVersionString` remains the user-facing package version. The
 Sparkle ordering key, `CFBundleVersion`, is explicitly allocated for signed
 builds that retain the stable bundle identifier. The 0.1.17 internal-dogfood
-build is `1023.3`; the 0.1.17 stable final remains `1024`. This final integrated
-candidate orders strictly after startup-recovery RC4 `1023.2`, migration RC3
-`1023.1`, retained RC2 `1023`, and earlier shared-identity dogfood `1022`, while
-stable orders after the dogfood candidate.
+RC6 build is `1023.4`; the 0.1.17 stable final remains `1024`. This corrected
+candidate orders strictly after installed RC5 `1023.3`, startup-recovery RC4
+`1023.2`, migration RC3 `1023.1`, retained RC2 `1023`, and earlier
+shared-identity dogfood `1022`, while stable orders after the dogfood candidate.
 A future signed version/channel must add a reviewed
 monotonic allocation before release tooling will run.
 
@@ -523,7 +523,7 @@ For a later stable release, use `--previous-stable-manifest` in place of
 the release command refuses to guess which continuity policy applies.
 `USAGE_MONITOR_BUNDLE_VERSION` is optional as an operator assertion only; when
 present it must exactly equal the checked-in allocation for the selected
-signed release version and channel (`1023.3` for 0.1.17 internal dogfood,
+signed release version and channel (`1023.4` for 0.1.17 internal dogfood,
 `1024` for 0.1.17 stable).
 
 `config/deployment-endpoints.js` is the reviewed source for the public origin

--- a/apps/macos/Sources/MenuBarStatus.swift
+++ b/apps/macos/Sources/MenuBarStatus.swift
@@ -289,7 +289,7 @@ enum LocalAnalysisTerminalOutcome: String, Equatable {
     /// `nil` preserves the current policy before any pass has completed.
     /// Only a clean success re-enables automatic stale-evidence refresh. A
     /// degraded, cancelled, or failed cold build must wait for an explicit
-    /// retry instead of restarting for up to two hours on every idle poll.
+    /// retry instead of restarting for up to four hours on every idle poll.
     var automaticRefreshSuppressed: Bool? {
         switch self {
         case .idle:

--- a/apps/macos/UsageMonitorApp.swift
+++ b/apps/macos/UsageMonitorApp.swift
@@ -4515,9 +4515,10 @@ private final class AppDelegate: NSObject, NSApplicationDelegate,
     /// Opaque companion token for the particular refresh this surface started
     /// or joined. It is never persisted or exposed in UI/notification text.
     private var nativeRefreshID: String?
-    // A missing unified index receives the companion's bounded four-hour cold
-    // rebuild window. Keep native progress attached through that same window
-    // plus one minute for cooperative worker shutdown and the terminal read;
+    // A fresh unified index or an authoritatively selected full accounting
+    // rebuild receives the companion's bounded four-hour cold-work window.
+    // Keep native progress attached through that same window plus one minute
+    // for cooperative worker shutdown and the terminal read;
     // the former 120 polls stopped after about 90 seconds and could label a
     // still-running first build as finished.
     private static let nativeRefreshPollIntervalMilliseconds = 750

--- a/apps/web/public/lib.js
+++ b/apps/web/public/lib.js
@@ -311,11 +311,12 @@ export function contributionBatchAdmission({
   });
 }
 
-// A fresh native index has a two-hour server-side cold-build bound. Keep the
-// browser attached for that bound plus one minute so progress and Cancel stay
-// usable; this does not extend the companion's own deadline, and ordinary
-// existing-index refreshes still settle at their five-minute server bound.
-export const LOCAL_REFRESH_POLLING_WINDOW_MS = 121 * 60 * 1_000;
+// A fresh index or an authoritatively selected full accounting rebuild has a
+// four-hour server-side cold-work bound. Keep the browser attached for that
+// bound plus one minute so progress and Cancel stay usable; this does not
+// extend the companion's own deadline, and ordinary cache-hit refreshes still
+// settle at their five-minute server bound.
+export const LOCAL_REFRESH_POLLING_WINDOW_MS = 241 * 60 * 1_000;
 
 export function createRefreshPollingBudget({
   now = () => Date.now(),

--- a/apps/web/test/lib.test.mjs
+++ b/apps/web/test/lib.test.mjs
@@ -1054,7 +1054,7 @@ test("refresh polling budget gives each accepted continuation a fresh window", (
 
 test("default local analysis permits only two bounded continuations", () => {
   const budget = createRefreshPollingBudget();
-  assert.equal(LOCAL_REFRESH_POLLING_WINDOW_MS, 121 * 60 * 1_000);
+  assert.equal(LOCAL_REFRESH_POLLING_WINDOW_MS, 241 * 60 * 1_000);
   assert.equal(budget.canContinue(), true);
   assert.equal(budget.noteContinuation(), true);
   assert.equal(budget.noteContinuation(), true);

--- a/docs/current-status.md
+++ b/docs/current-status.md
@@ -113,21 +113,26 @@ The complete qualification matrix and rules for changing these claims are in
 
 - The checked-out source contains unreleased changes after `v0.1.16`; the
   [changelog](../CHANGELOG.md) records them without claiming they shipped.
-- The installed RC4 proves only frozen source `735a59ce`, build `1023.2`. It
-  excludes PR #94. The integrated RC5 allocation is `1023.3`, but no signed,
-  notarized, or installed RC5 artifact is established by this snapshot.
-- The current RC5 R7 workload-source closure has fresh protected dual-runtime
+- Integrated RC5 source `ff506dc3`, build `1023.3`, was signed, notarized and
+  installed on 2026-08-31. Its state-preserving replacement and first launch
+  passed, but its real full-accounting refresh did not: a healthy v0.14 rebuild
+  was terminated by the ordinary five-minute deadline. RC5 is therefore not
+  the dogfood handoff. Corrective RC6 is allocated monotonic build `1023.4` and
+  still needs frozen-source, R7, signed-artifact, replacement and physical
+  refresh evidence.
+- The RC5 R7 workload-source closure has protected dual-runtime
   receipts for 359 files / workload SHA-256
   `4c3058b3453bda2696e946952d18e81310f26eb0187074d410c730e44162f1d6`.
-  Both decisions remain honestly `release_open`; a later workload change would
-  make these receipts historical again. Native UI and build-allocation files are
-  outside that R7 closure and require their separate macOS source, smoke,
+  Both decisions remain honestly `release_open`. RC6 changes workload-owned
+  refresh/accounting source, so those receipts are now historical for RC5 and
+  must be regenerated after the corrective source is frozen. Native UI and
+  build-allocation files remain subject to their separate macOS source, smoke,
   signed-artifact, and installed-artifact gates.
 - The public service and release feed are remote state. Their health and
   availability can change after this snapshot.
 - Public health is not proof that every admin, identity, contribution, deletion,
   or updater path works end to end.
-- Before RC5 dogfood sign-off or 0.1.17 stable qualification, PR #94 still needs
+- Before RC6 dogfood sign-off or 0.1.17 stable qualification, PR #94 still needs
   the fixed real-corpus before/after coverage, diagnostic-distribution, and
   resource review. Current APIs cannot emit the complete named fit-rejection
   reconciliation, so that gate remains open rather than inferred green. The
@@ -139,7 +144,7 @@ The complete qualification matrix and rules for changing these claims are in
   the strict pre-PR scan reported `codex_rollout_content_invalid`. The supported
   resource benchmark independently stopped at `benchmark_cold_rebuild_incomplete`
   on both exact PR #94 revisions. No empirical comparison receipt was produced,
-  no source was excluded, and this remains an open RC5/stable gate.
+  no source was excluded, and this remains an open RC6/stable gate.
 
 ## How to refresh this page
 

--- a/docs/decisions/2026-08-27-local-state-schema-and-release-channel-isolation.md
+++ b/docs/decisions/2026-08-27-local-state-schema-and-release-channel-isolation.md
@@ -147,6 +147,15 @@ startup-recovery RC4 used `1023.2`. The integrated RC5 allocation is now
 production bundle identity and therefore must be monotonic. RC4 evidence applies
 only to its frozen source and is not inherited by RC5 or stable.
 
+#### Allocation amendment, 2026-08-31 (RC6)
+
+RC5 build `1023.3` was subsequently signed, notarized, installed, and then
+failed its real full-accounting refresh gate because the ordinary five-minute
+deadline terminated a healthy v0.14 cache rebuild. The corrected RC6 dogfood is
+allocated `1023.4`, strictly after installed RC5 and before reserved stable
+`1024`. RC5 artifact evidence remains evidence for RC5 only; it cannot qualify
+RC6 or stable.
+
 The separately identified Preview app uses the deterministic migration epoch
 `(2000 + major).minor.patch`, so preview package `0.1.17` maps to
 `2000.1.17`. That keeps local preview builds deterministic and valid within

--- a/docs/decisions/2026-08-31-silent-keychain-migration.md
+++ b/docs/decisions/2026-08-31-silent-keychain-migration.md
@@ -292,3 +292,11 @@ qualified. The prompt-avoidance contract is unchanged: automatic Keychain reads
 remain bounded to three non-interactive attempts, and only the explained,
 deliberate Settings recovery action may request approval. An unexpected prompt
 in an automatic flow remains release-blocking.
+
+### RC6 allocation follow-up
+
+RC5 build `1023.3` was later signed, notarized and installed without an observed
+automatic Keychain prompt, but failed the separate real accounting-refresh
+gate. Corrective RC6 is build `1023.4`; the prompt-avoidance contract and its
+release-blocking treatment are unchanged and must be reverified on that exact
+installed artifact.

--- a/docs/plans/2026-08-30-native-dogfood-integration.md
+++ b/docs/plans/2026-08-30-native-dogfood-integration.md
@@ -243,7 +243,11 @@ and physical native checks remain. Public release/updater publication is not
 part of this internal dogfood. Private state records, comparisons, UI captures
 and release inputs remain local and outside tracked docs.
 
-## RC4 handoff and integrated RC5 boundary
+## RC4 handoff and integrated RC5 boundary (pre-RC5 snapshot)
+
+This section records the gate state before RC5 was frozen and built. The later
+RC5 installed-refresh finding and RC6 amendment below supersede its present-tense
+candidate status; the open PR #94 empirical boundary remains unchanged.
 
 Frozen RC4 source `735a59ce2ec01df0e381fb1aa878c5c7a39edcd8`, build
 `1023.2`, was subsequently signed, notarized, and installed. That artifact is
@@ -278,3 +282,34 @@ The current source repair requires both the newer desktop path and compatible
 hosted Worker behavior. Worker migrations/deployment, telemetry v1.1 activation,
 and new consent are protected operations outside this internal artifact build;
 desktop installation alone cannot establish end-to-end pairing repair.
+
+## RC5 installed-refresh finding and RC6 correction
+
+RC5 source `ff506dc3`, tagged for internal dogfood and allocated build `1023.3`,
+subsequently passed source, protected R7, Developer ID, notarization, stapling,
+Gatekeeper, state-preserving replacement and first-launch checks. The exact
+installed artifact then failed the required real refresh check. Its current
+schema-11 index was reusable, but the v0.14 accounting semantics required a
+full cache rebuild. That rebuild remained active below the fixed memory ceiling
+until the ordinary five-minute controller deadline aborted it; the previous
+cache remained intact and no partial result was published. Repeating RC5 would
+restart the same uncheckpointed work and is not an acceptable handoff.
+
+Corrective RC6 uses monotonic build `1023.4`. The runner now emits its fixed,
+count-free accounting marker only after the authoritative cache reuse check has
+failed and immediately before a real full rebuild. The controller accepts that
+exact marker once and extends the run to the existing four-hour total cold-work
+ceiling. Cache hits, malformed progress and repeated markers retain the normal
+five-minute deadline. Browser and native polling remain attached through the
+server ceiling plus one minute, and cancellation is rechecked immediately before
+atomic cache publication. Existing resource, generation, size, privacy and
+killable-child guards are unchanged.
+
+RC6 must rerun the exact source gates and protected R7 after source freeze, then
+repeat signing, notarization, replacement validation, state-preserving install
+and physical checks. The real full-accounting refresh must reach terminal
+success and publish current generation-matched v0.14 figures; the two-limit
+popover must also pass its installed interaction check. PR #94's purpose-built
+fixed-corpus comparator remains an open internal-dogfood/stable gate, and no
+hosted Worker deployment, migration, stable tag, appcast or public artifact is
+authorized by this correction.

--- a/docs/plans/2026-08-31-native-startup-recovery.md
+++ b/docs/plans/2026-08-31-native-startup-recovery.md
@@ -132,3 +132,8 @@ Installed RC4 source `735a59ce2ec01df0e381fb1aa878c5c7a39edcd8`, build
 `1023.2`, is signed and notarized but excludes PR #94. The next integrated
 dogfood therefore uses monotonic RC5 build `1023.3`; it has not yet been built,
 signed, notarized, or installed. Stable build `1024` remains separately reserved.
+
+RC5 was subsequently built, signed, notarized and installed, then failed its
+separate real full-accounting refresh gate at the ordinary five-minute timeout.
+The corrective RC6 allocation is `1023.4`; none of RC5's artifact or startup
+evidence qualifies that later source.

--- a/docs/reference/unified-index-schema.md
+++ b/docs/reference/unified-index-schema.md
@@ -81,6 +81,14 @@ for rotated sources do not keep extending ordinary refreshes. This metadata-only
 decision does not replace the worker's full compatibility, integrity, or
 publication checks.
 
+Index and accounting validity are separate. After indexing, the authoritative
+accounting cache reader may determine that no current generation-bound cache is
+reusable (for example after a reviewed accounting-semantics version change).
+Only when the runner actually enters that full rebuild does its exact,
+count-free accounting marker extend the same run to the four-hour total bound.
+A cache hit, malformed progress, or repeated marker cannot extend the ordinary
+deadline or re-arm it indefinitely.
+
 ## Current table groups
 
 | Group | Tables | Purpose |

--- a/docs/runbooks/macos-stable-release-runbook.md
+++ b/docs/runbooks/macos-stable-release-runbook.md
@@ -241,9 +241,9 @@ node scripts/release-macos-app.js \
 
 For the 0.1.17 stable release, `CFBundleShortVersionString` remains `0.1.17`
 and the owner-reviewed signed `CFBundleVersion` is exactly `1024`. It follows
-the final integrated internal-dogfood 0.1.17 allocation `1023.3`,
-startup-recovery RC4 `1023.2`, migration RC3 `1023.1`, retained RC2 `1023`,
-and earlier shared-identity dogfood `1022`. The
+the accounting-deadline RC6 internal-dogfood allocation `1023.4`, integrated
+RC5 `1023.3`, startup-recovery RC4 `1023.2`, migration RC3 `1023.1`, retained
+RC2 `1023`, and earlier shared-identity dogfood `1022`. The
 checked-in allocation is authoritative; the
 `USAGE_MONITOR_BUNDLE_VERSION` value above is only an exact assertion and
 cannot select or override a different build. A future stable version must add

--- a/docs/runbooks/unified-index-recovery.md
+++ b/docs/runbooks/unified-index-recovery.md
@@ -89,6 +89,14 @@ four-hour cold-refresh deadline; ordinary current-parser refreshes keep five
 minutes. Missing, unknown, or inconsistent provenance must not be relabelled to
 obtain that budget.
 
+A current-parser index can also require a full accounting rebuild after the
+current cache fails its authoritative schema, generation, context, or reuse
+check. The runner emits the fixed accounting-work marker only immediately before
+that rebuild; the controller then applies the same four-hour total deadline.
+Do not infer this state from displayed retained figures, edit cache metadata, or
+retry a five-minute failure in a loop: accounting has no durable mid-build
+checkpoint, so an interrupted rebuild restarts from its retained source state.
+
 Index publication and accounting completion are separate stages. If a refresh
 times out after publishing, inspect its published generation and accounting
 receipt separately: valid indexed tokens do not establish that the new

--- a/generated/r7-release-decision-node24.14.0-v0.1.json
+++ b/generated/r7-release-decision-node24.14.0-v0.1.json
@@ -482,7 +482,7 @@
     "resourcePolicyValuesSha256": "3cbe7853c8f75e96912885f64ba4ad1aeb13aff8a22e4ffbd51806b27c73b418",
     "schemaModuleSha256": "594d035e641e87b29db4027dca35157f8225fd5621816d67d5d9f25825468bbf",
     "workloadCodeFileCount": 359,
-    "workloadCodeSha256": "4c3058b3453bda2696e946952d18e81310f26eb0187074d410c730e44162f1d6"
+    "workloadCodeSha256": "fcb55e0cb729b56249e2c6f4d8fa4a08bc4b4c8fe99a506ce10cfe1068ed48d5"
   },
   "determinism": {
     "comparisons": {
@@ -939,7 +939,7 @@
         "decision": "unresolved",
         "dimension": "export_set_encoded_bytes",
         "exactBoundaryValue": "not_identified",
-        "realHistoryValue": 29090523,
+        "realHistoryValue": 29091579,
         "selectionBasis": "not_identified",
         "unit": "bytes"
       },
@@ -989,7 +989,7 @@
         "decision": "unresolved",
         "dimension": "elapsed_time",
         "exactBoundaryValue": "not_identified",
-        "realHistoryValue": 382845,
+        "realHistoryValue": 338893,
         "selectionBasis": "not_identified",
         "unit": "milliseconds"
       },
@@ -999,7 +999,7 @@
         "decision": "unresolved",
         "dimension": "rss",
         "exactBoundaryValue": "not_identified",
-        "realHistoryValue": 1489780736,
+        "realHistoryValue": 1265811456,
         "selectionBasis": "not_identified",
         "unit": "bytes"
       }
@@ -1007,20 +1007,20 @@
     "headroomBasisPoints": 2000,
     "inputReceipts": {
       "materializedBoundaries": {
-        "node24Sha256": "bff844d9d4d4d1699e975416c914cfecc31c34dfb626ba106882f7de1659c5ed",
-        "node26Sha256": "7bda1b915961762c8e961fd60b6fffc2eead86bfadd356b659b8c71f4bd12818"
+        "node24Sha256": "b16163d2635449b27b5dce0505a742a5dfc93b204f7063ef031282ee090c5591",
+        "node26Sha256": "4bbdc0738fb9b0d82124c02c954e61b98ac8c0770ef31d57d7b221f81f855b94"
       },
       "realLocalHistory": {
-        "node24Sha256": "4582408f1f578e1e23b705b9a44464cb989831c6528ece05415e268043336968",
-        "node26Sha256": "d2a7d60d12aedbb65811d4096ef5e3c04f13bd8855ae66897f4f994c138974c4"
+        "node24Sha256": "92ca409fa09c2d7b08b2f1a3164cd0fa022404ed567ab52989e99243263d9387",
+        "node26Sha256": "102992b206e95e4c6808c9373745dbbf0c6cd7679f21c3ffaa93409f395da7c4"
       },
       "syntheticPressure": {
-        "node24Sha256": "03341e66a24566b1f876bf0cec71b49fa530d273401a614584aac20954041a70",
-        "node26Sha256": "a10d939d59620e56b64c54a51371da30cdce7adaa5ab0832888825ee88c95c51"
+        "node24Sha256": "c694fabf1a0b802185d7ab0aa2dfbcce1996110acb454701e3c61b51afc0d0c7",
+        "node26Sha256": "1f23ce061f6f875b9157a7a4526bc3d7be6bc317bb1244f3a29a963a4e208096"
       },
       "syntheticSemantics": {
-        "node24Sha256": "4ddfe56b735cf44241ef3cd5119cdccb3490d17bc13e6ba44d1668c859b694a4",
-        "node26Sha256": "4e90b8b3bdd596f5eb5694c33f534417ce64dbca642013b7d14b4a644cbc75cc"
+        "node24Sha256": "7199e88864ad71aa06fd5b5ae70ef51dab25dafef482688da4d5851d33ec6dc3",
+        "node26Sha256": "4cfed5bf54a8a7bef98fdba3815c4d693e3b7a78fa6afdc2011df95f8861b624"
       }
     },
     "kind": "release_decision",
@@ -1039,7 +1039,7 @@
     "singleMachineLimitation": true
   },
   "protocolVersion": "g1-r7-release-evidence-v0.1",
-  "receiptSha256": "1b890470afb709cd3455a59306bd37cb95091a132e066382d73b7934271243da",
+  "receiptSha256": "3ac5552829303e48276489a4dcbb7f7b40406a8e5966a779f03f621b19d497bf",
   "runtimeProvenance": {
     "architecture": "arm64",
     "elapsedClock": "parent_monotonic",

--- a/generated/r7-release-decision-node26.2.0-v0.1.json
+++ b/generated/r7-release-decision-node26.2.0-v0.1.json
@@ -482,7 +482,7 @@
     "resourcePolicyValuesSha256": "3cbe7853c8f75e96912885f64ba4ad1aeb13aff8a22e4ffbd51806b27c73b418",
     "schemaModuleSha256": "594d035e641e87b29db4027dca35157f8225fd5621816d67d5d9f25825468bbf",
     "workloadCodeFileCount": 359,
-    "workloadCodeSha256": "4c3058b3453bda2696e946952d18e81310f26eb0187074d410c730e44162f1d6"
+    "workloadCodeSha256": "fcb55e0cb729b56249e2c6f4d8fa4a08bc4b4c8fe99a506ce10cfe1068ed48d5"
   },
   "determinism": {
     "comparisons": {
@@ -939,7 +939,7 @@
         "decision": "unresolved",
         "dimension": "export_set_encoded_bytes",
         "exactBoundaryValue": "not_identified",
-        "realHistoryValue": 29090523,
+        "realHistoryValue": 29091579,
         "selectionBasis": "not_identified",
         "unit": "bytes"
       },
@@ -989,7 +989,7 @@
         "decision": "unresolved",
         "dimension": "elapsed_time",
         "exactBoundaryValue": "not_identified",
-        "realHistoryValue": 382845,
+        "realHistoryValue": 338893,
         "selectionBasis": "not_identified",
         "unit": "milliseconds"
       },
@@ -999,7 +999,7 @@
         "decision": "unresolved",
         "dimension": "rss",
         "exactBoundaryValue": "not_identified",
-        "realHistoryValue": 1489780736,
+        "realHistoryValue": 1265811456,
         "selectionBasis": "not_identified",
         "unit": "bytes"
       }
@@ -1007,20 +1007,20 @@
     "headroomBasisPoints": 2000,
     "inputReceipts": {
       "materializedBoundaries": {
-        "node24Sha256": "bff844d9d4d4d1699e975416c914cfecc31c34dfb626ba106882f7de1659c5ed",
-        "node26Sha256": "7bda1b915961762c8e961fd60b6fffc2eead86bfadd356b659b8c71f4bd12818"
+        "node24Sha256": "b16163d2635449b27b5dce0505a742a5dfc93b204f7063ef031282ee090c5591",
+        "node26Sha256": "4bbdc0738fb9b0d82124c02c954e61b98ac8c0770ef31d57d7b221f81f855b94"
       },
       "realLocalHistory": {
-        "node24Sha256": "4582408f1f578e1e23b705b9a44464cb989831c6528ece05415e268043336968",
-        "node26Sha256": "d2a7d60d12aedbb65811d4096ef5e3c04f13bd8855ae66897f4f994c138974c4"
+        "node24Sha256": "92ca409fa09c2d7b08b2f1a3164cd0fa022404ed567ab52989e99243263d9387",
+        "node26Sha256": "102992b206e95e4c6808c9373745dbbf0c6cd7679f21c3ffaa93409f395da7c4"
       },
       "syntheticPressure": {
-        "node24Sha256": "03341e66a24566b1f876bf0cec71b49fa530d273401a614584aac20954041a70",
-        "node26Sha256": "a10d939d59620e56b64c54a51371da30cdce7adaa5ab0832888825ee88c95c51"
+        "node24Sha256": "c694fabf1a0b802185d7ab0aa2dfbcce1996110acb454701e3c61b51afc0d0c7",
+        "node26Sha256": "1f23ce061f6f875b9157a7a4526bc3d7be6bc317bb1244f3a29a963a4e208096"
       },
       "syntheticSemantics": {
-        "node24Sha256": "4ddfe56b735cf44241ef3cd5119cdccb3490d17bc13e6ba44d1668c859b694a4",
-        "node26Sha256": "4e90b8b3bdd596f5eb5694c33f534417ce64dbca642013b7d14b4a644cbc75cc"
+        "node24Sha256": "7199e88864ad71aa06fd5b5ae70ef51dab25dafef482688da4d5851d33ec6dc3",
+        "node26Sha256": "4cfed5bf54a8a7bef98fdba3815c4d693e3b7a78fa6afdc2011df95f8861b624"
       }
     },
     "kind": "release_decision",
@@ -1039,7 +1039,7 @@
     "singleMachineLimitation": true
   },
   "protocolVersion": "g1-r7-release-evidence-v0.1",
-  "receiptSha256": "33ebe20838a63301eaf50b892ea31bce4f31af0c50d11f23d7753fef01138a9b",
+  "receiptSha256": "5f5a5d252cdf555fadff9555f3029641427c4551131414a50d5c64f31c0ebfbe",
   "runtimeProvenance": {
     "architecture": "arm64",
     "elapsedClock": "parent_monotonic",

--- a/generated/r7-release-materialized-boundaries-node24.14.0-v0.1.json
+++ b/generated/r7-release-materialized-boundaries-node24.14.0-v0.1.json
@@ -482,7 +482,7 @@
     "resourcePolicyValuesSha256": "3cbe7853c8f75e96912885f64ba4ad1aeb13aff8a22e4ffbd51806b27c73b418",
     "schemaModuleSha256": "594d035e641e87b29db4027dca35157f8225fd5621816d67d5d9f25825468bbf",
     "workloadCodeFileCount": 359,
-    "workloadCodeSha256": "4c3058b3453bda2696e946952d18e81310f26eb0187074d410c730e44162f1d6"
+    "workloadCodeSha256": "fcb55e0cb729b56249e2c6f4d8fa4a08bc4b4c8fe99a506ce10cfe1068ed48d5"
   },
   "determinism": {
     "comparisons": {
@@ -500,8 +500,8 @@
     "projectionVersion": "g1-r7-release-deterministic-projection-v0.1",
     "runCount": 2,
     "runProjectionSha256es": [
-      "34780cd156643c6c62a33e7ce2dffb5c4b1fb66ae4eea4d4b5b0a6186c58c6c5",
-      "34780cd156643c6c62a33e7ce2dffb5c4b1fb66ae4eea4d4b5b0a6186c58c6c5"
+      "0e2cc55714270be78eabaf7819e54eba835e1b95e8009f5cdbc70ecdfe1175f9",
+      "0e2cc55714270be78eabaf7819e54eba835e1b95e8009f5cdbc70ecdfe1175f9"
     ],
     "status": "partial"
   },
@@ -822,16 +822,16 @@
       "decodedBytes": 0,
       "durablePeakRssBytes": 0,
       "encodedBytes": 0,
-      "externalPeakRssBytes": 324698112,
-      "externalRssSampleCount": 64,
-      "externalRssSampleFailureCount": 1,
+      "externalPeakRssBytes": 326156288,
+      "externalRssSampleCount": 62,
+      "externalRssSampleFailureCount": 0,
       "filesystem": {
         "afterBytes": 0,
         "beforeBytes": 0,
-        "sampledHighWaterBytes": 30807688
+        "sampledHighWaterBytes": 30816124
       },
       "outputRecords": 0,
-      "parentElapsedMs": 3365,
+      "parentElapsedMs": 3131,
       "runCount": 2,
       "sourceBytes": 0,
       "sourceFiles": 0,
@@ -894,7 +894,7 @@
     }
   },
   "protocolVersion": "g1-r7-release-evidence-v0.1",
-  "receiptSha256": "bff844d9d4d4d1699e975416c914cfecc31c34dfb626ba106882f7de1659c5ed",
+  "receiptSha256": "b16163d2635449b27b5dce0505a742a5dfc93b204f7063ef031282ee090c5591",
   "runtimeProvenance": {
     "architecture": "arm64",
     "elapsedClock": "parent_monotonic",

--- a/generated/r7-release-materialized-boundaries-node26.2.0-v0.1.json
+++ b/generated/r7-release-materialized-boundaries-node26.2.0-v0.1.json
@@ -482,7 +482,7 @@
     "resourcePolicyValuesSha256": "3cbe7853c8f75e96912885f64ba4ad1aeb13aff8a22e4ffbd51806b27c73b418",
     "schemaModuleSha256": "594d035e641e87b29db4027dca35157f8225fd5621816d67d5d9f25825468bbf",
     "workloadCodeFileCount": 359,
-    "workloadCodeSha256": "4c3058b3453bda2696e946952d18e81310f26eb0187074d410c730e44162f1d6"
+    "workloadCodeSha256": "fcb55e0cb729b56249e2c6f4d8fa4a08bc4b4c8fe99a506ce10cfe1068ed48d5"
   },
   "determinism": {
     "comparisons": {
@@ -500,8 +500,8 @@
     "projectionVersion": "g1-r7-release-deterministic-projection-v0.1",
     "runCount": 2,
     "runProjectionSha256es": [
-      "3786d4747f7bc24e4ebb58388f8a8b33c8dc721b47975e3e517ee484f8acaed8",
-      "3786d4747f7bc24e4ebb58388f8a8b33c8dc721b47975e3e517ee484f8acaed8"
+      "c422a5d43962f8a70ebbc7deff2b73c930bfae087a0541f3856d4c7d1200ec71",
+      "c422a5d43962f8a70ebbc7deff2b73c930bfae087a0541f3856d4c7d1200ec71"
     ],
     "status": "partial"
   },
@@ -822,16 +822,16 @@
       "decodedBytes": 0,
       "durablePeakRssBytes": 0,
       "encodedBytes": 0,
-      "externalPeakRssBytes": 345669632,
-      "externalRssSampleCount": 154,
+      "externalPeakRssBytes": 339902464,
+      "externalRssSampleCount": 143,
       "externalRssSampleFailureCount": 0,
       "filesystem": {
         "afterBytes": 0,
         "beforeBytes": 0,
-        "sampledHighWaterBytes": 30868184
+        "sampledHighWaterBytes": 30851373
       },
       "outputRecords": 0,
-      "parentElapsedMs": 8423,
+      "parentElapsedMs": 8163,
       "runCount": 2,
       "sourceBytes": 0,
       "sourceFiles": 0,
@@ -894,7 +894,7 @@
     }
   },
   "protocolVersion": "g1-r7-release-evidence-v0.1",
-  "receiptSha256": "7bda1b915961762c8e961fd60b6fffc2eead86bfadd356b659b8c71f4bd12818",
+  "receiptSha256": "4bbdc0738fb9b0d82124c02c954e61b98ac8c0770ef31d57d7b221f81f855b94",
   "runtimeProvenance": {
     "architecture": "arm64",
     "elapsedClock": "parent_monotonic",

--- a/generated/r7-release-real-local-history-node24.14.0-v0.1.json
+++ b/generated/r7-release-real-local-history-node24.14.0-v0.1.json
@@ -482,7 +482,7 @@
     "resourcePolicyValuesSha256": "3cbe7853c8f75e96912885f64ba4ad1aeb13aff8a22e4ffbd51806b27c73b418",
     "schemaModuleSha256": "594d035e641e87b29db4027dca35157f8225fd5621816d67d5d9f25825468bbf",
     "workloadCodeFileCount": 359,
-    "workloadCodeSha256": "4c3058b3453bda2696e946952d18e81310f26eb0187074d410c730e44162f1d6"
+    "workloadCodeSha256": "fcb55e0cb729b56249e2c6f4d8fa4a08bc4b4c8fe99a506ce10cfe1068ed48d5"
   },
   "determinism": {
     "comparisons": {
@@ -500,8 +500,8 @@
     "projectionVersion": "g1-r7-release-deterministic-projection-v0.1",
     "runCount": 2,
     "runProjectionSha256es": [
-      "4d202dd385b105ead21c63d82e1af1bbb3966432f4d7c471b37840481a15bbe6",
-      "4d202dd385b105ead21c63d82e1af1bbb3966432f4d7c471b37840481a15bbe6"
+      "36bd28400bf97279d210d913a0e049c79001ba53e1078c9d30708332dc79381b",
+      "36bd28400bf97279d210d913a0e049c79001ba53e1078c9d30708332dc79381b"
     ],
     "status": "passed"
   },
@@ -514,21 +514,21 @@
     {
       "failureCode": "none",
       "metrics": {
-        "childCpuMs": 326060,
-        "childMaxRssBytes": 1489780736,
+        "childCpuMs": 306476,
+        "childMaxRssBytes": 1116028928,
         "decodedBytes": 0,
-        "durablePeakRssBytes": 1489780736,
+        "durablePeakRssBytes": 1116028928,
         "encodedBytes": 0,
-        "externalPeakRssBytes": 1488781312,
-        "externalRssSampleCount": 6704,
-        "externalRssSampleFailureCount": 0,
+        "externalPeakRssBytes": 1113227264,
+        "externalRssSampleCount": 5795,
+        "externalRssSampleFailureCount": 1,
         "filesystem": {
-          "afterBytes": 1141571584,
+          "afterBytes": 1141407744,
           "beforeBytes": 0,
-          "sampledHighWaterBytes": 1141742203
+          "sampledHighWaterBytes": 1141407855
         },
         "outputRecords": 436557,
-        "parentElapsedMs": 382845,
+        "parentElapsedMs": 302942,
         "runCount": 2,
         "sourceBytes": 26380587616,
         "sourceFiles": 3123,
@@ -570,21 +570,21 @@
     {
       "failureCode": "none",
       "metrics": {
-        "childCpuMs": 32136,
-        "childMaxRssBytes": 836780032,
+        "childCpuMs": 31692,
+        "childMaxRssBytes": 831848448,
         "decodedBytes": 518442273,
-        "durablePeakRssBytes": 1489780736,
-        "encodedBytes": 29090523,
-        "externalPeakRssBytes": 821166080,
-        "externalRssSampleCount": 596,
-        "externalRssSampleFailureCount": 1,
+        "durablePeakRssBytes": 1116028928,
+        "encodedBytes": 29091579,
+        "externalPeakRssBytes": 830472192,
+        "externalRssSampleCount": 588,
+        "externalRssSampleFailureCount": 0,
         "filesystem": {
-          "afterBytes": 1170797163,
-          "beforeBytes": 1141571584,
-          "sampledHighWaterBytes": 1170797852
+          "afterBytes": 1170634379,
+          "beforeBytes": 1141407744,
+          "sampledHighWaterBytes": 1170634490
         },
         "outputRecords": 436557,
-        "parentElapsedMs": 30819,
+        "parentElapsedMs": 30034,
         "runCount": 2,
         "sourceBytes": 26380587616,
         "sourceFiles": 3123,
@@ -592,63 +592,63 @@
         "stdoutBytes": 1261
       },
       "name": "export_set_materialize",
-      "projectionSha256": "7bc786d8c45d113bdc32cb2d9d8a7ef8f7fbec6d156f39b3831040cff7f05c16",
+      "projectionSha256": "8d16b5ef527af88d5d8391f4a749a7678144b6a3ca0fa4920598c8f3e56b4d04",
       "status": "completed"
     },
     {
       "failureCode": "none",
       "metrics": {
-        "childCpuMs": 25319,
-        "childMaxRssBytes": 1063550976,
+        "childCpuMs": 27275,
+        "childMaxRssBytes": 888946688,
         "decodedBytes": 518442273,
         "durablePeakRssBytes": 0,
-        "encodedBytes": 29090523,
-        "externalPeakRssBytes": 1029996544,
-        "externalRssSampleCount": 509,
+        "encodedBytes": 29091579,
+        "externalPeakRssBytes": 854671360,
+        "externalRssSampleCount": 790,
         "externalRssSampleFailureCount": 0,
         "filesystem": {
-          "afterBytes": 1170797163,
-          "beforeBytes": 1170797163,
-          "sampledHighWaterBytes": 1268713427
+          "afterBytes": 1170634379,
+          "beforeBytes": 1170634379,
+          "sampledHighWaterBytes": 1268464411
         },
         "outputRecords": 436557,
-        "parentElapsedMs": 25897,
+        "parentElapsedMs": 54581,
         "runCount": 2,
         "sourceBytes": 0,
         "sourceFiles": 0,
         "stderrBytes": 169,
-        "stdoutBytes": 1017
+        "stdoutBytes": 1016
       },
       "name": "export_set_verify",
-      "projectionSha256": "c4e85ff4a4f70b1088aace276fbbd5d77c39158090a3c391ad55a7ac89d1353b",
+      "projectionSha256": "3d7c41b4520818b40140e8cdd4cdeb22b18148fb157319c4d43d0e62be95bbe6",
       "status": "completed"
     },
     {
       "failureCode": "none",
       "metrics": {
-        "childCpuMs": 89643,
-        "childMaxRssBytes": 1076101120,
+        "childCpuMs": 81164,
+        "childMaxRssBytes": 1178632192,
         "decodedBytes": 0,
         "durablePeakRssBytes": 0,
         "encodedBytes": 0,
-        "externalPeakRssBytes": 1076101120,
-        "externalRssSampleCount": 2085,
+        "externalPeakRssBytes": 1178632192,
+        "externalRssSampleCount": 1642,
         "externalRssSampleFailureCount": 0,
         "filesystem": {
           "afterBytes": 461,
-          "beforeBytes": 1170797163,
-          "sampledHighWaterBytes": 1170810501
+          "beforeBytes": 1170634379,
+          "sampledHighWaterBytes": 1170646535
         },
         "outputRecords": 0,
-        "parentElapsedMs": 126934,
+        "parentElapsedMs": 84893,
         "runCount": 2,
         "sourceBytes": 0,
         "sourceFiles": 0,
         "stderrBytes": 169,
-        "stdoutBytes": 1010
+        "stdoutBytes": 1009
       },
       "name": "complete_set_delete",
-      "projectionSha256": "de0fcb7d2693432989fecabedafdafd19823c669fa559f8dfd9b099b7a5f4b88",
+      "projectionSha256": "c560acc371efc44c5c1e67adff3e2214bd011d1e43e872ac4a9df3d84545b822",
       "status": "completed"
     },
     {
@@ -832,7 +832,7 @@
     "rawDurableCopyCreated": false
   },
   "protocolVersion": "g1-r7-release-evidence-v0.1",
-  "receiptSha256": "4582408f1f578e1e23b705b9a44464cb989831c6528ece05415e268043336968",
+  "receiptSha256": "92ca409fa09c2d7b08b2f1a3164cd0fa022404ed567ab52989e99243263d9387",
   "runtimeProvenance": {
     "architecture": "arm64",
     "elapsedClock": "parent_monotonic",

--- a/generated/r7-release-real-local-history-node26.2.0-v0.1.json
+++ b/generated/r7-release-real-local-history-node26.2.0-v0.1.json
@@ -482,7 +482,7 @@
     "resourcePolicyValuesSha256": "3cbe7853c8f75e96912885f64ba4ad1aeb13aff8a22e4ffbd51806b27c73b418",
     "schemaModuleSha256": "594d035e641e87b29db4027dca35157f8225fd5621816d67d5d9f25825468bbf",
     "workloadCodeFileCount": 359,
-    "workloadCodeSha256": "4c3058b3453bda2696e946952d18e81310f26eb0187074d410c730e44162f1d6"
+    "workloadCodeSha256": "fcb55e0cb729b56249e2c6f4d8fa4a08bc4b4c8fe99a506ce10cfe1068ed48d5"
   },
   "determinism": {
     "comparisons": {
@@ -500,8 +500,8 @@
     "projectionVersion": "g1-r7-release-deterministic-projection-v0.1",
     "runCount": 2,
     "runProjectionSha256es": [
-      "59ef4e3ca58306cbc02fb981dcfe3d0b859b3148da313f73a9f2636e719ab2aa",
-      "59ef4e3ca58306cbc02fb981dcfe3d0b859b3148da313f73a9f2636e719ab2aa"
+      "aff4aa2d19c29f929758f4bff0d0d8a65da63259b57ce5f6113ccafe234c951d",
+      "aff4aa2d19c29f929758f4bff0d0d8a65da63259b57ce5f6113ccafe234c951d"
     ],
     "status": "passed"
   },
@@ -514,21 +514,21 @@
     {
       "failureCode": "none",
       "metrics": {
-        "childCpuMs": 347543,
-        "childMaxRssBytes": 1325400064,
+        "childCpuMs": 336978,
+        "childMaxRssBytes": 1265811456,
         "decodedBytes": 0,
-        "durablePeakRssBytes": 1325400064,
+        "durablePeakRssBytes": 1265811456,
         "encodedBytes": 0,
-        "externalPeakRssBytes": 1322483712,
-        "externalRssSampleCount": 6762,
+        "externalPeakRssBytes": 1260470272,
+        "externalRssSampleCount": 6510,
         "externalRssSampleFailureCount": 0,
         "filesystem": {
-          "afterBytes": 1141571584,
+          "afterBytes": 1141407744,
           "beforeBytes": 0,
-          "sampledHighWaterBytes": 1143910791
+          "sampledHighWaterBytes": 1143546615
         },
         "outputRecords": 436557,
-        "parentElapsedMs": 348310,
+        "parentElapsedMs": 338893,
         "runCount": 2,
         "sourceBytes": 26380587616,
         "sourceFiles": 3123,
@@ -570,21 +570,21 @@
     {
       "failureCode": "none",
       "metrics": {
-        "childCpuMs": 29090,
-        "childMaxRssBytes": 921960448,
+        "childCpuMs": 28547,
+        "childMaxRssBytes": 919404544,
         "decodedBytes": 518442273,
-        "durablePeakRssBytes": 1325400064,
-        "encodedBytes": 29090523,
-        "externalPeakRssBytes": 921894912,
-        "externalRssSampleCount": 546,
+        "durablePeakRssBytes": 1265811456,
+        "encodedBytes": 29091579,
+        "externalPeakRssBytes": 919339008,
+        "externalRssSampleCount": 542,
         "externalRssSampleFailureCount": 0,
         "filesystem": {
-          "afterBytes": 1170797162,
-          "beforeBytes": 1141571584,
-          "sampledHighWaterBytes": 1170797162
+          "afterBytes": 1170634378,
+          "beforeBytes": 1141407744,
+          "sampledHighWaterBytes": 1170635266
         },
         "outputRecords": 436557,
-        "parentElapsedMs": 27797,
+        "parentElapsedMs": 27686,
         "runCount": 2,
         "sourceBytes": 26380587616,
         "sourceFiles": 3123,
@@ -592,27 +592,27 @@
         "stdoutBytes": 1261
       },
       "name": "export_set_materialize",
-      "projectionSha256": "7bc786d8c45d113bdc32cb2d9d8a7ef8f7fbec6d156f39b3831040cff7f05c16",
+      "projectionSha256": "8d16b5ef527af88d5d8391f4a749a7678144b6a3ca0fa4920598c8f3e56b4d04",
       "status": "completed"
     },
     {
       "failureCode": "none",
       "metrics": {
-        "childCpuMs": 24856,
-        "childMaxRssBytes": 729219072,
+        "childCpuMs": 23256,
+        "childMaxRssBytes": 722993152,
         "decodedBytes": 518442273,
         "durablePeakRssBytes": 0,
-        "encodedBytes": 29090523,
-        "externalPeakRssBytes": 727302144,
-        "externalRssSampleCount": 545,
+        "encodedBytes": 29091579,
+        "externalPeakRssBytes": 722960384,
+        "externalRssSampleCount": 468,
         "externalRssSampleFailureCount": 0,
         "filesystem": {
-          "afterBytes": 1170797162,
-          "beforeBytes": 1170797162,
-          "sampledHighWaterBytes": 1267586610
+          "afterBytes": 1170634378,
+          "beforeBytes": 1170634378,
+          "sampledHighWaterBytes": 1267698242
         },
         "outputRecords": 436557,
-        "parentElapsedMs": 31522,
+        "parentElapsedMs": 23789,
         "runCount": 2,
         "sourceBytes": 0,
         "sourceFiles": 0,
@@ -620,35 +620,35 @@
         "stdoutBytes": 1016
       },
       "name": "export_set_verify",
-      "projectionSha256": "c4e85ff4a4f70b1088aace276fbbd5d77c39158090a3c391ad55a7ac89d1353b",
+      "projectionSha256": "3d7c41b4520818b40140e8cdd4cdeb22b18148fb157319c4d43d0e62be95bbe6",
       "status": "completed"
     },
     {
       "failureCode": "none",
       "metrics": {
-        "childCpuMs": 79158,
-        "childMaxRssBytes": 804700160,
+        "childCpuMs": 73740,
+        "childMaxRssBytes": 841613312,
         "decodedBytes": 0,
         "durablePeakRssBytes": 0,
         "encodedBytes": 0,
-        "externalPeakRssBytes": 804061184,
-        "externalRssSampleCount": 1902,
-        "externalRssSampleFailureCount": 0,
+        "externalPeakRssBytes": 804634624,
+        "externalRssSampleCount": 1500,
+        "externalRssSampleFailureCount": 1,
         "filesystem": {
           "afterBytes": 461,
-          "beforeBytes": 1170797162,
-          "sampledHighWaterBytes": 1170809318
+          "beforeBytes": 1170634378,
+          "sampledHighWaterBytes": 1170634489
         },
         "outputRecords": 0,
-        "parentElapsedMs": 102676,
+        "parentElapsedMs": 77350,
         "runCount": 2,
         "sourceBytes": 0,
         "sourceFiles": 0,
         "stderrBytes": 0,
-        "stdoutBytes": 1009
+        "stdoutBytes": 1008
       },
       "name": "complete_set_delete",
-      "projectionSha256": "2b22e67a5730cb11919b8d8788db1a6b871c47af2fbf2378250f1a1ee76b278b",
+      "projectionSha256": "0834a8222338b1aa93988dc76861bc2c7025e113e0a03c788548f154638a6a75",
       "status": "completed"
     },
     {
@@ -832,7 +832,7 @@
     "rawDurableCopyCreated": false
   },
   "protocolVersion": "g1-r7-release-evidence-v0.1",
-  "receiptSha256": "d2a7d60d12aedbb65811d4096ef5e3c04f13bd8855ae66897f4f994c138974c4",
+  "receiptSha256": "102992b206e95e4c6808c9373745dbbf0c6cd7679f21c3ffaa93409f395da7c4",
   "runtimeProvenance": {
     "architecture": "arm64",
     "elapsedClock": "parent_monotonic",

--- a/generated/r7-release-synthetic-pressure-node24.14.0-v0.1.json
+++ b/generated/r7-release-synthetic-pressure-node24.14.0-v0.1.json
@@ -482,7 +482,7 @@
     "resourcePolicyValuesSha256": "3cbe7853c8f75e96912885f64ba4ad1aeb13aff8a22e4ffbd51806b27c73b418",
     "schemaModuleSha256": "594d035e641e87b29db4027dca35157f8225fd5621816d67d5d9f25825468bbf",
     "workloadCodeFileCount": 359,
-    "workloadCodeSha256": "4c3058b3453bda2696e946952d18e81310f26eb0187074d410c730e44162f1d6"
+    "workloadCodeSha256": "fcb55e0cb729b56249e2c6f4d8fa4a08bc4b4c8fe99a506ce10cfe1068ed48d5"
   },
   "determinism": {
     "comparisons": {
@@ -500,8 +500,8 @@
     "projectionVersion": "g1-r7-release-deterministic-projection-v0.1",
     "runCount": 2,
     "runProjectionSha256es": [
-      "1fca4155225420de75bd10bd4e9a724e465c2eac815b5e7f6c71e0ead6206e99",
-      "1fca4155225420de75bd10bd4e9a724e465c2eac815b5e7f6c71e0ead6206e99"
+      "bbb01c752237462989bb6232f65538d3056b6b166ed3251b17d976358ebe609d",
+      "bbb01c752237462989bb6232f65538d3056b6b166ed3251b17d976358ebe609d"
     ],
     "status": "passed"
   },
@@ -514,26 +514,26 @@
     {
       "failureCode": "none",
       "metrics": {
-        "childCpuMs": 17594,
-        "childMaxRssBytes": 689242112,
+        "childCpuMs": 20146,
+        "childMaxRssBytes": 680345600,
         "decodedBytes": 0,
-        "durablePeakRssBytes": 685473792,
+        "durablePeakRssBytes": 678002688,
         "encodedBytes": 0,
-        "externalPeakRssBytes": 682000384,
-        "externalRssSampleCount": 243,
+        "externalPeakRssBytes": 680345600,
+        "externalRssSampleCount": 372,
         "externalRssSampleFailureCount": 0,
         "filesystem": {
-          "afterBytes": 96927904,
+          "afterBytes": 96956576,
           "beforeBytes": 160,
-          "sampledHighWaterBytes": 97088623
+          "sampledHighWaterBytes": 96956576
         },
         "outputRecords": 29108,
-        "parentElapsedMs": 12337,
+        "parentElapsedMs": 22277,
         "runCount": 2,
         "sourceBytes": 47637907,
         "sourceFiles": 4096,
         "stderrBytes": 169,
-        "stdoutBytes": 1099
+        "stdoutBytes": 1098
       },
       "name": "source_scan",
       "projectionSha256": "c70ea4b8c4d71a9ee8b2a1cd72023877e32391e1f2b8fd7bfb355374b28f2395",
@@ -542,26 +542,26 @@
     {
       "failureCode": "none",
       "metrics": {
-        "childCpuMs": 10219,
-        "childMaxRssBytes": 682573824,
+        "childCpuMs": 13911,
+        "childMaxRssBytes": 480673792,
         "decodedBytes": 0,
-        "durablePeakRssBytes": 785268736,
+        "durablePeakRssBytes": 747143168,
         "encodedBytes": 0,
-        "externalPeakRssBytes": 682573824,
-        "externalRssSampleCount": 187,
+        "externalPeakRssBytes": 480673792,
+        "externalRssSampleCount": 287,
         "externalRssSampleFailureCount": 0,
         "filesystem": {
-          "afterBytes": 193855648,
-          "beforeBytes": 127037600,
-          "sampledHighWaterBytes": 194016367
+          "afterBytes": 193912992,
+          "beforeBytes": 127066272,
+          "sampledHighWaterBytes": 193912992
         },
         "outputRecords": 29108,
-        "parentElapsedMs": 9464,
+        "parentElapsedMs": 19257,
         "runCount": 2,
         "sourceBytes": 47637907,
         "sourceFiles": 4096,
         "stderrBytes": 169,
-        "stdoutBytes": 1103
+        "stdoutBytes": 1104
       },
       "name": "checkpoint_resume",
       "projectionSha256": "c70ea4b8c4d71a9ee8b2a1cd72023877e32391e1f2b8fd7bfb355374b28f2395",
@@ -570,21 +570,21 @@
     {
       "failureCode": "none",
       "metrics": {
-        "childCpuMs": 4092,
-        "childMaxRssBytes": 265273344,
+        "childCpuMs": 4165,
+        "childMaxRssBytes": 263864320,
         "decodedBytes": 46019365,
-        "durablePeakRssBytes": 685473792,
-        "encodedBytes": 2072942,
-        "externalPeakRssBytes": 265240576,
-        "externalRssSampleCount": 180,
+        "durablePeakRssBytes": 678002688,
+        "encodedBytes": 2072936,
+        "externalPeakRssBytes": 263864320,
+        "externalRssSampleCount": 203,
         "externalRssSampleFailureCount": 0,
         "filesystem": {
-          "afterBytes": 196963300,
-          "beforeBytes": 193855648,
-          "sampledHighWaterBytes": 196963990
+          "afterBytes": 197020638,
+          "beforeBytes": 193912992,
+          "sampledHighWaterBytes": 197020638
         },
         "outputRecords": 29108,
-        "parentElapsedMs": 9178,
+        "parentElapsedMs": 10416,
         "runCount": 2,
         "sourceBytes": 47637907,
         "sourceFiles": 4096,
@@ -592,27 +592,27 @@
         "stdoutBytes": 1251
       },
       "name": "export_set_materialize",
-      "projectionSha256": "d07ab8525b6edf84955d1c50eab884cdc158534953150969217fcf90a6967949",
+      "projectionSha256": "3671aacde251bcd8ab0baaed3450a239c54d125d2c0e432135dfb8c4132bcafe",
       "status": "completed"
     },
     {
       "failureCode": "none",
       "metrics": {
-        "childCpuMs": 1784,
-        "childMaxRssBytes": 277544960,
+        "childCpuMs": 2089,
+        "childMaxRssBytes": 267616256,
         "decodedBytes": 46019365,
         "durablePeakRssBytes": 0,
-        "encodedBytes": 2072942,
-        "externalPeakRssBytes": 276037632,
-        "externalRssSampleCount": 36,
+        "encodedBytes": 2072936,
+        "externalPeakRssBytes": 267616256,
+        "externalRssSampleCount": 58,
         "externalRssSampleFailureCount": 0,
         "filesystem": {
-          "afterBytes": 196963300,
-          "beforeBytes": 196963300,
-          "sampledHighWaterBytes": 203959852
+          "afterBytes": 197020638,
+          "beforeBytes": 197020638,
+          "sampledHighWaterBytes": 205312982
         },
         "outputRecords": 29108,
-        "parentElapsedMs": 1814,
+        "parentElapsedMs": 4042,
         "runCount": 2,
         "sourceBytes": 0,
         "sourceFiles": 0,
@@ -620,27 +620,27 @@
         "stdoutBytes": 1011
       },
       "name": "export_set_verify",
-      "projectionSha256": "41418659b080f75d258c95880ab31fe3cca71aba516c02bcefdaa3700a1b6401",
+      "projectionSha256": "ba38e64dc89854088e82e49b2aa016ea3b766d9cb320f3e1247a3aeadb60a509",
       "status": "completed"
     },
     {
       "failureCode": "none",
       "metrics": {
-        "childCpuMs": 6626,
-        "childMaxRssBytes": 320110592,
+        "childCpuMs": 6379,
+        "childMaxRssBytes": 301465600,
         "decodedBytes": 0,
         "durablePeakRssBytes": 0,
         "encodedBytes": 0,
-        "externalPeakRssBytes": 320110592,
-        "externalRssSampleCount": 177,
+        "externalPeakRssBytes": 299040768,
+        "externalRssSampleCount": 176,
         "externalRssSampleFailureCount": 0,
         "filesystem": {
-          "afterBytes": 96930436,
-          "beforeBytes": 196965371,
-          "sampledHighWaterBytes": 197046032
+          "afterBytes": 96959108,
+          "beforeBytes": 197022709,
+          "sampledHighWaterBytes": 197022820
         },
         "outputRecords": 0,
-        "parentElapsedMs": 9814,
+        "parentElapsedMs": 8965,
         "runCount": 2,
         "sourceBytes": 0,
         "sourceFiles": 0,
@@ -648,27 +648,27 @@
         "stdoutBytes": 1004
       },
       "name": "complete_set_delete",
-      "projectionSha256": "d4e2a4622bb6a44d55ebe591694f5b173e74f49b8f1d8804a9817e41681f91e6",
+      "projectionSha256": "661b02ea89a93ff27ac1826e7c0e018217b1076448a96f6f95ae79691c1f6f4a",
       "status": "completed"
     },
     {
       "failureCode": "interruption_injected",
       "metrics": {
-        "childCpuMs": 404,
-        "childMaxRssBytes": 130056192,
+        "childCpuMs": 401,
+        "childMaxRssBytes": 129253376,
         "decodedBytes": 0,
         "durablePeakRssBytes": 0,
         "encodedBytes": 0,
-        "externalPeakRssBytes": 130056192,
-        "externalRssSampleCount": 58,
+        "externalPeakRssBytes": 129040384,
+        "externalRssSampleCount": 64,
         "externalRssSampleFailureCount": 0,
         "filesystem": {
-          "afterBytes": 196965371,
-          "beforeBytes": 297080856,
-          "sampledHighWaterBytes": 297080856
+          "afterBytes": 197022709,
+          "beforeBytes": 297166860,
+          "sampledHighWaterBytes": 297166860
         },
         "outputRecords": 0,
-        "parentElapsedMs": 3472,
+        "parentElapsedMs": 3583,
         "runCount": 2,
         "sourceBytes": 0,
         "sourceFiles": 0,
@@ -676,27 +676,27 @@
         "stdoutBytes": 1012
       },
       "name": "complete_set_delete_recovery",
-      "projectionSha256": "d4e2a4622bb6a44d55ebe591694f5b173e74f49b8f1d8804a9817e41681f91e6",
+      "projectionSha256": "661b02ea89a93ff27ac1826e7c0e018217b1076448a96f6f95ae79691c1f6f4a",
       "status": "interrupted_recovered"
     },
     {
       "failureCode": "none",
       "metrics": {
-        "childCpuMs": 142,
-        "childMaxRssBytes": 117243904,
+        "childCpuMs": 141,
+        "childMaxRssBytes": 117555200,
         "decodedBytes": 0,
         "durablePeakRssBytes": 0,
         "encodedBytes": 0,
-        "externalPeakRssBytes": 117096448,
-        "externalRssSampleCount": 8,
+        "externalPeakRssBytes": 117489664,
+        "externalRssSampleCount": 9,
         "externalRssSampleFailureCount": 0,
         "filesystem": {
-          "afterBytes": 196963835,
-          "beforeBytes": 227072996,
-          "sampledHighWaterBytes": 227073107
+          "afterBytes": 197021173,
+          "beforeBytes": 227130334,
+          "sampledHighWaterBytes": 227131677
         },
         "outputRecords": 0,
-        "parentElapsedMs": 339,
+        "parentElapsedMs": 415,
         "runCount": 2,
         "sourceBytes": 0,
         "sourceFiles": 0,
@@ -710,21 +710,21 @@
     {
       "failureCode": "interruption_injected",
       "metrics": {
-        "childCpuMs": 92,
-        "childMaxRssBytes": 117047296,
+        "childCpuMs": 97,
+        "childMaxRssBytes": 116817920,
         "decodedBytes": 0,
         "durablePeakRssBytes": 0,
         "encodedBytes": 0,
-        "externalPeakRssBytes": 116965376,
-        "externalRssSampleCount": 6,
+        "externalPeakRssBytes": 116752384,
+        "externalRssSampleCount": 7,
         "externalRssSampleFailureCount": 0,
         "filesystem": {
-          "afterBytes": 196964370,
-          "beforeBytes": 227074763,
-          "sampledHighWaterBytes": 257184570
+          "afterBytes": 197021708,
+          "beforeBytes": 227132101,
+          "sampledHighWaterBytes": 257241908
         },
         "outputRecords": 0,
-        "parentElapsedMs": 271,
+        "parentElapsedMs": 312,
         "runCount": 2,
         "sourceBytes": 0,
         "sourceFiles": 0,
@@ -738,21 +738,21 @@
     {
       "failureCode": "none",
       "metrics": {
-        "childCpuMs": 5,
-        "childMaxRssBytes": 111607808,
+        "childCpuMs": 6,
+        "childMaxRssBytes": 111460352,
         "decodedBytes": 0,
         "durablePeakRssBytes": 0,
         "encodedBytes": 0,
-        "externalPeakRssBytes": 94011392,
+        "externalPeakRssBytes": 92798976,
         "externalRssSampleCount": 4,
         "externalRssSampleFailureCount": 0,
         "filesystem": {
-          "afterBytes": 196964640,
-          "beforeBytes": 196964819,
-          "sampledHighWaterBytes": 196964819
+          "afterBytes": 197021978,
+          "beforeBytes": 197022157,
+          "sampledHighWaterBytes": 197022157
         },
         "outputRecords": 0,
-        "parentElapsedMs": 172,
+        "parentElapsedMs": 199,
         "runCount": 2,
         "sourceBytes": 0,
         "sourceFiles": 0,
@@ -766,21 +766,21 @@
     {
       "failureCode": "interruption_injected",
       "metrics": {
-        "childCpuMs": 6,
-        "childMaxRssBytes": 111099904,
+        "childCpuMs": 5,
+        "childMaxRssBytes": 111968256,
         "decodedBytes": 0,
         "durablePeakRssBytes": 0,
         "encodedBytes": 0,
-        "externalPeakRssBytes": 99483648,
+        "externalPeakRssBytes": 92749824,
         "externalRssSampleCount": 4,
         "externalRssSampleFailureCount": 0,
         "filesystem": {
-          "afterBytes": 196964910,
-          "beforeBytes": 196965098,
-          "sampledHighWaterBytes": 196965098
+          "afterBytes": 197022248,
+          "beforeBytes": 197022436,
+          "sampledHighWaterBytes": 197022436
         },
         "outputRecords": 0,
-        "parentElapsedMs": 165,
+        "parentElapsedMs": 185,
         "runCount": 2,
         "sourceBytes": 0,
         "sourceFiles": 0,
@@ -827,7 +827,7 @@
     "targetChunks": 128
   },
   "protocolVersion": "g1-r7-release-evidence-v0.1",
-  "receiptSha256": "03341e66a24566b1f876bf0cec71b49fa530d273401a614584aac20954041a70",
+  "receiptSha256": "c694fabf1a0b802185d7ab0aa2dfbcce1996110acb454701e3c61b51afc0d0c7",
   "runtimeProvenance": {
     "architecture": "arm64",
     "elapsedClock": "parent_monotonic",

--- a/generated/r7-release-synthetic-pressure-node26.2.0-v0.1.json
+++ b/generated/r7-release-synthetic-pressure-node26.2.0-v0.1.json
@@ -482,7 +482,7 @@
     "resourcePolicyValuesSha256": "3cbe7853c8f75e96912885f64ba4ad1aeb13aff8a22e4ffbd51806b27c73b418",
     "schemaModuleSha256": "594d035e641e87b29db4027dca35157f8225fd5621816d67d5d9f25825468bbf",
     "workloadCodeFileCount": 359,
-    "workloadCodeSha256": "4c3058b3453bda2696e946952d18e81310f26eb0187074d410c730e44162f1d6"
+    "workloadCodeSha256": "fcb55e0cb729b56249e2c6f4d8fa4a08bc4b4c8fe99a506ce10cfe1068ed48d5"
   },
   "determinism": {
     "comparisons": {
@@ -500,8 +500,8 @@
     "projectionVersion": "g1-r7-release-deterministic-projection-v0.1",
     "runCount": 2,
     "runProjectionSha256es": [
-      "a54551a8d3154107c6a9d0583e073a8fd294f16d16ce5cff1b330a8ac1541ae3",
-      "a54551a8d3154107c6a9d0583e073a8fd294f16d16ce5cff1b330a8ac1541ae3"
+      "77aca87167ef86a53675d4763c5ad256e4ddc06ddee82e4bccaa3856c6b4d258",
+      "77aca87167ef86a53675d4763c5ad256e4ddc06ddee82e4bccaa3856c6b4d258"
     ],
     "status": "passed"
   },
@@ -514,26 +514,26 @@
     {
       "failureCode": "none",
       "metrics": {
-        "childCpuMs": 19185,
-        "childMaxRssBytes": 711868416,
+        "childCpuMs": 19396,
+        "childMaxRssBytes": 1063682048,
         "decodedBytes": 0,
-        "durablePeakRssBytes": 711770112,
+        "durablePeakRssBytes": 982417408,
         "encodedBytes": 0,
-        "externalPeakRssBytes": 711770112,
-        "externalRssSampleCount": 280,
+        "externalPeakRssBytes": 979402752,
+        "externalRssSampleCount": 275,
         "externalRssSampleFailureCount": 0,
         "filesystem": {
-          "afterBytes": 96919712,
+          "afterBytes": 96923808,
           "beforeBytes": 160,
-          "sampledHighWaterBytes": 96919712
+          "sampledHighWaterBytes": 96923919
         },
         "outputRecords": 29108,
-        "parentElapsedMs": 14218,
+        "parentElapsedMs": 14140,
         "runCount": 2,
         "sourceBytes": 47637907,
         "sourceFiles": 4096,
         "stderrBytes": 0,
-        "stdoutBytes": 1098
+        "stdoutBytes": 1099
       },
       "name": "source_scan",
       "projectionSha256": "c70ea4b8c4d71a9ee8b2a1cd72023877e32391e1f2b8fd7bfb355374b28f2395",
@@ -542,26 +542,26 @@
     {
       "failureCode": "none",
       "metrics": {
-        "childCpuMs": 12414,
-        "childMaxRssBytes": 456818688,
+        "childCpuMs": 15782,
+        "childMaxRssBytes": 659226624,
         "decodedBytes": 0,
-        "durablePeakRssBytes": 596475904,
+        "durablePeakRssBytes": 659177472,
         "encodedBytes": 0,
-        "externalPeakRssBytes": 454115328,
-        "externalRssSampleCount": 211,
+        "externalPeakRssBytes": 651182080,
+        "externalRssSampleCount": 461,
         "externalRssSampleFailureCount": 0,
         "filesystem": {
-          "afterBytes": 193839264,
-          "beforeBytes": 127029408,
-          "sampledHighWaterBytes": 193848143
+          "afterBytes": 193847456,
+          "beforeBytes": 127033504,
+          "sampledHighWaterBytes": 193872707
         },
         "outputRecords": 29108,
-        "parentElapsedMs": 10741,
+        "parentElapsedMs": 36107,
         "runCount": 2,
         "sourceBytes": 47637907,
         "sourceFiles": 4096,
         "stderrBytes": 0,
-        "stdoutBytes": 1103
+        "stdoutBytes": 1104
       },
       "name": "checkpoint_resume",
       "projectionSha256": "c70ea4b8c4d71a9ee8b2a1cd72023877e32391e1f2b8fd7bfb355374b28f2395",
@@ -570,77 +570,77 @@
     {
       "failureCode": "none",
       "metrics": {
-        "childCpuMs": 3724,
-        "childMaxRssBytes": 219578368,
+        "childCpuMs": 5511,
+        "childMaxRssBytes": 225181696,
         "decodedBytes": 46019365,
-        "durablePeakRssBytes": 711770112,
-        "encodedBytes": 2072942,
-        "externalPeakRssBytes": 219201536,
-        "externalRssSampleCount": 173,
+        "durablePeakRssBytes": 982417408,
+        "encodedBytes": 2072945,
+        "externalPeakRssBytes": 224804864,
+        "externalRssSampleCount": 346,
         "externalRssSampleFailureCount": 0,
         "filesystem": {
-          "afterBytes": 196946915,
-          "beforeBytes": 193839264,
-          "sampledHighWaterBytes": 196948184
+          "afterBytes": 196955110,
+          "beforeBytes": 193847456,
+          "sampledHighWaterBytes": 196955221
         },
         "outputRecords": 29108,
-        "parentElapsedMs": 8808,
+        "parentElapsedMs": 26382,
         "runCount": 2,
         "sourceBytes": 47637907,
         "sourceFiles": 4096,
         "stderrBytes": 0,
-        "stdoutBytes": 1250
+        "stdoutBytes": 1252
       },
       "name": "export_set_materialize",
-      "projectionSha256": "1be88270834d7fb3a810e42d80b0f08ba8443792ee6b8ebd7bc65f25099aa548",
+      "projectionSha256": "2925c74104b1c8eadd47309c30a307d187ac1ee766042df3ac2cc4e47b7841d4",
       "status": "completed"
     },
     {
       "failureCode": "none",
       "metrics": {
-        "childCpuMs": 1636,
-        "childMaxRssBytes": 239845376,
+        "childCpuMs": 3342,
+        "childMaxRssBytes": 241287168,
         "decodedBytes": 46019365,
         "durablePeakRssBytes": 0,
-        "encodedBytes": 2072942,
-        "externalPeakRssBytes": 239714304,
-        "externalRssSampleCount": 33,
+        "encodedBytes": 2072945,
+        "externalPeakRssBytes": 241221632,
+        "externalRssSampleCount": 204,
         "externalRssSampleFailureCount": 0,
         "filesystem": {
-          "afterBytes": 196946915,
-          "beforeBytes": 196946915,
-          "sampledHighWaterBytes": 204788323
+          "afterBytes": 196955110,
+          "beforeBytes": 196955110,
+          "sampledHighWaterBytes": 205390958
         },
         "outputRecords": 29108,
-        "parentElapsedMs": 1681,
+        "parentElapsedMs": 19008,
         "runCount": 2,
         "sourceBytes": 0,
         "sourceFiles": 0,
         "stderrBytes": 0,
-        "stdoutBytes": 1011
+        "stdoutBytes": 1012
       },
       "name": "export_set_verify",
-      "projectionSha256": "41418659b080f75d258c95880ab31fe3cca71aba516c02bcefdaa3700a1b6401",
+      "projectionSha256": "e8f0e07e88095e677b7705ba6f607939f4a2dd9594eb7a03439ec3478b66ac7f",
       "status": "completed"
     },
     {
       "failureCode": "none",
       "metrics": {
-        "childCpuMs": 7026,
-        "childMaxRssBytes": 267173888,
+        "childCpuMs": 8037,
+        "childMaxRssBytes": 257097728,
         "decodedBytes": 0,
         "durablePeakRssBytes": 0,
         "encodedBytes": 0,
-        "externalPeakRssBytes": 267173888,
-        "externalRssSampleCount": 234,
+        "externalPeakRssBytes": 256425984,
+        "externalRssSampleCount": 345,
         "externalRssSampleFailureCount": 0,
         "filesystem": {
-          "afterBytes": 96922244,
-          "beforeBytes": 196948986,
-          "sampledHighWaterBytes": 197030238
+          "afterBytes": 96926340,
+          "beforeBytes": 196957181,
+          "sampledHighWaterBytes": 197037842
         },
         "outputRecords": 0,
-        "parentElapsedMs": 16269,
+        "parentElapsedMs": 27880,
         "runCount": 2,
         "sourceBytes": 0,
         "sourceFiles": 0,
@@ -648,27 +648,27 @@
         "stdoutBytes": 1006
       },
       "name": "complete_set_delete",
-      "projectionSha256": "08024d5b1fa645ccb58d91e724d1262a468585f9700d754119c53bf5b7af46b6",
+      "projectionSha256": "b6fa895efacf2ce1825d91bba17dad9d0f8a012db57ac34a4aec6325d1aac1da",
       "status": "completed"
     },
     {
       "failureCode": "interruption_injected",
       "metrics": {
-        "childCpuMs": 450,
-        "childMaxRssBytes": 141099008,
+        "childCpuMs": 416,
+        "childMaxRssBytes": 138805248,
         "decodedBytes": 0,
         "durablePeakRssBytes": 0,
         "encodedBytes": 0,
-        "externalPeakRssBytes": 140886016,
-        "externalRssSampleCount": 66,
+        "externalPeakRssBytes": 138788864,
+        "externalRssSampleCount": 70,
         "externalRssSampleFailureCount": 0,
         "filesystem": {
-          "afterBytes": 196948986,
-          "beforeBytes": 297056278,
-          "sampledHighWaterBytes": 297056278
+          "afterBytes": 196957181,
+          "beforeBytes": 297068572,
+          "sampledHighWaterBytes": 297068572
         },
         "outputRecords": 0,
-        "parentElapsedMs": 4260,
+        "parentElapsedMs": 4640,
         "runCount": 2,
         "sourceBytes": 0,
         "sourceFiles": 0,
@@ -676,27 +676,27 @@
         "stdoutBytes": 1012
       },
       "name": "complete_set_delete_recovery",
-      "projectionSha256": "08024d5b1fa645ccb58d91e724d1262a468585f9700d754119c53bf5b7af46b6",
+      "projectionSha256": "b6fa895efacf2ce1825d91bba17dad9d0f8a012db57ac34a4aec6325d1aac1da",
       "status": "interrupted_recovered"
     },
     {
       "failureCode": "none",
       "metrics": {
         "childCpuMs": 146,
-        "childMaxRssBytes": 125206528,
+        "childMaxRssBytes": 124518400,
         "decodedBytes": 0,
         "durablePeakRssBytes": 0,
         "encodedBytes": 0,
-        "externalPeakRssBytes": 125059072,
-        "externalRssSampleCount": 8,
+        "externalPeakRssBytes": 124469248,
+        "externalRssSampleCount": 9,
         "externalRssSampleFailureCount": 0,
         "filesystem": {
-          "afterBytes": 196947450,
-          "beforeBytes": 227056611,
-          "sampledHighWaterBytes": 227056722
+          "afterBytes": 196955645,
+          "beforeBytes": 227064806,
+          "sampledHighWaterBytes": 257175845
         },
         "outputRecords": 0,
-        "parentElapsedMs": 334,
+        "parentElapsedMs": 477,
         "runCount": 2,
         "sourceBytes": 0,
         "sourceFiles": 0,
@@ -710,21 +710,21 @@
     {
       "failureCode": "interruption_injected",
       "metrics": {
-        "childCpuMs": 98,
-        "childMaxRssBytes": 124452864,
+        "childCpuMs": 97,
+        "childMaxRssBytes": 124485632,
         "decodedBytes": 0,
         "durablePeakRssBytes": 0,
         "encodedBytes": 0,
-        "externalPeakRssBytes": 124452864,
+        "externalPeakRssBytes": 123944960,
         "externalRssSampleCount": 7,
         "externalRssSampleFailureCount": 0,
         "filesystem": {
-          "afterBytes": 196947985,
-          "beforeBytes": 227058378,
-          "sampledHighWaterBytes": 257168185
+          "afterBytes": 196956180,
+          "beforeBytes": 227066573,
+          "sampledHighWaterBytes": 257176380
         },
         "outputRecords": 0,
-        "parentElapsedMs": 313,
+        "parentElapsedMs": 402,
         "runCount": 2,
         "sourceBytes": 0,
         "sourceFiles": 0,
@@ -738,26 +738,26 @@
     {
       "failureCode": "none",
       "metrics": {
-        "childCpuMs": 6,
-        "childMaxRssBytes": 118996992,
+        "childCpuMs": 8,
+        "childMaxRssBytes": 118865920,
         "decodedBytes": 0,
         "durablePeakRssBytes": 0,
         "encodedBytes": 0,
-        "externalPeakRssBytes": 104595456,
-        "externalRssSampleCount": 4,
+        "externalPeakRssBytes": 118833152,
+        "externalRssSampleCount": 5,
         "externalRssSampleFailureCount": 0,
         "filesystem": {
-          "afterBytes": 196948255,
-          "beforeBytes": 196948434,
-          "sampledHighWaterBytes": 196948434
+          "afterBytes": 196956450,
+          "beforeBytes": 196956629,
+          "sampledHighWaterBytes": 196956629
         },
         "outputRecords": 0,
-        "parentElapsedMs": 172,
+        "parentElapsedMs": 273,
         "runCount": 2,
         "sourceBytes": 0,
         "sourceFiles": 0,
         "stderrBytes": 0,
-        "stdoutBytes": 993
+        "stdoutBytes": 994
       },
       "name": "claude_callback_uninstall",
       "projectionSha256": "5d38a4aa94abb27b809f1949c8c9cfdc8361453401f51bca076b93b14707316a",
@@ -766,21 +766,21 @@
     {
       "failureCode": "interruption_injected",
       "metrics": {
-        "childCpuMs": 5,
-        "childMaxRssBytes": 118407168,
+        "childCpuMs": 7,
+        "childMaxRssBytes": 119013376,
         "decodedBytes": 0,
         "durablePeakRssBytes": 0,
         "encodedBytes": 0,
-        "externalPeakRssBytes": 104251392,
-        "externalRssSampleCount": 4,
+        "externalPeakRssBytes": 118996992,
+        "externalRssSampleCount": 5,
         "externalRssSampleFailureCount": 0,
         "filesystem": {
-          "afterBytes": 196948525,
-          "beforeBytes": 196948713,
-          "sampledHighWaterBytes": 196948713
+          "afterBytes": 196956720,
+          "beforeBytes": 196956908,
+          "sampledHighWaterBytes": 196956908
         },
         "outputRecords": 0,
-        "parentElapsedMs": 162,
+        "parentElapsedMs": 248,
         "runCount": 2,
         "sourceBytes": 0,
         "sourceFiles": 0,
@@ -827,7 +827,7 @@
     "targetChunks": 128
   },
   "protocolVersion": "g1-r7-release-evidence-v0.1",
-  "receiptSha256": "a10d939d59620e56b64c54a51371da30cdce7adaa5ab0832888825ee88c95c51",
+  "receiptSha256": "1f23ce061f6f875b9157a7a4526bc3d7be6bc317bb1244f3a29a963a4e208096",
   "runtimeProvenance": {
     "architecture": "arm64",
     "elapsedClock": "parent_monotonic",

--- a/generated/r7-release-synthetic-semantics-node24.14.0-v0.1.json
+++ b/generated/r7-release-synthetic-semantics-node24.14.0-v0.1.json
@@ -482,7 +482,7 @@
     "resourcePolicyValuesSha256": "3cbe7853c8f75e96912885f64ba4ad1aeb13aff8a22e4ffbd51806b27c73b418",
     "schemaModuleSha256": "594d035e641e87b29db4027dca35157f8225fd5621816d67d5d9f25825468bbf",
     "workloadCodeFileCount": 359,
-    "workloadCodeSha256": "4c3058b3453bda2696e946952d18e81310f26eb0187074d410c730e44162f1d6"
+    "workloadCodeSha256": "fcb55e0cb729b56249e2c6f4d8fa4a08bc4b4c8fe99a506ce10cfe1068ed48d5"
   },
   "determinism": {
     "comparisons": {
@@ -500,8 +500,8 @@
     "projectionVersion": "g1-r7-release-deterministic-projection-v0.1",
     "runCount": 2,
     "runProjectionSha256es": [
-      "9ac7325be54ac2b04d51f620fab54ceec1fdd26a37b8ba2e0547e449f4cc735e",
-      "9ac7325be54ac2b04d51f620fab54ceec1fdd26a37b8ba2e0547e449f4cc735e"
+      "19f3c061b361246f5eebd68dfb4a4d0d1362683d1f706dcef8937778918b3570",
+      "19f3c061b361246f5eebd68dfb4a4d0d1362683d1f706dcef8937778918b3570"
     ],
     "status": "passed"
   },
@@ -514,13 +514,13 @@
     {
       "failureCode": "none",
       "metrics": {
-        "childCpuMs": 71,
-        "childMaxRssBytes": 122503168,
+        "childCpuMs": 99,
+        "childMaxRssBytes": 123568128,
         "decodedBytes": 0,
-        "durablePeakRssBytes": 122503168,
+        "durablePeakRssBytes": 123535360,
         "encodedBytes": 0,
-        "externalPeakRssBytes": 122519552,
-        "externalRssSampleCount": 6,
+        "externalPeakRssBytes": 123191296,
+        "externalRssSampleCount": 8,
         "externalRssSampleFailureCount": 0,
         "filesystem": {
           "afterBytes": 200864,
@@ -528,12 +528,12 @@
           "sampledHighWaterBytes": 200864
         },
         "outputRecords": 27,
-        "parentElapsedMs": 210,
+        "parentElapsedMs": 461,
         "runCount": 2,
         "sourceBytes": 154645,
         "sourceFiles": 14,
         "stderrBytes": 169,
-        "stdoutBytes": 1071
+        "stdoutBytes": 1073
       },
       "name": "source_scan",
       "projectionSha256": "9a32d3d160adf2c4f0f900f4583abf8c4b37c5460377fcdd74447945cfa9acd7",
@@ -542,13 +542,13 @@
     {
       "failureCode": "none",
       "metrics": {
-        "childCpuMs": 48,
-        "childMaxRssBytes": 120324096,
+        "childCpuMs": 56,
+        "childMaxRssBytes": 119439360,
         "decodedBytes": 0,
-        "durablePeakRssBytes": 162381824,
+        "durablePeakRssBytes": 162594816,
         "encodedBytes": 0,
-        "externalPeakRssBytes": 97435648,
-        "externalRssSampleCount": 4,
+        "externalPeakRssBytes": 119029760,
+        "externalRssSampleCount": 5,
         "externalRssSampleFailureCount": 0,
         "filesystem": {
           "afterBytes": 401568,
@@ -556,12 +556,12 @@
           "sampledHighWaterBytes": 401568
         },
         "outputRecords": 27,
-        "parentElapsedMs": 180,
+        "parentElapsedMs": 239,
         "runCount": 2,
         "sourceBytes": 154645,
         "sourceFiles": 14,
         "stderrBytes": 169,
-        "stdoutBytes": 1077
+        "stdoutBytes": 1078
       },
       "name": "checkpoint_resume",
       "projectionSha256": "9a32d3d160adf2c4f0f900f4583abf8c4b37c5460377fcdd74447945cfa9acd7",
@@ -570,46 +570,46 @@
     {
       "failureCode": "none",
       "metrics": {
-        "childCpuMs": 201,
-        "childMaxRssBytes": 131317760,
+        "childCpuMs": 205,
+        "childMaxRssBytes": 132366336,
         "decodedBytes": 109963,
-        "durablePeakRssBytes": 131235840,
-        "encodedBytes": 32465,
-        "externalPeakRssBytes": 130957312,
-        "externalRssSampleCount": 19,
+        "durablePeakRssBytes": 132317184,
+        "encodedBytes": 32470,
+        "externalPeakRssBytes": 132300800,
+        "externalRssSampleCount": 25,
         "externalRssSampleFailureCount": 0,
         "filesystem": {
-          "afterBytes": 554635,
+          "afterBytes": 554640,
           "beforeBytes": 401568,
-          "sampledHighWaterBytes": 555902
+          "sampledHighWaterBytes": 571935
         },
         "outputRecords": 27,
-        "parentElapsedMs": 957,
+        "parentElapsedMs": 1477,
         "runCount": 2,
         "sourceBytes": 154645,
         "sourceFiles": 14,
         "stderrBytes": 169,
-        "stdoutBytes": 1223
+        "stdoutBytes": 1225
       },
       "name": "export_set_materialize",
-      "projectionSha256": "5944426c3bba1db00f51fb699c78207922f06671e526ee390a76d401a58adeff",
+      "projectionSha256": "56e207b61618cc7f8e82a8441d20dc78f9259277833650c9b67d1184ed0d53bb",
       "status": "completed"
     },
     {
       "failureCode": "none",
       "metrics": {
-        "childCpuMs": 46,
-        "childMaxRssBytes": 124289024,
+        "childCpuMs": 42,
+        "childMaxRssBytes": 123764736,
         "decodedBytes": 109963,
         "durablePeakRssBytes": 0,
-        "encodedBytes": 32465,
-        "externalPeakRssBytes": 92733440,
+        "encodedBytes": 32470,
+        "externalPeakRssBytes": 92471296,
         "externalRssSampleCount": 4,
         "externalRssSampleFailureCount": 0,
         "filesystem": {
-          "afterBytes": 554635,
-          "beforeBytes": 554635,
-          "sampledHighWaterBytes": 554635
+          "afterBytes": 554640,
+          "beforeBytes": 554640,
+          "sampledHighWaterBytes": 554640
         },
         "outputRecords": 27,
         "parentElapsedMs": 180,
@@ -620,55 +620,55 @@
         "stdoutBytes": 997
       },
       "name": "export_set_verify",
-      "projectionSha256": "2839288640255af62cb6bc1795aa861729379bda98d141bf0909aeabf4336c58",
+      "projectionSha256": "206b153d04a6331c83d5049cae8a4c19ca30b7bd3cc074cfbb6dd2596f2add3f",
       "status": "completed"
     },
     {
       "failureCode": "none",
       "metrics": {
-        "childCpuMs": 142,
-        "childMaxRssBytes": 138035200,
+        "childCpuMs": 173,
+        "childMaxRssBytes": 136921088,
         "decodedBytes": 0,
         "durablePeakRssBytes": 0,
         "encodedBytes": 0,
-        "externalPeakRssBytes": 137854976,
-        "externalRssSampleCount": 12,
+        "externalPeakRssBytes": 136871936,
+        "externalRssSampleCount": 18,
         "externalRssSampleFailureCount": 0,
         "filesystem": {
           "afterBytes": 203384,
-          "beforeBytes": 556698,
-          "sampledHighWaterBytes": 556809
+          "beforeBytes": 556703,
+          "sampledHighWaterBytes": 567586
         },
         "outputRecords": 0,
-        "parentElapsedMs": 561,
+        "parentElapsedMs": 1002,
         "runCount": 2,
         "sourceBytes": 0,
         "sourceFiles": 0,
         "stderrBytes": 169,
-        "stdoutBytes": 996
+        "stdoutBytes": 997
       },
       "name": "complete_set_delete",
-      "projectionSha256": "e744484b9c219eea32283dd229742e4f71e76573c1baebde450e4474c616a91f",
+      "projectionSha256": "976e73a695ccdabaef12fc0137c96f55f6edfc1d77c3bcb565ebdda50afb5171",
       "status": "completed"
     },
     {
       "failureCode": "interruption_injected",
       "metrics": {
-        "childCpuMs": 38,
-        "childMaxRssBytes": 115032064,
+        "childCpuMs": 59,
+        "childMaxRssBytes": 114065408,
         "decodedBytes": 0,
         "durablePeakRssBytes": 0,
         "encodedBytes": 0,
-        "externalPeakRssBytes": 114982912,
-        "externalRssSampleCount": 10,
+        "externalPeakRssBytes": 114032640,
+        "externalRssSampleCount": 15,
         "externalRssSampleFailureCount": 0,
         "filesystem": {
-          "afterBytes": 556698,
-          "beforeBytes": 920784,
-          "sampledHighWaterBytes": 920784
+          "afterBytes": 556703,
+          "beforeBytes": 920794,
+          "sampledHighWaterBytes": 920794
         },
         "outputRecords": 0,
-        "parentElapsedMs": 435,
+        "parentElapsedMs": 764,
         "runCount": 2,
         "sourceBytes": 0,
         "sourceFiles": 0,
@@ -676,32 +676,32 @@
         "stdoutBytes": 1005
       },
       "name": "complete_set_delete_recovery",
-      "projectionSha256": "e744484b9c219eea32283dd229742e4f71e76573c1baebde450e4474c616a91f",
+      "projectionSha256": "976e73a695ccdabaef12fc0137c96f55f6edfc1d77c3bcb565ebdda50afb5171",
       "status": "interrupted_recovered"
     },
     {
       "failureCode": "none",
       "metrics": {
-        "childCpuMs": 17,
-        "childMaxRssBytes": 115392512,
+        "childCpuMs": 18,
+        "childMaxRssBytes": 115277824,
         "decodedBytes": 0,
         "durablePeakRssBytes": 0,
         "encodedBytes": 0,
-        "externalPeakRssBytes": 115195904,
+        "externalPeakRssBytes": 112508928,
         "externalRssSampleCount": 5,
         "externalRssSampleFailureCount": 0,
         "filesystem": {
-          "afterBytes": 555168,
-          "beforeBytes": 722571,
-          "sampledHighWaterBytes": 722571
+          "afterBytes": 555173,
+          "beforeBytes": 722576,
+          "sampledHighWaterBytes": 722576
         },
         "outputRecords": 0,
-        "parentElapsedMs": 216,
+        "parentElapsedMs": 249,
         "runCount": 2,
         "sourceBytes": 0,
         "sourceFiles": 0,
         "stderrBytes": 169,
-        "stdoutBytes": 991
+        "stdoutBytes": 992
       },
       "name": "workspace_discard",
       "projectionSha256": "495426e69724d58733a4605ce62a0a9e61a094e67823671e64b872acf28bbea5",
@@ -710,21 +710,21 @@
     {
       "failureCode": "interruption_injected",
       "metrics": {
-        "childCpuMs": 13,
-        "childMaxRssBytes": 114573312,
+        "childCpuMs": 14,
+        "childMaxRssBytes": 114212864,
         "decodedBytes": 0,
         "durablePeakRssBytes": 0,
         "encodedBytes": 0,
-        "externalPeakRssBytes": 94633984,
-        "externalRssSampleCount": 4,
+        "externalPeakRssBytes": 114081792,
+        "externalRssSampleCount": 5,
         "externalRssSampleFailureCount": 0,
         "filesystem": {
-          "afterBytes": 555701,
-          "beforeBytes": 724332,
-          "sampledHighWaterBytes": 724332
+          "afterBytes": 555706,
+          "beforeBytes": 724337,
+          "sampledHighWaterBytes": 724337
         },
         "outputRecords": 0,
-        "parentElapsedMs": 191,
+        "parentElapsedMs": 243,
         "runCount": 2,
         "sourceBytes": 0,
         "sourceFiles": 0,
@@ -739,20 +739,20 @@
       "failureCode": "none",
       "metrics": {
         "childCpuMs": 6,
-        "childMaxRssBytes": 112082944,
+        "childMaxRssBytes": 109707264,
         "decodedBytes": 0,
         "durablePeakRssBytes": 0,
         "encodedBytes": 0,
-        "externalPeakRssBytes": 93011968,
+        "externalPeakRssBytes": 94470144,
         "externalRssSampleCount": 4,
         "externalRssSampleFailureCount": 0,
         "filesystem": {
-          "afterBytes": 555971,
-          "beforeBytes": 556150,
-          "sampledHighWaterBytes": 556150
+          "afterBytes": 555976,
+          "beforeBytes": 556155,
+          "sampledHighWaterBytes": 556155
         },
         "outputRecords": 0,
-        "parentElapsedMs": 171,
+        "parentElapsedMs": 196,
         "runCount": 2,
         "sourceBytes": 0,
         "sourceFiles": 0,
@@ -767,20 +767,20 @@
       "failureCode": "interruption_injected",
       "metrics": {
         "childCpuMs": 5,
-        "childMaxRssBytes": 111591424,
+        "childMaxRssBytes": 111640576,
         "decodedBytes": 0,
         "durablePeakRssBytes": 0,
         "encodedBytes": 0,
-        "externalPeakRssBytes": 92782592,
+        "externalPeakRssBytes": 92667904,
         "externalRssSampleCount": 4,
         "externalRssSampleFailureCount": 0,
         "filesystem": {
-          "afterBytes": 556241,
-          "beforeBytes": 556429,
-          "sampledHighWaterBytes": 556429
+          "afterBytes": 556246,
+          "beforeBytes": 556434,
+          "sampledHighWaterBytes": 556434
         },
         "outputRecords": 0,
-        "parentElapsedMs": 165,
+        "parentElapsedMs": 190,
         "runCount": 2,
         "sourceBytes": 0,
         "sourceFiles": 0,
@@ -836,7 +836,7 @@
     "kind": "release_synthetic_semantics"
   },
   "protocolVersion": "g1-r7-release-evidence-v0.1",
-  "receiptSha256": "4ddfe56b735cf44241ef3cd5119cdccb3490d17bc13e6ba44d1668c859b694a4",
+  "receiptSha256": "7199e88864ad71aa06fd5b5ae70ef51dab25dafef482688da4d5851d33ec6dc3",
   "runtimeProvenance": {
     "architecture": "arm64",
     "elapsedClock": "parent_monotonic",

--- a/generated/r7-release-synthetic-semantics-node26.2.0-v0.1.json
+++ b/generated/r7-release-synthetic-semantics-node26.2.0-v0.1.json
@@ -482,7 +482,7 @@
     "resourcePolicyValuesSha256": "3cbe7853c8f75e96912885f64ba4ad1aeb13aff8a22e4ffbd51806b27c73b418",
     "schemaModuleSha256": "594d035e641e87b29db4027dca35157f8225fd5621816d67d5d9f25825468bbf",
     "workloadCodeFileCount": 359,
-    "workloadCodeSha256": "4c3058b3453bda2696e946952d18e81310f26eb0187074d410c730e44162f1d6"
+    "workloadCodeSha256": "fcb55e0cb729b56249e2c6f4d8fa4a08bc4b4c8fe99a506ce10cfe1068ed48d5"
   },
   "determinism": {
     "comparisons": {
@@ -500,8 +500,8 @@
     "projectionVersion": "g1-r7-release-deterministic-projection-v0.1",
     "runCount": 2,
     "runProjectionSha256es": [
-      "541414ca938c50980d496589a0dd63e37b33f3aba5b3d361d467d2f770607ed2",
-      "541414ca938c50980d496589a0dd63e37b33f3aba5b3d361d467d2f770607ed2"
+      "a9206ec38b725180649cd9fe0eabca560f5ef13b1147dba79ec3eb3d25cdd2a0",
+      "a9206ec38b725180649cd9fe0eabca560f5ef13b1147dba79ec3eb3d25cdd2a0"
     ],
     "status": "passed"
   },
@@ -514,12 +514,12 @@
     {
       "failureCode": "none",
       "metrics": {
-        "childCpuMs": 74,
-        "childMaxRssBytes": 131891200,
+        "childCpuMs": 73,
+        "childMaxRssBytes": 130957312,
         "decodedBytes": 0,
-        "durablePeakRssBytes": 131858432,
+        "durablePeakRssBytes": 130924544,
         "encodedBytes": 0,
-        "externalPeakRssBytes": 128598016,
+        "externalPeakRssBytes": 130629632,
         "externalRssSampleCount": 6,
         "externalRssSampleFailureCount": 0,
         "filesystem": {
@@ -528,7 +528,7 @@
           "sampledHighWaterBytes": 200864
         },
         "outputRecords": 27,
-        "parentElapsedMs": 237,
+        "parentElapsedMs": 221,
         "runCount": 2,
         "sourceBytes": 154645,
         "sourceFiles": 14,
@@ -543,11 +543,11 @@
       "failureCode": "none",
       "metrics": {
         "childCpuMs": 49,
-        "childMaxRssBytes": 128712704,
+        "childMaxRssBytes": 128843776,
         "decodedBytes": 0,
-        "durablePeakRssBytes": 167313408,
+        "durablePeakRssBytes": 171442176,
         "encodedBytes": 0,
-        "externalPeakRssBytes": 106790912,
+        "externalPeakRssBytes": 109248512,
         "externalRssSampleCount": 4,
         "externalRssSampleFailureCount": 0,
         "filesystem": {
@@ -556,7 +556,7 @@
           "sampledHighWaterBytes": 401568
         },
         "outputRecords": 27,
-        "parentElapsedMs": 183,
+        "parentElapsedMs": 182,
         "runCount": 2,
         "sourceBytes": 154645,
         "sourceFiles": 14,
@@ -570,21 +570,21 @@
     {
       "failureCode": "none",
       "metrics": {
-        "childCpuMs": 205,
-        "childMaxRssBytes": 140115968,
+        "childCpuMs": 214,
+        "childMaxRssBytes": 140541952,
         "decodedBytes": 109963,
-        "durablePeakRssBytes": 140099584,
-        "encodedBytes": 32431,
-        "externalPeakRssBytes": 140165120,
-        "externalRssSampleCount": 20,
+        "durablePeakRssBytes": 140525568,
+        "encodedBytes": 32428,
+        "externalPeakRssBytes": 140525568,
+        "externalRssSampleCount": 19,
         "externalRssSampleFailureCount": 0,
         "filesystem": {
-          "afterBytes": 554600,
+          "afterBytes": 554597,
           "beforeBytes": 401568,
-          "sampledHighWaterBytes": 555488
+          "sampledHighWaterBytes": 554708
         },
         "outputRecords": 27,
-        "parentElapsedMs": 950,
+        "parentElapsedMs": 944,
         "runCount": 2,
         "sourceBytes": 154645,
         "sourceFiles": 14,
@@ -592,27 +592,27 @@
         "stdoutBytes": 1223
       },
       "name": "export_set_materialize",
-      "projectionSha256": "6a12d5a201d85e88a0a8486a1a346cb22e67c67373ecbe0107b242d9abc9c3f4",
+      "projectionSha256": "fdbefdee2ba54fe49937e50a4c25f51d67f34afeee031d0eea063dc7feab00cd",
       "status": "completed"
     },
     {
       "failureCode": "none",
       "metrics": {
-        "childCpuMs": 42,
-        "childMaxRssBytes": 134397952,
+        "childCpuMs": 41,
+        "childMaxRssBytes": 134184960,
         "decodedBytes": 109963,
         "durablePeakRssBytes": 0,
-        "encodedBytes": 32431,
-        "externalPeakRssBytes": 98025472,
+        "encodedBytes": 32428,
+        "externalPeakRssBytes": 98779136,
         "externalRssSampleCount": 4,
         "externalRssSampleFailureCount": 0,
         "filesystem": {
-          "afterBytes": 554600,
-          "beforeBytes": 554600,
-          "sampledHighWaterBytes": 554600
+          "afterBytes": 554597,
+          "beforeBytes": 554597,
+          "sampledHighWaterBytes": 554597
         },
         "outputRecords": 27,
-        "parentElapsedMs": 179,
+        "parentElapsedMs": 173,
         "runCount": 2,
         "sourceBytes": 0,
         "sourceFiles": 0,
@@ -620,55 +620,55 @@
         "stdoutBytes": 997
       },
       "name": "export_set_verify",
-      "projectionSha256": "3273ab99840aa9026615572e61d9b4b877ea7b024da7a0ea11dc975f3510953e",
+      "projectionSha256": "3a96b880d7a641fc00af361b2f4b9d64302f20250004b17afadce2d2c5e87d6b",
       "status": "completed"
     },
     {
       "failureCode": "none",
       "metrics": {
-        "childCpuMs": 145,
-        "childMaxRssBytes": 145358848,
+        "childCpuMs": 156,
+        "childMaxRssBytes": 146145280,
         "decodedBytes": 0,
         "durablePeakRssBytes": 0,
         "encodedBytes": 0,
-        "externalPeakRssBytes": 145063936,
+        "externalPeakRssBytes": 145932288,
         "externalRssSampleCount": 12,
         "externalRssSampleFailureCount": 0,
         "filesystem": {
           "afterBytes": 203384,
-          "beforeBytes": 556663,
-          "sampledHighWaterBytes": 556774
+          "beforeBytes": 556660,
+          "sampledHighWaterBytes": 556771
         },
         "outputRecords": 0,
-        "parentElapsedMs": 560,
+        "parentElapsedMs": 569,
         "runCount": 2,
         "sourceBytes": 0,
         "sourceFiles": 0,
         "stderrBytes": 0,
-        "stdoutBytes": 996
+        "stdoutBytes": 997
       },
       "name": "complete_set_delete",
-      "projectionSha256": "3e165319d4b31f383f0e155b3a07725087d0665b31cb61ee2f9299f72c4498d0",
+      "projectionSha256": "0eefbb6a04bff72344a9a74f8fcb3008a15ac67becf47d3146a8c10ba72cc975",
       "status": "completed"
     },
     {
       "failureCode": "interruption_injected",
       "metrics": {
-        "childCpuMs": 37,
+        "childCpuMs": 36,
         "childMaxRssBytes": 122044416,
         "decodedBytes": 0,
         "durablePeakRssBytes": 0,
         "encodedBytes": 0,
-        "externalPeakRssBytes": 121995264,
+        "externalPeakRssBytes": 121929728,
         "externalRssSampleCount": 10,
         "externalRssSampleFailureCount": 0,
         "filesystem": {
-          "afterBytes": 556663,
-          "beforeBytes": 920714,
-          "sampledHighWaterBytes": 920714
+          "afterBytes": 556660,
+          "beforeBytes": 920708,
+          "sampledHighWaterBytes": 920708
         },
         "outputRecords": 0,
-        "parentElapsedMs": 425,
+        "parentElapsedMs": 438,
         "runCount": 2,
         "sourceBytes": 0,
         "sourceFiles": 0,
@@ -676,27 +676,27 @@
         "stdoutBytes": 1005
       },
       "name": "complete_set_delete_recovery",
-      "projectionSha256": "3e165319d4b31f383f0e155b3a07725087d0665b31cb61ee2f9299f72c4498d0",
+      "projectionSha256": "0eefbb6a04bff72344a9a74f8fcb3008a15ac67becf47d3146a8c10ba72cc975",
       "status": "interrupted_recovered"
     },
     {
       "failureCode": "none",
       "metrics": {
-        "childCpuMs": 16,
-        "childMaxRssBytes": 123371520,
+        "childCpuMs": 17,
+        "childMaxRssBytes": 122503168,
         "decodedBytes": 0,
         "durablePeakRssBytes": 0,
         "encodedBytes": 0,
-        "externalPeakRssBytes": 106872832,
+        "externalPeakRssBytes": 106971136,
         "externalRssSampleCount": 4,
-        "externalRssSampleFailureCount": 1,
+        "externalRssSampleFailureCount": 0,
         "filesystem": {
-          "afterBytes": 555133,
-          "beforeBytes": 722536,
-          "sampledHighWaterBytes": 722536
+          "afterBytes": 555130,
+          "beforeBytes": 722533,
+          "sampledHighWaterBytes": 722533
         },
         "outputRecords": 0,
-        "parentElapsedMs": 204,
+        "parentElapsedMs": 200,
         "runCount": 2,
         "sourceBytes": 0,
         "sourceFiles": 0,
@@ -710,21 +710,21 @@
     {
       "failureCode": "interruption_injected",
       "metrics": {
-        "childCpuMs": 12,
-        "childMaxRssBytes": 121913344,
+        "childCpuMs": 13,
+        "childMaxRssBytes": 122372096,
         "decodedBytes": 0,
         "durablePeakRssBytes": 0,
         "encodedBytes": 0,
-        "externalPeakRssBytes": 106741760,
+        "externalPeakRssBytes": 106889216,
         "externalRssSampleCount": 4,
         "externalRssSampleFailureCount": 0,
         "filesystem": {
-          "afterBytes": 555666,
-          "beforeBytes": 724297,
-          "sampledHighWaterBytes": 724297
+          "afterBytes": 555663,
+          "beforeBytes": 724294,
+          "sampledHighWaterBytes": 724294
         },
         "outputRecords": 0,
-        "parentElapsedMs": 190,
+        "parentElapsedMs": 188,
         "runCount": 2,
         "sourceBytes": 0,
         "sourceFiles": 0,
@@ -738,21 +738,21 @@
     {
       "failureCode": "none",
       "metrics": {
-        "childCpuMs": 5,
-        "childMaxRssBytes": 118390784,
+        "childCpuMs": 6,
+        "childMaxRssBytes": 118734848,
         "decodedBytes": 0,
         "durablePeakRssBytes": 0,
         "encodedBytes": 0,
-        "externalPeakRssBytes": 103202816,
+        "externalPeakRssBytes": 104759296,
         "externalRssSampleCount": 4,
         "externalRssSampleFailureCount": 0,
         "filesystem": {
-          "afterBytes": 555936,
-          "beforeBytes": 556115,
-          "sampledHighWaterBytes": 556115
+          "afterBytes": 555933,
+          "beforeBytes": 556112,
+          "sampledHighWaterBytes": 556112
         },
         "outputRecords": 0,
-        "parentElapsedMs": 176,
+        "parentElapsedMs": 169,
         "runCount": 2,
         "sourceBytes": 0,
         "sourceFiles": 0,
@@ -767,20 +767,20 @@
       "failureCode": "interruption_injected",
       "metrics": {
         "childCpuMs": 5,
-        "childMaxRssBytes": 118571008,
+        "childMaxRssBytes": 118734848,
         "decodedBytes": 0,
         "durablePeakRssBytes": 0,
         "encodedBytes": 0,
-        "externalPeakRssBytes": 101777408,
+        "externalPeakRssBytes": 106086400,
         "externalRssSampleCount": 4,
         "externalRssSampleFailureCount": 0,
         "filesystem": {
-          "afterBytes": 556206,
-          "beforeBytes": 556394,
-          "sampledHighWaterBytes": 556394
+          "afterBytes": 556203,
+          "beforeBytes": 556391,
+          "sampledHighWaterBytes": 556391
         },
         "outputRecords": 0,
-        "parentElapsedMs": 161,
+        "parentElapsedMs": 160,
         "runCount": 2,
         "sourceBytes": 0,
         "sourceFiles": 0,
@@ -836,7 +836,7 @@
     "kind": "release_synthetic_semantics"
   },
   "protocolVersion": "g1-r7-release-evidence-v0.1",
-  "receiptSha256": "4e90b8b3bdd596f5eb5694c33f534417ce64dbca642013b7d14b4a644cbc75cc",
+  "receiptSha256": "4cfed5bf54a8a7bef98fdba3815c4d693e3b7a78fa6afdc2011df95f8861b624",
   "runtimeProvenance": {
     "architecture": "arm64",
     "elapsedClock": "parent_monotonic",

--- a/release-notes/0.1.17.md
+++ b/release-notes/0.1.17.md
@@ -1,10 +1,13 @@
 # TiboTattle 0.1.17
 
-**Status:** Candidate source notes for native dogfood. Frozen RC4 source
-`735a59ce2ec01df0e381fb1aa878c5c7a39edcd8` produced a signed, notarized, and
-installed build `1023.2`, but that artifact excludes PR #94 and does not qualify
-the current integrated source or stable 0.1.17. No stable `v0.1.17` tag, GitHub
-release, published appcast, or integrated RC5 artifact is claimed yet.
+**Status:** Candidate source notes for native dogfood. Integrated RC5 source
+produced signed, notarized, and installed build `1023.3`; physical testing then
+found that its five-minute ordinary refresh deadline stopped a legitimate full
+accounting-cache rebuild. RC6 build `1023.4` is allocated to the correction but
+still requires exact-source validation, protected R7 regeneration, signing,
+notarization, state-preserving installation, and installed native verification.
+No stable `v0.1.17` tag, GitHub release, published appcast, or RC6 artifact is
+claimed yet.
 
 The native Mac app is easier to recover, clearer while it starts, and ready for
 the newer Codex history, plan, and quota formats already appearing in current
@@ -214,19 +217,21 @@ and Preview never opts into automatic updates.
 Internal dogfood is deliberately different: it keeps the stable bundle and
 local-state identity so it can test an in-place upgrade, while using its own
 update channel. Earlier 0.1.17 internal candidates used builds **1023**,
-**1023.1**, and **1023.2**. The integrated RC5 allocation is **1023.3**, while
+**1023.1**, **1023.2**, and **1023.3**. RC6 is allocated build **1023.4**, while
 **1024** remains reserved for the stable final, keeping stable ordered after the
 candidate. Signed tooling also requires a clean checkout and exactly one
 matching annotated source tag at `HEAD`: `v0.1.17` for stable, or the strict
 `tibotattle-internal-dogfood-0.1.17-rcN-source-YYYYMMDD` form for a dated
 candidate.
 
-RC4 build `1023.2` is signed, notarized, and installed evidence only for its
-frozen source; it predates the PR #94 merge. The integrated RC5 source still
-needs exact-source gates, signing, notarization, state-preserving replacement,
-and installed native checks. No 0.1.17 artifact has been published or made
-available through an updater. Browser rendering and compiled native tests do
-not prove physical popover interaction or thread-link handoff to Codex.
+RC5 build `1023.3` is signed, notarized, and installed evidence only for its
+frozen source. It preserved schema-11 data and launched without an automatic
+Keychain prompt, but its full accounting-cache rebuild exceeded the ordinary
+five-minute refresh deadline. RC6 corrects that lifetime boundary and still
+requires exact-source gates, R7, signing, notarization, state-preserving
+replacement, and installed native checks. No 0.1.17 artifact has been published
+or made available through an updater. Browser rendering and compiled native
+tests do not prove physical popover interaction or thread-link handoff to Codex.
 
 ## Prompt-free credential upgrades
 
@@ -283,6 +288,13 @@ lifecycle, but it remains staged source. Worker migrations 0042-0044, hosted
 activation, and a new explicit consent are separate operations. Installing the
 desktop app neither deploys that protocol nor changes an existing contribution
 consent.
+
+The fixed-real-corpus, before/after attribution comparison required by the PR
+#94 plan remains open and has not been represented as passed by R7. Existing
+tools provide partial content-free aggregates but no reviewed, schema-validated
+cross-revision comparator with the required reconciliation and resource receipt.
+That empirical gate must remain explicit in dogfood evaluation and must be
+closed or deliberately resolved before stable sign-off.
 
 ## Known limitations
 

--- a/scripts/macos-bundle-version.js
+++ b/scripts/macos-bundle-version.js
@@ -18,12 +18,13 @@ export const MACOS_BUNDLE_VERSION_EPOCH = 2_000;
 // Freeze the owner-reviewed allocations per marketing version and channel;
 // adding a future release is an explicit policy change, never an implicit
 // timestamp or environment-controlled counter.
-// The 0.1.17 RC2 used 1023, RC3 used 1023.1, and the installed
-// startup-recovery RC4 used 1023.2. The integrated RC5 uses 1023.3,
-// preserving the allocated stable 1024 and monotonic upgrades.
+// The 0.1.17 RC2 used 1023, RC3 used 1023.1, installed startup-recovery RC4
+// used 1023.2, and installed integrated RC5 used 1023.3. The accounting-
+// deadline correction uses monotonic RC6 build 1023.4, preserving the
+// allocated stable 1024 and upgrade ordering.
 export const SIGNED_MACOS_BUNDLE_VERSION_PLAN = Object.freeze({
   "0.1.17": Object.freeze({
-    "internal-dogfood": "1023.3",
+    "internal-dogfood": "1023.4",
     stable: "1024",
   }),
 });

--- a/src/local-collector-state.js
+++ b/src/local-collector-state.js
@@ -17,6 +17,7 @@ import {
   unlinkDurably,
 } from "./storage.js";
 import { readBoundedUtf8LineEntries } from "./platform/index.js";
+import { validAbortSignal } from "./valid-abort-signal.js";
 
 // This database is deliberately the one durable owner-controlled store for
 // local collector facts, cursors, quota observations and derived accounting.
@@ -59,6 +60,13 @@ function fixedError(code) {
   const error = new Error(code);
   error.code = code;
   return error;
+}
+
+function throwIfAccountingCachePublicationAborted(signal) {
+  if (!signal?.aborted) return;
+  const error = fixedError("accounting_refresh_aborted");
+  error.name = "AbortError";
+  throw error;
 }
 
 function ownerOnlyRegularFile(metadata) {
@@ -1366,14 +1374,28 @@ export async function saveLocalCollectorCheckpoint({
 export async function writeLocalCollectorAccountingCache({
   stateFile = defaultLocalCollectorStatePath(),
   cache,
+  signal = null,
 } = {}) {
-  if (!cache || typeof cache !== "object" || Array.isArray(cache)) {
+  if (!cache
+      || typeof cache !== "object"
+      || Array.isArray(cache)
+      || !validAbortSignal(signal)) {
     throw new TypeError("Local collector accounting cache is invalid");
   }
+  throwIfAccountingCachePublicationAborted(signal);
   await ensureDatabase(stateFile);
+  // Database preparation crosses asynchronous filesystem boundaries. A
+  // refresh can be cancelled while those owner-only durability checks are in
+  // flight, so preparation must not imply permission to replace the retained
+  // accounting row.
+  throwIfAccountingCachePublicationAborted(signal);
   let database;
   try {
     database = openDatabase(stateFile, { readOnly: false });
+    // From this check through COMMIT the operation is deliberately
+    // synchronous, so no later abort event can interleave with the atomic row
+    // replacement. Keep the check adjacent to that boundary.
+    throwIfAccountingCachePublicationAborted(signal);
     transaction(database, () => {
       writeMeta(database, "accounting_cache", cache);
     });

--- a/src/local-companion-refresh.js
+++ b/src/local-companion-refresh.js
@@ -1,6 +1,7 @@
 import { randomInt, randomUUID } from "node:crypto";
 import { homedir } from "node:os";
 import { join } from "node:path";
+import { performance } from "node:perf_hooks";
 import {
   isValidQuotaWindowDuration,
 } from "@app-usagemonitor/quota-analysis";
@@ -1207,16 +1208,6 @@ export function createLocalCollectorRefreshRunner({
     if (refreshAccounting !== null
         && accountingMayRun
         && unifiedAccountingReady) {
-      if (accountingSourceMode === "unified" && signal?.aborted !== true) {
-        // Cursor reuse means the last scan count can be only a handful of
-        // changed files. It is no longer progress once ingestion has returned.
-        // Keep this count-free stage through accounting and the controller's
-        // full snapshot reload; neither boundary is a completion claim.
-        await onProgress?.({
-          kind: ACCOUNTING_PROGRESS_KIND,
-          status: "calculating",
-        });
-      }
       // A provider quota observation does not alter replay-safe token
       // accounting. Reuse a current cache when no rollout usage record was
       // added, while the collector state continues to supply the fresh quota
@@ -1268,6 +1259,19 @@ export function createLocalCollectorRefreshRunner({
         }
       }
       if (accounting === null && !withinRebuildBackoff) {
+        if (accountingSourceMode === "unified" && signal?.aborted !== true) {
+          // This exact count-free marker is emitted only after the current
+          // cache has failed the authoritative reuse check and immediately
+          // before a full replay-safe rebuild. The controller can therefore
+          // grant the bounded cold-work deadline without guessing from stale
+          // presentation state or extending an ordinary cache-hit refresh.
+          // Keep it through the controller's full snapshot reload; neither
+          // boundary is itself a completion claim.
+          await onProgress?.({
+            kind: ACCOUNTING_PROGRESS_KIND,
+            status: "calculating",
+          });
+        }
         let rebuilt = null;
         try {
           rebuilt = await refreshAccounting({
@@ -1712,10 +1716,17 @@ export const LOCAL_COMPANION_FRESH_INDEX_REFRESH_TIMEOUT_MS =
   4 * 60 * 60_000;
 export const LOCAL_COMPANION_REFRESH_TIMEOUT_MAX_MS =
   LOCAL_COMPANION_FRESH_INDEX_REFRESH_TIMEOUT_MS;
+export const LOCAL_COMPANION_REFRESH_CANCEL_SETTLEMENT_MS = 30_000;
+const LOCAL_COMPANION_REFRESH_CANCEL_SETTLEMENT_MAX_MS = 60_000;
+const CANCEL_SETTLEMENT_EXPIRED = Symbol("cancel_settlement_expired");
 
 export class LocalCompanionRefreshController {
+  #accountingTimeoutMs;
   #abortController = null;
+  #beginCancellationSettlement = null;
+  #cancelSettlementMs;
   #cancelRequested = false;
+  #clearTimeoutImpl;
   #clock;
   #createRefreshId;
   #dataStore;
@@ -1725,16 +1736,23 @@ export class LocalCompanionRefreshController {
   #onDegradedOutcome;
   #onTerminalFailure;
   #runner;
+  #setTimeoutImpl;
   #state;
   #timeoutMs;
   #timeoutMsForRun;
+  #monotonicClock;
 
   constructor({
     runner,
     dataStore,
     timeoutMs = 5 * 60_000,
     timeoutMsForRun = null,
+    accountingTimeoutMs = LOCAL_COMPANION_FRESH_INDEX_REFRESH_TIMEOUT_MS,
+    cancelSettlementMs = LOCAL_COMPANION_REFRESH_CANCEL_SETTLEMENT_MS,
     clock = () => Date.now(),
+    monotonicClock = () => performance.now(),
+    setTimeoutImpl = setTimeout,
+    clearTimeoutImpl = clearTimeout,
     createRefreshId = randomUUID,
     // Observer for terminal refresh failures. Receives only the bounded
     // identity the failed state itself carries — errorCode, and failedStep /
@@ -1761,6 +1779,30 @@ export class LocalCompanionRefreshController {
     if (timeoutMsForRun !== null && typeof timeoutMsForRun !== "function") {
       throw new TypeError("timeoutMsForRun must be a function or null");
     }
+    if (!Number.isSafeInteger(accountingTimeoutMs)
+        || accountingTimeoutMs < 1_000
+        || accountingTimeoutMs > LOCAL_COMPANION_REFRESH_TIMEOUT_MAX_MS) {
+      throw new TypeError(
+        "accountingTimeoutMs must be between 1,000 and 14,400,000",
+      );
+    }
+    if (!Number.isSafeInteger(cancelSettlementMs)
+        || cancelSettlementMs < 1_000
+        || cancelSettlementMs
+          > LOCAL_COMPANION_REFRESH_CANCEL_SETTLEMENT_MAX_MS) {
+      throw new TypeError(
+        "cancelSettlementMs must be between 1,000 and 60,000",
+      );
+    }
+    if (typeof monotonicClock !== "function") {
+      throw new TypeError("monotonicClock must be a function");
+    }
+    if (typeof setTimeoutImpl !== "function"
+        || typeof clearTimeoutImpl !== "function") {
+      throw new TypeError(
+        "setTimeoutImpl and clearTimeoutImpl must be functions",
+      );
+    }
     if (typeof createRefreshId !== "function") {
       throw new TypeError("createRefreshId must be a function");
     }
@@ -1774,7 +1816,12 @@ export class LocalCompanionRefreshController {
     this.#dataStore = dataStore;
     this.#timeoutMs = timeoutMs;
     this.#timeoutMsForRun = timeoutMsForRun;
+    this.#accountingTimeoutMs = accountingTimeoutMs;
+    this.#cancelSettlementMs = cancelSettlementMs;
     this.#clock = clock;
+    this.#monotonicClock = monotonicClock;
+    this.#setTimeoutImpl = setTimeoutImpl;
+    this.#clearTimeoutImpl = clearTimeoutImpl;
     this.#createRefreshId = createRefreshId;
     this.#onTerminalFailure = onTerminalFailure;
     this.#onDegradedOutcome = onDegradedOutcome;
@@ -1808,6 +1855,11 @@ export class LocalCompanionRefreshController {
       ...this.#state,
       status: "cancelling",
     };
+    // An explicit cancel supersedes the ordinary or extended work deadline.
+    // Bound settlement independently so an injected or defective runner that
+    // ignores AbortSignal cannot hold the foreground refresh lock for the
+    // remainder of a four-hour cold-accounting allowance.
+    this.#beginCancellationSettlement?.();
     this.#abortController.abort();
     return true;
   }
@@ -1886,16 +1938,75 @@ export class LocalCompanionRefreshController {
     };
     let timedOut = false;
     let timeout;
+    let cancellationSettlementTimeout;
+    let accountingDeadlineApplied = false;
+    const timeoutStartedAt = this.#monotonicClock();
     const controller = new AbortController();
     this.#abortController = controller;
-    const work = Promise.resolve()
+    const expire = () => {
+      if (this.#state.refreshId !== refreshId
+          || this.#cancelRequested
+          || !["running", "cancelling"].includes(this.#state.status)) return;
+      timedOut = true;
+      controller.abort();
+      this.#state = {
+        status: "failed",
+        refreshId: this.#state.refreshId,
+        startedAt: this.#state.startedAt,
+        finishedAt: new Date(this.#clock()).toISOString(),
+        result: null,
+        progress: terminalRefreshProgress(this.#state.progress),
+        quickResultAt: this.#state.quickResultAt,
+        errorCode: "refresh_timed_out",
+      };
+      // The timeout IS the terminal failure the user sees, and a hung runner
+      // may never settle — file the trail entry now, not at settlement.
+      this.#notifyTerminalFailure();
+    };
+    const armTimeoutFromStart = (budgetMs) => {
+      this.#clearTimeoutImpl(timeout);
+      const elapsedMs = Math.max(
+        0,
+        this.#monotonicClock() - timeoutStartedAt,
+      );
+      const remainingMs = Math.max(1, Math.ceil(budgetMs - elapsedMs));
+      timeout = this.#setTimeoutImpl(expire, remainingMs);
+      timeout.unref?.();
+    };
+    let resolveCancellationSettlement;
+    const cancellationSettlement = new Promise((resolve) => {
+      resolveCancellationSettlement = resolve;
+    });
+    this.#beginCancellationSettlement = () => {
+      this.#clearTimeoutImpl(timeout);
+      if (cancellationSettlementTimeout !== undefined) return;
+      cancellationSettlementTimeout = this.#setTimeoutImpl(
+        () => resolveCancellationSettlement(CANCEL_SETTLEMENT_EXPIRED),
+        this.#cancelSettlementMs,
+      );
+      cancellationSettlementTimeout.unref?.();
+    };
+    const runnerWork = Promise.resolve()
       .then(() => this.#runner({
         signal: controller.signal,
         onProgress: async (progress) => {
-          if (timedOut
+          if (this.#state.refreshId !== refreshId
+              || timedOut
               || !["running", "cancelling"].includes(this.#state.status)) return;
           const projected = publicRefreshProgress(progress);
           if (projected === null) return;
+          if (!accountingDeadlineApplied
+              && !this.#cancelRequested
+              && this.#state.status === "running"
+              && projected.kind === ACCOUNTING_PROGRESS_KIND
+              && this.#accountingTimeoutMs > selectedTimeoutMs) {
+            // The runner emits this exact marker only for an actual full
+            // replay-safe rebuild. Extend once to the same four-hour total
+            // bound used by a fresh index; repeated or malformed progress
+            // cannot keep a run alive indefinitely.
+            accountingDeadlineApplied = true;
+            armTimeoutFromStart(this.#accountingTimeoutMs);
+          }
           let quickResultAt = this.#state.quickResultAt;
           if (projected.kind !== ARCHIVE_INDEX_PROGRESS_KIND
               && projected.phase === "quick_result"
@@ -1918,19 +2029,26 @@ export class LocalCompanionRefreshController {
             quickResultAt,
           };
         },
-      }))
+      }));
+    const work = Promise.race([runnerWork, cancellationSettlement])
       .then(async (result) => {
         if (this.#cancelRequested) {
           // The data store already owns the last verified snapshot. A cancel
-          // must become terminal as soon as worker shutdown is confirmed,
-          // rather than entering another potentially expensive projection.
+          // becomes terminal as soon as worker shutdown is confirmed. If a
+          // defective runner ignores abort, the short settlement watchdog
+          // instead detaches it from the foreground generation; the runner's
+          // AbortSignal still fences durable accounting publication.
           this.#state = {
             status: "cancelled",
             refreshId: this.#state.refreshId,
             startedAt: this.#state.startedAt,
             finishedAt: new Date(this.#clock()).toISOString(),
-            result: publicRefreshResult(result, this.#clock()),
-            progress: publicIndexingResult(result?.indexing)
+            result: result === CANCEL_SETTLEMENT_EXPIRED
+              ? null
+              : publicRefreshResult(result, this.#clock()),
+            progress: result === CANCEL_SETTLEMENT_EXPIRED
+              ? terminalRefreshProgress(this.#state.progress)
+              : publicIndexingResult(result?.indexing)
               ?? terminalRefreshProgress(this.#state.progress),
             quickResultAt: this.#state.quickResultAt,
             errorCode: "refresh_cancelled",
@@ -2036,29 +2154,14 @@ export class LocalCompanionRefreshController {
         this.#notifyTerminalFailure();
       })
       .finally(() => {
-        clearTimeout(timeout);
+        this.#clearTimeoutImpl(timeout);
+        this.#clearTimeoutImpl(cancellationSettlementTimeout);
         this.#abortController = null;
+        this.#beginCancellationSettlement = null;
         this.#cancelRequested = false;
         this.#inFlight = null;
       });
-    timeout = setTimeout(() => {
-      timedOut = true;
-      controller.abort();
-      this.#state = {
-        status: "failed",
-        refreshId: this.#state.refreshId,
-        startedAt: this.#state.startedAt,
-        finishedAt: new Date(this.#clock()).toISOString(),
-        result: null,
-        progress: terminalRefreshProgress(this.#state.progress),
-        quickResultAt: this.#state.quickResultAt,
-        errorCode: "refresh_timed_out",
-      };
-      // The timeout IS the terminal failure the user sees, and a hung runner
-      // may never settle — file the trail entry now, not at settlement.
-      this.#notifyTerminalFailure();
-    }, selectedTimeoutMs);
-    timeout.unref?.();
+    armTimeoutFromStart(selectedTimeoutMs);
     this.#inFlight = work;
     return true;
   }

--- a/src/replay-safe-accounting-cache.js
+++ b/src/replay-safe-accounting-cache.js
@@ -4761,7 +4761,16 @@ export async function refreshReplaySafeAccountingCache({
   if (Buffer.byteLength(stableJson(cache)) > MAX_CACHE_BYTES) {
     throw fixedError("cache_invalid_size");
   }
-  await writeLocalCollectorAccountingCache({ stateFile: selectedStateFile, cache });
+  // A timeout/cancel can arrive after the isolated child has returned a valid
+  // artifact but before its atomic publication. Recheck at the final durable
+  // boundary so a run already reported as stopped cannot replace the retained
+  // cache behind that terminal state.
+  throwIfAborted(options.signal ?? null);
+  await writeLocalCollectorAccountingCache({
+    stateFile: selectedStateFile,
+    cache,
+    signal: options.signal ?? null,
+  });
   return cache;
 }
 

--- a/test/local-companion-refresh.test.js
+++ b/test/local-companion-refresh.test.js
@@ -14,6 +14,7 @@ import {
   createLocalCollectorRefreshRunner,
   createTerminalRefreshFailureRecorder,
   LOCAL_COMPANION_FRESH_INDEX_REFRESH_TIMEOUT_MS,
+  LOCAL_COMPANION_REFRESH_CANCEL_SETTLEMENT_MS,
   LOCAL_COMPANION_REFRESH_TIMEOUT_MAX_MS,
   LocalCompanionRefreshController,
 } from "../src/local-companion-refresh.js";
@@ -70,6 +71,53 @@ const PAUSED_INDEX = Object.freeze({
   },
 });
 
+function createManualTimerScheduler() {
+  let nowMs = 0;
+  let nextId = 1;
+  const scheduled = new Map();
+  return {
+    now: () => nowMs,
+    setTimeout(callback, delayMs) {
+      const handle = {
+        id: nextId,
+        unref() {},
+      };
+      nextId += 1;
+      scheduled.set(handle, {
+        callback,
+        dueAt: nowMs + delayMs,
+        id: handle.id,
+      });
+      return handle;
+    },
+    clearTimeout(handle) {
+      scheduled.delete(handle);
+    },
+    advanceBy(elapsedMs) {
+      const target = nowMs + elapsedMs;
+      while (true) {
+        const ready = [...scheduled.entries()]
+          .filter(([, value]) => value.dueAt <= target)
+          .sort((left, right) => (
+            left[1].dueAt - right[1].dueAt || left[1].id - right[1].id
+          ))[0];
+        if (ready === undefined) break;
+        const [handle, value] = ready;
+        scheduled.delete(handle);
+        nowMs = value.dueAt;
+        value.callback();
+      }
+      nowMs = target;
+    },
+  };
+}
+
+async function flushControllerSettlement(controller) {
+  for (let attempt = 0; attempt < 100 && controller.isRunning(); attempt += 1) {
+    await new Promise((resolve) => setImmediate(resolve));
+  }
+}
+
 test("refresh controller admits the bounded fresh-index ceiling", () => {
   const dependencies = {
     runner: async () => ({}),
@@ -83,9 +131,11 @@ test("refresh controller admits the bounded fresh-index ceiling", () => {
     LOCAL_COMPANION_REFRESH_TIMEOUT_MAX_MS,
     14_400_000,
   );
+  assert.equal(LOCAL_COMPANION_REFRESH_CANCEL_SETTLEMENT_MS, 30_000);
   assert.doesNotThrow(() => new LocalCompanionRefreshController({
     ...dependencies,
     timeoutMs: LOCAL_COMPANION_REFRESH_TIMEOUT_MAX_MS,
+    accountingTimeoutMs: LOCAL_COMPANION_REFRESH_TIMEOUT_MAX_MS,
   }));
   assert.throws(
     () => new LocalCompanionRefreshController({
@@ -94,6 +144,24 @@ test("refresh controller admits the bounded fresh-index ceiling", () => {
     }),
     /14,400,000/u,
   );
+  for (const accountingTimeoutMs of [999, 14_400_001]) {
+    assert.throws(
+      () => new LocalCompanionRefreshController({
+        ...dependencies,
+        accountingTimeoutMs,
+      }),
+      /accountingTimeoutMs.*14,400,000/u,
+    );
+  }
+  for (const cancelSettlementMs of [999, 60_001]) {
+    assert.throws(
+      () => new LocalCompanionRefreshController({
+        ...dependencies,
+        cancelSettlementMs,
+      }),
+      /cancelSettlementMs.*60,000/u,
+    );
+  }
   const dynamicallyInvalid = new LocalCompanionRefreshController({
     ...dependencies,
     timeoutMsForRun: () => LOCAL_COMPANION_REFRESH_TIMEOUT_MAX_MS + 1,
@@ -834,6 +902,165 @@ test("unified authority keeps quota-only collection prospective and softens a co
   assert.equal(result.indexing.status, "bounded_pause");
   assert.equal(result.accounting.sourceMode, "unified");
   assert.equal(result.accounting.refreshStatus, "rebuilt");
+});
+
+test("a reusable unified accounting cache does not announce a cold rebuild", async () => {
+  const progress = [];
+  let rebuilds = 0;
+  const expectedGeneration = {
+    id: 14,
+    fingerprint: "r".repeat(64),
+    status: "complete",
+    discoveryComplete: true,
+    diagnosticsComplete: true,
+    usageProvenanceComplete: true,
+    sourceOrderComplete: true,
+    quotaProvenanceComplete: true,
+    toolProvenanceComplete: true,
+  };
+  const runner = createLocalCollectorRefreshRunner({
+    accountingSourceMode: "unified",
+    unifiedIndexFile: "/private/local-unified-index-v1.sqlite",
+    selectAccountObservationSecret: () => ({
+      loadAccountObservationSecret: null,
+    }),
+    runCollector: async () => ({
+      rolloutRecordsWritten: 0,
+      filesDiscovered: 1,
+      refresh: { attempted: false, recordWritten: false, errorCode: null },
+      indexing: COMPLETE_INDEX,
+    }),
+    refreshUnifiedIndex: async () => ({
+      status: "ingested",
+      generation: expectedGeneration,
+    }),
+    readAccountingCache: async (options) => {
+      assert.equal(options.expectedGeneration.id, expectedGeneration.id);
+      assert.equal(
+        options.expectedGeneration.fingerprint,
+        expectedGeneration.fingerprint,
+      );
+      return {
+        status: "available",
+        errorCode: null,
+        cache: {
+          ...REUSABLE_ACCOUNTING_CACHE,
+          sourceDescriptor: {
+            mode: "unified",
+            fallbackCount: 0,
+          },
+        },
+      };
+    },
+    refreshAccounting: async () => {
+      rebuilds += 1;
+      throw new Error("a reusable cache must not rebuild");
+    },
+  });
+
+  const result = await runner({ onProgress: (value) => progress.push(value) });
+
+  assert.equal(rebuilds, 0);
+  assert.equal(result.accounting.refreshStatus, "reused");
+  assert.equal(progress.some((value) => value?.kind === "accounting"), false);
+});
+
+test("a semantics-outdated unified cache announces one rebuild and receives the cold-work bound", async (t) => {
+  const timers = createManualTimerScheduler();
+  const rebuildEntered = Promise.withResolvers();
+  const rebuildSettled = Promise.withResolvers();
+  const events = [];
+  let rebuilds = 0;
+  let rebuildSignal;
+  t.after(() => rebuildSettled.resolve({}));
+  const generation = {
+    id: 15,
+    fingerprint: "s".repeat(64),
+    status: "complete",
+    discoveryComplete: true,
+    diagnosticsComplete: true,
+    usageProvenanceComplete: true,
+    sourceOrderComplete: true,
+    quotaProvenanceComplete: true,
+    toolProvenanceComplete: true,
+  };
+  const collectorRunner = createLocalCollectorRefreshRunner({
+    accountingSourceMode: "unified",
+    unifiedIndexFile: "/private/local-unified-index-v1.sqlite",
+    selectAccountObservationSecret: () => ({
+      loadAccountObservationSecret: null,
+    }),
+    runCollector: async () => ({
+      rolloutRecordsWritten: 0,
+      filesDiscovered: 1,
+      refresh: { attempted: false, recordWritten: false, errorCode: null },
+      indexing: COMPLETE_INDEX,
+    }),
+    refreshUnifiedIndex: async () => ({
+      status: "ingested",
+      generation,
+    }),
+    readAccountingCache: async (options) => {
+      assert.equal(options.sourceMode, "unified");
+      assert.equal(options.expectedGeneration.id, generation.id);
+      events.push("cache_accounting_semantics_outdated");
+      return {
+        status: "unavailable",
+        errorCode: "cache_accounting_semantics_outdated",
+        cache: null,
+      };
+    },
+    refreshAccounting: async ({ expectedGeneration, signal }) => {
+      rebuilds += 1;
+      rebuildSignal = signal;
+      assert.equal(expectedGeneration.id, generation.id);
+      events.push("rebuild");
+      rebuildEntered.resolve();
+      return rebuildSettled.promise;
+    },
+  });
+  const runner = ({ onProgress, ...options }) => collectorRunner({
+    ...options,
+    onProgress: async (progress) => {
+      if (progress?.kind === "accounting") events.push("accounting_marker");
+      await onProgress(progress);
+    },
+  });
+  const controller = new LocalCompanionRefreshController({
+    runner,
+    dataStore: { async reload() {} },
+    timeoutMs: 1_000,
+    accountingTimeoutMs: 4_000,
+    monotonicClock: timers.now,
+    setTimeoutImpl: timers.setTimeout,
+    clearTimeoutImpl: timers.clearTimeout,
+  });
+
+  assert.equal(controller.start(), true);
+  await rebuildEntered.promise;
+  assert.deepEqual(events, [
+    "cache_accounting_semantics_outdated",
+    "accounting_marker",
+    "rebuild",
+  ]);
+  assert.equal(rebuilds, 1);
+  assert.deepEqual(controller.getStatus().progress, {
+    kind: "accounting",
+    status: "calculating",
+  });
+
+  timers.advanceBy(3_999);
+  assert.equal(controller.getStatus().status, "running");
+  assert.equal(rebuildSignal.aborted, false);
+  timers.advanceBy(1);
+  assert.equal(controller.getStatus().status, "failed");
+  assert.equal(controller.getStatus().errorCode, "refresh_timed_out");
+  assert.equal(rebuildSignal.aborted, true);
+
+  rebuildSettled.resolve({});
+  await flushControllerSettlement(controller);
+  assert.equal(rebuilds, 1);
+  assert.equal(controller.getStatus().status, "failed");
 });
 
 test("a fresh unified machine completes its first refresh when the app-server read fails", async () => {
@@ -2543,6 +2770,175 @@ test("accounting progress accepts only its exact count-free work marker", async 
   assert.deepEqual(reloadPurposes, ["full"]);
 });
 
+test("an exact accounting rebuild marker extends the ordinary deadline once to the cold-work bound", async (t) => {
+  const timers = createManualTimerScheduler();
+  const entered = Promise.withResolvers();
+  const settled = Promise.withResolvers();
+  let publish;
+  let signal;
+  t.after(() => settled.resolve({}));
+  const controller = new LocalCompanionRefreshController({
+    runner: async ({ signal: activeSignal, onProgress }) => {
+      signal = activeSignal;
+      publish = onProgress;
+      entered.resolve();
+      return settled.promise;
+    },
+    dataStore: { async reload() {} },
+    timeoutMs: 1_000,
+    accountingTimeoutMs: 1_500,
+    monotonicClock: timers.now,
+    setTimeoutImpl: timers.setTimeout,
+    clearTimeoutImpl: timers.clearTimeout,
+  });
+
+  assert.equal(controller.start(), true);
+  await entered.promise;
+  // The first marker arrives close to the ordinary deadline. It grants a
+  // 1,500 ms total-from-start bound, not another 1,500 ms from this point.
+  timers.advanceBy(900);
+  await publish({ kind: "accounting", status: "calculating" });
+  timers.advanceBy(300);
+  // Repeated and future-shaped markers cannot move the total deadline again.
+  await publish({ kind: "accounting", status: "calculating" });
+  await publish({
+    kind: "accounting",
+    status: "calculating",
+    privateUnreviewedField: true,
+  });
+  timers.advanceBy(299);
+  assert.equal(controller.getStatus().status, "running");
+  assert.equal(signal.aborted, false);
+
+  timers.advanceBy(1);
+  assert.equal(controller.getStatus().status, "failed");
+  assert.equal(controller.getStatus().errorCode, "refresh_timed_out");
+  assert.equal(signal.aborted, true);
+  settled.resolve({});
+  await flushControllerSettlement(controller);
+  assert.equal(controller.getStatus().status, "failed");
+});
+
+test("a late accounting marker cannot extend work after cancellation", async (t) => {
+  const timers = createManualTimerScheduler();
+  const entered = Promise.withResolvers();
+  const settled = Promise.withResolvers();
+  let publish;
+  let signal;
+  t.after(() => settled.resolve({}));
+  const controller = new LocalCompanionRefreshController({
+    runner: async ({ signal: activeSignal, onProgress }) => {
+      signal = activeSignal;
+      publish = onProgress;
+      entered.resolve();
+      return settled.promise;
+    },
+    dataStore: { async reload() {} },
+    timeoutMs: 1_000,
+    accountingTimeoutMs: 1_500,
+    cancelSettlementMs: 1_000,
+    monotonicClock: timers.now,
+    setTimeoutImpl: timers.setTimeout,
+    clearTimeoutImpl: timers.clearTimeout,
+  });
+
+  assert.equal(controller.start(), true);
+  await entered.promise;
+  assert.equal(controller.cancel(), true);
+  assert.equal(signal.aborted, true);
+  await publish({ kind: "accounting", status: "calculating" });
+  timers.advanceBy(999);
+  assert.equal(controller.getStatus().status, "cancelling");
+  assert.equal(controller.isRunning(), true);
+
+  timers.advanceBy(1);
+  await flushControllerSettlement(controller);
+  assert.equal(controller.getStatus().status, "cancelled");
+  assert.equal(controller.getStatus().errorCode, "refresh_cancelled");
+  assert.equal(controller.isRunning(), false);
+
+  settled.resolve({});
+  await new Promise((resolve) => setImmediate(resolve));
+  assert.equal(controller.getStatus().status, "cancelled");
+});
+
+test("the cancellation watchdog releases an abort-ignoring accounting run without clobbering its successor", async (t) => {
+  const timers = createManualTimerScheduler();
+  const firstEntered = Promise.withResolvers();
+  const firstSettled = Promise.withResolvers();
+  const secondEntered = Promise.withResolvers();
+  const secondSettled = Promise.withResolvers();
+  let firstPublish;
+  let firstSignal;
+  let runs = 0;
+  let reloads = 0;
+  t.after(() => {
+    firstSettled.resolve({});
+    secondSettled.resolve({});
+  });
+  const controller = new LocalCompanionRefreshController({
+    runner: async ({ signal, onProgress }) => {
+      runs += 1;
+      if (runs === 1) {
+        firstSignal = signal;
+        firstPublish = onProgress;
+        await onProgress({ kind: "accounting", status: "calculating" });
+        firstEntered.resolve();
+        // Deliberately ignore AbortSignal: the controller must bound how long
+        // this defective runner owns the foreground slot.
+        return firstSettled.promise;
+      }
+      secondEntered.resolve();
+      return secondSettled.promise;
+    },
+    dataStore: { async reload() { reloads += 1; } },
+    timeoutMs: 1_000,
+    accountingTimeoutMs: 4_000,
+    cancelSettlementMs: 1_000,
+    monotonicClock: timers.now,
+    setTimeoutImpl: timers.setTimeout,
+    clearTimeoutImpl: timers.clearTimeout,
+  });
+
+  assert.equal(controller.start(), true);
+  await firstEntered.promise;
+  assert.equal(controller.cancel(), true);
+  assert.equal(firstSignal.aborted, true);
+  timers.advanceBy(999);
+  assert.equal(controller.isRunning(), true);
+  assert.equal(controller.getStatus().status, "cancelling");
+
+  timers.advanceBy(1);
+  await flushControllerSettlement(controller);
+  assert.equal(controller.isRunning(), false);
+  assert.equal(controller.getStatus().status, "cancelled");
+  assert.equal(controller.getStatus().result, null);
+  assert.equal(reloads, 0);
+
+  assert.equal(controller.start(), true);
+  await secondEntered.promise;
+  const successorId = controller.getStatus().refreshId;
+  assert.equal(controller.getStatus().status, "running");
+
+  // A late progress callback and settlement from the detached first runner
+  // belong to its old refresh generation. Neither may mutate or release the
+  // successor's state or in-flight ownership.
+  await firstPublish({ kind: "accounting", status: "calculating" });
+  firstSettled.resolve({ indexing: COMPLETE_INDEX });
+  await new Promise((resolve) => setImmediate(resolve));
+  assert.equal(controller.isRunning(), true);
+  assert.equal(controller.getStatus().refreshId, successorId);
+  assert.equal(controller.getStatus().status, "running");
+  assert.equal(controller.getStatus().progress, null);
+  assert.equal(reloads, 0);
+
+  secondSettled.resolve({ indexing: COMPLETE_INDEX });
+  await flushControllerSettlement(controller);
+  assert.equal(controller.getStatus().refreshId, successorId);
+  assert.equal(controller.getStatus().status, "succeeded");
+  assert.equal(reloads, 1);
+});
+
 test("accounting work markers never survive failure, cancellation, or timeout as running work", async (t) => {
   for (const outcome of ["failure", "cancel", "timeout"]) {
     await t.test(outcome, async (t) => {
@@ -2560,6 +2956,9 @@ test("accounting work markers never survive failure, cancellation, or timeout as
         },
         dataStore: { async reload({ purpose }) { reloadPurposes.push(purpose); } },
         timeoutMs: 1_000,
+        // This test owns terminal-state cleanup, not deadline extension; keep
+        // its accounting bound equal to its deliberately tiny base timeout.
+        accountingTimeoutMs: 1_000,
       });
       assert.equal(controller.start(), true);
       await entered.promise;

--- a/test/macos-app-bundle.test.js
+++ b/test/macos-app-bundle.test.js
@@ -4299,11 +4299,11 @@ test("development and preview builds treat the release-channel policy as optiona
 
 test("macOS release metadata validates versions, production mode, and Keychain references", async () => {
   assert.equal(normalizeMacOSBundleVersion(), DERIVED_MACOS_BUNDLE_VERSION);
-  assert.equal(INTERNAL_DOGFOOD_SIGNED_BUNDLE_VERSION, "1023.3");
+  assert.equal(INTERNAL_DOGFOOD_SIGNED_BUNDLE_VERSION, "1023.4");
   assert.equal(STABLE_SIGNED_BUNDLE_VERSION, "1024");
   assert.equal(
     normalizeMacOSBundleVersion(INTERNAL_DOGFOOD_SIGNED_BUNDLE_VERSION),
-    "1023.3",
+    "1023.4",
   );
   assert.equal(
     compareMacOSBundleVersions(
@@ -4328,13 +4328,18 @@ test("macOS release metadata validates versions, production mode, and Keychain r
     "the final integrated dogfood must be strictly newer than startup-recovery RC4",
   );
   assert.equal(
+    compareMacOSBundleVersions("1023.3", INTERNAL_DOGFOOD_SIGNED_BUNDLE_VERSION),
+    -1,
+    "the accounting-deadline correction must be strictly newer than installed RC5",
+  );
+  assert.equal(
     compareMacOSBundleVersions(
       STABLE_SIGNED_BUNDLE_VERSION,
       INTERNAL_DOGFOOD_SIGNED_BUNDLE_VERSION,
     ) > 0,
     true,
   );
-  for (const unallocated of ["1023", "1023.0", "1023.1", "1023.1.0", "1023.2", "1023.2.0", "1023.3.0", "1024", "2000.1.17"]) {
+  for (const unallocated of ["1023", "1023.0", "1023.1", "1023.1.0", "1023.2", "1023.2.0", "1023.3", "1023.3.0", "1023.4.0", "1024", "2000.1.17"]) {
     assert.throws(
       () => readMacOSReleaseBuildConfiguration({
         USAGE_MONITOR_BUNDLE_VERSION: unallocated,

--- a/test/replay-safe-accounting-cache.test.js
+++ b/test/replay-safe-accounting-cache.test.js
@@ -2959,6 +2959,45 @@ test("refresh forwards AbortSignal and never writes an aborted projection", asyn
   assert.equal(await readTestCache(cacheFile), null);
 });
 
+test("an abort during cache-store preparation preserves the retained cache", async () => {
+  const directory = await mkdtemp(join(tmpdir(), "usage-monitor-publish-abort-"));
+  const cacheFile = join(directory, "accounting.json");
+  await refreshReplaySafeAccountingCache({
+    cacheFile,
+    now: () => NOW,
+    scan: scanner([
+      usageEvent({
+        timestamp: "2026-07-27T11:55:00.000Z",
+        components: { input_uncached_tokens: 1_000_000 },
+      }),
+    ]),
+  });
+  const before = await readTestCache(cacheFile);
+  const controller = new AbortController();
+
+  // The async writer has entered ensureDatabase before returning this promise.
+  // Abort immediately while that preparation is awaiting filesystem work; the
+  // post-preparation check must stop the synchronous replacement transaction.
+  const publication = writeLocalCollectorAccountingCache({
+    stateFile: cacheFile,
+    cache: {
+      ...before,
+      generatedAt: new Date(NOW + 1_000).toISOString(),
+    },
+    signal: controller.signal,
+  });
+  controller.abort();
+
+  await assert.rejects(
+    publication,
+    (error) => (
+      error?.name === "AbortError"
+      && error?.code === "accounting_refresh_aborted"
+    ),
+  );
+  assert.deepEqual(await readTestCache(cacheFile), before);
+});
+
 test("compact transition input ceilings fail closed without truncating or replacing the last good cache", async () => {
   const directory = await mkdtemp(join(tmpdir(), "usage-monitor-bounds-"));
   const cacheFile = join(directory, "accounting.json");


### PR DESCRIPTION
## Summary

- extend only a confirmed full accounting rebuild from the ordinary five-minute refresh lifetime to one bounded four-hour total lifetime
- keep cancellation responsive with a 30-second settlement watchdog and fence late or detached work from successor refreshes
- prevent an aborted or timed-out accounting pass from publishing a replacement cache
- allocate internal dogfood build 1023.4 and update maintained recovery and release guidance
- regenerate all ten protected R7 receipts on the exact frozen source

## Validation

- focused refresh and cache suites: 153/153
- local companion: 300/300
- browser UI: 473/473
- native macOS: 89/89 on macOS arm64 with Node 26.2.0
- Worker gate: 179 script tests and 524 Worker tests, plus default and staging dry-run bundles
- architecture: 382 production files, 1,538 imports, zero debt
- full root: 3,471 tests; 3,454 passed; 0 failed; 17 platform-only skips
- R7: 10/10 receipts regenerated and independently revalidated across Node 24.14.0 and 26.2.0; 359-file source closure; decision remains release_open

## Release boundary

This is an internal dogfood candidate. The separate PR 94 fixed-real-corpus before/after attribution comparator remains OPEN / NOT RUN because the repository does not yet contain one reviewed closed receipt generator. No Worker deployment, hosted migration, updater publication, stable release publication, or user-data reset is included.