### PR TITLE
Prepare 0.1.17 RC7 unified accounting dogfood

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -281,14 +281,20 @@ published-release claim.
 - Gives Preview its own app, bundle, semantic-open, local-state, Keychain,
   preferences, and Sparkle-feed identities, preventing preview installation or
   updates from replacing stable state.
-- Records builds 1023, 1023.1, 1023.2, and 1023.3 as earlier 0.1.17 internal
-  dogfoods, allocates build 1023.4 to RC6, and retains build 1024 for stable.
+- Records builds 1023, 1023.1, 1023.2, 1023.3, and 1023.4 as earlier 0.1.17
+  internal dogfoods, allocates build 1023.5 to RC7, and retains build 1024 for
+  stable.
   Signed tooling requires a clean checkout with exactly one matching annotated
   channel tag at `HEAD` before it can proceed. RC5 build 1023.3 is signed,
   notarized, and installed evidence for its frozen source, but physical testing
   found that its ordinary five-minute refresh deadline stopped a legitimate
-  full accounting-cache rebuild. RC6 still requires exact-source gates,
-  protected R7 regeneration, signing, installation, and physical verification.
+  full accounting-cache rebuild. RC6 build 1023.4 subsequently proved that
+  timeout correction in a signed, notarized, installed refresh, but exposed an
+  inherited `recent_7d_indexing` legacy checkpoint suppressing otherwise-
+  authoritative unified accounting. RC7 removes only that retired collector
+  gate, retains the fail-closed unified-generation authority check, and still
+  requires fresh exact-source gates, protected R7 regeneration, signing,
+  installation, and physical verification.
 - Establishes scoped, machine-checked repository guidance for coding agents and
   the root layout they may extend
   ([PR #77](https://github.com/adamallcock/tibotattle/pull/77)).

--- a/apps/macos/README.md
+++ b/apps/macos/README.md
@@ -422,12 +422,22 @@ a claim that Sparkle has updated the preview client.
 `CFBundleShortVersionString` remains the user-facing package version. The
 Sparkle ordering key, `CFBundleVersion`, is explicitly allocated for signed
 builds that retain the stable bundle identifier. The 0.1.17 internal-dogfood
-RC6 build is `1023.4`; the 0.1.17 stable final remains `1024`. This corrected
-candidate orders strictly after installed RC5 `1023.3`, startup-recovery RC4
-`1023.2`, migration RC3 `1023.1`, retained RC2 `1023`, and earlier
-shared-identity dogfood `1022`, while stable orders after the dogfood candidate.
+RC7 build is `1023.5`; the 0.1.17 stable final remains `1024`. This corrected
+candidate orders strictly after installed RC6 `1023.4`, integrated RC5
+`1023.3`, startup-recovery RC4 `1023.2`, migration RC3 `1023.1`, retained RC2
+`1023`, and earlier shared-identity dogfood `1022`, while stable orders after
+the dogfood candidate.
 A future signed version/channel must add a reviewed
 monotonic allocation before release tooling will run.
+
+Installed RC6 proved that the cold-accounting lifetime can safely exceed the
+ordinary five-minute refresh deadline. Its real refresh then exposed the
+inherited `recent_7d_indexing` legacy checkpoint suppressing otherwise-
+authoritative unified accounting. RC7 removes only that retired collector gate;
+`unifiedGenerationAuthoritative` and every generation, completeness, resource,
+and publication guard remain fail-closed. The allocation is not artifact or
+installed-app evidence: exact-source gates, protected R7, signing, notarization,
+state-preserving replacement, and physical verification must be repeated.
 
 Release tooling accepts `USAGE_MONITOR_BUNDLE_VERSION` only when it exactly
 matches the checked-in channel allocation, and the signed stable path still
@@ -523,7 +533,7 @@ For a later stable release, use `--previous-stable-manifest` in place of
 the release command refuses to guess which continuity policy applies.
 `USAGE_MONITOR_BUNDLE_VERSION` is optional as an operator assertion only; when
 present it must exactly equal the checked-in allocation for the selected
-signed release version and channel (`1023.4` for 0.1.17 internal dogfood,
+signed release version and channel (`1023.5` for 0.1.17 internal dogfood,
 `1024` for 0.1.17 stable).
 
 `config/deployment-endpoints.js` is the reviewed source for the public origin

--- a/docs/current-status.md
+++ b/docs/current-status.md
@@ -1,10 +1,10 @@
 ---
 title: Current product and release status
-date: 2026-08-31
+date: 2026-09-01
 type: status
 status: current
-source_commit: 3b0f2d23775c0ca1f092fe3eb48f0c3166c8461a
-observation_date: 2026-08-31
+source_commit: 64fc79e44f671336e8060416932538ff360ac4ca
+observation_date: 2026-09-01
 ---
 
 # Current product and release status
@@ -18,8 +18,8 @@ using this page for a later release or operational decision.
 
 | Boundary | Verified state |
 |---|---|
-| Documentation/source review | Release-preparation base `origin/main` commit `3b0f2d23775c0ca1f092fe3eb48f0c3166c8461a`, reviewed 2026-08-31; final source freeze is pending |
-| Installed internal dogfood | Signed and notarized RC4 source `735a59ce2ec01df0e381fb1aa878c5c7a39edcd8`, build `1023.2`, installed 2026-08-31; excludes PR #94 and is not current main or stable |
+| Documentation/source review | RC7 preparation source `64fc79e44f671336e8060416932538ff360ac4ca`, reviewed 2026-09-01; final source freeze is pending |
+| Installed internal dogfood | Signed and notarized RC6 source `e59115d41958f6b23496a65c9732a6a9944fdde0`, build `1023.4`, installed 2026-08-31; the timeout correction passed but the advanced-accounting handoff did not |
 | Public service | Read-only `GET https://tibotattle.com/api/health`, HTTP 200, deployment source `304f3d736b6f9451d32a616bf3046ea628e828a3`, observed 2026-08-31 |
 | Public updater | Read-only `GET https://updates.tibotattle.com/appcast.xml`, observed 2026-08-27 |
 | Published release | GitHub release API for `adamallcock/tibotattle`, observed 2026-08-27 |
@@ -116,35 +116,50 @@ The complete qualification matrix and rules for changing these claims are in
 - Integrated RC5 source `ff506dc3`, build `1023.3`, was signed, notarized and
   installed on 2026-08-31. Its state-preserving replacement and first launch
   passed, but its real full-accounting refresh did not: a healthy v0.14 rebuild
-  was terminated by the ordinary five-minute deadline. RC5 is therefore not
-  the dogfood handoff. Corrective RC6 is allocated monotonic build `1023.4` and
-  still needs frozen-source, R7, signed-artifact, replacement and physical
-  refresh evidence.
-- The RC5 R7 workload-source closure has protected dual-runtime
-  receipts for 359 files / workload SHA-256
-  `4c3058b3453bda2696e946952d18e81310f26eb0187074d410c730e44162f1d6`.
-  Both decisions remain honestly `release_open`. RC6 changes workload-owned
-  refresh/accounting source, so those receipts are now historical for RC5 and
-  must be regenerated after the corrective source is frozen. Native UI and
+  was terminated by the ordinary five-minute deadline. That evidence remains
+  specific to RC5.
+- RC6 source `e59115d41958f6b23496a65c9732a6a9944fdde0`, build `1023.4`,
+  subsequently passed its source gates, protected R7, Developer ID signing,
+  notarization, stapling, Gatekeeper, state-preserving replacement, and installed
+  launch without an observed Keychain prompt. Its real refresh ran past five
+  minutes and reached terminal success, proving the deadline correction. The
+  installed result then exposed an inherited `recent_7d_indexing` legacy
+  checkpoint suppressing otherwise-authoritative unified accounting. RC6 is
+  therefore not the final dogfood handoff.
+- RC7 source preparation removes only that retired collector checkpoint. It
+  continues to require `unifiedGenerationAuthoritative` before accounting can
+  publish and does not relax source completeness, generation matching, resource
+  ceilings, or atomic publication. RC7 is allocated monotonic build `1023.5`,
+  strictly after installed RC6 and before reserved stable build `1024`. Fresh
+  exact-source gates, R7, signed-artifact, replacement, and physical installed
+  refresh evidence remain required.
+- The RC6 R7 workload-source closure has protected dual-runtime receipts for
+  359 files / workload SHA-256
+  `fcb55e0cb729b56249e2c6f4d8fa4a08bc4b4c8fe99a506ce10cfe1068ed48d5`.
+  Both decisions remain honestly `release_open`. RC7 changes workload-owned
+  refresh/accounting source, so those receipts are historical for RC6 and must
+  be regenerated after the corrective source is frozen. Native UI and
   build-allocation files remain subject to their separate macOS source, smoke,
   signed-artifact, and installed-artifact gates.
 - The public service and release feed are remote state. Their health and
   availability can change after this snapshot.
 - Public health is not proof that every admin, identity, contribution, deletion,
   or updater path works end to end.
-- Before RC6 dogfood sign-off or 0.1.17 stable qualification, PR #94 still needs
-  the fixed real-corpus before/after coverage, diagnostic-distribution, and
-  resource review. Current APIs cannot emit the complete named fit-rejection
-  reconciliation, so that gate remains open rather than inferred green. The
-  exact integrated native artifact must also pass signing, notarization,
-  state-preserving installation, updater, and physical native checks. Pairing
-  continuity needs compatible hosted Worker migrations/deployment before the
-  repaired desktop flow can be validated end to end.
+- PR #94's fixed-real-corpus before/after coverage, diagnostic-distribution, and
+  resource comparator remains **OPEN / NOT RUN**. Current APIs cannot emit the
+  complete named fit-rejection reconciliation, so R7 cannot be used as a
+  substitute. An explicitly open-gate internal dogfood may proceed for testing,
+  but this blocks stable and public 0.1.17 qualification until it is closed or
+  deliberately resolved. The exact RC7 native artifact must separately pass
+  signing, notarization, state-preserving installation, updater, and physical
+  native checks. Pairing continuity needs compatible hosted Worker migrations
+  and deployment before the repaired desktop flow can be validated end to end.
 - An owner-only fixed-window attempt on 2026-08-31 failed closed before comparison:
   the strict pre-PR scan reported `codex_rollout_content_invalid`. The supported
   resource benchmark independently stopped at `benchmark_cold_rebuild_incomplete`
   on both exact PR #94 revisions. No empirical comparison receipt was produced,
-  no source was excluded, and this remains an open RC6/stable gate.
+  no source was excluded, and this does not constitute a run of the formal
+  comparator. Its **OPEN / NOT RUN** state remains a stable/public gate.
 
 ## How to refresh this page
 

--- a/docs/decisions/2026-08-27-local-state-schema-and-release-channel-isolation.md
+++ b/docs/decisions/2026-08-27-local-state-schema-and-release-channel-isolation.md
@@ -156,6 +156,20 @@ allocated `1023.4`, strictly after installed RC5 and before reserved stable
 `1024`. RC5 artifact evidence remains evidence for RC5 only; it cannot qualify
 RC6 or stable.
 
+#### Allocation amendment, 2026-09-01 (RC7)
+
+RC6 build `1023.4` was subsequently signed, notarized, installed, and refreshed
+against preserved schema-11 state. Its real accounting rebuild ran past five
+minutes and reached terminal refresh success, proving the RC5 deadline defect
+was corrected. The installed result then exposed an inherited
+`recent_7d_indexing` legacy checkpoint suppressing otherwise-authoritative
+unified accounting. RC7 removes only that retired collector checkpoint while
+retaining the fail-closed `unifiedGenerationAuthoritative` predicate and all
+generation, completeness, resource, and atomic-publication guards. Its monotonic
+internal-dogfood allocation is `1023.5`, strictly after installed RC6 and before
+reserved stable `1024`. RC6 artifact evidence remains evidence for RC6 only;
+RC7 requires fresh exact-source, R7, artifact, replacement, and installed checks.
+
 The separately identified Preview app uses the deterministic migration epoch
 `(2000 + major).minor.patch`, so preview package `0.1.17` maps to
 `2000.1.17`. That keeps local preview builds deterministic and valid within

--- a/docs/decisions/2026-08-31-silent-keychain-migration.md
+++ b/docs/decisions/2026-08-31-silent-keychain-migration.md
@@ -300,3 +300,14 @@ automatic Keychain prompt, but failed the separate real accounting-refresh
 gate. Corrective RC6 is build `1023.4`; the prompt-avoidance contract and its
 release-blocking treatment are unchanged and must be reverified on that exact
 installed artifact.
+
+### RC7 allocation follow-up
+
+RC6 build `1023.4` was subsequently signed, notarized, installed, launched, and
+refreshed without an observed automatic Keychain prompt. That qualifies the
+prompt-free automatic path only for the exact RC6 artifact. Its refresh exposed
+a separate inherited `recent_7d_indexing` accounting checkpoint, so the narrow
+correction must ship as a newly signed candidate rather than relabel RC6. RC7 is
+allocated monotonic build `1023.5`; the Keychain contract is unchanged, and an
+unexpected prompt remains release-blocking during its fresh installed-artifact
+qualification.

--- a/docs/plans/2026-08-30-native-dogfood-integration.md
+++ b/docs/plans/2026-08-30-native-dogfood-integration.md
@@ -13,6 +13,10 @@ Electron release, or new signed-Preview workflow. Source integration, tests,
 state migration, signing, installation, and native verification are separate
 gates; none is complete merely because an earlier gate passed.
 
+The current candidate state is the RC7 amendment at the end of this plan.
+Earlier RC4, RC5, and RC6 sections preserve their checkpoint evidence and are
+not current build allocations.
+
 The installed RC4 source is `735a59ce`, build `1023.2`. Its prompt-free Keychain
 foundation, approved recovery boundary, and qualification are recorded in the
 [silent-migration decision](../decisions/2026-08-31-silent-keychain-migration.md).
@@ -79,8 +83,9 @@ automatically included in the retained validation run.
 5. Commit and merge the reviewed result, then create one exact annotated
    `tibotattle-internal-dogfood-0.1.17-rcN-source-YYYYMMDD` tag. Use the reviewed
    channel allocation from `scripts/macos-bundle-version.js`, clean source and
-   retained release finalizer. Earlier candidates used `1023`, `1023.1`, and
-   `1023.2`; the integrated RC5 uses `1023.3`. Stable remains `1024`.
+   retained release finalizer. Earlier candidates used `1023`, `1023.1`,
+   `1023.2`, `1023.3`, and `1023.4`; corrective RC7 uses `1023.5`. Stable
+   remains `1024`.
    Signing and notarization are authorized; public updater/release publication
    and hosted deployment are not part of this task.
 6. Install only the verified signed artifact with a recoverable prior-app and
@@ -283,7 +288,7 @@ hosted Worker behavior. Worker migrations/deployment, telemetry v1.1 activation,
 and new consent are protected operations outside this internal artifact build;
 desktop installation alone cannot establish end-to-end pairing repair.
 
-## RC5 installed-refresh finding and RC6 correction
+## RC5 installed-refresh finding and RC6 correction (historical checkpoint)
 
 RC5 source `ff506dc3`, tagged for internal dogfood and allocated build `1023.3`,
 subsequently passed source, protected R7, Developer ID, notarization, stapling,
@@ -305,11 +310,37 @@ server ceiling plus one minute, and cancellation is rechecked immediately before
 atomic cache publication. Existing resource, generation, size, privacy and
 killable-child guards are unchanged.
 
-RC6 must rerun the exact source gates and protected R7 after source freeze, then
-repeat signing, notarization, replacement validation, state-preserving install
-and physical checks. The real full-accounting refresh must reach terminal
-success and publish current generation-matched v0.14 figures; the two-limit
-popover must also pass its installed interaction check. PR #94's purpose-built
-fixed-corpus comparator remains an open internal-dogfood/stable gate, and no
-hosted Worker deployment, migration, stable tag, appcast or public artifact is
-authorized by this correction.
+At this checkpoint, RC6 still had to rerun the exact source gates and protected
+R7 after source freeze, then repeat signing, notarization, replacement
+validation, state-preserving install, and physical checks. The real full-
+accounting refresh had to reach terminal success and publish current generation-
+matched v0.14 figures; the two-limit popover also remained an installed
+interaction check. The later section records the RC6 result and superseding RC7
+allocation. No hosted Worker deployment, migration, stable tag, appcast, or
+public artifact was authorized by this correction.
+
+## RC6 installed result and RC7 correction
+
+RC6 source `e59115d41958f6b23496a65c9732a6a9944fdde0`, build `1023.4`,
+subsequently completed its exact source gates, protected R7, Developer ID
+signing, notarization, stapling, Gatekeeper, state-preserving replacement, and
+installed launch without an observed Keychain prompt. Its real refresh ran
+past five minutes and reached terminal success, proving the RC5 lifetime fix.
+The result nevertheless did not publish current advanced accounting because an
+inherited `recent_7d_indexing` legacy checkpoint suppressed otherwise-
+authoritative unified accounting.
+
+RC7 removes only that retired collector checkpoint. It continues to require
+`unifiedGenerationAuthoritative`, matching generations, complete accounting
+provenance, resource ceilings, cancellation fencing, and atomic publication.
+Its monotonic build is `1023.5`, strictly after installed RC6 and before stable
+`1024`. The source change invalidates RC6's workload receipts for RC7, so fresh
+exact-source gates and protected R7 must precede a new tag, signed/notarized
+artifact, state-preserving replacement, and installed refresh and two-limit
+popover checks.
+
+PR #94's fixed-real-corpus comparator remains **OPEN / NOT RUN**. RC7 may be
+used only as an explicitly open-gate internal dogfood; stable and public
+qualification remain blocked until that comparator is closed or deliberately
+resolved. No hosted Worker deployment, migration, stable tag, appcast, or
+public artifact is authorized by this correction.

--- a/docs/plans/2026-08-31-native-startup-recovery.md
+++ b/docs/plans/2026-08-31-native-startup-recovery.md
@@ -39,9 +39,16 @@ or public release is part of this correction.
   its monotonic native build and freeze the source separately from newer main.
 - [x] Sign, notarize, preserve state and the prior app, and install frozen RC4
   build `1023.2`. This qualifies only source `735a59ce`.
-- [ ] Re-run exact-source artifact gates and verify native startup, refresh,
-  restart, pairing repair, and prompt-free behavior on integrated RC5 build
-  `1023.3`.
+- [x] Re-run exact-source artifact gates and verify native startup, refresh,
+  restart, and prompt-free behavior on integrated RC5 build `1023.3`. Its real
+  refresh failed at five minutes, leading to RC6.
+- [x] Repeat the source, R7, signed-artifact, replacement, startup, and real
+  refresh gates on RC6 build `1023.4`. The lifetime correction passed; the
+  installed run exposed the separate legacy accounting checkpoint recorded
+  below.
+- [ ] Repeat the exact-source, R7, signed-artifact, replacement, native startup,
+  refresh, pairing-repair, prompt-free, and accounting checks on RC7 build
+  `1023.5`.
 
 ## Acceptance
 
@@ -129,11 +136,31 @@ closed. The native startup and RC5 allocation files are outside that workload
 closure and remain subject to their separate native and artifact gates.
 
 Installed RC4 source `735a59ce2ec01df0e381fb1aa878c5c7a39edcd8`, build
-`1023.2`, is signed and notarized but excludes PR #94. The next integrated
-dogfood therefore uses monotonic RC5 build `1023.3`; it has not yet been built,
-signed, notarized, or installed. Stable build `1024` remains separately reserved.
+`1023.2`, is signed and notarized but excludes PR #94. At that checkpoint, the
+next integrated dogfood used monotonic RC5 build `1023.3`; it had not yet been
+built, signed, notarized, or installed. Stable build `1024` remained separately
+reserved.
 
 RC5 was subsequently built, signed, notarized and installed, then failed its
 separate real full-accounting refresh gate at the ordinary five-minute timeout.
 The corrective RC6 allocation is `1023.4`; none of RC5's artifact or startup
 evidence qualifies that later source.
+
+## RC6 installed follow-up and RC7 boundary
+
+RC6 source `e59115d41958f6b23496a65c9732a6a9944fdde0`, build `1023.4`,
+was subsequently signed, notarized, installed, and launched against preserved
+schema-11 state without an observed automatic Keychain prompt. Its real refresh
+ran beyond five minutes and reached terminal success, so the RC5 lifetime defect
+is corrected. Native startup recovery also remained successful on that artifact.
+
+The same installed run exposed a separate inherited `recent_7d_indexing` legacy
+checkpoint suppressing otherwise-authoritative unified accounting. RC7 removes
+only that retired collector gate and retains the fail-closed
+`unifiedGenerationAuthoritative` decision. RC7 is allocated build `1023.5`,
+strictly after installed RC6 and before stable `1024`; it still requires fresh
+exact-source gates, protected R7, signing, notarization, state-preserving
+replacement, and installed native verification. PR #94's fixed-real-corpus
+comparator remains **OPEN / NOT RUN**: an explicitly open-gate internal dogfood
+may be tested, but stable and public qualification remain blocked until that
+gate is closed or deliberately resolved.

--- a/docs/runbooks/macos-stable-release-runbook.md
+++ b/docs/runbooks/macos-stable-release-runbook.md
@@ -241,9 +241,10 @@ node scripts/release-macos-app.js \
 
 For the 0.1.17 stable release, `CFBundleShortVersionString` remains `0.1.17`
 and the owner-reviewed signed `CFBundleVersion` is exactly `1024`. It follows
-the accounting-deadline RC6 internal-dogfood allocation `1023.4`, integrated
-RC5 `1023.3`, startup-recovery RC4 `1023.2`, migration RC3 `1023.1`, retained
-RC2 `1023`, and earlier shared-identity dogfood `1022`. The
+the retired-checkpoint RC7 internal-dogfood allocation `1023.5`, accounting-
+deadline RC6 `1023.4`, integrated RC5 `1023.3`, startup-recovery RC4 `1023.2`,
+migration RC3 `1023.1`, retained RC2 `1023`, and earlier shared-identity
+dogfood `1022`. The
 checked-in allocation is authoritative; the
 `USAGE_MONITOR_BUNDLE_VERSION` value above is only an exact assertion and
 cannot select or override a different build. A future stable version must add

--- a/generated/r7-release-decision-node24.14.0-v0.1.json
+++ b/generated/r7-release-decision-node24.14.0-v0.1.json
@@ -482,7 +482,7 @@
     "resourcePolicyValuesSha256": "3cbe7853c8f75e96912885f64ba4ad1aeb13aff8a22e4ffbd51806b27c73b418",
     "schemaModuleSha256": "594d035e641e87b29db4027dca35157f8225fd5621816d67d5d9f25825468bbf",
     "workloadCodeFileCount": 359,
-    "workloadCodeSha256": "fcb55e0cb729b56249e2c6f4d8fa4a08bc4b4c8fe99a506ce10cfe1068ed48d5"
+    "workloadCodeSha256": "ea504fde37402622239d5405aa74c264b98a111c8da5b4031a0977fa5bd80741"
   },
   "determinism": {
     "comparisons": {
@@ -939,7 +939,7 @@
         "decision": "unresolved",
         "dimension": "export_set_encoded_bytes",
         "exactBoundaryValue": "not_identified",
-        "realHistoryValue": 29091579,
+        "realHistoryValue": 29090074,
         "selectionBasis": "not_identified",
         "unit": "bytes"
       },
@@ -989,7 +989,7 @@
         "decision": "unresolved",
         "dimension": "elapsed_time",
         "exactBoundaryValue": "not_identified",
-        "realHistoryValue": 338893,
+        "realHistoryValue": 439301,
         "selectionBasis": "not_identified",
         "unit": "milliseconds"
       },
@@ -999,7 +999,7 @@
         "decision": "unresolved",
         "dimension": "rss",
         "exactBoundaryValue": "not_identified",
-        "realHistoryValue": 1265811456,
+        "realHistoryValue": 1322385408,
         "selectionBasis": "not_identified",
         "unit": "bytes"
       }
@@ -1007,20 +1007,20 @@
     "headroomBasisPoints": 2000,
     "inputReceipts": {
       "materializedBoundaries": {
-        "node24Sha256": "b16163d2635449b27b5dce0505a742a5dfc93b204f7063ef031282ee090c5591",
-        "node26Sha256": "4bbdc0738fb9b0d82124c02c954e61b98ac8c0770ef31d57d7b221f81f855b94"
+        "node24Sha256": "0cf7d41f0cc318d9cb6a554b575f5265140854262b270f512a79d5a49130aa55",
+        "node26Sha256": "2b2107b6c4f968d1a1231bd8a630adc4b11a4111b26c18e7b6cb6e49b2fc1ce5"
       },
       "realLocalHistory": {
-        "node24Sha256": "92ca409fa09c2d7b08b2f1a3164cd0fa022404ed567ab52989e99243263d9387",
-        "node26Sha256": "102992b206e95e4c6808c9373745dbbf0c6cd7679f21c3ffaa93409f395da7c4"
+        "node24Sha256": "ae242691686959fdcb455ef223df3c1a85e072e42b7604525bd2f461efb4fccc",
+        "node26Sha256": "41143106b7ae67bcb80709cb6f9826b62cf9cf7e91bce4fa4bd4b16d09e1541b"
       },
       "syntheticPressure": {
-        "node24Sha256": "c694fabf1a0b802185d7ab0aa2dfbcce1996110acb454701e3c61b51afc0d0c7",
-        "node26Sha256": "1f23ce061f6f875b9157a7a4526bc3d7be6bc317bb1244f3a29a963a4e208096"
+        "node24Sha256": "2005820c8451fd94be70c23cec5868ee66ee031e39d316cac80610eef39449dd",
+        "node26Sha256": "97213974a20feed5e75206e81aec2f2ee3a94f7c35c34801315b5c0b8aabd28e"
       },
       "syntheticSemantics": {
-        "node24Sha256": "7199e88864ad71aa06fd5b5ae70ef51dab25dafef482688da4d5851d33ec6dc3",
-        "node26Sha256": "4cfed5bf54a8a7bef98fdba3815c4d693e3b7a78fa6afdc2011df95f8861b624"
+        "node24Sha256": "9a778ac5013f41a813f2e27a2a016b80ca3aa4c45c9413b721d58fe62983de10",
+        "node26Sha256": "012565a67bc9bcb451eaaa0201e3027e628f1ab787700720c4dd69ce7762a0f5"
       }
     },
     "kind": "release_decision",
@@ -1039,7 +1039,7 @@
     "singleMachineLimitation": true
   },
   "protocolVersion": "g1-r7-release-evidence-v0.1",
-  "receiptSha256": "3ac5552829303e48276489a4dcbb7f7b40406a8e5966a779f03f621b19d497bf",
+  "receiptSha256": "676b012bfbd34abc34a21e2ce307ff6b9511c9414cb49fbe5f0334cfa4a0cb31",
   "runtimeProvenance": {
     "architecture": "arm64",
     "elapsedClock": "parent_monotonic",

--- a/generated/r7-release-decision-node26.2.0-v0.1.json
+++ b/generated/r7-release-decision-node26.2.0-v0.1.json
@@ -482,7 +482,7 @@
     "resourcePolicyValuesSha256": "3cbe7853c8f75e96912885f64ba4ad1aeb13aff8a22e4ffbd51806b27c73b418",
     "schemaModuleSha256": "594d035e641e87b29db4027dca35157f8225fd5621816d67d5d9f25825468bbf",
     "workloadCodeFileCount": 359,
-    "workloadCodeSha256": "fcb55e0cb729b56249e2c6f4d8fa4a08bc4b4c8fe99a506ce10cfe1068ed48d5"
+    "workloadCodeSha256": "ea504fde37402622239d5405aa74c264b98a111c8da5b4031a0977fa5bd80741"
   },
   "determinism": {
     "comparisons": {
@@ -939,7 +939,7 @@
         "decision": "unresolved",
         "dimension": "export_set_encoded_bytes",
         "exactBoundaryValue": "not_identified",
-        "realHistoryValue": 29091579,
+        "realHistoryValue": 29090074,
         "selectionBasis": "not_identified",
         "unit": "bytes"
       },
@@ -989,7 +989,7 @@
         "decision": "unresolved",
         "dimension": "elapsed_time",
         "exactBoundaryValue": "not_identified",
-        "realHistoryValue": 338893,
+        "realHistoryValue": 439301,
         "selectionBasis": "not_identified",
         "unit": "milliseconds"
       },
@@ -999,7 +999,7 @@
         "decision": "unresolved",
         "dimension": "rss",
         "exactBoundaryValue": "not_identified",
-        "realHistoryValue": 1265811456,
+        "realHistoryValue": 1322385408,
         "selectionBasis": "not_identified",
         "unit": "bytes"
       }
@@ -1007,20 +1007,20 @@
     "headroomBasisPoints": 2000,
     "inputReceipts": {
       "materializedBoundaries": {
-        "node24Sha256": "b16163d2635449b27b5dce0505a742a5dfc93b204f7063ef031282ee090c5591",
-        "node26Sha256": "4bbdc0738fb9b0d82124c02c954e61b98ac8c0770ef31d57d7b221f81f855b94"
+        "node24Sha256": "0cf7d41f0cc318d9cb6a554b575f5265140854262b270f512a79d5a49130aa55",
+        "node26Sha256": "2b2107b6c4f968d1a1231bd8a630adc4b11a4111b26c18e7b6cb6e49b2fc1ce5"
       },
       "realLocalHistory": {
-        "node24Sha256": "92ca409fa09c2d7b08b2f1a3164cd0fa022404ed567ab52989e99243263d9387",
-        "node26Sha256": "102992b206e95e4c6808c9373745dbbf0c6cd7679f21c3ffaa93409f395da7c4"
+        "node24Sha256": "ae242691686959fdcb455ef223df3c1a85e072e42b7604525bd2f461efb4fccc",
+        "node26Sha256": "41143106b7ae67bcb80709cb6f9826b62cf9cf7e91bce4fa4bd4b16d09e1541b"
       },
       "syntheticPressure": {
-        "node24Sha256": "c694fabf1a0b802185d7ab0aa2dfbcce1996110acb454701e3c61b51afc0d0c7",
-        "node26Sha256": "1f23ce061f6f875b9157a7a4526bc3d7be6bc317bb1244f3a29a963a4e208096"
+        "node24Sha256": "2005820c8451fd94be70c23cec5868ee66ee031e39d316cac80610eef39449dd",
+        "node26Sha256": "97213974a20feed5e75206e81aec2f2ee3a94f7c35c34801315b5c0b8aabd28e"
       },
       "syntheticSemantics": {
-        "node24Sha256": "7199e88864ad71aa06fd5b5ae70ef51dab25dafef482688da4d5851d33ec6dc3",
-        "node26Sha256": "4cfed5bf54a8a7bef98fdba3815c4d693e3b7a78fa6afdc2011df95f8861b624"
+        "node24Sha256": "9a778ac5013f41a813f2e27a2a016b80ca3aa4c45c9413b721d58fe62983de10",
+        "node26Sha256": "012565a67bc9bcb451eaaa0201e3027e628f1ab787700720c4dd69ce7762a0f5"
       }
     },
     "kind": "release_decision",
@@ -1039,7 +1039,7 @@
     "singleMachineLimitation": true
   },
   "protocolVersion": "g1-r7-release-evidence-v0.1",
-  "receiptSha256": "5f5a5d252cdf555fadff9555f3029641427c4551131414a50d5c64f31c0ebfbe",
+  "receiptSha256": "06fd202e647d7c6f51ff642ccb7bf6a852dfb808ee559f5f412a6b7ad57477f2",
   "runtimeProvenance": {
     "architecture": "arm64",
     "elapsedClock": "parent_monotonic",

--- a/generated/r7-release-materialized-boundaries-node24.14.0-v0.1.json
+++ b/generated/r7-release-materialized-boundaries-node24.14.0-v0.1.json
@@ -482,7 +482,7 @@
     "resourcePolicyValuesSha256": "3cbe7853c8f75e96912885f64ba4ad1aeb13aff8a22e4ffbd51806b27c73b418",
     "schemaModuleSha256": "594d035e641e87b29db4027dca35157f8225fd5621816d67d5d9f25825468bbf",
     "workloadCodeFileCount": 359,
-    "workloadCodeSha256": "fcb55e0cb729b56249e2c6f4d8fa4a08bc4b4c8fe99a506ce10cfe1068ed48d5"
+    "workloadCodeSha256": "ea504fde37402622239d5405aa74c264b98a111c8da5b4031a0977fa5bd80741"
   },
   "determinism": {
     "comparisons": {
@@ -500,8 +500,8 @@
     "projectionVersion": "g1-r7-release-deterministic-projection-v0.1",
     "runCount": 2,
     "runProjectionSha256es": [
-      "0e2cc55714270be78eabaf7819e54eba835e1b95e8009f5cdbc70ecdfe1175f9",
-      "0e2cc55714270be78eabaf7819e54eba835e1b95e8009f5cdbc70ecdfe1175f9"
+      "32b93b8f85e2ab03ac8debd5aa2b87a31a446a15f9509bf78382d86dc63faa0a",
+      "32b93b8f85e2ab03ac8debd5aa2b87a31a446a15f9509bf78382d86dc63faa0a"
     ],
     "status": "partial"
   },
@@ -822,20 +822,20 @@
       "decodedBytes": 0,
       "durablePeakRssBytes": 0,
       "encodedBytes": 0,
-      "externalPeakRssBytes": 326156288,
-      "externalRssSampleCount": 62,
+      "externalPeakRssBytes": 330694656,
+      "externalRssSampleCount": 77,
       "externalRssSampleFailureCount": 0,
       "filesystem": {
         "afterBytes": 0,
         "beforeBytes": 0,
-        "sampledHighWaterBytes": 30816124
+        "sampledHighWaterBytes": 30808382
       },
       "outputRecords": 0,
-      "parentElapsedMs": 3131,
+      "parentElapsedMs": 3974,
       "runCount": 2,
       "sourceBytes": 0,
       "sourceFiles": 0,
-      "stderrBytes": 169,
+      "stderrBytes": 168,
       "stdoutBytes": 42487
     },
     "kind": "release_materialized_boundaries",
@@ -894,7 +894,7 @@
     }
   },
   "protocolVersion": "g1-r7-release-evidence-v0.1",
-  "receiptSha256": "b16163d2635449b27b5dce0505a742a5dfc93b204f7063ef031282ee090c5591",
+  "receiptSha256": "0cf7d41f0cc318d9cb6a554b575f5265140854262b270f512a79d5a49130aa55",
   "runtimeProvenance": {
     "architecture": "arm64",
     "elapsedClock": "parent_monotonic",

--- a/generated/r7-release-materialized-boundaries-node26.2.0-v0.1.json
+++ b/generated/r7-release-materialized-boundaries-node26.2.0-v0.1.json
@@ -482,7 +482,7 @@
     "resourcePolicyValuesSha256": "3cbe7853c8f75e96912885f64ba4ad1aeb13aff8a22e4ffbd51806b27c73b418",
     "schemaModuleSha256": "594d035e641e87b29db4027dca35157f8225fd5621816d67d5d9f25825468bbf",
     "workloadCodeFileCount": 359,
-    "workloadCodeSha256": "fcb55e0cb729b56249e2c6f4d8fa4a08bc4b4c8fe99a506ce10cfe1068ed48d5"
+    "workloadCodeSha256": "ea504fde37402622239d5405aa74c264b98a111c8da5b4031a0977fa5bd80741"
   },
   "determinism": {
     "comparisons": {
@@ -500,8 +500,8 @@
     "projectionVersion": "g1-r7-release-deterministic-projection-v0.1",
     "runCount": 2,
     "runProjectionSha256es": [
-      "c422a5d43962f8a70ebbc7deff2b73c930bfae087a0541f3856d4c7d1200ec71",
-      "c422a5d43962f8a70ebbc7deff2b73c930bfae087a0541f3856d4c7d1200ec71"
+      "e59beedb5a38b7f2e9a68c4707f0a3a8dffe74563676c13585cd9859a33e39c5",
+      "e59beedb5a38b7f2e9a68c4707f0a3a8dffe74563676c13585cd9859a33e39c5"
     ],
     "status": "partial"
   },
@@ -822,16 +822,16 @@
       "decodedBytes": 0,
       "durablePeakRssBytes": 0,
       "encodedBytes": 0,
-      "externalPeakRssBytes": 339902464,
-      "externalRssSampleCount": 143,
+      "externalPeakRssBytes": 349159424,
+      "externalRssSampleCount": 120,
       "externalRssSampleFailureCount": 0,
       "filesystem": {
         "afterBytes": 0,
         "beforeBytes": 0,
-        "sampledHighWaterBytes": 30851373
+        "sampledHighWaterBytes": 30819852
       },
       "outputRecords": 0,
-      "parentElapsedMs": 8163,
+      "parentElapsedMs": 6096,
       "runCount": 2,
       "sourceBytes": 0,
       "sourceFiles": 0,
@@ -894,7 +894,7 @@
     }
   },
   "protocolVersion": "g1-r7-release-evidence-v0.1",
-  "receiptSha256": "4bbdc0738fb9b0d82124c02c954e61b98ac8c0770ef31d57d7b221f81f855b94",
+  "receiptSha256": "2b2107b6c4f968d1a1231bd8a630adc4b11a4111b26c18e7b6cb6e49b2fc1ce5",
   "runtimeProvenance": {
     "architecture": "arm64",
     "elapsedClock": "parent_monotonic",

--- a/generated/r7-release-real-local-history-node24.14.0-v0.1.json
+++ b/generated/r7-release-real-local-history-node24.14.0-v0.1.json
@@ -482,7 +482,7 @@
     "resourcePolicyValuesSha256": "3cbe7853c8f75e96912885f64ba4ad1aeb13aff8a22e4ffbd51806b27c73b418",
     "schemaModuleSha256": "594d035e641e87b29db4027dca35157f8225fd5621816d67d5d9f25825468bbf",
     "workloadCodeFileCount": 359,
-    "workloadCodeSha256": "fcb55e0cb729b56249e2c6f4d8fa4a08bc4b4c8fe99a506ce10cfe1068ed48d5"
+    "workloadCodeSha256": "ea504fde37402622239d5405aa74c264b98a111c8da5b4031a0977fa5bd80741"
   },
   "determinism": {
     "comparisons": {
@@ -500,8 +500,8 @@
     "projectionVersion": "g1-r7-release-deterministic-projection-v0.1",
     "runCount": 2,
     "runProjectionSha256es": [
-      "36bd28400bf97279d210d913a0e049c79001ba53e1078c9d30708332dc79381b",
-      "36bd28400bf97279d210d913a0e049c79001ba53e1078c9d30708332dc79381b"
+      "e93dcffc4d7226bc00afda6b605c8776351ebff3eb7f62c8e50b7955d76b4424",
+      "e93dcffc4d7226bc00afda6b605c8776351ebff3eb7f62c8e50b7955d76b4424"
     ],
     "status": "passed"
   },
@@ -514,21 +514,21 @@
     {
       "failureCode": "none",
       "metrics": {
-        "childCpuMs": 306476,
-        "childMaxRssBytes": 1116028928,
+        "childCpuMs": 332224,
+        "childMaxRssBytes": 1322385408,
         "decodedBytes": 0,
-        "durablePeakRssBytes": 1116028928,
+        "durablePeakRssBytes": 1322385408,
         "encodedBytes": 0,
-        "externalPeakRssBytes": 1113227264,
-        "externalRssSampleCount": 5795,
-        "externalRssSampleFailureCount": 1,
+        "externalPeakRssBytes": 1310277632,
+        "externalRssSampleCount": 8578,
+        "externalRssSampleFailureCount": 0,
         "filesystem": {
-          "afterBytes": 1141407744,
+          "afterBytes": 1141846016,
           "beforeBytes": 0,
-          "sampledHighWaterBytes": 1141407855
+          "sampledHighWaterBytes": 1144204686
         },
         "outputRecords": 436557,
-        "parentElapsedMs": 302942,
+        "parentElapsedMs": 439301,
         "runCount": 2,
         "sourceBytes": 26380587616,
         "sourceFiles": 3123,
@@ -570,21 +570,21 @@
     {
       "failureCode": "none",
       "metrics": {
-        "childCpuMs": 31692,
-        "childMaxRssBytes": 831848448,
+        "childCpuMs": 32301,
+        "childMaxRssBytes": 832864256,
         "decodedBytes": 518442273,
-        "durablePeakRssBytes": 1116028928,
-        "encodedBytes": 29091579,
-        "externalPeakRssBytes": 830472192,
-        "externalRssSampleCount": 588,
-        "externalRssSampleFailureCount": 0,
+        "durablePeakRssBytes": 1322385408,
+        "encodedBytes": 29090074,
+        "externalPeakRssBytes": 832307200,
+        "externalRssSampleCount": 607,
+        "externalRssSampleFailureCount": 1,
         "filesystem": {
-          "afterBytes": 1170634379,
-          "beforeBytes": 1141407744,
-          "sampledHighWaterBytes": 1170634490
+          "afterBytes": 1171071146,
+          "beforeBytes": 1141846016,
+          "sampledHighWaterBytes": 1171071146
         },
         "outputRecords": 436557,
-        "parentElapsedMs": 30034,
+        "parentElapsedMs": 30894,
         "runCount": 2,
         "sourceBytes": 26380587616,
         "sourceFiles": 3123,
@@ -592,27 +592,27 @@
         "stdoutBytes": 1261
       },
       "name": "export_set_materialize",
-      "projectionSha256": "8d16b5ef527af88d5d8391f4a749a7678144b6a3ca0fa4920598c8f3e56b4d04",
+      "projectionSha256": "c60cd51fbb74e80820fb71d8a8aa4c636b7f4c5400fbe85d52b33916628caf9e",
       "status": "completed"
     },
     {
       "failureCode": "none",
       "metrics": {
-        "childCpuMs": 27275,
-        "childMaxRssBytes": 888946688,
+        "childCpuMs": 31092,
+        "childMaxRssBytes": 781795328,
         "decodedBytes": 518442273,
         "durablePeakRssBytes": 0,
-        "encodedBytes": 29091579,
-        "externalPeakRssBytes": 854671360,
-        "externalRssSampleCount": 790,
+        "encodedBytes": 29090074,
+        "externalPeakRssBytes": 781778944,
+        "externalRssSampleCount": 982,
         "externalRssSampleFailureCount": 0,
         "filesystem": {
-          "afterBytes": 1170634379,
-          "beforeBytes": 1170634379,
-          "sampledHighWaterBytes": 1268464411
+          "afterBytes": 1171071146,
+          "beforeBytes": 1171071146,
+          "sampledHighWaterBytes": 1268510614
         },
         "outputRecords": 436557,
-        "parentElapsedMs": 54581,
+        "parentElapsedMs": 56841,
         "runCount": 2,
         "sourceBytes": 0,
         "sourceFiles": 0,
@@ -620,27 +620,27 @@
         "stdoutBytes": 1016
       },
       "name": "export_set_verify",
-      "projectionSha256": "3d7c41b4520818b40140e8cdd4cdeb22b18148fb157319c4d43d0e62be95bbe6",
+      "projectionSha256": "783715ed556e9ea3b716384d05c0213d06abac1f68887d1bf726c3d0a5c2a5da",
       "status": "completed"
     },
     {
       "failureCode": "none",
       "metrics": {
-        "childCpuMs": 81164,
-        "childMaxRssBytes": 1178632192,
+        "childCpuMs": 97281,
+        "childMaxRssBytes": 799588352,
         "decodedBytes": 0,
         "durablePeakRssBytes": 0,
         "encodedBytes": 0,
-        "externalPeakRssBytes": 1178632192,
-        "externalRssSampleCount": 1642,
+        "externalPeakRssBytes": 799588352,
+        "externalRssSampleCount": 3457,
         "externalRssSampleFailureCount": 0,
         "filesystem": {
           "afterBytes": 461,
-          "beforeBytes": 1170634379,
-          "sampledHighWaterBytes": 1170646535
+          "beforeBytes": 1171071146,
+          "sampledHighWaterBytes": 1171095938
         },
         "outputRecords": 0,
-        "parentElapsedMs": 84893,
+        "parentElapsedMs": 180075,
         "runCount": 2,
         "sourceBytes": 0,
         "sourceFiles": 0,
@@ -648,7 +648,7 @@
         "stdoutBytes": 1009
       },
       "name": "complete_set_delete",
-      "projectionSha256": "c560acc371efc44c5c1e67adff3e2214bd011d1e43e872ac4a9df3d84545b822",
+      "projectionSha256": "829c3e268165f08442dc64e5dd543a50a2ce67cd48c85b8a911eb60a137098eb",
       "status": "completed"
     },
     {
@@ -832,7 +832,7 @@
     "rawDurableCopyCreated": false
   },
   "protocolVersion": "g1-r7-release-evidence-v0.1",
-  "receiptSha256": "92ca409fa09c2d7b08b2f1a3164cd0fa022404ed567ab52989e99243263d9387",
+  "receiptSha256": "ae242691686959fdcb455ef223df3c1a85e072e42b7604525bd2f461efb4fccc",
   "runtimeProvenance": {
     "architecture": "arm64",
     "elapsedClock": "parent_monotonic",

--- a/generated/r7-release-real-local-history-node26.2.0-v0.1.json
+++ b/generated/r7-release-real-local-history-node26.2.0-v0.1.json
@@ -482,7 +482,7 @@
     "resourcePolicyValuesSha256": "3cbe7853c8f75e96912885f64ba4ad1aeb13aff8a22e4ffbd51806b27c73b418",
     "schemaModuleSha256": "594d035e641e87b29db4027dca35157f8225fd5621816d67d5d9f25825468bbf",
     "workloadCodeFileCount": 359,
-    "workloadCodeSha256": "fcb55e0cb729b56249e2c6f4d8fa4a08bc4b4c8fe99a506ce10cfe1068ed48d5"
+    "workloadCodeSha256": "ea504fde37402622239d5405aa74c264b98a111c8da5b4031a0977fa5bd80741"
   },
   "determinism": {
     "comparisons": {
@@ -500,8 +500,8 @@
     "projectionVersion": "g1-r7-release-deterministic-projection-v0.1",
     "runCount": 2,
     "runProjectionSha256es": [
-      "aff4aa2d19c29f929758f4bff0d0d8a65da63259b57ce5f6113ccafe234c951d",
-      "aff4aa2d19c29f929758f4bff0d0d8a65da63259b57ce5f6113ccafe234c951d"
+      "12f2bbf5863ab42a19f2631c2e1b449822796998eb91e45aa9acd987338f8ed7",
+      "12f2bbf5863ab42a19f2631c2e1b449822796998eb91e45aa9acd987338f8ed7"
     ],
     "status": "passed"
   },
@@ -514,21 +514,21 @@
     {
       "failureCode": "none",
       "metrics": {
-        "childCpuMs": 336978,
-        "childMaxRssBytes": 1265811456,
+        "childCpuMs": 353331,
+        "childMaxRssBytes": 1205207040,
         "decodedBytes": 0,
-        "durablePeakRssBytes": 1265811456,
+        "durablePeakRssBytes": 1205207040,
         "encodedBytes": 0,
-        "externalPeakRssBytes": 1260470272,
-        "externalRssSampleCount": 6510,
+        "externalPeakRssBytes": 1205207040,
+        "externalRssSampleCount": 6770,
         "externalRssSampleFailureCount": 0,
         "filesystem": {
-          "afterBytes": 1141407744,
+          "afterBytes": 1141846016,
           "beforeBytes": 0,
-          "sampledHighWaterBytes": 1143546615
+          "sampledHighWaterBytes": 1141846127
         },
         "outputRecords": 436557,
-        "parentElapsedMs": 338893,
+        "parentElapsedMs": 363463,
         "runCount": 2,
         "sourceBytes": 26380587616,
         "sourceFiles": 3123,
@@ -570,21 +570,21 @@
     {
       "failureCode": "none",
       "metrics": {
-        "childCpuMs": 28547,
-        "childMaxRssBytes": 919404544,
+        "childCpuMs": 28493,
+        "childMaxRssBytes": 917995520,
         "decodedBytes": 518442273,
-        "durablePeakRssBytes": 1265811456,
-        "encodedBytes": 29091579,
-        "externalPeakRssBytes": 919339008,
-        "externalRssSampleCount": 542,
+        "durablePeakRssBytes": 1205207040,
+        "encodedBytes": 29090074,
+        "externalPeakRssBytes": 917929984,
+        "externalRssSampleCount": 540,
         "externalRssSampleFailureCount": 0,
         "filesystem": {
-          "afterBytes": 1170634378,
-          "beforeBytes": 1141407744,
-          "sampledHighWaterBytes": 1170635266
+          "afterBytes": 1171071145,
+          "beforeBytes": 1141846016,
+          "sampledHighWaterBytes": 1171071834
         },
         "outputRecords": 436557,
-        "parentElapsedMs": 27686,
+        "parentElapsedMs": 27477,
         "runCount": 2,
         "sourceBytes": 26380587616,
         "sourceFiles": 3123,
@@ -592,27 +592,27 @@
         "stdoutBytes": 1261
       },
       "name": "export_set_materialize",
-      "projectionSha256": "8d16b5ef527af88d5d8391f4a749a7678144b6a3ca0fa4920598c8f3e56b4d04",
+      "projectionSha256": "c60cd51fbb74e80820fb71d8a8aa4c636b7f4c5400fbe85d52b33916628caf9e",
       "status": "completed"
     },
     {
       "failureCode": "none",
       "metrics": {
-        "childCpuMs": 23256,
-        "childMaxRssBytes": 722993152,
+        "childCpuMs": 23195,
+        "childMaxRssBytes": 751599616,
         "decodedBytes": 518442273,
         "durablePeakRssBytes": 0,
-        "encodedBytes": 29091579,
-        "externalPeakRssBytes": 722960384,
-        "externalRssSampleCount": 468,
+        "encodedBytes": 29090074,
+        "externalPeakRssBytes": 700317696,
+        "externalRssSampleCount": 467,
         "externalRssSampleFailureCount": 0,
         "filesystem": {
-          "afterBytes": 1170634378,
-          "beforeBytes": 1170634378,
-          "sampledHighWaterBytes": 1267698242
+          "afterBytes": 1171071145,
+          "beforeBytes": 1171071145,
+          "sampledHighWaterBytes": 1268581425
         },
         "outputRecords": 436557,
-        "parentElapsedMs": 23789,
+        "parentElapsedMs": 23806,
         "runCount": 2,
         "sourceBytes": 0,
         "sourceFiles": 0,
@@ -620,27 +620,27 @@
         "stdoutBytes": 1016
       },
       "name": "export_set_verify",
-      "projectionSha256": "3d7c41b4520818b40140e8cdd4cdeb22b18148fb157319c4d43d0e62be95bbe6",
+      "projectionSha256": "783715ed556e9ea3b716384d05c0213d06abac1f68887d1bf726c3d0a5c2a5da",
       "status": "completed"
     },
     {
       "failureCode": "none",
       "metrics": {
-        "childCpuMs": 73740,
-        "childMaxRssBytes": 841613312,
+        "childCpuMs": 75340,
+        "childMaxRssBytes": 843005952,
         "decodedBytes": 0,
         "durablePeakRssBytes": 0,
         "encodedBytes": 0,
-        "externalPeakRssBytes": 804634624,
-        "externalRssSampleCount": 1500,
-        "externalRssSampleFailureCount": 1,
+        "externalPeakRssBytes": 808861696,
+        "externalRssSampleCount": 1513,
+        "externalRssSampleFailureCount": 0,
         "filesystem": {
           "afterBytes": 461,
-          "beforeBytes": 1170634378,
-          "sampledHighWaterBytes": 1170634489
+          "beforeBytes": 1171071145,
+          "sampledHighWaterBytes": 1171071256
         },
         "outputRecords": 0,
-        "parentElapsedMs": 77350,
+        "parentElapsedMs": 78341,
         "runCount": 2,
         "sourceBytes": 0,
         "sourceFiles": 0,
@@ -648,7 +648,7 @@
         "stdoutBytes": 1008
       },
       "name": "complete_set_delete",
-      "projectionSha256": "0834a8222338b1aa93988dc76861bc2c7025e113e0a03c788548f154638a6a75",
+      "projectionSha256": "625785647c75da37dec2cbf2ab685243b0649dc6a71abf2555bab77549d051ae",
       "status": "completed"
     },
     {
@@ -832,7 +832,7 @@
     "rawDurableCopyCreated": false
   },
   "protocolVersion": "g1-r7-release-evidence-v0.1",
-  "receiptSha256": "102992b206e95e4c6808c9373745dbbf0c6cd7679f21c3ffaa93409f395da7c4",
+  "receiptSha256": "41143106b7ae67bcb80709cb6f9826b62cf9cf7e91bce4fa4bd4b16d09e1541b",
   "runtimeProvenance": {
     "architecture": "arm64",
     "elapsedClock": "parent_monotonic",

--- a/generated/r7-release-synthetic-pressure-node24.14.0-v0.1.json
+++ b/generated/r7-release-synthetic-pressure-node24.14.0-v0.1.json
@@ -482,7 +482,7 @@
     "resourcePolicyValuesSha256": "3cbe7853c8f75e96912885f64ba4ad1aeb13aff8a22e4ffbd51806b27c73b418",
     "schemaModuleSha256": "594d035e641e87b29db4027dca35157f8225fd5621816d67d5d9f25825468bbf",
     "workloadCodeFileCount": 359,
-    "workloadCodeSha256": "fcb55e0cb729b56249e2c6f4d8fa4a08bc4b4c8fe99a506ce10cfe1068ed48d5"
+    "workloadCodeSha256": "ea504fde37402622239d5405aa74c264b98a111c8da5b4031a0977fa5bd80741"
   },
   "determinism": {
     "comparisons": {
@@ -500,8 +500,8 @@
     "projectionVersion": "g1-r7-release-deterministic-projection-v0.1",
     "runCount": 2,
     "runProjectionSha256es": [
-      "bbb01c752237462989bb6232f65538d3056b6b166ed3251b17d976358ebe609d",
-      "bbb01c752237462989bb6232f65538d3056b6b166ed3251b17d976358ebe609d"
+      "1ca3bd8f21e0675bc3bbb5606bd6ae1a76ef6e52b978c67b8ff4e6d6c321719a",
+      "1ca3bd8f21e0675bc3bbb5606bd6ae1a76ef6e52b978c67b8ff4e6d6c321719a"
     ],
     "status": "passed"
   },
@@ -514,26 +514,26 @@
     {
       "failureCode": "none",
       "metrics": {
-        "childCpuMs": 20146,
-        "childMaxRssBytes": 680345600,
+        "childCpuMs": 20685,
+        "childMaxRssBytes": 677036032,
         "decodedBytes": 0,
-        "durablePeakRssBytes": 678002688,
+        "durablePeakRssBytes": 670138368,
         "encodedBytes": 0,
-        "externalPeakRssBytes": 680345600,
-        "externalRssSampleCount": 372,
+        "externalPeakRssBytes": 667713536,
+        "externalRssSampleCount": 403,
         "externalRssSampleFailureCount": 0,
         "filesystem": {
-          "afterBytes": 96956576,
+          "afterBytes": 96927904,
           "beforeBytes": 160,
-          "sampledHighWaterBytes": 96956576
+          "sampledHighWaterBytes": 96927904
         },
         "outputRecords": 29108,
-        "parentElapsedMs": 22277,
+        "parentElapsedMs": 21451,
         "runCount": 2,
         "sourceBytes": 47637907,
         "sourceFiles": 4096,
         "stderrBytes": 169,
-        "stdoutBytes": 1098
+        "stdoutBytes": 1099
       },
       "name": "source_scan",
       "projectionSha256": "c70ea4b8c4d71a9ee8b2a1cd72023877e32391e1f2b8fd7bfb355374b28f2395",
@@ -542,26 +542,26 @@
     {
       "failureCode": "none",
       "metrics": {
-        "childCpuMs": 13911,
-        "childMaxRssBytes": 480673792,
+        "childCpuMs": 17383,
+        "childMaxRssBytes": 475791360,
         "decodedBytes": 0,
-        "durablePeakRssBytes": 747143168,
+        "durablePeakRssBytes": 789954560,
         "encodedBytes": 0,
-        "externalPeakRssBytes": 480673792,
-        "externalRssSampleCount": 287,
+        "externalPeakRssBytes": 475463680,
+        "externalRssSampleCount": 513,
         "externalRssSampleFailureCount": 0,
         "filesystem": {
-          "afterBytes": 193912992,
-          "beforeBytes": 127066272,
-          "sampledHighWaterBytes": 193912992
+          "afterBytes": 193855648,
+          "beforeBytes": 127037600,
+          "sampledHighWaterBytes": 193855759
         },
         "outputRecords": 29108,
-        "parentElapsedMs": 19257,
+        "parentElapsedMs": 32486,
         "runCount": 2,
         "sourceBytes": 47637907,
         "sourceFiles": 4096,
         "stderrBytes": 169,
-        "stdoutBytes": 1104
+        "stdoutBytes": 1105
       },
       "name": "checkpoint_resume",
       "projectionSha256": "c70ea4b8c4d71a9ee8b2a1cd72023877e32391e1f2b8fd7bfb355374b28f2395",
@@ -570,49 +570,49 @@
     {
       "failureCode": "none",
       "metrics": {
-        "childCpuMs": 4165,
-        "childMaxRssBytes": 263864320,
+        "childCpuMs": 4620,
+        "childMaxRssBytes": 263208960,
         "decodedBytes": 46019365,
-        "durablePeakRssBytes": 678002688,
-        "encodedBytes": 2072936,
-        "externalPeakRssBytes": 263864320,
-        "externalRssSampleCount": 203,
+        "durablePeakRssBytes": 670138368,
+        "encodedBytes": 2072956,
+        "externalPeakRssBytes": 262275072,
+        "externalRssSampleCount": 266,
         "externalRssSampleFailureCount": 0,
         "filesystem": {
-          "afterBytes": 197020638,
-          "beforeBytes": 193912992,
-          "sampledHighWaterBytes": 197020638
+          "afterBytes": 196963314,
+          "beforeBytes": 193855648,
+          "sampledHighWaterBytes": 196963425
         },
         "outputRecords": 29108,
-        "parentElapsedMs": 10416,
+        "parentElapsedMs": 14577,
         "runCount": 2,
         "sourceBytes": 47637907,
         "sourceFiles": 4096,
         "stderrBytes": 169,
-        "stdoutBytes": 1251
+        "stdoutBytes": 1252
       },
       "name": "export_set_materialize",
-      "projectionSha256": "3671aacde251bcd8ab0baaed3450a239c54d125d2c0e432135dfb8c4132bcafe",
+      "projectionSha256": "7709ae36a134ae382b8f4cd35ec76cb4728e1c68b83717b334479af919b8ee23",
       "status": "completed"
     },
     {
       "failureCode": "none",
       "metrics": {
-        "childCpuMs": 2089,
-        "childMaxRssBytes": 267616256,
+        "childCpuMs": 2200,
+        "childMaxRssBytes": 280035328,
         "decodedBytes": 46019365,
         "durablePeakRssBytes": 0,
-        "encodedBytes": 2072936,
-        "externalPeakRssBytes": 267616256,
-        "externalRssSampleCount": 58,
+        "encodedBytes": 2072956,
+        "externalPeakRssBytes": 280035328,
+        "externalRssSampleCount": 64,
         "externalRssSampleFailureCount": 0,
         "filesystem": {
-          "afterBytes": 197020638,
-          "beforeBytes": 197020638,
-          "sampledHighWaterBytes": 205312982
+          "afterBytes": 196963314,
+          "beforeBytes": 196963314,
+          "sampledHighWaterBytes": 205255658
         },
         "outputRecords": 29108,
-        "parentElapsedMs": 4042,
+        "parentElapsedMs": 3829,
         "runCount": 2,
         "sourceBytes": 0,
         "sourceFiles": 0,
@@ -620,55 +620,55 @@
         "stdoutBytes": 1011
       },
       "name": "export_set_verify",
-      "projectionSha256": "ba38e64dc89854088e82e49b2aa016ea3b766d9cb320f3e1247a3aeadb60a509",
+      "projectionSha256": "afe30ea6628fcaef0aecf52b55e58e69c3a0c8cc88155d320d60ceda8f9937cf",
       "status": "completed"
     },
     {
       "failureCode": "none",
       "metrics": {
-        "childCpuMs": 6379,
-        "childMaxRssBytes": 301465600,
+        "childCpuMs": 6768,
+        "childMaxRssBytes": 312197120,
         "decodedBytes": 0,
         "durablePeakRssBytes": 0,
         "encodedBytes": 0,
-        "externalPeakRssBytes": 299040768,
-        "externalRssSampleCount": 176,
+        "externalPeakRssBytes": 312164352,
+        "externalRssSampleCount": 183,
         "externalRssSampleFailureCount": 0,
         "filesystem": {
-          "afterBytes": 96959108,
-          "beforeBytes": 197022709,
-          "sampledHighWaterBytes": 197022820
+          "afterBytes": 96930436,
+          "beforeBytes": 196965385,
+          "sampledHighWaterBytes": 197047225
         },
         "outputRecords": 0,
-        "parentElapsedMs": 8965,
+        "parentElapsedMs": 10265,
         "runCount": 2,
         "sourceBytes": 0,
         "sourceFiles": 0,
         "stderrBytes": 169,
-        "stdoutBytes": 1004
+        "stdoutBytes": 1006
       },
       "name": "complete_set_delete",
-      "projectionSha256": "661b02ea89a93ff27ac1826e7c0e018217b1076448a96f6f95ae79691c1f6f4a",
+      "projectionSha256": "dfb8a98eac13aef28ecb4b79c9f3881f60242c33d63033ee9bbde3f727bd6be7",
       "status": "completed"
     },
     {
       "failureCode": "interruption_injected",
       "metrics": {
-        "childCpuMs": 401,
-        "childMaxRssBytes": 129253376,
+        "childCpuMs": 342,
+        "childMaxRssBytes": 129597440,
         "decodedBytes": 0,
         "durablePeakRssBytes": 0,
         "encodedBytes": 0,
-        "externalPeakRssBytes": 129040384,
-        "externalRssSampleCount": 64,
+        "externalPeakRssBytes": 129548288,
+        "externalRssSampleCount": 54,
         "externalRssSampleFailureCount": 0,
         "filesystem": {
-          "afterBytes": 197022709,
-          "beforeBytes": 297166860,
-          "sampledHighWaterBytes": 297166860
+          "afterBytes": 196965385,
+          "beforeBytes": 297080884,
+          "sampledHighWaterBytes": 297080884
         },
         "outputRecords": 0,
-        "parentElapsedMs": 3583,
+        "parentElapsedMs": 2981,
         "runCount": 2,
         "sourceBytes": 0,
         "sourceFiles": 0,
@@ -676,32 +676,32 @@
         "stdoutBytes": 1012
       },
       "name": "complete_set_delete_recovery",
-      "projectionSha256": "661b02ea89a93ff27ac1826e7c0e018217b1076448a96f6f95ae79691c1f6f4a",
+      "projectionSha256": "dfb8a98eac13aef28ecb4b79c9f3881f60242c33d63033ee9bbde3f727bd6be7",
       "status": "interrupted_recovered"
     },
     {
       "failureCode": "none",
       "metrics": {
-        "childCpuMs": 141,
-        "childMaxRssBytes": 117555200,
+        "childCpuMs": 137,
+        "childMaxRssBytes": 117800960,
         "decodedBytes": 0,
         "durablePeakRssBytes": 0,
         "encodedBytes": 0,
-        "externalPeakRssBytes": 117489664,
-        "externalRssSampleCount": 9,
+        "externalPeakRssBytes": 117620736,
+        "externalRssSampleCount": 8,
         "externalRssSampleFailureCount": 0,
         "filesystem": {
-          "afterBytes": 197021173,
-          "beforeBytes": 227130334,
-          "sampledHighWaterBytes": 227131677
+          "afterBytes": 196963849,
+          "beforeBytes": 227073010,
+          "sampledHighWaterBytes": 227073121
         },
         "outputRecords": 0,
-        "parentElapsedMs": 415,
+        "parentElapsedMs": 353,
         "runCount": 2,
         "sourceBytes": 0,
         "sourceFiles": 0,
         "stderrBytes": 169,
-        "stdoutBytes": 996
+        "stdoutBytes": 995
       },
       "name": "workspace_discard",
       "projectionSha256": "064fdfeb99edbc148aa8778a62741f99119e5abad545d4e846cb39e835736056",
@@ -711,20 +711,20 @@
       "failureCode": "interruption_injected",
       "metrics": {
         "childCpuMs": 97,
-        "childMaxRssBytes": 116817920,
+        "childMaxRssBytes": 115851264,
         "decodedBytes": 0,
         "durablePeakRssBytes": 0,
         "encodedBytes": 0,
-        "externalPeakRssBytes": 116752384,
-        "externalRssSampleCount": 7,
+        "externalPeakRssBytes": 115441664,
+        "externalRssSampleCount": 8,
         "externalRssSampleFailureCount": 0,
         "filesystem": {
-          "afterBytes": 197021708,
-          "beforeBytes": 227132101,
-          "sampledHighWaterBytes": 257241908
+          "afterBytes": 196964384,
+          "beforeBytes": 227074777,
+          "sampledHighWaterBytes": 257184584
         },
         "outputRecords": 0,
-        "parentElapsedMs": 312,
+        "parentElapsedMs": 324,
         "runCount": 2,
         "sourceBytes": 0,
         "sourceFiles": 0,
@@ -739,20 +739,20 @@
       "failureCode": "none",
       "metrics": {
         "childCpuMs": 6,
-        "childMaxRssBytes": 111460352,
+        "childMaxRssBytes": 112001024,
         "decodedBytes": 0,
         "durablePeakRssBytes": 0,
         "encodedBytes": 0,
-        "externalPeakRssBytes": 92798976,
+        "externalPeakRssBytes": 93306880,
         "externalRssSampleCount": 4,
         "externalRssSampleFailureCount": 0,
         "filesystem": {
-          "afterBytes": 197021978,
-          "beforeBytes": 197022157,
-          "sampledHighWaterBytes": 197022157
+          "afterBytes": 196964654,
+          "beforeBytes": 196964833,
+          "sampledHighWaterBytes": 196964833
         },
         "outputRecords": 0,
-        "parentElapsedMs": 199,
+        "parentElapsedMs": 190,
         "runCount": 2,
         "sourceBytes": 0,
         "sourceFiles": 0,
@@ -767,20 +767,20 @@
       "failureCode": "interruption_injected",
       "metrics": {
         "childCpuMs": 5,
-        "childMaxRssBytes": 111968256,
+        "childMaxRssBytes": 111689728,
         "decodedBytes": 0,
         "durablePeakRssBytes": 0,
         "encodedBytes": 0,
-        "externalPeakRssBytes": 92749824,
+        "externalPeakRssBytes": 92864512,
         "externalRssSampleCount": 4,
         "externalRssSampleFailureCount": 0,
         "filesystem": {
-          "afterBytes": 197022248,
-          "beforeBytes": 197022436,
-          "sampledHighWaterBytes": 197022436
+          "afterBytes": 196964924,
+          "beforeBytes": 196965112,
+          "sampledHighWaterBytes": 196965112
         },
         "outputRecords": 0,
-        "parentElapsedMs": 185,
+        "parentElapsedMs": 179,
         "runCount": 2,
         "sourceBytes": 0,
         "sourceFiles": 0,
@@ -827,7 +827,7 @@
     "targetChunks": 128
   },
   "protocolVersion": "g1-r7-release-evidence-v0.1",
-  "receiptSha256": "c694fabf1a0b802185d7ab0aa2dfbcce1996110acb454701e3c61b51afc0d0c7",
+  "receiptSha256": "2005820c8451fd94be70c23cec5868ee66ee031e39d316cac80610eef39449dd",
   "runtimeProvenance": {
     "architecture": "arm64",
     "elapsedClock": "parent_monotonic",

--- a/generated/r7-release-synthetic-pressure-node26.2.0-v0.1.json
+++ b/generated/r7-release-synthetic-pressure-node26.2.0-v0.1.json
@@ -482,7 +482,7 @@
     "resourcePolicyValuesSha256": "3cbe7853c8f75e96912885f64ba4ad1aeb13aff8a22e4ffbd51806b27c73b418",
     "schemaModuleSha256": "594d035e641e87b29db4027dca35157f8225fd5621816d67d5d9f25825468bbf",
     "workloadCodeFileCount": 359,
-    "workloadCodeSha256": "fcb55e0cb729b56249e2c6f4d8fa4a08bc4b4c8fe99a506ce10cfe1068ed48d5"
+    "workloadCodeSha256": "ea504fde37402622239d5405aa74c264b98a111c8da5b4031a0977fa5bd80741"
   },
   "determinism": {
     "comparisons": {
@@ -500,8 +500,8 @@
     "projectionVersion": "g1-r7-release-deterministic-projection-v0.1",
     "runCount": 2,
     "runProjectionSha256es": [
-      "77aca87167ef86a53675d4763c5ad256e4ddc06ddee82e4bccaa3856c6b4d258",
-      "77aca87167ef86a53675d4763c5ad256e4ddc06ddee82e4bccaa3856c6b4d258"
+      "e2d6bcf086febf272ad2f68c4b688b614f1ea5b5dee1bd1be44c6361cf8573dd",
+      "e2d6bcf086febf272ad2f68c4b688b614f1ea5b5dee1bd1be44c6361cf8573dd"
     ],
     "status": "passed"
   },
@@ -514,26 +514,26 @@
     {
       "failureCode": "none",
       "metrics": {
-        "childCpuMs": 19396,
-        "childMaxRssBytes": 1063682048,
+        "childCpuMs": 21873,
+        "childMaxRssBytes": 988135424,
         "decodedBytes": 0,
-        "durablePeakRssBytes": 982417408,
+        "durablePeakRssBytes": 988135424,
         "encodedBytes": 0,
-        "externalPeakRssBytes": 979402752,
-        "externalRssSampleCount": 275,
+        "externalPeakRssBytes": 987709440,
+        "externalRssSampleCount": 476,
         "externalRssSampleFailureCount": 0,
         "filesystem": {
-          "afterBytes": 96923808,
+          "afterBytes": 96936096,
           "beforeBytes": 160,
-          "sampledHighWaterBytes": 96923919
+          "sampledHighWaterBytes": 96940878
         },
         "outputRecords": 29108,
-        "parentElapsedMs": 14140,
+        "parentElapsedMs": 29159,
         "runCount": 2,
         "sourceBytes": 47637907,
         "sourceFiles": 4096,
         "stderrBytes": 0,
-        "stdoutBytes": 1099
+        "stdoutBytes": 1098
       },
       "name": "source_scan",
       "projectionSha256": "c70ea4b8c4d71a9ee8b2a1cd72023877e32391e1f2b8fd7bfb355374b28f2395",
@@ -542,21 +542,21 @@
     {
       "failureCode": "none",
       "metrics": {
-        "childCpuMs": 15782,
-        "childMaxRssBytes": 659226624,
+        "childCpuMs": 16798,
+        "childMaxRssBytes": 668352512,
         "decodedBytes": 0,
-        "durablePeakRssBytes": 659177472,
+        "durablePeakRssBytes": 668352512,
         "encodedBytes": 0,
-        "externalPeakRssBytes": 651182080,
-        "externalRssSampleCount": 461,
+        "externalPeakRssBytes": 649838592,
+        "externalRssSampleCount": 376,
         "externalRssSampleFailureCount": 0,
         "filesystem": {
-          "afterBytes": 193847456,
-          "beforeBytes": 127033504,
-          "sampledHighWaterBytes": 193872707
+          "afterBytes": 193872032,
+          "beforeBytes": 127045792,
+          "sampledHighWaterBytes": 193872032
         },
         "outputRecords": 29108,
-        "parentElapsedMs": 36107,
+        "parentElapsedMs": 25103,
         "runCount": 2,
         "sourceBytes": 47637907,
         "sourceFiles": 4096,
@@ -570,105 +570,105 @@
     {
       "failureCode": "none",
       "metrics": {
-        "childCpuMs": 5511,
-        "childMaxRssBytes": 225181696,
+        "childCpuMs": 4012,
+        "childMaxRssBytes": 225034240,
         "decodedBytes": 46019365,
-        "durablePeakRssBytes": 982417408,
-        "encodedBytes": 2072945,
-        "externalPeakRssBytes": 224804864,
-        "externalRssSampleCount": 346,
+        "durablePeakRssBytes": 988135424,
+        "encodedBytes": 2072932,
+        "externalPeakRssBytes": 224657408,
+        "externalRssSampleCount": 218,
         "externalRssSampleFailureCount": 0,
         "filesystem": {
-          "afterBytes": 196955110,
-          "beforeBytes": 193847456,
-          "sampledHighWaterBytes": 196955221
+          "afterBytes": 196979673,
+          "beforeBytes": 193872032,
+          "sampledHighWaterBytes": 196979783
         },
         "outputRecords": 29108,
-        "parentElapsedMs": 26382,
+        "parentElapsedMs": 12443,
         "runCount": 2,
         "sourceBytes": 47637907,
         "sourceFiles": 4096,
         "stderrBytes": 0,
-        "stdoutBytes": 1252
+        "stdoutBytes": 1251
       },
       "name": "export_set_materialize",
-      "projectionSha256": "2925c74104b1c8eadd47309c30a307d187ac1ee766042df3ac2cc4e47b7841d4",
+      "projectionSha256": "dc22dcf72d5b5bf4a30cc27b40fcdd2d22055800fc845cfa91115d8a97aa6bad",
       "status": "completed"
     },
     {
       "failureCode": "none",
       "metrics": {
-        "childCpuMs": 3342,
-        "childMaxRssBytes": 241287168,
+        "childCpuMs": 1772,
+        "childMaxRssBytes": 238632960,
         "decodedBytes": 46019365,
         "durablePeakRssBytes": 0,
-        "encodedBytes": 2072945,
-        "externalPeakRssBytes": 241221632,
-        "externalRssSampleCount": 204,
+        "encodedBytes": 2072932,
+        "externalPeakRssBytes": 238501888,
+        "externalRssSampleCount": 41,
         "externalRssSampleFailureCount": 0,
         "filesystem": {
-          "afterBytes": 196955110,
-          "beforeBytes": 196955110,
-          "sampledHighWaterBytes": 205390958
+          "afterBytes": 196979673,
+          "beforeBytes": 196979673,
+          "sampledHighWaterBytes": 204825185
         },
         "outputRecords": 29108,
-        "parentElapsedMs": 19008,
+        "parentElapsedMs": 2373,
         "runCount": 2,
         "sourceBytes": 0,
         "sourceFiles": 0,
         "stderrBytes": 0,
-        "stdoutBytes": 1012
+        "stdoutBytes": 1011
       },
       "name": "export_set_verify",
-      "projectionSha256": "e8f0e07e88095e677b7705ba6f607939f4a2dd9594eb7a03439ec3478b66ac7f",
+      "projectionSha256": "07b12154385d591cdb03cdc5acc05e851cfe570adff8caf49d9f75dc03dd6d8d",
       "status": "completed"
     },
     {
       "failureCode": "none",
       "metrics": {
-        "childCpuMs": 8037,
-        "childMaxRssBytes": 257097728,
+        "childCpuMs": 6300,
+        "childMaxRssBytes": 261390336,
         "decodedBytes": 0,
         "durablePeakRssBytes": 0,
         "encodedBytes": 0,
-        "externalPeakRssBytes": 256425984,
-        "externalRssSampleCount": 345,
+        "externalPeakRssBytes": 261373952,
+        "externalRssSampleCount": 210,
         "externalRssSampleFailureCount": 0,
         "filesystem": {
-          "afterBytes": 96926340,
-          "beforeBytes": 196957181,
-          "sampledHighWaterBytes": 197037842
+          "afterBytes": 96938628,
+          "beforeBytes": 196981744,
+          "sampledHighWaterBytes": 196981854
         },
         "outputRecords": 0,
-        "parentElapsedMs": 27880,
+        "parentElapsedMs": 11241,
         "runCount": 2,
         "sourceBytes": 0,
         "sourceFiles": 0,
         "stderrBytes": 0,
-        "stdoutBytes": 1006
+        "stdoutBytes": 1005
       },
       "name": "complete_set_delete",
-      "projectionSha256": "b6fa895efacf2ce1825d91bba17dad9d0f8a012db57ac34a4aec6325d1aac1da",
+      "projectionSha256": "9ded5897ddfad15e7de5426b7412f01d1ef635ccabaa51a567709df452698e6c",
       "status": "completed"
     },
     {
       "failureCode": "interruption_injected",
       "metrics": {
-        "childCpuMs": 416,
-        "childMaxRssBytes": 138805248,
+        "childCpuMs": 391,
+        "childMaxRssBytes": 139149312,
         "decodedBytes": 0,
         "durablePeakRssBytes": 0,
         "encodedBytes": 0,
-        "externalPeakRssBytes": 138788864,
-        "externalRssSampleCount": 70,
+        "externalPeakRssBytes": 139149312,
+        "externalRssSampleCount": 66,
         "externalRssSampleFailureCount": 0,
         "filesystem": {
-          "afterBytes": 196957181,
-          "beforeBytes": 297068572,
-          "sampledHighWaterBytes": 297068572
+          "afterBytes": 196981744,
+          "beforeBytes": 297105410,
+          "sampledHighWaterBytes": 297105410
         },
         "outputRecords": 0,
-        "parentElapsedMs": 4640,
+        "parentElapsedMs": 3472,
         "runCount": 2,
         "sourceBytes": 0,
         "sourceFiles": 0,
@@ -676,32 +676,32 @@
         "stdoutBytes": 1012
       },
       "name": "complete_set_delete_recovery",
-      "projectionSha256": "b6fa895efacf2ce1825d91bba17dad9d0f8a012db57ac34a4aec6325d1aac1da",
+      "projectionSha256": "9ded5897ddfad15e7de5426b7412f01d1ef635ccabaa51a567709df452698e6c",
       "status": "interrupted_recovered"
     },
     {
       "failureCode": "none",
       "metrics": {
-        "childCpuMs": 146,
-        "childMaxRssBytes": 124518400,
+        "childCpuMs": 144,
+        "childMaxRssBytes": 126500864,
         "decodedBytes": 0,
         "durablePeakRssBytes": 0,
         "encodedBytes": 0,
-        "externalPeakRssBytes": 124469248,
-        "externalRssSampleCount": 9,
+        "externalPeakRssBytes": 126304256,
+        "externalRssSampleCount": 8,
         "externalRssSampleFailureCount": 0,
         "filesystem": {
-          "afterBytes": 196955645,
-          "beforeBytes": 227064806,
-          "sampledHighWaterBytes": 257175845
+          "afterBytes": 196980208,
+          "beforeBytes": 227089369,
+          "sampledHighWaterBytes": 227089479
         },
         "outputRecords": 0,
-        "parentElapsedMs": 477,
+        "parentElapsedMs": 373,
         "runCount": 2,
         "sourceBytes": 0,
         "sourceFiles": 0,
         "stderrBytes": 0,
-        "stdoutBytes": 996
+        "stdoutBytes": 995
       },
       "name": "workspace_discard",
       "projectionSha256": "064fdfeb99edbc148aa8778a62741f99119e5abad545d4e846cb39e835736056",
@@ -710,21 +710,21 @@
     {
       "failureCode": "interruption_injected",
       "metrics": {
-        "childCpuMs": 97,
-        "childMaxRssBytes": 124485632,
+        "childCpuMs": 99,
+        "childMaxRssBytes": 124862464,
         "decodedBytes": 0,
         "durablePeakRssBytes": 0,
         "encodedBytes": 0,
-        "externalPeakRssBytes": 123944960,
-        "externalRssSampleCount": 7,
+        "externalPeakRssBytes": 124157952,
+        "externalRssSampleCount": 6,
         "externalRssSampleFailureCount": 0,
         "filesystem": {
-          "afterBytes": 196956180,
-          "beforeBytes": 227066573,
-          "sampledHighWaterBytes": 257176380
+          "afterBytes": 196980743,
+          "beforeBytes": 227091136,
+          "sampledHighWaterBytes": 257200942
         },
         "outputRecords": 0,
-        "parentElapsedMs": 402,
+        "parentElapsedMs": 300,
         "runCount": 2,
         "sourceBytes": 0,
         "sourceFiles": 0,
@@ -738,26 +738,26 @@
     {
       "failureCode": "none",
       "metrics": {
-        "childCpuMs": 8,
-        "childMaxRssBytes": 118865920,
+        "childCpuMs": 5,
+        "childMaxRssBytes": 119013376,
         "decodedBytes": 0,
         "durablePeakRssBytes": 0,
         "encodedBytes": 0,
-        "externalPeakRssBytes": 118833152,
-        "externalRssSampleCount": 5,
+        "externalPeakRssBytes": 106086400,
+        "externalRssSampleCount": 4,
         "externalRssSampleFailureCount": 0,
         "filesystem": {
-          "afterBytes": 196956450,
-          "beforeBytes": 196956629,
-          "sampledHighWaterBytes": 196956629
+          "afterBytes": 196981013,
+          "beforeBytes": 196981192,
+          "sampledHighWaterBytes": 196981192
         },
         "outputRecords": 0,
-        "parentElapsedMs": 273,
+        "parentElapsedMs": 184,
         "runCount": 2,
         "sourceBytes": 0,
         "sourceFiles": 0,
         "stderrBytes": 0,
-        "stdoutBytes": 994
+        "stdoutBytes": 993
       },
       "name": "claude_callback_uninstall",
       "projectionSha256": "5d38a4aa94abb27b809f1949c8c9cfdc8361453401f51bca076b93b14707316a",
@@ -766,21 +766,21 @@
     {
       "failureCode": "interruption_injected",
       "metrics": {
-        "childCpuMs": 7,
-        "childMaxRssBytes": 119013376,
+        "childCpuMs": 5,
+        "childMaxRssBytes": 118554624,
         "decodedBytes": 0,
         "durablePeakRssBytes": 0,
         "encodedBytes": 0,
-        "externalPeakRssBytes": 118996992,
-        "externalRssSampleCount": 5,
+        "externalPeakRssBytes": 105086976,
+        "externalRssSampleCount": 4,
         "externalRssSampleFailureCount": 0,
         "filesystem": {
-          "afterBytes": 196956720,
-          "beforeBytes": 196956908,
-          "sampledHighWaterBytes": 196956908
+          "afterBytes": 196981283,
+          "beforeBytes": 196981471,
+          "sampledHighWaterBytes": 196981471
         },
         "outputRecords": 0,
-        "parentElapsedMs": 248,
+        "parentElapsedMs": 172,
         "runCount": 2,
         "sourceBytes": 0,
         "sourceFiles": 0,
@@ -827,7 +827,7 @@
     "targetChunks": 128
   },
   "protocolVersion": "g1-r7-release-evidence-v0.1",
-  "receiptSha256": "1f23ce061f6f875b9157a7a4526bc3d7be6bc317bb1244f3a29a963a4e208096",
+  "receiptSha256": "97213974a20feed5e75206e81aec2f2ee3a94f7c35c34801315b5c0b8aabd28e",
   "runtimeProvenance": {
     "architecture": "arm64",
     "elapsedClock": "parent_monotonic",

--- a/generated/r7-release-synthetic-semantics-node24.14.0-v0.1.json
+++ b/generated/r7-release-synthetic-semantics-node24.14.0-v0.1.json
@@ -482,7 +482,7 @@
     "resourcePolicyValuesSha256": "3cbe7853c8f75e96912885f64ba4ad1aeb13aff8a22e4ffbd51806b27c73b418",
     "schemaModuleSha256": "594d035e641e87b29db4027dca35157f8225fd5621816d67d5d9f25825468bbf",
     "workloadCodeFileCount": 359,
-    "workloadCodeSha256": "fcb55e0cb729b56249e2c6f4d8fa4a08bc4b4c8fe99a506ce10cfe1068ed48d5"
+    "workloadCodeSha256": "ea504fde37402622239d5405aa74c264b98a111c8da5b4031a0977fa5bd80741"
   },
   "determinism": {
     "comparisons": {
@@ -500,8 +500,8 @@
     "projectionVersion": "g1-r7-release-deterministic-projection-v0.1",
     "runCount": 2,
     "runProjectionSha256es": [
-      "19f3c061b361246f5eebd68dfb4a4d0d1362683d1f706dcef8937778918b3570",
-      "19f3c061b361246f5eebd68dfb4a4d0d1362683d1f706dcef8937778918b3570"
+      "5f778d981543b222ed2e0e8619f168c80055b07063e4296b193c69e3c2a22af3",
+      "5f778d981543b222ed2e0e8619f168c80055b07063e4296b193c69e3c2a22af3"
     ],
     "status": "passed"
   },
@@ -514,13 +514,13 @@
     {
       "failureCode": "none",
       "metrics": {
-        "childCpuMs": 99,
-        "childMaxRssBytes": 123568128,
+        "childCpuMs": 93,
+        "childMaxRssBytes": 124010496,
         "decodedBytes": 0,
-        "durablePeakRssBytes": 123535360,
+        "durablePeakRssBytes": 123994112,
         "encodedBytes": 0,
-        "externalPeakRssBytes": 123191296,
-        "externalRssSampleCount": 8,
+        "externalPeakRssBytes": 122355712,
+        "externalRssSampleCount": 6,
         "externalRssSampleFailureCount": 0,
         "filesystem": {
           "afterBytes": 200864,
@@ -528,12 +528,12 @@
           "sampledHighWaterBytes": 200864
         },
         "outputRecords": 27,
-        "parentElapsedMs": 461,
+        "parentElapsedMs": 245,
         "runCount": 2,
         "sourceBytes": 154645,
         "sourceFiles": 14,
         "stderrBytes": 169,
-        "stdoutBytes": 1073
+        "stdoutBytes": 1072
       },
       "name": "source_scan",
       "projectionSha256": "9a32d3d160adf2c4f0f900f4583abf8c4b37c5460377fcdd74447945cfa9acd7",
@@ -542,13 +542,13 @@
     {
       "failureCode": "none",
       "metrics": {
-        "childCpuMs": 56,
-        "childMaxRssBytes": 119439360,
+        "childCpuMs": 53,
+        "childMaxRssBytes": 120389632,
         "decodedBytes": 0,
-        "durablePeakRssBytes": 162594816,
+        "durablePeakRssBytes": 165511168,
         "encodedBytes": 0,
-        "externalPeakRssBytes": 119029760,
-        "externalRssSampleCount": 5,
+        "externalPeakRssBytes": 97927168,
+        "externalRssSampleCount": 4,
         "externalRssSampleFailureCount": 0,
         "filesystem": {
           "afterBytes": 401568,
@@ -556,12 +556,12 @@
           "sampledHighWaterBytes": 401568
         },
         "outputRecords": 27,
-        "parentElapsedMs": 239,
+        "parentElapsedMs": 193,
         "runCount": 2,
         "sourceBytes": 154645,
         "sourceFiles": 14,
         "stderrBytes": 169,
-        "stdoutBytes": 1078
+        "stdoutBytes": 1077
       },
       "name": "checkpoint_resume",
       "projectionSha256": "9a32d3d160adf2c4f0f900f4583abf8c4b37c5460377fcdd74447945cfa9acd7",
@@ -570,21 +570,21 @@
     {
       "failureCode": "none",
       "metrics": {
-        "childCpuMs": 205,
-        "childMaxRssBytes": 132366336,
+        "childCpuMs": 192,
+        "childMaxRssBytes": 131645440,
         "decodedBytes": 109963,
-        "durablePeakRssBytes": 132317184,
-        "encodedBytes": 32470,
-        "externalPeakRssBytes": 132300800,
-        "externalRssSampleCount": 25,
+        "durablePeakRssBytes": 131432448,
+        "encodedBytes": 32463,
+        "externalPeakRssBytes": 131612672,
+        "externalRssSampleCount": 23,
         "externalRssSampleFailureCount": 0,
         "filesystem": {
-          "afterBytes": 554640,
+          "afterBytes": 554633,
           "beforeBytes": 401568,
-          "sampledHighWaterBytes": 571935
+          "sampledHighWaterBytes": 554744
         },
         "outputRecords": 27,
-        "parentElapsedMs": 1477,
+        "parentElapsedMs": 1339,
         "runCount": 2,
         "sourceBytes": 154645,
         "sourceFiles": 14,
@@ -592,27 +592,27 @@
         "stdoutBytes": 1225
       },
       "name": "export_set_materialize",
-      "projectionSha256": "56e207b61618cc7f8e82a8441d20dc78f9259277833650c9b67d1184ed0d53bb",
+      "projectionSha256": "28c1e6d7d0e2c968554c072fffab32a3990be8c75dd940c79ab9c59b1cefd03e",
       "status": "completed"
     },
     {
       "failureCode": "none",
       "metrics": {
-        "childCpuMs": 42,
-        "childMaxRssBytes": 123764736,
+        "childCpuMs": 43,
+        "childMaxRssBytes": 124157952,
         "decodedBytes": 109963,
         "durablePeakRssBytes": 0,
-        "encodedBytes": 32470,
-        "externalPeakRssBytes": 92471296,
+        "encodedBytes": 32463,
+        "externalPeakRssBytes": 92913664,
         "externalRssSampleCount": 4,
         "externalRssSampleFailureCount": 0,
         "filesystem": {
-          "afterBytes": 554640,
-          "beforeBytes": 554640,
-          "sampledHighWaterBytes": 554640
+          "afterBytes": 554633,
+          "beforeBytes": 554633,
+          "sampledHighWaterBytes": 554633
         },
         "outputRecords": 27,
-        "parentElapsedMs": 180,
+        "parentElapsedMs": 182,
         "runCount": 2,
         "sourceBytes": 0,
         "sourceFiles": 0,
@@ -620,27 +620,27 @@
         "stdoutBytes": 997
       },
       "name": "export_set_verify",
-      "projectionSha256": "206b153d04a6331c83d5049cae8a4c19ca30b7bd3cc074cfbb6dd2596f2add3f",
+      "projectionSha256": "fee0a5a9fd13a89d161de25ba3eb37804d0efef223e6d45fd623639c9ea0423f",
       "status": "completed"
     },
     {
       "failureCode": "none",
       "metrics": {
-        "childCpuMs": 173,
-        "childMaxRssBytes": 136921088,
+        "childCpuMs": 151,
+        "childMaxRssBytes": 137838592,
         "decodedBytes": 0,
         "durablePeakRssBytes": 0,
         "encodedBytes": 0,
-        "externalPeakRssBytes": 136871936,
-        "externalRssSampleCount": 18,
+        "externalPeakRssBytes": 137478144,
+        "externalRssSampleCount": 12,
         "externalRssSampleFailureCount": 0,
         "filesystem": {
           "afterBytes": 203384,
-          "beforeBytes": 556703,
-          "sampledHighWaterBytes": 567586
+          "beforeBytes": 556696,
+          "sampledHighWaterBytes": 556807
         },
         "outputRecords": 0,
-        "parentElapsedMs": 1002,
+        "parentElapsedMs": 571,
         "runCount": 2,
         "sourceBytes": 0,
         "sourceFiles": 0,
@@ -648,27 +648,27 @@
         "stdoutBytes": 997
       },
       "name": "complete_set_delete",
-      "projectionSha256": "976e73a695ccdabaef12fc0137c96f55f6edfc1d77c3bcb565ebdda50afb5171",
+      "projectionSha256": "60f732f952e80497d873a4511e928e4ada204eed47dc29dd2838d3a4d516d3b4",
       "status": "completed"
     },
     {
       "failureCode": "interruption_injected",
       "metrics": {
-        "childCpuMs": 59,
-        "childMaxRssBytes": 114065408,
+        "childCpuMs": 36,
+        "childMaxRssBytes": 115032064,
         "decodedBytes": 0,
         "durablePeakRssBytes": 0,
         "encodedBytes": 0,
-        "externalPeakRssBytes": 114032640,
-        "externalRssSampleCount": 15,
+        "externalPeakRssBytes": 114950144,
+        "externalRssSampleCount": 10,
         "externalRssSampleFailureCount": 0,
         "filesystem": {
-          "afterBytes": 556703,
-          "beforeBytes": 920794,
-          "sampledHighWaterBytes": 920794
+          "afterBytes": 556696,
+          "beforeBytes": 920780,
+          "sampledHighWaterBytes": 920780
         },
         "outputRecords": 0,
-        "parentElapsedMs": 764,
+        "parentElapsedMs": 488,
         "runCount": 2,
         "sourceBytes": 0,
         "sourceFiles": 0,
@@ -676,27 +676,27 @@
         "stdoutBytes": 1005
       },
       "name": "complete_set_delete_recovery",
-      "projectionSha256": "976e73a695ccdabaef12fc0137c96f55f6edfc1d77c3bcb565ebdda50afb5171",
+      "projectionSha256": "60f732f952e80497d873a4511e928e4ada204eed47dc29dd2838d3a4d516d3b4",
       "status": "interrupted_recovered"
     },
     {
       "failureCode": "none",
       "metrics": {
-        "childCpuMs": 18,
-        "childMaxRssBytes": 115277824,
+        "childCpuMs": 19,
+        "childMaxRssBytes": 115720192,
         "decodedBytes": 0,
         "durablePeakRssBytes": 0,
         "encodedBytes": 0,
-        "externalPeakRssBytes": 112508928,
+        "externalPeakRssBytes": 115523584,
         "externalRssSampleCount": 5,
         "externalRssSampleFailureCount": 0,
         "filesystem": {
-          "afterBytes": 555173,
-          "beforeBytes": 722576,
-          "sampledHighWaterBytes": 722576
+          "afterBytes": 555166,
+          "beforeBytes": 722569,
+          "sampledHighWaterBytes": 722569
         },
         "outputRecords": 0,
-        "parentElapsedMs": 249,
+        "parentElapsedMs": 269,
         "runCount": 2,
         "sourceBytes": 0,
         "sourceFiles": 0,
@@ -711,25 +711,25 @@
       "failureCode": "interruption_injected",
       "metrics": {
         "childCpuMs": 14,
-        "childMaxRssBytes": 114212864,
+        "childMaxRssBytes": 114589696,
         "decodedBytes": 0,
         "durablePeakRssBytes": 0,
         "encodedBytes": 0,
-        "externalPeakRssBytes": 114081792,
+        "externalPeakRssBytes": 114065408,
         "externalRssSampleCount": 5,
         "externalRssSampleFailureCount": 0,
         "filesystem": {
-          "afterBytes": 555706,
-          "beforeBytes": 724337,
-          "sampledHighWaterBytes": 724337
+          "afterBytes": 555699,
+          "beforeBytes": 724330,
+          "sampledHighWaterBytes": 724330
         },
         "outputRecords": 0,
-        "parentElapsedMs": 243,
+        "parentElapsedMs": 247,
         "runCount": 2,
         "sourceBytes": 0,
         "sourceFiles": 0,
         "stderrBytes": 169,
-        "stdoutBytes": 999
+        "stdoutBytes": 1000
       },
       "name": "workspace_discard_recovery",
       "projectionSha256": "495426e69724d58733a4605ce62a0a9e61a094e67823671e64b872acf28bbea5",
@@ -739,20 +739,20 @@
       "failureCode": "none",
       "metrics": {
         "childCpuMs": 6,
-        "childMaxRssBytes": 109707264,
+        "childMaxRssBytes": 111280128,
         "decodedBytes": 0,
         "durablePeakRssBytes": 0,
         "encodedBytes": 0,
-        "externalPeakRssBytes": 94470144,
+        "externalPeakRssBytes": 92504064,
         "externalRssSampleCount": 4,
         "externalRssSampleFailureCount": 0,
         "filesystem": {
-          "afterBytes": 555976,
-          "beforeBytes": 556155,
-          "sampledHighWaterBytes": 556155
+          "afterBytes": 555969,
+          "beforeBytes": 556148,
+          "sampledHighWaterBytes": 556148
         },
         "outputRecords": 0,
-        "parentElapsedMs": 196,
+        "parentElapsedMs": 179,
         "runCount": 2,
         "sourceBytes": 0,
         "sourceFiles": 0,
@@ -767,20 +767,20 @@
       "failureCode": "interruption_injected",
       "metrics": {
         "childCpuMs": 5,
-        "childMaxRssBytes": 111640576,
+        "childMaxRssBytes": 111280128,
         "decodedBytes": 0,
         "durablePeakRssBytes": 0,
         "encodedBytes": 0,
-        "externalPeakRssBytes": 92667904,
+        "externalPeakRssBytes": 92684288,
         "externalRssSampleCount": 4,
         "externalRssSampleFailureCount": 0,
         "filesystem": {
-          "afterBytes": 556246,
-          "beforeBytes": 556434,
-          "sampledHighWaterBytes": 556434
+          "afterBytes": 556239,
+          "beforeBytes": 556427,
+          "sampledHighWaterBytes": 556427
         },
         "outputRecords": 0,
-        "parentElapsedMs": 190,
+        "parentElapsedMs": 166,
         "runCount": 2,
         "sourceBytes": 0,
         "sourceFiles": 0,
@@ -836,7 +836,7 @@
     "kind": "release_synthetic_semantics"
   },
   "protocolVersion": "g1-r7-release-evidence-v0.1",
-  "receiptSha256": "7199e88864ad71aa06fd5b5ae70ef51dab25dafef482688da4d5851d33ec6dc3",
+  "receiptSha256": "9a778ac5013f41a813f2e27a2a016b80ca3aa4c45c9413b721d58fe62983de10",
   "runtimeProvenance": {
     "architecture": "arm64",
     "elapsedClock": "parent_monotonic",

--- a/generated/r7-release-synthetic-semantics-node26.2.0-v0.1.json
+++ b/generated/r7-release-synthetic-semantics-node26.2.0-v0.1.json
@@ -482,7 +482,7 @@
     "resourcePolicyValuesSha256": "3cbe7853c8f75e96912885f64ba4ad1aeb13aff8a22e4ffbd51806b27c73b418",
     "schemaModuleSha256": "594d035e641e87b29db4027dca35157f8225fd5621816d67d5d9f25825468bbf",
     "workloadCodeFileCount": 359,
-    "workloadCodeSha256": "fcb55e0cb729b56249e2c6f4d8fa4a08bc4b4c8fe99a506ce10cfe1068ed48d5"
+    "workloadCodeSha256": "ea504fde37402622239d5405aa74c264b98a111c8da5b4031a0977fa5bd80741"
   },
   "determinism": {
     "comparisons": {
@@ -500,8 +500,8 @@
     "projectionVersion": "g1-r7-release-deterministic-projection-v0.1",
     "runCount": 2,
     "runProjectionSha256es": [
-      "a9206ec38b725180649cd9fe0eabca560f5ef13b1147dba79ec3eb3d25cdd2a0",
-      "a9206ec38b725180649cd9fe0eabca560f5ef13b1147dba79ec3eb3d25cdd2a0"
+      "524570722835ad060efe26b8e7819f4063bbbc0f641d545dd71bc0510699f2b8",
+      "524570722835ad060efe26b8e7819f4063bbbc0f641d545dd71bc0510699f2b8"
     ],
     "status": "passed"
   },
@@ -514,26 +514,26 @@
     {
       "failureCode": "none",
       "metrics": {
-        "childCpuMs": 73,
-        "childMaxRssBytes": 130957312,
+        "childCpuMs": 77,
+        "childMaxRssBytes": 131055616,
         "decodedBytes": 0,
-        "durablePeakRssBytes": 130924544,
+        "durablePeakRssBytes": 131055616,
         "encodedBytes": 0,
-        "externalPeakRssBytes": 130629632,
+        "externalPeakRssBytes": 130449408,
         "externalRssSampleCount": 6,
         "externalRssSampleFailureCount": 0,
         "filesystem": {
           "afterBytes": 200864,
           "beforeBytes": 160,
-          "sampledHighWaterBytes": 200864
+          "sampledHighWaterBytes": 209742
         },
         "outputRecords": 27,
-        "parentElapsedMs": 221,
+        "parentElapsedMs": 300,
         "runCount": 2,
         "sourceBytes": 154645,
         "sourceFiles": 14,
         "stderrBytes": 0,
-        "stdoutBytes": 1071
+        "stdoutBytes": 1073
       },
       "name": "source_scan",
       "projectionSha256": "9a32d3d160adf2c4f0f900f4583abf8c4b37c5460377fcdd74447945cfa9acd7",
@@ -542,13 +542,13 @@
     {
       "failureCode": "none",
       "metrics": {
-        "childCpuMs": 49,
-        "childMaxRssBytes": 128843776,
+        "childCpuMs": 51,
+        "childMaxRssBytes": 130695168,
         "decodedBytes": 0,
-        "durablePeakRssBytes": 171442176,
+        "durablePeakRssBytes": 161742848,
         "encodedBytes": 0,
-        "externalPeakRssBytes": 109248512,
-        "externalRssSampleCount": 4,
+        "externalPeakRssBytes": 128565248,
+        "externalRssSampleCount": 5,
         "externalRssSampleFailureCount": 0,
         "filesystem": {
           "afterBytes": 401568,
@@ -556,7 +556,7 @@
           "sampledHighWaterBytes": 401568
         },
         "outputRecords": 27,
-        "parentElapsedMs": 182,
+        "parentElapsedMs": 211,
         "runCount": 2,
         "sourceBytes": 154645,
         "sourceFiles": 14,
@@ -570,21 +570,21 @@
     {
       "failureCode": "none",
       "metrics": {
-        "childCpuMs": 214,
-        "childMaxRssBytes": 140541952,
+        "childCpuMs": 162,
+        "childMaxRssBytes": 139657216,
         "decodedBytes": 109963,
-        "durablePeakRssBytes": 140525568,
-        "encodedBytes": 32428,
-        "externalPeakRssBytes": 140525568,
-        "externalRssSampleCount": 19,
+        "durablePeakRssBytes": 139608064,
+        "encodedBytes": 32464,
+        "externalPeakRssBytes": 139591680,
+        "externalRssSampleCount": 22,
         "externalRssSampleFailureCount": 0,
         "filesystem": {
-          "afterBytes": 554597,
+          "afterBytes": 554633,
           "beforeBytes": 401568,
-          "sampledHighWaterBytes": 554708
+          "sampledHighWaterBytes": 554743
         },
         "outputRecords": 27,
-        "parentElapsedMs": 944,
+        "parentElapsedMs": 1082,
         "runCount": 2,
         "sourceBytes": 154645,
         "sourceFiles": 14,
@@ -592,27 +592,27 @@
         "stdoutBytes": 1223
       },
       "name": "export_set_materialize",
-      "projectionSha256": "fdbefdee2ba54fe49937e50a4c25f51d67f34afeee031d0eea063dc7feab00cd",
+      "projectionSha256": "d0604db98d792c5e10a057396c645bf6470b1ca812f52561b26dfcddbde2c196",
       "status": "completed"
     },
     {
       "failureCode": "none",
       "metrics": {
-        "childCpuMs": 41,
-        "childMaxRssBytes": 134184960,
+        "childCpuMs": 42,
+        "childMaxRssBytes": 135069696,
         "decodedBytes": 109963,
         "durablePeakRssBytes": 0,
-        "encodedBytes": 32428,
-        "externalPeakRssBytes": 98779136,
+        "encodedBytes": 32464,
+        "externalPeakRssBytes": 100532224,
         "externalRssSampleCount": 4,
         "externalRssSampleFailureCount": 0,
         "filesystem": {
-          "afterBytes": 554597,
-          "beforeBytes": 554597,
-          "sampledHighWaterBytes": 554597
+          "afterBytes": 554633,
+          "beforeBytes": 554633,
+          "sampledHighWaterBytes": 554633
         },
         "outputRecords": 27,
-        "parentElapsedMs": 173,
+        "parentElapsedMs": 174,
         "runCount": 2,
         "sourceBytes": 0,
         "sourceFiles": 0,
@@ -620,27 +620,27 @@
         "stdoutBytes": 997
       },
       "name": "export_set_verify",
-      "projectionSha256": "3a96b880d7a641fc00af361b2f4b9d64302f20250004b17afadce2d2c5e87d6b",
+      "projectionSha256": "1d44bb7cf1841c949150c722d34718d53e435d50b82f57cd75599e4d553070f4",
       "status": "completed"
     },
     {
       "failureCode": "none",
       "metrics": {
-        "childCpuMs": 156,
-        "childMaxRssBytes": 146145280,
+        "childCpuMs": 146,
+        "childMaxRssBytes": 147423232,
         "decodedBytes": 0,
         "durablePeakRssBytes": 0,
         "encodedBytes": 0,
-        "externalPeakRssBytes": 145932288,
+        "externalPeakRssBytes": 146980864,
         "externalRssSampleCount": 12,
         "externalRssSampleFailureCount": 0,
         "filesystem": {
           "afterBytes": 203384,
-          "beforeBytes": 556660,
-          "sampledHighWaterBytes": 556771
+          "beforeBytes": 556696,
+          "sampledHighWaterBytes": 556806
         },
         "outputRecords": 0,
-        "parentElapsedMs": 569,
+        "parentElapsedMs": 580,
         "runCount": 2,
         "sourceBytes": 0,
         "sourceFiles": 0,
@@ -648,24 +648,24 @@
         "stdoutBytes": 997
       },
       "name": "complete_set_delete",
-      "projectionSha256": "0eefbb6a04bff72344a9a74f8fcb3008a15ac67becf47d3146a8c10ba72cc975",
+      "projectionSha256": "60f732f952e80497d873a4511e928e4ada204eed47dc29dd2838d3a4d516d3b4",
       "status": "completed"
     },
     {
       "failureCode": "interruption_injected",
       "metrics": {
-        "childCpuMs": 36,
-        "childMaxRssBytes": 122044416,
+        "childCpuMs": 33,
+        "childMaxRssBytes": 122617856,
         "decodedBytes": 0,
         "durablePeakRssBytes": 0,
         "encodedBytes": 0,
-        "externalPeakRssBytes": 121929728,
+        "externalPeakRssBytes": 122486784,
         "externalRssSampleCount": 10,
         "externalRssSampleFailureCount": 0,
         "filesystem": {
-          "afterBytes": 556660,
-          "beforeBytes": 920708,
-          "sampledHighWaterBytes": 920708
+          "afterBytes": 556696,
+          "beforeBytes": 920780,
+          "sampledHighWaterBytes": 920780
         },
         "outputRecords": 0,
         "parentElapsedMs": 438,
@@ -676,27 +676,27 @@
         "stdoutBytes": 1005
       },
       "name": "complete_set_delete_recovery",
-      "projectionSha256": "0eefbb6a04bff72344a9a74f8fcb3008a15ac67becf47d3146a8c10ba72cc975",
+      "projectionSha256": "60f732f952e80497d873a4511e928e4ada204eed47dc29dd2838d3a4d516d3b4",
       "status": "interrupted_recovered"
     },
     {
       "failureCode": "none",
       "metrics": {
         "childCpuMs": 17,
-        "childMaxRssBytes": 122503168,
+        "childMaxRssBytes": 122454016,
         "decodedBytes": 0,
         "durablePeakRssBytes": 0,
         "encodedBytes": 0,
-        "externalPeakRssBytes": 106971136,
-        "externalRssSampleCount": 4,
+        "externalPeakRssBytes": 122437632,
+        "externalRssSampleCount": 6,
         "externalRssSampleFailureCount": 0,
         "filesystem": {
-          "afterBytes": 555130,
-          "beforeBytes": 722533,
-          "sampledHighWaterBytes": 722533
+          "afterBytes": 555166,
+          "beforeBytes": 722569,
+          "sampledHighWaterBytes": 722569
         },
         "outputRecords": 0,
-        "parentElapsedMs": 200,
+        "parentElapsedMs": 224,
         "runCount": 2,
         "sourceBytes": 0,
         "sourceFiles": 0,
@@ -711,20 +711,20 @@
       "failureCode": "interruption_injected",
       "metrics": {
         "childCpuMs": 13,
-        "childMaxRssBytes": 122372096,
+        "childMaxRssBytes": 122290176,
         "decodedBytes": 0,
         "durablePeakRssBytes": 0,
         "encodedBytes": 0,
-        "externalPeakRssBytes": 106889216,
-        "externalRssSampleCount": 4,
-        "externalRssSampleFailureCount": 0,
+        "externalPeakRssBytes": 122273792,
+        "externalRssSampleCount": 5,
+        "externalRssSampleFailureCount": 1,
         "filesystem": {
-          "afterBytes": 555663,
-          "beforeBytes": 724294,
-          "sampledHighWaterBytes": 724294
+          "afterBytes": 555699,
+          "beforeBytes": 724330,
+          "sampledHighWaterBytes": 724330
         },
         "outputRecords": 0,
-        "parentElapsedMs": 188,
+        "parentElapsedMs": 210,
         "runCount": 2,
         "sourceBytes": 0,
         "sourceFiles": 0,
@@ -738,21 +738,21 @@
     {
       "failureCode": "none",
       "metrics": {
-        "childCpuMs": 6,
-        "childMaxRssBytes": 118734848,
+        "childCpuMs": 5,
+        "childMaxRssBytes": 120438784,
         "decodedBytes": 0,
         "durablePeakRssBytes": 0,
         "encodedBytes": 0,
-        "externalPeakRssBytes": 104759296,
+        "externalPeakRssBytes": 103464960,
         "externalRssSampleCount": 4,
         "externalRssSampleFailureCount": 0,
         "filesystem": {
-          "afterBytes": 555933,
-          "beforeBytes": 556112,
-          "sampledHighWaterBytes": 556112
+          "afterBytes": 555969,
+          "beforeBytes": 556148,
+          "sampledHighWaterBytes": 556148
         },
         "outputRecords": 0,
-        "parentElapsedMs": 169,
+        "parentElapsedMs": 177,
         "runCount": 2,
         "sourceBytes": 0,
         "sourceFiles": 0,
@@ -767,20 +767,20 @@
       "failureCode": "interruption_injected",
       "metrics": {
         "childCpuMs": 5,
-        "childMaxRssBytes": 118734848,
+        "childMaxRssBytes": 118276096,
         "decodedBytes": 0,
         "durablePeakRssBytes": 0,
         "encodedBytes": 0,
-        "externalPeakRssBytes": 106086400,
+        "externalPeakRssBytes": 102498304,
         "externalRssSampleCount": 4,
         "externalRssSampleFailureCount": 0,
         "filesystem": {
-          "afterBytes": 556203,
-          "beforeBytes": 556391,
-          "sampledHighWaterBytes": 556391
+          "afterBytes": 556239,
+          "beforeBytes": 556427,
+          "sampledHighWaterBytes": 556427
         },
         "outputRecords": 0,
-        "parentElapsedMs": 160,
+        "parentElapsedMs": 168,
         "runCount": 2,
         "sourceBytes": 0,
         "sourceFiles": 0,
@@ -836,7 +836,7 @@
     "kind": "release_synthetic_semantics"
   },
   "protocolVersion": "g1-r7-release-evidence-v0.1",
-  "receiptSha256": "4cfed5bf54a8a7bef98fdba3815c4d693e3b7a78fa6afdc2011df95f8861b624",
+  "receiptSha256": "012565a67bc9bcb451eaaa0201e3027e628f1ab787700720c4dd69ce7762a0f5",
   "runtimeProvenance": {
     "architecture": "arm64",
     "elapsedClock": "parent_monotonic",

--- a/release-notes/0.1.17.md
+++ b/release-notes/0.1.17.md
@@ -3,11 +3,15 @@
 **Status:** Candidate source notes for native dogfood. Integrated RC5 source
 produced signed, notarized, and installed build `1023.3`; physical testing then
 found that its five-minute ordinary refresh deadline stopped a legitimate full
-accounting-cache rebuild. RC6 build `1023.4` is allocated to the correction but
-still requires exact-source validation, protected R7 regeneration, signing,
-notarization, state-preserving installation, and installed native verification.
-No stable `v0.1.17` tag, GitHub release, published appcast, or RC6 artifact is
-claimed yet.
+accounting-cache rebuild. Signed, notarized, and installed RC6 build `1023.4`
+proved that timeout correction, then exposed an inherited
+`recent_7d_indexing` legacy checkpoint suppressing otherwise-authoritative
+unified accounting. RC7 build `1023.5` is allocated to remove only that retired
+collector gate while preserving the fail-closed unified-generation authority
+check. RC7 still requires exact-source validation, protected R7 regeneration,
+signing, notarization, state-preserving installation, and installed native
+verification. No stable `v0.1.17` tag, GitHub release, published appcast, or RC7
+artifact is claimed yet.
 
 The native Mac app is easier to recover, clearer while it starts, and ready for
 the newer Codex history, plan, and quota formats already appearing in current
@@ -217,21 +221,28 @@ and Preview never opts into automatic updates.
 Internal dogfood is deliberately different: it keeps the stable bundle and
 local-state identity so it can test an in-place upgrade, while using its own
 update channel. Earlier 0.1.17 internal candidates used builds **1023**,
-**1023.1**, **1023.2**, and **1023.3**. RC6 is allocated build **1023.4**, while
-**1024** remains reserved for the stable final, keeping stable ordered after the
-candidate. Signed tooling also requires a clean checkout and exactly one
-matching annotated source tag at `HEAD`: `v0.1.17` for stable, or the strict
+**1023.1**, **1023.2**, **1023.3**, and **1023.4**. RC7 is allocated build
+**1023.5**, while **1024** remains reserved for the stable final, keeping stable
+ordered after the candidate. Signed tooling also requires a clean checkout and
+exactly one matching annotated source tag at `HEAD`: `v0.1.17` for stable, or
+the strict
 `tibotattle-internal-dogfood-0.1.17-rcN-source-YYYYMMDD` form for a dated
 candidate.
 
 RC5 build `1023.3` is signed, notarized, and installed evidence only for its
 frozen source. It preserved schema-11 data and launched without an automatic
 Keychain prompt, but its full accounting-cache rebuild exceeded the ordinary
-five-minute refresh deadline. RC6 corrects that lifetime boundary and still
-requires exact-source gates, R7, signing, notarization, state-preserving
-replacement, and installed native checks. No 0.1.17 artifact has been published
-or made available through an updater. Browser rendering and compiled native
-tests do not prove physical popover interaction or thread-link handoff to Codex.
+five-minute refresh deadline. RC6 build `1023.4` then passed source, R7, signing,
+notarization, state-preserving replacement, and installed launch gates; its real
+refresh ran beyond five minutes and reached terminal success. That run exposed
+an older `recent_7d_indexing` checkpoint still withholding advanced accounting
+even though the unified generation itself was authoritative. RC7 removes only
+that retired checkpoint dependency. It does not relax
+`unifiedGenerationAuthoritative`, source completeness, generation matching, or
+atomic cache publication, and must repeat every exact-source and installed gate.
+No 0.1.17 artifact has been published or made available through an updater.
+Browser rendering and compiled native tests do not prove physical popover
+interaction or thread-link handoff to Codex.
 
 ## Prompt-free credential upgrades
 
@@ -290,11 +301,12 @@ desktop app neither deploys that protocol nor changes an existing contribution
 consent.
 
 The fixed-real-corpus, before/after attribution comparison required by the PR
-#94 plan remains open and has not been represented as passed by R7. Existing
-tools provide partial content-free aggregates but no reviewed, schema-validated
-cross-revision comparator with the required reconciliation and resource receipt.
-That empirical gate must remain explicit in dogfood evaluation and must be
-closed or deliberately resolved before stable sign-off.
+#94 plan remains **OPEN / NOT RUN** and has not been represented as passed by
+R7. Existing tools provide partial content-free aggregates but no reviewed,
+schema-validated cross-revision comparator with the required reconciliation and
+resource receipt. An explicitly open-gate internal dogfood may be used for
+testing, but this empirical gate must be closed or deliberately resolved before
+stable or public qualification.
 
 ## Known limitations
 

--- a/scripts/macos-bundle-version.js
+++ b/scripts/macos-bundle-version.js
@@ -14,17 +14,17 @@ export const LEGACY_STABLE_MACOS_BUNDLE_VERSION = "0.1.16";
 export const MACOS_BUNDLE_VERSION_EPOCH = 2_000;
 
 // Signed releases keep the production bundle identifier, so their build
-// numbers must advance from the last shared-identity dogfood build (1023.2).
+// numbers must advance from the last installed shared-identity dogfood build.
 // Freeze the owner-reviewed allocations per marketing version and channel;
 // adding a future release is an explicit policy change, never an implicit
 // timestamp or environment-controlled counter.
 // The 0.1.17 RC2 used 1023, RC3 used 1023.1, installed startup-recovery RC4
-// used 1023.2, and installed integrated RC5 used 1023.3. The accounting-
-// deadline correction uses monotonic RC6 build 1023.4, preserving the
-// allocated stable 1024 and upgrade ordering.
+// used 1023.2, installed integrated RC5 used 1023.3, and installed accounting-
+// deadline RC6 used 1023.4. The retired-checkpoint correction uses monotonic
+// RC7 build 1023.5, preserving the allocated stable 1024 and upgrade ordering.
 export const SIGNED_MACOS_BUNDLE_VERSION_PLAN = Object.freeze({
   "0.1.17": Object.freeze({
-    "internal-dogfood": "1023.4",
+    "internal-dogfood": "1023.5",
     stable: "1024",
   }),
 });

--- a/src/local-companion-refresh.js
+++ b/src/local-companion-refresh.js
@@ -1133,20 +1133,15 @@ export function createLocalCollectorRefreshRunner({
     }
     const completedIndex = publicIndexingResult(result?.indexing);
     await publishHeadline(completedIndex);
+    // Unified accounting reads the independently published unified index.
+    // The quota-only collector deliberately preserves its inherited legacy
+    // indexing descriptor, which may still say `recent_7d_indexing`; that
+    // retired checkpoint must not suppress an authoritative unified rebuild.
+    // `unifiedGenerationAuthoritative` remains the fail-closed source gate.
     const accountingMayRun = accountingSourceMode === "unified"
-      ? completedIndex === null
-        || [
-          "recent_7d_complete",
-          "recent_7d_partial",
-          "prospective_only",
-          // Unified accounting reads the published index, not the bounded
-          // collector ledger, so a collector-only pause must not suppress a
-          // complete-generation accounting pass.
-          "bounded_pause",
-        ].includes(completedIndex.status)
-      : completedIndex === null
-        || ["recent_7d_complete", "recent_7d_partial", "prospective_only"]
-          .includes(completedIndex.status);
+      || completedIndex === null
+      || ["recent_7d_complete", "recent_7d_partial", "prospective_only"]
+        .includes(completedIndex.status);
     let unifiedIndex = null;
     refreshStep = "unified_index";
     if (accountingSourceMode === "unified"

--- a/test/local-companion-refresh.test.js
+++ b/test/local-companion-refresh.test.js
@@ -670,7 +670,7 @@ test("unified accounting mode never advances the legacy archive and passes expli
   assert.equal(result.accounting.sourceMode, "unified");
 });
 
-test("tool-only partial coverage does not block complete usage accounting", async () => {
+test("tool-only partial coverage and an inherited legacy indexing status do not block unified accounting", async () => {
   let accountingCalls = 0;
   const generation = {
     id: 8,
@@ -694,7 +694,15 @@ test("tool-only partial coverage does not block complete usage accounting", asyn
       rolloutRecordsWritten: 1,
       filesDiscovered: 1,
       refresh: { attempted: false, recordWritten: false, errorCode: null },
-      indexing: COMPLETE_INDEX,
+      indexing: {
+        ...COMPLETE_INDEX,
+        status: "recent_7d_indexing",
+        phase: "rollout_index",
+        coveredAt: {
+          ...COMPLETE_INDEX.coveredAt,
+          endAt: null,
+        },
+      },
     }),
     refreshUnifiedIndex: async () => ({ status: "ingested", generation }),
     refreshAccounting: async (options) => {
@@ -717,6 +725,7 @@ test("tool-only partial coverage does not block complete usage accounting", asyn
   assert.equal(accountingCalls, 1);
   assert.equal(result.accounting.sourceMode, "unified");
   assert.equal(result.accounting.refreshStatus, "rebuilt");
+  assert.equal(result.indexing.status, "recent_7d_indexing");
   assert.equal(result.unifiedIndex.generation.toolProvenanceComplete, false);
 });
 

--- a/test/macos-app-bundle.test.js
+++ b/test/macos-app-bundle.test.js
@@ -4299,11 +4299,11 @@ test("development and preview builds treat the release-channel policy as optiona
 
 test("macOS release metadata validates versions, production mode, and Keychain references", async () => {
   assert.equal(normalizeMacOSBundleVersion(), DERIVED_MACOS_BUNDLE_VERSION);
-  assert.equal(INTERNAL_DOGFOOD_SIGNED_BUNDLE_VERSION, "1023.4");
+  assert.equal(INTERNAL_DOGFOOD_SIGNED_BUNDLE_VERSION, "1023.5");
   assert.equal(STABLE_SIGNED_BUNDLE_VERSION, "1024");
   assert.equal(
     normalizeMacOSBundleVersion(INTERNAL_DOGFOOD_SIGNED_BUNDLE_VERSION),
-    "1023.4",
+    "1023.5",
   );
   assert.equal(
     compareMacOSBundleVersions(
@@ -4333,13 +4333,18 @@ test("macOS release metadata validates versions, production mode, and Keychain r
     "the accounting-deadline correction must be strictly newer than installed RC5",
   );
   assert.equal(
+    compareMacOSBundleVersions("1023.4", INTERNAL_DOGFOOD_SIGNED_BUNDLE_VERSION),
+    -1,
+    "the retired-checkpoint correction must be strictly newer than installed RC6",
+  );
+  assert.equal(
     compareMacOSBundleVersions(
       STABLE_SIGNED_BUNDLE_VERSION,
       INTERNAL_DOGFOOD_SIGNED_BUNDLE_VERSION,
     ) > 0,
     true,
   );
-  for (const unallocated of ["1023", "1023.0", "1023.1", "1023.1.0", "1023.2", "1023.2.0", "1023.3", "1023.3.0", "1023.4.0", "1024", "2000.1.17"]) {
+  for (const unallocated of ["1023", "1023.0", "1023.1", "1023.1.0", "1023.2", "1023.2.0", "1023.3", "1023.3.0", "1023.4", "1023.4.0", "1023.5.0", "1024", "2000.1.17"]) {
     assert.throws(
       () => readMacOSReleaseBuildConfiguration({
         USAGE_MONITOR_BUNDLE_VERSION: unallocated,


### PR DESCRIPTION
## Summary

- allow authoritative unified accounting to rebuild even when the retired legacy collector checkpoint still reports `recent_7d_indexing`
- retain the existing fail-closed unified-generation authority checks, including tool-provenance-only partial generations
- allocate internal dogfood build `1023.5` while keeping stable build `1024` reserved
- regenerate and commit all ten protected R7 receipts against the exact RC7 workload

## Validation

- final clean-tree `npm run check`: passed
- root suite: 3,471 tests; 3,454 passed; 17 platform skips; 0 failed
- Worker operational tests: 179/179
- Worker functional tests: 524/524
- macOS owning gate: 89/89
- local-review runtime qualification: passed; same-epoch builds byte-identical; 12 required lifecycle invocations; 0 covered network attempts; no private content included
- retained R7 validation: 2/2; exactly ten generated receipts changed
- R7 workload: 359 source files; SHA-256 `ea504fde37402622239d5405aa74c264b98a111c8da5b4031a0977fa5bd80741`

The first protected R7 attempt failed closed during `export_set_verify` when the filesystem sampler observed a transient owned zero-link inode. It published no receipts and cleaned its journal/staging state. RC7 did not change that sampler or verifier code. After stopping the installed dogfood and companion to make the machine quiescent, one documented full retry completed successfully in 50.3 minutes and atomically installed ten validated receipts. No partial run or loop-until-green evidence was retained.

## Release boundary

This PR prepares an internal 0.1.17 RC7 dogfood source candidate. It does not deploy the Worker, apply hosted migrations, publish an appcast/site/release, install an app, or qualify stable/public 0.1.17.

The PR #94 fixed-real-corpus before/after comparator remains `OPEN / NOT RUN`. R7 decision receipts remain honestly `release_open` because network and other public-promotion evidence are not measured. Those gates block stable/public qualification, not local RC7 dogfood testing.
