### PR TITLE
Prepare 0.1.17 RC8 accounting cache recovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -281,9 +281,9 @@ published-release claim.
 - Gives Preview its own app, bundle, semantic-open, local-state, Keychain,
   preferences, and Sparkle-feed identities, preventing preview installation or
   updates from replacing stable state.
-- Records builds 1023, 1023.1, 1023.2, 1023.3, and 1023.4 as earlier 0.1.17
-  internal dogfoods, allocates build 1023.5 to RC7, and retains build 1024 for
-  stable.
+- Records builds 1023, 1023.1, 1023.2, 1023.3, 1023.4, and 1023.5 as earlier
+  0.1.17 internal dogfoods, allocates build 1023.6 to RC8, and retains build
+  1024 for stable.
   Signed tooling requires a clean checkout with exactly one matching annotated
   channel tag at `HEAD` before it can proceed. RC5 build 1023.3 is signed,
   notarized, and installed evidence for its frozen source, but physical testing
@@ -292,9 +292,14 @@ published-release claim.
   timeout correction in a signed, notarized, installed refresh, but exposed an
   inherited `recent_7d_indexing` legacy checkpoint suppressing otherwise-
   authoritative unified accounting. RC7 removes only that retired collector
-  gate, retains the fail-closed unified-generation authority check, and still
-  requires fresh exact-source gates, protected R7 regeneration, signing,
-  installation, and physical verification.
+  gate and subsequently passed its protected R7, full source gate, Developer ID
+  signing, notarization, stapling, and state-preserving installation gates. Its
+  first installed refresh ingested unified-index generation 44, but the strict
+  v0.14 cache validator rejected accounting because the projection copied an
+  excluded diagnostic-only row's eligibility onto a reset fitted from later
+  eligible transitions. RC8 retains that strict validator, projects fit
+  metadata from the first eligible row, and requires fresh exact-source R7,
+  artifact, install, and physical verification before it can replace RC7.
 - Establishes scoped, machine-checked repository guidance for coding agents and
   the root layout they may extend
   ([PR #77](https://github.com/adamallcock/tibotattle/pull/77)).

--- a/apps/macos/README.md
+++ b/apps/macos/README.md
@@ -422,22 +422,28 @@ a claim that Sparkle has updated the preview client.
 `CFBundleShortVersionString` remains the user-facing package version. The
 Sparkle ordering key, `CFBundleVersion`, is explicitly allocated for signed
 builds that retain the stable bundle identifier. The 0.1.17 internal-dogfood
-RC7 build is `1023.5`; the 0.1.17 stable final remains `1024`. This corrected
-candidate orders strictly after installed RC6 `1023.4`, integrated RC5
-`1023.3`, startup-recovery RC4 `1023.2`, migration RC3 `1023.1`, retained RC2
-`1023`, and earlier shared-identity dogfood `1022`, while stable orders after
-the dogfood candidate.
+RC8 build is `1023.6`; the 0.1.17 stable final remains `1024`. This corrected
+candidate orders strictly after installed RC7 `1023.5`, RC6 `1023.4`,
+integrated RC5 `1023.3`, startup-recovery RC4 `1023.2`, migration RC3
+`1023.1`, retained RC2 `1023`, and earlier shared-identity dogfood `1022`,
+while stable orders after the dogfood candidate.
 A future signed version/channel must add a reviewed
 monotonic allocation before release tooling will run.
 
 Installed RC6 proved that the cold-accounting lifetime can safely exceed the
 ordinary five-minute refresh deadline. Its real refresh then exposed the
 inherited `recent_7d_indexing` legacy checkpoint suppressing otherwise-
-authoritative unified accounting. RC7 removes only that retired collector gate;
-`unifiedGenerationAuthoritative` and every generation, completeness, resource,
-and publication guard remain fail-closed. The allocation is not artifact or
-installed-app evidence: exact-source gates, protected R7, signing, notarization,
-state-preserving replacement, and physical verification must be repeated.
+authoritative unified accounting. RC7 removed only that retired collector gate
+and passed protected R7, the full source gate, signing, notarization, stapling,
+and state-preserving installation. Its first installed refresh ingested
+generation 44, then the strict v0.14 cache validator rejected inconsistent fit
+metadata. The fit correctly excluded an early diagnostic-only transition, but
+the projection copied that rejected row's eligibility onto the reset fitted from
+later eligible transitions. RC8 retains the strict validator and projects fit
+metadata from the first eligible row. Its allocation is not
+artifact or installed-app evidence: exact-source gates, protected R7, signing,
+notarization, state-preserving replacement, and physical verification must be
+repeated.
 
 Release tooling accepts `USAGE_MONITOR_BUNDLE_VERSION` only when it exactly
 matches the checked-in channel allocation, and the signed stable path still
@@ -533,7 +539,7 @@ For a later stable release, use `--previous-stable-manifest` in place of
 the release command refuses to guess which continuity policy applies.
 `USAGE_MONITOR_BUNDLE_VERSION` is optional as an operator assertion only; when
 present it must exactly equal the checked-in allocation for the selected
-signed release version and channel (`1023.5` for 0.1.17 internal dogfood,
+signed release version and channel (`1023.6` for 0.1.17 internal dogfood,
 `1024` for 0.1.17 stable).
 
 `config/deployment-endpoints.js` is the reviewed source for the public origin

--- a/docs/current-status.md
+++ b/docs/current-status.md
@@ -3,7 +3,7 @@ title: Current product and release status
 date: 2026-09-01
 type: status
 status: current
-source_commit: 64fc79e44f671336e8060416932538ff360ac4ca
+source_commit: 87e07be350582713d815a21b4db470ed84aae037
 observation_date: 2026-09-01
 ---
 
@@ -18,8 +18,8 @@ using this page for a later release or operational decision.
 
 | Boundary | Verified state |
 |---|---|
-| Documentation/source review | RC7 preparation source `64fc79e44f671336e8060416932538ff360ac4ca`, reviewed 2026-09-01; final source freeze is pending |
-| Installed internal dogfood | Signed and notarized RC6 source `e59115d41958f6b23496a65c9732a6a9944fdde0`, build `1023.4`, installed 2026-08-31; the timeout correction passed but the advanced-accounting handoff did not |
+| Documentation/source review | RC7 source merge `87e07be350582713d815a21b4db470ed84aae037`, reviewed 2026-09-01; RC8 corrective source is not yet frozen |
+| Installed internal dogfood | Signed, notarized, and stapled RC7 source `87e07be350582713d815a21b4db470ed84aae037`, build `1023.5`, installed 2026-09-01; generation 44 ingestion passed but the strict v0.14 cache validator withheld advanced accounting |
 | Public service | Read-only `GET https://tibotattle.com/api/health`, HTTP 200, deployment source `304f3d736b6f9451d32a616bf3046ea628e828a3`, observed 2026-08-31 |
 | Public updater | Read-only `GET https://updates.tibotattle.com/appcast.xml`, observed 2026-08-27 |
 | Published release | GitHub release API for `adamallcock/tibotattle`, observed 2026-08-27 |
@@ -126,21 +126,29 @@ The complete qualification matrix and rules for changing these claims are in
   installed result then exposed an inherited `recent_7d_indexing` legacy
   checkpoint suppressing otherwise-authoritative unified accounting. RC6 is
   therefore not the final dogfood handoff.
-- RC7 source preparation removes only that retired collector checkpoint. It
-  continues to require `unifiedGenerationAuthoritative` before accounting can
-  publish and does not relax source completeness, generation matching, resource
-  ceilings, or atomic publication. RC7 is allocated monotonic build `1023.5`,
-  strictly after installed RC6 and before reserved stable build `1024`. Fresh
-  exact-source gates, R7, signed-artifact, replacement, and physical installed
-  refresh evidence remain required.
-- The RC6 R7 workload-source closure has protected dual-runtime receipts for
+- RC7 source merge `87e07be350582713d815a21b4db470ed84aae037`, build
+  `1023.5`, removed only that retired collector checkpoint and subsequently
+  passed protected R7, the full source gate, Developer ID signing, notarization,
+  stapling, Gatekeeper, state-preserving replacement, and installation. Its
+  first installed refresh ingested unified-index generation 44, then correctly
+  withheld advanced accounting when the strict v0.14 cache validator found
+  inconsistent fit metadata. The fit correctly excluded an early
+  diagnostic-only transition, but the projection copied that rejected row's
+  eligibility onto the reset fitted from later eligible transitions.
+- RC8 retains the strict validator and projects reset fit metadata from the
+  first eligible row. It is allocated monotonic build `1023.6`, strictly after
+  installed RC7 and before reserved stable build `1024`. This source change
+  invalidates RC7's workload receipts, so RC8 still requires a fresh exact-source
+  freeze, protected R7, full source gate, signed/notarized/stapled artifact,
+  state-preserving replacement, installed refresh, and physical native checks.
+  This allocation and source diagnosis are not evidence that RC8 was built or
+  passed.
+- The RC7 R7 workload-source closure has protected dual-runtime receipts for
   359 files / workload SHA-256
-  `fcb55e0cb729b56249e2c6f4d8fa4a08bc4b4c8fe99a506ce10cfe1068ed48d5`.
-  Both decisions remain honestly `release_open`. RC7 changes workload-owned
-  refresh/accounting source, so those receipts are historical for RC6 and must
-  be regenerated after the corrective source is frozen. Native UI and
-  build-allocation files remain subject to their separate macOS source, smoke,
-  signed-artifact, and installed-artifact gates.
+  `ea504fde37402622239d5405aa74c264b98a111c8da5b4031a0977fa5bd80741`.
+  Both decisions remain honestly `release_open`. Native UI and build-allocation
+  files remain subject to their separate macOS source, smoke, signed-artifact,
+  and installed-artifact gates.
 - The public service and release feed are remote state. Their health and
   availability can change after this snapshot.
 - Public health is not proof that every admin, identity, contribution, deletion,
@@ -150,7 +158,7 @@ The complete qualification matrix and rules for changing these claims are in
   complete named fit-rejection reconciliation, so R7 cannot be used as a
   substitute. An explicitly open-gate internal dogfood may proceed for testing,
   but this blocks stable and public 0.1.17 qualification until it is closed or
-  deliberately resolved. The exact RC7 native artifact must separately pass
+  deliberately resolved. The exact RC8 native artifact must separately pass
   signing, notarization, state-preserving installation, updater, and physical
   native checks. Pairing continuity needs compatible hosted Worker migrations
   and deployment before the repaired desktop flow can be validated end to end.

--- a/docs/decisions/2026-08-27-local-state-schema-and-release-channel-isolation.md
+++ b/docs/decisions/2026-08-27-local-state-schema-and-release-channel-isolation.md
@@ -170,6 +170,23 @@ internal-dogfood allocation is `1023.5`, strictly after installed RC6 and before
 reserved stable `1024`. RC6 artifact evidence remains evidence for RC6 only;
 RC7 requires fresh exact-source, R7, artifact, replacement, and installed checks.
 
+#### Allocation amendment, 2026-09-01 (RC8)
+
+RC7 source merge `87e07be350582713d815a21b4db470ed84aae037`, build
+`1023.5`, subsequently passed protected R7, the full source gate, Developer ID
+signing, notarization, stapling, and state-preserving installation. Its first
+installed refresh ingested unified-index generation 44, then the strict v0.14
+cache validator rejected inconsistent fit metadata. An early diagnostic-only
+transition was excluded from the fit, but its eligibility was still projected
+onto a reset fitted from later eligible transitions. RC8 preserves that strict
+validator and projects reset fit metadata from the first eligible row. Its
+monotonic internal-dogfood allocation is
+`1023.6`, strictly after installed RC7 and before reserved stable `1024`.
+RC7's artifact and R7 evidence remain evidence for RC7 only; RC8 requires a
+fresh exact-source freeze, protected R7, artifact, replacement, installed
+refresh, and physical native verification. Allocation does not claim those
+gates have passed.
+
 The separately identified Preview app uses the deterministic migration epoch
 `(2000 + major).minor.patch`, so preview package `0.1.17` maps to
 `2000.1.17`. That keeps local preview builds deterministic and valid within

--- a/docs/decisions/2026-08-31-silent-keychain-migration.md
+++ b/docs/decisions/2026-08-31-silent-keychain-migration.md
@@ -311,3 +311,13 @@ correction must ship as a newly signed candidate rather than relabel RC6. RC7 is
 allocated monotonic build `1023.5`; the Keychain contract is unchanged, and an
 unexpected prompt remains release-blocking during its fresh installed-artifact
 qualification.
+
+### RC8 allocation follow-up
+
+RC7 source merge `87e07be350582713d815a21b4db470ed84aae037`, build
+`1023.5`, subsequently passed signing, notarization, stapling, installation,
+launch, and automatic prompt-free checks. Its installed refresh exposed a
+separate accounting fit-metadata defect, so that source cannot be relabelled.
+RC8 is allocated monotonic build `1023.6`; the Keychain contract is unchanged,
+and an unexpected automatic prompt remains release-blocking during fresh RC8
+artifact and installed qualification. No RC8 artifact result is claimed here.

--- a/docs/plans/2026-08-30-native-dogfood-integration.md
+++ b/docs/plans/2026-08-30-native-dogfood-integration.md
@@ -13,8 +13,8 @@ Electron release, or new signed-Preview workflow. Source integration, tests,
 state migration, signing, installation, and native verification are separate
 gates; none is complete merely because an earlier gate passed.
 
-The current candidate state is the RC7 amendment at the end of this plan.
-Earlier RC4, RC5, and RC6 sections preserve their checkpoint evidence and are
+The current candidate state is the RC8 amendment at the end of this plan.
+Earlier RC4, RC5, RC6, and RC7 sections preserve their checkpoint evidence and are
 not current build allocations.
 
 The installed RC4 source is `735a59ce`, build `1023.2`. Its prompt-free Keychain
@@ -84,8 +84,8 @@ automatically included in the retained validation run.
    `tibotattle-internal-dogfood-0.1.17-rcN-source-YYYYMMDD` tag. Use the reviewed
    channel allocation from `scripts/macos-bundle-version.js`, clean source and
    retained release finalizer. Earlier candidates used `1023`, `1023.1`,
-   `1023.2`, `1023.3`, and `1023.4`; corrective RC7 uses `1023.5`. Stable
-   remains `1024`.
+   `1023.2`, `1023.3`, `1023.4`, and `1023.5`; corrective RC8 uses `1023.6`.
+   Stable remains `1024`.
    Signing and notarization are authorized; public updater/release publication
    and hosted deployment are not part of this task.
 6. Install only the verified signed artifact with a recoverable prior-app and
@@ -344,3 +344,26 @@ used only as an explicitly open-gate internal dogfood; stable and public
 qualification remain blocked until that comparator is closed or deliberately
 resolved. No hosted Worker deployment, migration, stable tag, appcast, or
 public artifact is authorized by this correction.
+
+## RC7 installed result and RC8 correction
+
+RC7 source merge `87e07be350582713d815a21b4db470ed84aae037`, build
+`1023.5`, completed protected R7, the full source gate, Developer ID signing,
+notarization, stapling, and state-preserving installation. Its first installed
+refresh ingested unified-index generation 44, then withheld advanced accounting
+because the strict v0.14 cache validator rejected inconsistent fit metadata. The
+fit correctly excluded an early diagnostic-only transition, but the projection
+copied that rejected row's eligibility onto the reset fitted from later eligible
+transitions.
+
+RC8 preserves the strict validator and projects reset fit metadata from the
+first eligible row. Its monotonic build is `1023.6`, strictly after installed
+RC7 and before stable `1024`. RC7's R7 and artifact evidence cannot qualify this
+source change: RC8 still needs fresh exact-source R7, full source, artifact,
+replacement, installed-refresh, and physical native checks. This amendment does
+not claim any RC8 gate has passed.
+
+PR #94's formal fixed-real-corpus comparator remains **OPEN / NOT RUN** and
+blocks stable or public qualification. Internal RC8 dogfood testing may proceed
+only with that gate explicitly open. No hosted Worker deployment, migration,
+stable tag, appcast, or public artifact is authorized here.

--- a/docs/plans/2026-08-31-native-startup-recovery.md
+++ b/docs/plans/2026-08-31-native-startup-recovery.md
@@ -46,9 +46,14 @@ or public release is part of this correction.
   refresh gates on RC6 build `1023.4`. The lifetime correction passed; the
   installed run exposed the separate legacy accounting checkpoint recorded
   below.
+- [x] Repeat the exact-source, R7, signed-artifact, replacement, native startup,
+  prompt-free, and existing local binding/diagnostic checks on RC7 build
+  `1023.5`. End-to-end pairing repair remains unqualified until a compatible
+  hosted Worker is deployed. Its installed refresh ingested generation 44 but
+  exposed the separate fit-metadata defect below.
 - [ ] Repeat the exact-source, R7, signed-artifact, replacement, native startup,
-  refresh, pairing-repair, prompt-free, and accounting checks on RC7 build
-  `1023.5`.
+  refresh, pairing-repair, prompt-free, and accounting checks on RC8 build
+  `1023.6`.
 
 ## Acceptance
 
@@ -164,3 +169,20 @@ replacement, and installed native verification. PR #94's fixed-real-corpus
 comparator remains **OPEN / NOT RUN**: an explicitly open-gate internal dogfood
 may be tested, but stable and public qualification remain blocked until that
 gate is closed or deliberately resolved.
+
+## RC7 installed follow-up and RC8 boundary
+
+RC7 source merge `87e07be350582713d815a21b4db470ed84aae037`, build
+`1023.5`, passed protected R7, the full source gate, signing, notarization,
+stapling, and state-preserving installation. Startup recovery remained healthy.
+The first installed refresh ingested generation 44, then the strict v0.14 cache
+validator rejected inconsistent fit metadata. The fit correctly excluded an
+early diagnostic-only transition, but the projection copied that rejected row's
+eligibility onto the reset fitted from later eligible rows.
+
+RC8 keeps the strict validator and starts reset fit-metadata projection at the
+first eligible row. Build `1023.6` is allocated strictly after RC7 and before
+stable `1024`, but it has not yet passed exact-source R7, artifact, replacement,
+installed-refresh, or physical-native gates. PR #94's formal comparator remains
+**OPEN / NOT RUN** and blocks stable/public qualification; explicitly open-gate
+internal dogfood testing may continue.

--- a/docs/runbooks/macos-stable-release-runbook.md
+++ b/docs/runbooks/macos-stable-release-runbook.md
@@ -241,10 +241,10 @@ node scripts/release-macos-app.js \
 
 For the 0.1.17 stable release, `CFBundleShortVersionString` remains `0.1.17`
 and the owner-reviewed signed `CFBundleVersion` is exactly `1024`. It follows
-the retired-checkpoint RC7 internal-dogfood allocation `1023.5`, accounting-
-deadline RC6 `1023.4`, integrated RC5 `1023.3`, startup-recovery RC4 `1023.2`,
-migration RC3 `1023.1`, retained RC2 `1023`, and earlier shared-identity
-dogfood `1022`. The
+the fit-metadata RC8 internal-dogfood allocation `1023.6`, retired-checkpoint
+RC7 `1023.5`, accounting-deadline RC6 `1023.4`, integrated RC5 `1023.3`,
+startup-recovery RC4 `1023.2`, migration RC3 `1023.1`, retained RC2 `1023`,
+and earlier shared-identity dogfood `1022`. The
 checked-in allocation is authoritative; the
 `USAGE_MONITOR_BUNDLE_VERSION` value above is only an exact assertion and
 cannot select or override a different build. A future stable version must add
@@ -252,6 +252,17 @@ and test a new monotonic channel allocation before the release path will run.
 The separate `TiboTattle Preview.app` identity may use the deterministic
 preview epoch (`2000.1.17` for 0.1.17); it does not participate in stable
 Sparkle ordering.
+
+RC7 source merge `87e07be350582713d815a21b4db470ed84aae037` passed its
+protected R7, full source, signing, notarization, stapling, and installation
+gates. Its first installed refresh ingested generation 44 but the strict v0.14
+cache validator rejected inconsistent fit metadata. RC8 retains that validator
+and projects fit metadata from the first eligible row. Before any RC8 candidate
+is treated as installed dogfood evidence, repeat exact-source R7, full source,
+artifact, state-preserving install, installed refresh, and physical native
+checks. The formal PR #94 real-corpus comparator remains **OPEN / NOT RUN** and
+blocks stable or public qualification; an explicitly open-gate internal
+dogfood does not close it.
 
 Signing-key access on the release machine is a separate owner provisioning
 step, not an end-user permission requirement. If signing requests approval,

--- a/generated/r7-release-decision-node24.14.0-v0.1.json
+++ b/generated/r7-release-decision-node24.14.0-v0.1.json
@@ -482,7 +482,7 @@
     "resourcePolicyValuesSha256": "3cbe7853c8f75e96912885f64ba4ad1aeb13aff8a22e4ffbd51806b27c73b418",
     "schemaModuleSha256": "594d035e641e87b29db4027dca35157f8225fd5621816d67d5d9f25825468bbf",
     "workloadCodeFileCount": 359,
-    "workloadCodeSha256": "ea504fde37402622239d5405aa74c264b98a111c8da5b4031a0977fa5bd80741"
+    "workloadCodeSha256": "7a60f50547c7240e88357161542de2b6ceda3afecc004af776eaf6741e195772"
   },
   "determinism": {
     "comparisons": {
@@ -939,7 +939,7 @@
         "decision": "unresolved",
         "dimension": "export_set_encoded_bytes",
         "exactBoundaryValue": "not_identified",
-        "realHistoryValue": 29090074,
+        "realHistoryValue": 29090342,
         "selectionBasis": "not_identified",
         "unit": "bytes"
       },
@@ -989,7 +989,7 @@
         "decision": "unresolved",
         "dimension": "elapsed_time",
         "exactBoundaryValue": "not_identified",
-        "realHistoryValue": 439301,
+        "realHistoryValue": 364601,
         "selectionBasis": "not_identified",
         "unit": "milliseconds"
       },
@@ -999,7 +999,7 @@
         "decision": "unresolved",
         "dimension": "rss",
         "exactBoundaryValue": "not_identified",
-        "realHistoryValue": 1322385408,
+        "realHistoryValue": 1383055360,
         "selectionBasis": "not_identified",
         "unit": "bytes"
       }
@@ -1007,20 +1007,20 @@
     "headroomBasisPoints": 2000,
     "inputReceipts": {
       "materializedBoundaries": {
-        "node24Sha256": "0cf7d41f0cc318d9cb6a554b575f5265140854262b270f512a79d5a49130aa55",
-        "node26Sha256": "2b2107b6c4f968d1a1231bd8a630adc4b11a4111b26c18e7b6cb6e49b2fc1ce5"
+        "node24Sha256": "10d129f82141a504c05da96cec48fd0bd68f024c813fc94ad4f3d5572865351f",
+        "node26Sha256": "e4cb8dec98797b481814e20fa3188c8050ed835f427df5e8a936ee7174f2bd8d"
       },
       "realLocalHistory": {
-        "node24Sha256": "ae242691686959fdcb455ef223df3c1a85e072e42b7604525bd2f461efb4fccc",
-        "node26Sha256": "41143106b7ae67bcb80709cb6f9826b62cf9cf7e91bce4fa4bd4b16d09e1541b"
+        "node24Sha256": "9f1aa6546b2b56b7bce3aea6fc13b6a19b856b1889ffe164250c3295daebbc4c",
+        "node26Sha256": "021414e96c5faf4e08c5379081b7769e94e697a3821d3931b5fdbe57a5be4d72"
       },
       "syntheticPressure": {
-        "node24Sha256": "2005820c8451fd94be70c23cec5868ee66ee031e39d316cac80610eef39449dd",
-        "node26Sha256": "97213974a20feed5e75206e81aec2f2ee3a94f7c35c34801315b5c0b8aabd28e"
+        "node24Sha256": "4bdb3c75c06138b66deb51bbd5fff9f86b2b24ed177d398f3097cc49690221f5",
+        "node26Sha256": "b785ed92ed7267343ec5e15745236728bdc1102cd09296e1cd51aedc5eea82c0"
       },
       "syntheticSemantics": {
-        "node24Sha256": "9a778ac5013f41a813f2e27a2a016b80ca3aa4c45c9413b721d58fe62983de10",
-        "node26Sha256": "012565a67bc9bcb451eaaa0201e3027e628f1ab787700720c4dd69ce7762a0f5"
+        "node24Sha256": "cdfaa5d2e212bad434279dc04701da19695c7cf9f336a50de5feb42cfe50bbf1",
+        "node26Sha256": "b1649675c8d2ee1376250606efa84679cef3d438279e524c8e91dbf58656d296"
       }
     },
     "kind": "release_decision",
@@ -1039,7 +1039,7 @@
     "singleMachineLimitation": true
   },
   "protocolVersion": "g1-r7-release-evidence-v0.1",
-  "receiptSha256": "676b012bfbd34abc34a21e2ce307ff6b9511c9414cb49fbe5f0334cfa4a0cb31",
+  "receiptSha256": "04a94b9fc8677fa12c2ed3ebebbcd2b3348fbfc4d197500fd586bdb373caef75",
   "runtimeProvenance": {
     "architecture": "arm64",
     "elapsedClock": "parent_monotonic",

--- a/generated/r7-release-decision-node26.2.0-v0.1.json
+++ b/generated/r7-release-decision-node26.2.0-v0.1.json
@@ -482,7 +482,7 @@
     "resourcePolicyValuesSha256": "3cbe7853c8f75e96912885f64ba4ad1aeb13aff8a22e4ffbd51806b27c73b418",
     "schemaModuleSha256": "594d035e641e87b29db4027dca35157f8225fd5621816d67d5d9f25825468bbf",
     "workloadCodeFileCount": 359,
-    "workloadCodeSha256": "ea504fde37402622239d5405aa74c264b98a111c8da5b4031a0977fa5bd80741"
+    "workloadCodeSha256": "7a60f50547c7240e88357161542de2b6ceda3afecc004af776eaf6741e195772"
   },
   "determinism": {
     "comparisons": {
@@ -939,7 +939,7 @@
         "decision": "unresolved",
         "dimension": "export_set_encoded_bytes",
         "exactBoundaryValue": "not_identified",
-        "realHistoryValue": 29090074,
+        "realHistoryValue": 29090342,
         "selectionBasis": "not_identified",
         "unit": "bytes"
       },
@@ -989,7 +989,7 @@
         "decision": "unresolved",
         "dimension": "elapsed_time",
         "exactBoundaryValue": "not_identified",
-        "realHistoryValue": 439301,
+        "realHistoryValue": 364601,
         "selectionBasis": "not_identified",
         "unit": "milliseconds"
       },
@@ -999,7 +999,7 @@
         "decision": "unresolved",
         "dimension": "rss",
         "exactBoundaryValue": "not_identified",
-        "realHistoryValue": 1322385408,
+        "realHistoryValue": 1383055360,
         "selectionBasis": "not_identified",
         "unit": "bytes"
       }
@@ -1007,20 +1007,20 @@
     "headroomBasisPoints": 2000,
     "inputReceipts": {
       "materializedBoundaries": {
-        "node24Sha256": "0cf7d41f0cc318d9cb6a554b575f5265140854262b270f512a79d5a49130aa55",
-        "node26Sha256": "2b2107b6c4f968d1a1231bd8a630adc4b11a4111b26c18e7b6cb6e49b2fc1ce5"
+        "node24Sha256": "10d129f82141a504c05da96cec48fd0bd68f024c813fc94ad4f3d5572865351f",
+        "node26Sha256": "e4cb8dec98797b481814e20fa3188c8050ed835f427df5e8a936ee7174f2bd8d"
       },
       "realLocalHistory": {
-        "node24Sha256": "ae242691686959fdcb455ef223df3c1a85e072e42b7604525bd2f461efb4fccc",
-        "node26Sha256": "41143106b7ae67bcb80709cb6f9826b62cf9cf7e91bce4fa4bd4b16d09e1541b"
+        "node24Sha256": "9f1aa6546b2b56b7bce3aea6fc13b6a19b856b1889ffe164250c3295daebbc4c",
+        "node26Sha256": "021414e96c5faf4e08c5379081b7769e94e697a3821d3931b5fdbe57a5be4d72"
       },
       "syntheticPressure": {
-        "node24Sha256": "2005820c8451fd94be70c23cec5868ee66ee031e39d316cac80610eef39449dd",
-        "node26Sha256": "97213974a20feed5e75206e81aec2f2ee3a94f7c35c34801315b5c0b8aabd28e"
+        "node24Sha256": "4bdb3c75c06138b66deb51bbd5fff9f86b2b24ed177d398f3097cc49690221f5",
+        "node26Sha256": "b785ed92ed7267343ec5e15745236728bdc1102cd09296e1cd51aedc5eea82c0"
       },
       "syntheticSemantics": {
-        "node24Sha256": "9a778ac5013f41a813f2e27a2a016b80ca3aa4c45c9413b721d58fe62983de10",
-        "node26Sha256": "012565a67bc9bcb451eaaa0201e3027e628f1ab787700720c4dd69ce7762a0f5"
+        "node24Sha256": "cdfaa5d2e212bad434279dc04701da19695c7cf9f336a50de5feb42cfe50bbf1",
+        "node26Sha256": "b1649675c8d2ee1376250606efa84679cef3d438279e524c8e91dbf58656d296"
       }
     },
     "kind": "release_decision",
@@ -1039,7 +1039,7 @@
     "singleMachineLimitation": true
   },
   "protocolVersion": "g1-r7-release-evidence-v0.1",
-  "receiptSha256": "06fd202e647d7c6f51ff642ccb7bf6a852dfb808ee559f5f412a6b7ad57477f2",
+  "receiptSha256": "5ea30be959a696dfda1680e47485a1e6c8598771b85afc6f22ac04883e47e577",
   "runtimeProvenance": {
     "architecture": "arm64",
     "elapsedClock": "parent_monotonic",

--- a/generated/r7-release-materialized-boundaries-node24.14.0-v0.1.json
+++ b/generated/r7-release-materialized-boundaries-node24.14.0-v0.1.json
@@ -482,7 +482,7 @@
     "resourcePolicyValuesSha256": "3cbe7853c8f75e96912885f64ba4ad1aeb13aff8a22e4ffbd51806b27c73b418",
     "schemaModuleSha256": "594d035e641e87b29db4027dca35157f8225fd5621816d67d5d9f25825468bbf",
     "workloadCodeFileCount": 359,
-    "workloadCodeSha256": "ea504fde37402622239d5405aa74c264b98a111c8da5b4031a0977fa5bd80741"
+    "workloadCodeSha256": "7a60f50547c7240e88357161542de2b6ceda3afecc004af776eaf6741e195772"
   },
   "determinism": {
     "comparisons": {
@@ -500,8 +500,8 @@
     "projectionVersion": "g1-r7-release-deterministic-projection-v0.1",
     "runCount": 2,
     "runProjectionSha256es": [
-      "32b93b8f85e2ab03ac8debd5aa2b87a31a446a15f9509bf78382d86dc63faa0a",
-      "32b93b8f85e2ab03ac8debd5aa2b87a31a446a15f9509bf78382d86dc63faa0a"
+      "e50899ad5620356da8ea6272b42a060f6782fd1333b8e2f6c0b1c7e2affc73b6",
+      "e50899ad5620356da8ea6272b42a060f6782fd1333b8e2f6c0b1c7e2affc73b6"
     ],
     "status": "partial"
   },
@@ -822,20 +822,20 @@
       "decodedBytes": 0,
       "durablePeakRssBytes": 0,
       "encodedBytes": 0,
-      "externalPeakRssBytes": 330694656,
-      "externalRssSampleCount": 77,
+      "externalPeakRssBytes": 337510400,
+      "externalRssSampleCount": 62,
       "externalRssSampleFailureCount": 0,
       "filesystem": {
         "afterBytes": 0,
         "beforeBytes": 0,
-        "sampledHighWaterBytes": 30808382
+        "sampledHighWaterBytes": 30808260
       },
       "outputRecords": 0,
-      "parentElapsedMs": 3974,
+      "parentElapsedMs": 3142,
       "runCount": 2,
       "sourceBytes": 0,
       "sourceFiles": 0,
-      "stderrBytes": 168,
+      "stderrBytes": 169,
       "stdoutBytes": 42487
     },
     "kind": "release_materialized_boundaries",
@@ -894,7 +894,7 @@
     }
   },
   "protocolVersion": "g1-r7-release-evidence-v0.1",
-  "receiptSha256": "0cf7d41f0cc318d9cb6a554b575f5265140854262b270f512a79d5a49130aa55",
+  "receiptSha256": "10d129f82141a504c05da96cec48fd0bd68f024c813fc94ad4f3d5572865351f",
   "runtimeProvenance": {
     "architecture": "arm64",
     "elapsedClock": "parent_monotonic",

--- a/generated/r7-release-materialized-boundaries-node26.2.0-v0.1.json
+++ b/generated/r7-release-materialized-boundaries-node26.2.0-v0.1.json
@@ -482,7 +482,7 @@
     "resourcePolicyValuesSha256": "3cbe7853c8f75e96912885f64ba4ad1aeb13aff8a22e4ffbd51806b27c73b418",
     "schemaModuleSha256": "594d035e641e87b29db4027dca35157f8225fd5621816d67d5d9f25825468bbf",
     "workloadCodeFileCount": 359,
-    "workloadCodeSha256": "ea504fde37402622239d5405aa74c264b98a111c8da5b4031a0977fa5bd80741"
+    "workloadCodeSha256": "7a60f50547c7240e88357161542de2b6ceda3afecc004af776eaf6741e195772"
   },
   "determinism": {
     "comparisons": {
@@ -500,8 +500,8 @@
     "projectionVersion": "g1-r7-release-deterministic-projection-v0.1",
     "runCount": 2,
     "runProjectionSha256es": [
-      "e59beedb5a38b7f2e9a68c4707f0a3a8dffe74563676c13585cd9859a33e39c5",
-      "e59beedb5a38b7f2e9a68c4707f0a3a8dffe74563676c13585cd9859a33e39c5"
+      "b01ad563facf2f94148de73ab3b834c4d1b37b94a8b8298353957a1998920bcc",
+      "b01ad563facf2f94148de73ab3b834c4d1b37b94a8b8298353957a1998920bcc"
     ],
     "status": "partial"
   },
@@ -822,16 +822,16 @@
       "decodedBytes": 0,
       "durablePeakRssBytes": 0,
       "encodedBytes": 0,
-      "externalPeakRssBytes": 349159424,
-      "externalRssSampleCount": 120,
-      "externalRssSampleFailureCount": 0,
+      "externalPeakRssBytes": 349683712,
+      "externalRssSampleCount": 69,
+      "externalRssSampleFailureCount": 1,
       "filesystem": {
         "afterBytes": 0,
         "beforeBytes": 0,
-        "sampledHighWaterBytes": 30819852
+        "sampledHighWaterBytes": 30851489
       },
       "outputRecords": 0,
-      "parentElapsedMs": 6096,
+      "parentElapsedMs": 3864,
       "runCount": 2,
       "sourceBytes": 0,
       "sourceFiles": 0,
@@ -894,7 +894,7 @@
     }
   },
   "protocolVersion": "g1-r7-release-evidence-v0.1",
-  "receiptSha256": "2b2107b6c4f968d1a1231bd8a630adc4b11a4111b26c18e7b6cb6e49b2fc1ce5",
+  "receiptSha256": "e4cb8dec98797b481814e20fa3188c8050ed835f427df5e8a936ee7174f2bd8d",
   "runtimeProvenance": {
     "architecture": "arm64",
     "elapsedClock": "parent_monotonic",

--- a/generated/r7-release-real-local-history-node24.14.0-v0.1.json
+++ b/generated/r7-release-real-local-history-node24.14.0-v0.1.json
@@ -482,7 +482,7 @@
     "resourcePolicyValuesSha256": "3cbe7853c8f75e96912885f64ba4ad1aeb13aff8a22e4ffbd51806b27c73b418",
     "schemaModuleSha256": "594d035e641e87b29db4027dca35157f8225fd5621816d67d5d9f25825468bbf",
     "workloadCodeFileCount": 359,
-    "workloadCodeSha256": "ea504fde37402622239d5405aa74c264b98a111c8da5b4031a0977fa5bd80741"
+    "workloadCodeSha256": "7a60f50547c7240e88357161542de2b6ceda3afecc004af776eaf6741e195772"
   },
   "determinism": {
     "comparisons": {
@@ -500,8 +500,8 @@
     "projectionVersion": "g1-r7-release-deterministic-projection-v0.1",
     "runCount": 2,
     "runProjectionSha256es": [
-      "e93dcffc4d7226bc00afda6b605c8776351ebff3eb7f62c8e50b7955d76b4424",
-      "e93dcffc4d7226bc00afda6b605c8776351ebff3eb7f62c8e50b7955d76b4424"
+      "b6490ed0628399df04c717c9852834b8d71bfb7da1ad90498beebafbfeaf15ac",
+      "b6490ed0628399df04c717c9852834b8d71bfb7da1ad90498beebafbfeaf15ac"
     ],
     "status": "passed"
   },
@@ -514,21 +514,21 @@
     {
       "failureCode": "none",
       "metrics": {
-        "childCpuMs": 332224,
-        "childMaxRssBytes": 1322385408,
+        "childCpuMs": 304575,
+        "childMaxRssBytes": 1383055360,
         "decodedBytes": 0,
-        "durablePeakRssBytes": 1322385408,
+        "durablePeakRssBytes": 1383055360,
         "encodedBytes": 0,
-        "externalPeakRssBytes": 1310277632,
-        "externalRssSampleCount": 8578,
+        "externalPeakRssBytes": 1381859328,
+        "externalRssSampleCount": 5901,
         "externalRssSampleFailureCount": 0,
         "filesystem": {
-          "afterBytes": 1141846016,
+          "afterBytes": 1141125120,
           "beforeBytes": 0,
-          "sampledHighWaterBytes": 1144204686
+          "sampledHighWaterBytes": 1143309022
         },
         "outputRecords": 436557,
-        "parentElapsedMs": 439301,
+        "parentElapsedMs": 311305,
         "runCount": 2,
         "sourceBytes": 26380587616,
         "sourceFiles": 3123,
@@ -570,21 +570,21 @@
     {
       "failureCode": "none",
       "metrics": {
-        "childCpuMs": 32301,
-        "childMaxRssBytes": 832864256,
+        "childCpuMs": 31854,
+        "childMaxRssBytes": 831111168,
         "decodedBytes": 518442273,
-        "durablePeakRssBytes": 1322385408,
-        "encodedBytes": 29090074,
-        "externalPeakRssBytes": 832307200,
-        "externalRssSampleCount": 607,
-        "externalRssSampleFailureCount": 1,
+        "durablePeakRssBytes": 1383055360,
+        "encodedBytes": 29090342,
+        "externalPeakRssBytes": 814972928,
+        "externalRssSampleCount": 593,
+        "externalRssSampleFailureCount": 0,
         "filesystem": {
-          "afterBytes": 1171071146,
-          "beforeBytes": 1141846016,
-          "sampledHighWaterBytes": 1171071146
+          "afterBytes": 1170350518,
+          "beforeBytes": 1141125120,
+          "sampledHighWaterBytes": 1170351406
         },
         "outputRecords": 436557,
-        "parentElapsedMs": 30894,
+        "parentElapsedMs": 30495,
         "runCount": 2,
         "sourceBytes": 26380587616,
         "sourceFiles": 3123,
@@ -592,63 +592,63 @@
         "stdoutBytes": 1261
       },
       "name": "export_set_materialize",
-      "projectionSha256": "c60cd51fbb74e80820fb71d8a8aa4c636b7f4c5400fbe85d52b33916628caf9e",
+      "projectionSha256": "70f6cb7ae91664b4f52368af2e8516b776e9f7bcfa92ecebda7b5bf201b149bf",
       "status": "completed"
     },
     {
       "failureCode": "none",
       "metrics": {
-        "childCpuMs": 31092,
-        "childMaxRssBytes": 781795328,
+        "childCpuMs": 25552,
+        "childMaxRssBytes": 1064452096,
         "decodedBytes": 518442273,
         "durablePeakRssBytes": 0,
-        "encodedBytes": 29090074,
-        "externalPeakRssBytes": 781778944,
-        "externalRssSampleCount": 982,
-        "externalRssSampleFailureCount": 0,
+        "encodedBytes": 29090342,
+        "externalPeakRssBytes": 1030914048,
+        "externalRssSampleCount": 513,
+        "externalRssSampleFailureCount": 1,
         "filesystem": {
-          "afterBytes": 1171071146,
-          "beforeBytes": 1171071146,
-          "sampledHighWaterBytes": 1268510614
+          "afterBytes": 1170350518,
+          "beforeBytes": 1170350518,
+          "sampledHighWaterBytes": 1267496238
         },
         "outputRecords": 436557,
-        "parentElapsedMs": 56841,
+        "parentElapsedMs": 26391,
         "runCount": 2,
         "sourceBytes": 0,
         "sourceFiles": 0,
-        "stderrBytes": 169,
-        "stdoutBytes": 1016
+        "stderrBytes": 168,
+        "stdoutBytes": 1017
       },
       "name": "export_set_verify",
-      "projectionSha256": "783715ed556e9ea3b716384d05c0213d06abac1f68887d1bf726c3d0a5c2a5da",
+      "projectionSha256": "cf1b9cd17d2885e3af566db7c7f16e776e21c6151958441111d28d7c1d2076de",
       "status": "completed"
     },
     {
       "failureCode": "none",
       "metrics": {
-        "childCpuMs": 97281,
-        "childMaxRssBytes": 799588352,
+        "childCpuMs": 85774,
+        "childMaxRssBytes": 1073102848,
         "decodedBytes": 0,
         "durablePeakRssBytes": 0,
         "encodedBytes": 0,
-        "externalPeakRssBytes": 799588352,
-        "externalRssSampleCount": 3457,
+        "externalPeakRssBytes": 1039515648,
+        "externalRssSampleCount": 2266,
         "externalRssSampleFailureCount": 0,
         "filesystem": {
           "afterBytes": 461,
-          "beforeBytes": 1171071146,
-          "sampledHighWaterBytes": 1171095938
+          "beforeBytes": 1170350518,
+          "sampledHighWaterBytes": 1170363263
         },
         "outputRecords": 0,
-        "parentElapsedMs": 180075,
+        "parentElapsedMs": 126161,
         "runCount": 2,
         "sourceBytes": 0,
         "sourceFiles": 0,
-        "stderrBytes": 169,
-        "stdoutBytes": 1009
+        "stderrBytes": 168,
+        "stdoutBytes": 1010
       },
       "name": "complete_set_delete",
-      "projectionSha256": "829c3e268165f08442dc64e5dd543a50a2ce67cd48c85b8a911eb60a137098eb",
+      "projectionSha256": "bab931c1ca32490b7ec83fc1e8c6e83080ce51cfcc142a7705c0d126426fbbd7",
       "status": "completed"
     },
     {
@@ -832,7 +832,7 @@
     "rawDurableCopyCreated": false
   },
   "protocolVersion": "g1-r7-release-evidence-v0.1",
-  "receiptSha256": "ae242691686959fdcb455ef223df3c1a85e072e42b7604525bd2f461efb4fccc",
+  "receiptSha256": "9f1aa6546b2b56b7bce3aea6fc13b6a19b856b1889ffe164250c3295daebbc4c",
   "runtimeProvenance": {
     "architecture": "arm64",
     "elapsedClock": "parent_monotonic",

--- a/generated/r7-release-real-local-history-node26.2.0-v0.1.json
+++ b/generated/r7-release-real-local-history-node26.2.0-v0.1.json
@@ -482,7 +482,7 @@
     "resourcePolicyValuesSha256": "3cbe7853c8f75e96912885f64ba4ad1aeb13aff8a22e4ffbd51806b27c73b418",
     "schemaModuleSha256": "594d035e641e87b29db4027dca35157f8225fd5621816d67d5d9f25825468bbf",
     "workloadCodeFileCount": 359,
-    "workloadCodeSha256": "ea504fde37402622239d5405aa74c264b98a111c8da5b4031a0977fa5bd80741"
+    "workloadCodeSha256": "7a60f50547c7240e88357161542de2b6ceda3afecc004af776eaf6741e195772"
   },
   "determinism": {
     "comparisons": {
@@ -500,8 +500,8 @@
     "projectionVersion": "g1-r7-release-deterministic-projection-v0.1",
     "runCount": 2,
     "runProjectionSha256es": [
-      "12f2bbf5863ab42a19f2631c2e1b449822796998eb91e45aa9acd987338f8ed7",
-      "12f2bbf5863ab42a19f2631c2e1b449822796998eb91e45aa9acd987338f8ed7"
+      "a10542ef4a2e372cb9fd884e45f09a1b4a8375591118c8c4594908b0c9855700",
+      "a10542ef4a2e372cb9fd884e45f09a1b4a8375591118c8c4594908b0c9855700"
     ],
     "status": "passed"
   },
@@ -514,21 +514,21 @@
     {
       "failureCode": "none",
       "metrics": {
-        "childCpuMs": 353331,
-        "childMaxRssBytes": 1205207040,
+        "childCpuMs": 344916,
+        "childMaxRssBytes": 1211482112,
         "decodedBytes": 0,
-        "durablePeakRssBytes": 1205207040,
+        "durablePeakRssBytes": 1211482112,
         "encodedBytes": 0,
-        "externalPeakRssBytes": 1205207040,
-        "externalRssSampleCount": 6770,
+        "externalPeakRssBytes": 1210548224,
+        "externalRssSampleCount": 6987,
         "externalRssSampleFailureCount": 0,
         "filesystem": {
-          "afterBytes": 1141846016,
+          "afterBytes": 1141125120,
           "beforeBytes": 0,
-          "sampledHighWaterBytes": 1141846127
+          "sampledHighWaterBytes": 1141142167
         },
         "outputRecords": 436557,
-        "parentElapsedMs": 363463,
+        "parentElapsedMs": 364601,
         "runCount": 2,
         "sourceBytes": 26380587616,
         "sourceFiles": 3123,
@@ -570,21 +570,21 @@
     {
       "failureCode": "none",
       "metrics": {
-        "childCpuMs": 28493,
-        "childMaxRssBytes": 917995520,
+        "childCpuMs": 28786,
+        "childMaxRssBytes": 920272896,
         "decodedBytes": 518442273,
-        "durablePeakRssBytes": 1205207040,
-        "encodedBytes": 29090074,
-        "externalPeakRssBytes": 917929984,
-        "externalRssSampleCount": 540,
+        "durablePeakRssBytes": 1211482112,
+        "encodedBytes": 29090342,
+        "externalPeakRssBytes": 920174592,
+        "externalRssSampleCount": 542,
         "externalRssSampleFailureCount": 0,
         "filesystem": {
-          "afterBytes": 1171071145,
-          "beforeBytes": 1141846016,
-          "sampledHighWaterBytes": 1171071834
+          "afterBytes": 1170350517,
+          "beforeBytes": 1141125120,
+          "sampledHighWaterBytes": 1170350628
         },
         "outputRecords": 436557,
-        "parentElapsedMs": 27477,
+        "parentElapsedMs": 27651,
         "runCount": 2,
         "sourceBytes": 26380587616,
         "sourceFiles": 3123,
@@ -592,27 +592,27 @@
         "stdoutBytes": 1261
       },
       "name": "export_set_materialize",
-      "projectionSha256": "c60cd51fbb74e80820fb71d8a8aa4c636b7f4c5400fbe85d52b33916628caf9e",
+      "projectionSha256": "70f6cb7ae91664b4f52368af2e8516b776e9f7bcfa92ecebda7b5bf201b149bf",
       "status": "completed"
     },
     {
       "failureCode": "none",
       "metrics": {
-        "childCpuMs": 23195,
-        "childMaxRssBytes": 751599616,
+        "childCpuMs": 24149,
+        "childMaxRssBytes": 923549696,
         "decodedBytes": 518442273,
         "durablePeakRssBytes": 0,
-        "encodedBytes": 29090074,
-        "externalPeakRssBytes": 700317696,
-        "externalRssSampleCount": 467,
+        "encodedBytes": 29090342,
+        "externalPeakRssBytes": 907116544,
+        "externalRssSampleCount": 518,
         "externalRssSampleFailureCount": 0,
         "filesystem": {
-          "afterBytes": 1171071145,
-          "beforeBytes": 1171071145,
-          "sampledHighWaterBytes": 1268581425
+          "afterBytes": 1170350517,
+          "beforeBytes": 1170350517,
+          "sampledHighWaterBytes": 1267852821
         },
         "outputRecords": 436557,
-        "parentElapsedMs": 23806,
+        "parentElapsedMs": 28846,
         "runCount": 2,
         "sourceBytes": 0,
         "sourceFiles": 0,
@@ -620,35 +620,35 @@
         "stdoutBytes": 1016
       },
       "name": "export_set_verify",
-      "projectionSha256": "783715ed556e9ea3b716384d05c0213d06abac1f68887d1bf726c3d0a5c2a5da",
+      "projectionSha256": "cf1b9cd17d2885e3af566db7c7f16e776e21c6151958441111d28d7c1d2076de",
       "status": "completed"
     },
     {
       "failureCode": "none",
       "metrics": {
-        "childCpuMs": 75340,
-        "childMaxRssBytes": 843005952,
+        "childCpuMs": 89138,
+        "childMaxRssBytes": 849641472,
         "decodedBytes": 0,
         "durablePeakRssBytes": 0,
         "encodedBytes": 0,
-        "externalPeakRssBytes": 808861696,
-        "externalRssSampleCount": 1513,
+        "externalPeakRssBytes": 849002496,
+        "externalRssSampleCount": 2641,
         "externalRssSampleFailureCount": 0,
         "filesystem": {
           "afterBytes": 461,
-          "beforeBytes": 1171071145,
-          "sampledHighWaterBytes": 1171071256
+          "beforeBytes": 1170350517,
+          "sampledHighWaterBytes": 1170363855
         },
         "outputRecords": 0,
-        "parentElapsedMs": 78341,
+        "parentElapsedMs": 192488,
         "runCount": 2,
         "sourceBytes": 0,
         "sourceFiles": 0,
         "stderrBytes": 0,
-        "stdoutBytes": 1008
+        "stdoutBytes": 1009
       },
       "name": "complete_set_delete",
-      "projectionSha256": "625785647c75da37dec2cbf2ab685243b0649dc6a71abf2555bab77549d051ae",
+      "projectionSha256": "7fa103fc50b2ecd172baa07b831b7c5aeca51fabc4028b88eed93702220b5a08",
       "status": "completed"
     },
     {
@@ -832,7 +832,7 @@
     "rawDurableCopyCreated": false
   },
   "protocolVersion": "g1-r7-release-evidence-v0.1",
-  "receiptSha256": "41143106b7ae67bcb80709cb6f9826b62cf9cf7e91bce4fa4bd4b16d09e1541b",
+  "receiptSha256": "021414e96c5faf4e08c5379081b7769e94e697a3821d3931b5fdbe57a5be4d72",
   "runtimeProvenance": {
     "architecture": "arm64",
     "elapsedClock": "parent_monotonic",

--- a/generated/r7-release-synthetic-pressure-node24.14.0-v0.1.json
+++ b/generated/r7-release-synthetic-pressure-node24.14.0-v0.1.json
@@ -482,7 +482,7 @@
     "resourcePolicyValuesSha256": "3cbe7853c8f75e96912885f64ba4ad1aeb13aff8a22e4ffbd51806b27c73b418",
     "schemaModuleSha256": "594d035e641e87b29db4027dca35157f8225fd5621816d67d5d9f25825468bbf",
     "workloadCodeFileCount": 359,
-    "workloadCodeSha256": "ea504fde37402622239d5405aa74c264b98a111c8da5b4031a0977fa5bd80741"
+    "workloadCodeSha256": "7a60f50547c7240e88357161542de2b6ceda3afecc004af776eaf6741e195772"
   },
   "determinism": {
     "comparisons": {
@@ -500,8 +500,8 @@
     "projectionVersion": "g1-r7-release-deterministic-projection-v0.1",
     "runCount": 2,
     "runProjectionSha256es": [
-      "1ca3bd8f21e0675bc3bbb5606bd6ae1a76ef6e52b978c67b8ff4e6d6c321719a",
-      "1ca3bd8f21e0675bc3bbb5606bd6ae1a76ef6e52b978c67b8ff4e6d6c321719a"
+      "149ade97764155abe2c9992e6bc0fc8e5c0ea9ca5955380623271fd4f92caa62",
+      "149ade97764155abe2c9992e6bc0fc8e5c0ea9ca5955380623271fd4f92caa62"
     ],
     "status": "passed"
   },
@@ -514,26 +514,26 @@
     {
       "failureCode": "none",
       "metrics": {
-        "childCpuMs": 20685,
-        "childMaxRssBytes": 677036032,
+        "childCpuMs": 18734,
+        "childMaxRssBytes": 682065920,
         "decodedBytes": 0,
-        "durablePeakRssBytes": 670138368,
+        "durablePeakRssBytes": 677150720,
         "encodedBytes": 0,
-        "externalPeakRssBytes": 667713536,
-        "externalRssSampleCount": 403,
+        "externalPeakRssBytes": 681426944,
+        "externalRssSampleCount": 260,
         "externalRssSampleFailureCount": 0,
         "filesystem": {
-          "afterBytes": 96927904,
+          "afterBytes": 96903328,
           "beforeBytes": 160,
-          "sampledHighWaterBytes": 96927904
+          "sampledHighWaterBytes": 96903328
         },
         "outputRecords": 29108,
-        "parentElapsedMs": 21451,
+        "parentElapsedMs": 14172,
         "runCount": 2,
         "sourceBytes": 47637907,
         "sourceFiles": 4096,
         "stderrBytes": 169,
-        "stdoutBytes": 1099
+        "stdoutBytes": 1098
       },
       "name": "source_scan",
       "projectionSha256": "c70ea4b8c4d71a9ee8b2a1cd72023877e32391e1f2b8fd7bfb355374b28f2395",
@@ -542,26 +542,26 @@
     {
       "failureCode": "none",
       "metrics": {
-        "childCpuMs": 17383,
-        "childMaxRssBytes": 475791360,
+        "childCpuMs": 12018,
+        "childMaxRssBytes": 473317376,
         "decodedBytes": 0,
-        "durablePeakRssBytes": 789954560,
+        "durablePeakRssBytes": 789676032,
         "encodedBytes": 0,
-        "externalPeakRssBytes": 475463680,
-        "externalRssSampleCount": 513,
+        "externalPeakRssBytes": 468090880,
+        "externalRssSampleCount": 214,
         "externalRssSampleFailureCount": 0,
         "filesystem": {
-          "afterBytes": 193855648,
-          "beforeBytes": 127037600,
-          "sampledHighWaterBytes": 193855759
+          "afterBytes": 193806496,
+          "beforeBytes": 127013024,
+          "sampledHighWaterBytes": 193806496
         },
         "outputRecords": 29108,
-        "parentElapsedMs": 32486,
+        "parentElapsedMs": 12253,
         "runCount": 2,
         "sourceBytes": 47637907,
         "sourceFiles": 4096,
         "stderrBytes": 169,
-        "stdoutBytes": 1105
+        "stdoutBytes": 1103
       },
       "name": "checkpoint_resume",
       "projectionSha256": "c70ea4b8c4d71a9ee8b2a1cd72023877e32391e1f2b8fd7bfb355374b28f2395",
@@ -570,49 +570,49 @@
     {
       "failureCode": "none",
       "metrics": {
-        "childCpuMs": 4620,
-        "childMaxRssBytes": 263208960,
+        "childCpuMs": 4141,
+        "childMaxRssBytes": 261603328,
         "decodedBytes": 46019365,
-        "durablePeakRssBytes": 670138368,
+        "durablePeakRssBytes": 677150720,
         "encodedBytes": 2072956,
-        "externalPeakRssBytes": 262275072,
-        "externalRssSampleCount": 266,
+        "externalPeakRssBytes": 260882432,
+        "externalRssSampleCount": 195,
         "externalRssSampleFailureCount": 0,
         "filesystem": {
-          "afterBytes": 196963314,
-          "beforeBytes": 193855648,
-          "sampledHighWaterBytes": 196963425
+          "afterBytes": 196914162,
+          "beforeBytes": 193806496,
+          "sampledHighWaterBytes": 196915431
         },
         "outputRecords": 29108,
-        "parentElapsedMs": 14577,
+        "parentElapsedMs": 10695,
         "runCount": 2,
         "sourceBytes": 47637907,
         "sourceFiles": 4096,
         "stderrBytes": 169,
-        "stdoutBytes": 1252
+        "stdoutBytes": 1251
       },
       "name": "export_set_materialize",
-      "projectionSha256": "7709ae36a134ae382b8f4cd35ec76cb4728e1c68b83717b334479af919b8ee23",
+      "projectionSha256": "190fd295ce06e65da4375e959ab135910cf3f72ffd6afcb5293a1db7df39a573",
       "status": "completed"
     },
     {
       "failureCode": "none",
       "metrics": {
-        "childCpuMs": 2200,
-        "childMaxRssBytes": 280035328,
+        "childCpuMs": 1818,
+        "childMaxRssBytes": 270155776,
         "decodedBytes": 46019365,
         "durablePeakRssBytes": 0,
         "encodedBytes": 2072956,
-        "externalPeakRssBytes": 280035328,
-        "externalRssSampleCount": 64,
+        "externalPeakRssBytes": 270139392,
+        "externalRssSampleCount": 37,
         "externalRssSampleFailureCount": 0,
         "filesystem": {
-          "afterBytes": 196963314,
-          "beforeBytes": 196963314,
-          "sampledHighWaterBytes": 205255658
+          "afterBytes": 196914162,
+          "beforeBytes": 196914162,
+          "sampledHighWaterBytes": 204755570
         },
         "outputRecords": 29108,
-        "parentElapsedMs": 3829,
+        "parentElapsedMs": 1835,
         "runCount": 2,
         "sourceBytes": 0,
         "sourceFiles": 0,
@@ -626,49 +626,49 @@
     {
       "failureCode": "none",
       "metrics": {
-        "childCpuMs": 6768,
-        "childMaxRssBytes": 312197120,
+        "childCpuMs": 6593,
+        "childMaxRssBytes": 299139072,
         "decodedBytes": 0,
         "durablePeakRssBytes": 0,
         "encodedBytes": 0,
-        "externalPeakRssBytes": 312164352,
-        "externalRssSampleCount": 183,
+        "externalPeakRssBytes": 299139072,
+        "externalRssSampleCount": 176,
         "externalRssSampleFailureCount": 0,
         "filesystem": {
-          "afterBytes": 96930436,
-          "beforeBytes": 196965385,
-          "sampledHighWaterBytes": 197047225
+          "afterBytes": 96905860,
+          "beforeBytes": 196916233,
+          "sampledHighWaterBytes": 196998076
         },
         "outputRecords": 0,
-        "parentElapsedMs": 10265,
+        "parentElapsedMs": 9912,
         "runCount": 2,
         "sourceBytes": 0,
         "sourceFiles": 0,
         "stderrBytes": 169,
-        "stdoutBytes": 1006
+        "stdoutBytes": 1004
       },
       "name": "complete_set_delete",
-      "projectionSha256": "dfb8a98eac13aef28ecb4b79c9f3881f60242c33d63033ee9bbde3f727bd6be7",
+      "projectionSha256": "510dac9b47ef9f84c1ba7e74e52e2e0972d3d8f36ae71974dda04a43389c1734",
       "status": "completed"
     },
     {
       "failureCode": "interruption_injected",
       "metrics": {
-        "childCpuMs": 342,
-        "childMaxRssBytes": 129597440,
+        "childCpuMs": 368,
+        "childMaxRssBytes": 130056192,
         "decodedBytes": 0,
         "durablePeakRssBytes": 0,
         "encodedBytes": 0,
-        "externalPeakRssBytes": 129548288,
-        "externalRssSampleCount": 54,
+        "externalPeakRssBytes": 129908736,
+        "externalRssSampleCount": 48,
         "externalRssSampleFailureCount": 0,
         "filesystem": {
-          "afterBytes": 196965385,
-          "beforeBytes": 297080884,
-          "sampledHighWaterBytes": 297080884
+          "afterBytes": 196916233,
+          "beforeBytes": 297007156,
+          "sampledHighWaterBytes": 297007156
         },
         "outputRecords": 0,
-        "parentElapsedMs": 2981,
+        "parentElapsedMs": 2367,
         "runCount": 2,
         "sourceBytes": 0,
         "sourceFiles": 0,
@@ -676,32 +676,32 @@
         "stdoutBytes": 1012
       },
       "name": "complete_set_delete_recovery",
-      "projectionSha256": "dfb8a98eac13aef28ecb4b79c9f3881f60242c33d63033ee9bbde3f727bd6be7",
+      "projectionSha256": "510dac9b47ef9f84c1ba7e74e52e2e0972d3d8f36ae71974dda04a43389c1734",
       "status": "interrupted_recovered"
     },
     {
       "failureCode": "none",
       "metrics": {
-        "childCpuMs": 137,
-        "childMaxRssBytes": 117800960,
+        "childCpuMs": 146,
+        "childMaxRssBytes": 117178368,
         "decodedBytes": 0,
         "durablePeakRssBytes": 0,
         "encodedBytes": 0,
-        "externalPeakRssBytes": 117620736,
+        "externalPeakRssBytes": 117080064,
         "externalRssSampleCount": 8,
         "externalRssSampleFailureCount": 0,
         "filesystem": {
-          "afterBytes": 196963849,
-          "beforeBytes": 227073010,
-          "sampledHighWaterBytes": 227073121
+          "afterBytes": 196914697,
+          "beforeBytes": 227023858,
+          "sampledHighWaterBytes": 227023969
         },
         "outputRecords": 0,
-        "parentElapsedMs": 353,
+        "parentElapsedMs": 335,
         "runCount": 2,
         "sourceBytes": 0,
         "sourceFiles": 0,
         "stderrBytes": 169,
-        "stdoutBytes": 995
+        "stdoutBytes": 996
       },
       "name": "workspace_discard",
       "projectionSha256": "064fdfeb99edbc148aa8778a62741f99119e5abad545d4e846cb39e835736056",
@@ -710,21 +710,21 @@
     {
       "failureCode": "interruption_injected",
       "metrics": {
-        "childCpuMs": 97,
-        "childMaxRssBytes": 115851264,
+        "childCpuMs": 100,
+        "childMaxRssBytes": 116293632,
         "decodedBytes": 0,
         "durablePeakRssBytes": 0,
         "encodedBytes": 0,
-        "externalPeakRssBytes": 115441664,
-        "externalRssSampleCount": 8,
+        "externalPeakRssBytes": 115884032,
+        "externalRssSampleCount": 6,
         "externalRssSampleFailureCount": 0,
         "filesystem": {
-          "afterBytes": 196964384,
-          "beforeBytes": 227074777,
-          "sampledHighWaterBytes": 257184584
+          "afterBytes": 196915232,
+          "beforeBytes": 227025625,
+          "sampledHighWaterBytes": 257135432
         },
         "outputRecords": 0,
-        "parentElapsedMs": 324,
+        "parentElapsedMs": 286,
         "runCount": 2,
         "sourceBytes": 0,
         "sourceFiles": 0,
@@ -738,21 +738,21 @@
     {
       "failureCode": "none",
       "metrics": {
-        "childCpuMs": 6,
-        "childMaxRssBytes": 112001024,
+        "childCpuMs": 5,
+        "childMaxRssBytes": 111820800,
         "decodedBytes": 0,
         "durablePeakRssBytes": 0,
         "encodedBytes": 0,
-        "externalPeakRssBytes": 93306880,
+        "externalPeakRssBytes": 93044736,
         "externalRssSampleCount": 4,
         "externalRssSampleFailureCount": 0,
         "filesystem": {
-          "afterBytes": 196964654,
-          "beforeBytes": 196964833,
-          "sampledHighWaterBytes": 196964833
+          "afterBytes": 196915502,
+          "beforeBytes": 196915681,
+          "sampledHighWaterBytes": 196915681
         },
         "outputRecords": 0,
-        "parentElapsedMs": 190,
+        "parentElapsedMs": 178,
         "runCount": 2,
         "sourceBytes": 0,
         "sourceFiles": 0,
@@ -767,20 +767,20 @@
       "failureCode": "interruption_injected",
       "metrics": {
         "childCpuMs": 5,
-        "childMaxRssBytes": 111689728,
+        "childMaxRssBytes": 111738880,
         "decodedBytes": 0,
         "durablePeakRssBytes": 0,
         "encodedBytes": 0,
-        "externalPeakRssBytes": 92864512,
+        "externalPeakRssBytes": 95404032,
         "externalRssSampleCount": 4,
         "externalRssSampleFailureCount": 0,
         "filesystem": {
-          "afterBytes": 196964924,
-          "beforeBytes": 196965112,
-          "sampledHighWaterBytes": 196965112
+          "afterBytes": 196915772,
+          "beforeBytes": 196915960,
+          "sampledHighWaterBytes": 196915960
         },
         "outputRecords": 0,
-        "parentElapsedMs": 179,
+        "parentElapsedMs": 180,
         "runCount": 2,
         "sourceBytes": 0,
         "sourceFiles": 0,
@@ -827,7 +827,7 @@
     "targetChunks": 128
   },
   "protocolVersion": "g1-r7-release-evidence-v0.1",
-  "receiptSha256": "2005820c8451fd94be70c23cec5868ee66ee031e39d316cac80610eef39449dd",
+  "receiptSha256": "4bdb3c75c06138b66deb51bbd5fff9f86b2b24ed177d398f3097cc49690221f5",
   "runtimeProvenance": {
     "architecture": "arm64",
     "elapsedClock": "parent_monotonic",

--- a/generated/r7-release-synthetic-pressure-node26.2.0-v0.1.json
+++ b/generated/r7-release-synthetic-pressure-node26.2.0-v0.1.json
@@ -482,7 +482,7 @@
     "resourcePolicyValuesSha256": "3cbe7853c8f75e96912885f64ba4ad1aeb13aff8a22e4ffbd51806b27c73b418",
     "schemaModuleSha256": "594d035e641e87b29db4027dca35157f8225fd5621816d67d5d9f25825468bbf",
     "workloadCodeFileCount": 359,
-    "workloadCodeSha256": "ea504fde37402622239d5405aa74c264b98a111c8da5b4031a0977fa5bd80741"
+    "workloadCodeSha256": "7a60f50547c7240e88357161542de2b6ceda3afecc004af776eaf6741e195772"
   },
   "determinism": {
     "comparisons": {
@@ -500,8 +500,8 @@
     "projectionVersion": "g1-r7-release-deterministic-projection-v0.1",
     "runCount": 2,
     "runProjectionSha256es": [
-      "e2d6bcf086febf272ad2f68c4b688b614f1ea5b5dee1bd1be44c6361cf8573dd",
-      "e2d6bcf086febf272ad2f68c4b688b614f1ea5b5dee1bd1be44c6361cf8573dd"
+      "fe044d3d1413d4a99d3c2531e032a44461461a358af9c1ad4b0b9c49ed30a72c",
+      "fe044d3d1413d4a99d3c2531e032a44461461a358af9c1ad4b0b9c49ed30a72c"
     ],
     "status": "passed"
   },
@@ -514,21 +514,21 @@
     {
       "failureCode": "none",
       "metrics": {
-        "childCpuMs": 21873,
-        "childMaxRssBytes": 988135424,
+        "childCpuMs": 18570,
+        "childMaxRssBytes": 623345664,
         "decodedBytes": 0,
-        "durablePeakRssBytes": 988135424,
+        "durablePeakRssBytes": 623329280,
         "encodedBytes": 0,
-        "externalPeakRssBytes": 987709440,
-        "externalRssSampleCount": 476,
+        "externalPeakRssBytes": 618315776,
+        "externalRssSampleCount": 275,
         "externalRssSampleFailureCount": 0,
         "filesystem": {
-          "afterBytes": 96936096,
+          "afterBytes": 96956576,
           "beforeBytes": 160,
-          "sampledHighWaterBytes": 96940878
+          "sampledHighWaterBytes": 96956576
         },
         "outputRecords": 29108,
-        "parentElapsedMs": 29159,
+        "parentElapsedMs": 14065,
         "runCount": 2,
         "sourceBytes": 47637907,
         "sourceFiles": 4096,
@@ -542,21 +542,21 @@
     {
       "failureCode": "none",
       "metrics": {
-        "childCpuMs": 16798,
-        "childMaxRssBytes": 668352512,
+        "childCpuMs": 13452,
+        "childMaxRssBytes": 469434368,
         "decodedBytes": 0,
-        "durablePeakRssBytes": 668352512,
+        "durablePeakRssBytes": 574636032,
         "encodedBytes": 0,
-        "externalPeakRssBytes": 649838592,
-        "externalRssSampleCount": 376,
+        "externalPeakRssBytes": 468598784,
+        "externalRssSampleCount": 232,
         "externalRssSampleFailureCount": 0,
         "filesystem": {
-          "afterBytes": 193872032,
-          "beforeBytes": 127045792,
-          "sampledHighWaterBytes": 193872032
+          "afterBytes": 193912992,
+          "beforeBytes": 127066272,
+          "sampledHighWaterBytes": 193912992
         },
         "outputRecords": 29108,
-        "parentElapsedMs": 25103,
+        "parentElapsedMs": 13215,
         "runCount": 2,
         "sourceBytes": 47637907,
         "sourceFiles": 4096,
@@ -570,49 +570,49 @@
     {
       "failureCode": "none",
       "metrics": {
-        "childCpuMs": 4012,
-        "childMaxRssBytes": 225034240,
+        "childCpuMs": 3718,
+        "childMaxRssBytes": 217169920,
         "decodedBytes": 46019365,
-        "durablePeakRssBytes": 988135424,
-        "encodedBytes": 2072932,
-        "externalPeakRssBytes": 224657408,
-        "externalRssSampleCount": 218,
+        "durablePeakRssBytes": 623329280,
+        "encodedBytes": 2072944,
+        "externalPeakRssBytes": 216481792,
+        "externalRssSampleCount": 174,
         "externalRssSampleFailureCount": 0,
         "filesystem": {
-          "afterBytes": 196979673,
-          "beforeBytes": 193872032,
-          "sampledHighWaterBytes": 196979783
+          "afterBytes": 197020645,
+          "beforeBytes": 193912992,
+          "sampledHighWaterBytes": 197020756
         },
         "outputRecords": 29108,
-        "parentElapsedMs": 12443,
+        "parentElapsedMs": 8772,
         "runCount": 2,
         "sourceBytes": 47637907,
         "sourceFiles": 4096,
         "stderrBytes": 0,
-        "stdoutBytes": 1251
+        "stdoutBytes": 1250
       },
       "name": "export_set_materialize",
-      "projectionSha256": "dc22dcf72d5b5bf4a30cc27b40fcdd2d22055800fc845cfa91115d8a97aa6bad",
+      "projectionSha256": "42e49d6c42dbf77ef74aa459e45db904590c426dcd39d2ffd44ec81d93700125",
       "status": "completed"
     },
     {
       "failureCode": "none",
       "metrics": {
-        "childCpuMs": 1772,
-        "childMaxRssBytes": 238632960,
+        "childCpuMs": 1766,
+        "childMaxRssBytes": 243531776,
         "decodedBytes": 46019365,
         "durablePeakRssBytes": 0,
-        "encodedBytes": 2072932,
-        "externalPeakRssBytes": 238501888,
+        "encodedBytes": 2072944,
+        "externalPeakRssBytes": 243154944,
         "externalRssSampleCount": 41,
-        "externalRssSampleFailureCount": 0,
+        "externalRssSampleFailureCount": 1,
         "filesystem": {
-          "afterBytes": 196979673,
-          "beforeBytes": 196979673,
-          "sampledHighWaterBytes": 204825185
+          "afterBytes": 197020645,
+          "beforeBytes": 197020645,
+          "sampledHighWaterBytes": 204783745
         },
         "outputRecords": 29108,
-        "parentElapsedMs": 2373,
+        "parentElapsedMs": 2548,
         "runCount": 2,
         "sourceBytes": 0,
         "sourceFiles": 0,
@@ -620,27 +620,27 @@
         "stdoutBytes": 1011
       },
       "name": "export_set_verify",
-      "projectionSha256": "07b12154385d591cdb03cdc5acc05e851cfe570adff8caf49d9f75dc03dd6d8d",
+      "projectionSha256": "376c44a59189a94a1733571bb46a213ee37d3f31e8c3adf7e30b219bcc4fc161",
       "status": "completed"
     },
     {
       "failureCode": "none",
       "metrics": {
-        "childCpuMs": 6300,
-        "childMaxRssBytes": 261390336,
+        "childCpuMs": 6506,
+        "childMaxRssBytes": 255066112,
         "decodedBytes": 0,
         "durablePeakRssBytes": 0,
         "encodedBytes": 0,
-        "externalPeakRssBytes": 261373952,
-        "externalRssSampleCount": 210,
+        "externalPeakRssBytes": 254803968,
+        "externalRssSampleCount": 188,
         "externalRssSampleFailureCount": 0,
         "filesystem": {
-          "afterBytes": 96938628,
-          "beforeBytes": 196981744,
-          "sampledHighWaterBytes": 196981854
+          "afterBytes": 96959108,
+          "beforeBytes": 197022716,
+          "sampledHighWaterBytes": 197103377
         },
         "outputRecords": 0,
-        "parentElapsedMs": 11241,
+        "parentElapsedMs": 11776,
         "runCount": 2,
         "sourceBytes": 0,
         "sourceFiles": 0,
@@ -648,27 +648,27 @@
         "stdoutBytes": 1005
       },
       "name": "complete_set_delete",
-      "projectionSha256": "9ded5897ddfad15e7de5426b7412f01d1ef635ccabaa51a567709df452698e6c",
+      "projectionSha256": "98c031927b3c54721400b4fda21f6a03eb3f38bfef393ad389a35331cbca2a70",
       "status": "completed"
     },
     {
       "failureCode": "interruption_injected",
       "metrics": {
-        "childCpuMs": 391,
-        "childMaxRssBytes": 139149312,
+        "childCpuMs": 464,
+        "childMaxRssBytes": 139264000,
         "decodedBytes": 0,
         "durablePeakRssBytes": 0,
         "encodedBytes": 0,
-        "externalPeakRssBytes": 139149312,
-        "externalRssSampleCount": 66,
+        "externalPeakRssBytes": 139067392,
+        "externalRssSampleCount": 73,
         "externalRssSampleFailureCount": 0,
         "filesystem": {
-          "afterBytes": 196981744,
-          "beforeBytes": 297105410,
-          "sampledHighWaterBytes": 297105410
+          "afterBytes": 197022716,
+          "beforeBytes": 297166874,
+          "sampledHighWaterBytes": 297166874
         },
         "outputRecords": 0,
-        "parentElapsedMs": 3472,
+        "parentElapsedMs": 4972,
         "runCount": 2,
         "sourceBytes": 0,
         "sourceFiles": 0,
@@ -676,32 +676,32 @@
         "stdoutBytes": 1012
       },
       "name": "complete_set_delete_recovery",
-      "projectionSha256": "9ded5897ddfad15e7de5426b7412f01d1ef635ccabaa51a567709df452698e6c",
+      "projectionSha256": "98c031927b3c54721400b4fda21f6a03eb3f38bfef393ad389a35331cbca2a70",
       "status": "interrupted_recovered"
     },
     {
       "failureCode": "none",
       "metrics": {
-        "childCpuMs": 144,
-        "childMaxRssBytes": 126500864,
+        "childCpuMs": 141,
+        "childMaxRssBytes": 124977152,
         "decodedBytes": 0,
         "durablePeakRssBytes": 0,
         "encodedBytes": 0,
-        "externalPeakRssBytes": 126304256,
+        "externalPeakRssBytes": 124878848,
         "externalRssSampleCount": 8,
         "externalRssSampleFailureCount": 0,
         "filesystem": {
-          "afterBytes": 196980208,
-          "beforeBytes": 227089369,
-          "sampledHighWaterBytes": 227089479
+          "afterBytes": 197021180,
+          "beforeBytes": 227130341,
+          "sampledHighWaterBytes": 227131239
         },
         "outputRecords": 0,
-        "parentElapsedMs": 373,
+        "parentElapsedMs": 355,
         "runCount": 2,
         "sourceBytes": 0,
         "sourceFiles": 0,
         "stderrBytes": 0,
-        "stdoutBytes": 995
+        "stdoutBytes": 996
       },
       "name": "workspace_discard",
       "projectionSha256": "064fdfeb99edbc148aa8778a62741f99119e5abad545d4e846cb39e835736056",
@@ -711,20 +711,20 @@
       "failureCode": "interruption_injected",
       "metrics": {
         "childCpuMs": 99,
-        "childMaxRssBytes": 124862464,
+        "childMaxRssBytes": 124321792,
         "decodedBytes": 0,
         "durablePeakRssBytes": 0,
         "encodedBytes": 0,
-        "externalPeakRssBytes": 124157952,
-        "externalRssSampleCount": 6,
+        "externalPeakRssBytes": 124321792,
+        "externalRssSampleCount": 7,
         "externalRssSampleFailureCount": 0,
         "filesystem": {
-          "afterBytes": 196980743,
-          "beforeBytes": 227091136,
-          "sampledHighWaterBytes": 257200942
+          "afterBytes": 197021715,
+          "beforeBytes": 227132108,
+          "sampledHighWaterBytes": 257241915
         },
         "outputRecords": 0,
-        "parentElapsedMs": 300,
+        "parentElapsedMs": 312,
         "runCount": 2,
         "sourceBytes": 0,
         "sourceFiles": 0,
@@ -738,8 +738,8 @@
     {
       "failureCode": "none",
       "metrics": {
-        "childCpuMs": 5,
-        "childMaxRssBytes": 119013376,
+        "childCpuMs": 6,
+        "childMaxRssBytes": 118718464,
         "decodedBytes": 0,
         "durablePeakRssBytes": 0,
         "encodedBytes": 0,
@@ -747,12 +747,12 @@
         "externalRssSampleCount": 4,
         "externalRssSampleFailureCount": 0,
         "filesystem": {
-          "afterBytes": 196981013,
-          "beforeBytes": 196981192,
-          "sampledHighWaterBytes": 196981192
+          "afterBytes": 197021985,
+          "beforeBytes": 197022164,
+          "sampledHighWaterBytes": 197022164
         },
         "outputRecords": 0,
-        "parentElapsedMs": 184,
+        "parentElapsedMs": 192,
         "runCount": 2,
         "sourceBytes": 0,
         "sourceFiles": 0,
@@ -767,20 +767,20 @@
       "failureCode": "interruption_injected",
       "metrics": {
         "childCpuMs": 5,
-        "childMaxRssBytes": 118554624,
+        "childMaxRssBytes": 118374400,
         "decodedBytes": 0,
         "durablePeakRssBytes": 0,
         "encodedBytes": 0,
-        "externalPeakRssBytes": 105086976,
+        "externalPeakRssBytes": 104808448,
         "externalRssSampleCount": 4,
         "externalRssSampleFailureCount": 0,
         "filesystem": {
-          "afterBytes": 196981283,
-          "beforeBytes": 196981471,
-          "sampledHighWaterBytes": 196981471
+          "afterBytes": 197022255,
+          "beforeBytes": 197022443,
+          "sampledHighWaterBytes": 197022443
         },
         "outputRecords": 0,
-        "parentElapsedMs": 172,
+        "parentElapsedMs": 163,
         "runCount": 2,
         "sourceBytes": 0,
         "sourceFiles": 0,
@@ -827,7 +827,7 @@
     "targetChunks": 128
   },
   "protocolVersion": "g1-r7-release-evidence-v0.1",
-  "receiptSha256": "97213974a20feed5e75206e81aec2f2ee3a94f7c35c34801315b5c0b8aabd28e",
+  "receiptSha256": "b785ed92ed7267343ec5e15745236728bdc1102cd09296e1cd51aedc5eea82c0",
   "runtimeProvenance": {
     "architecture": "arm64",
     "elapsedClock": "parent_monotonic",

--- a/generated/r7-release-synthetic-semantics-node24.14.0-v0.1.json
+++ b/generated/r7-release-synthetic-semantics-node24.14.0-v0.1.json
@@ -482,7 +482,7 @@
     "resourcePolicyValuesSha256": "3cbe7853c8f75e96912885f64ba4ad1aeb13aff8a22e4ffbd51806b27c73b418",
     "schemaModuleSha256": "594d035e641e87b29db4027dca35157f8225fd5621816d67d5d9f25825468bbf",
     "workloadCodeFileCount": 359,
-    "workloadCodeSha256": "ea504fde37402622239d5405aa74c264b98a111c8da5b4031a0977fa5bd80741"
+    "workloadCodeSha256": "7a60f50547c7240e88357161542de2b6ceda3afecc004af776eaf6741e195772"
   },
   "determinism": {
     "comparisons": {
@@ -500,8 +500,8 @@
     "projectionVersion": "g1-r7-release-deterministic-projection-v0.1",
     "runCount": 2,
     "runProjectionSha256es": [
-      "5f778d981543b222ed2e0e8619f168c80055b07063e4296b193c69e3c2a22af3",
-      "5f778d981543b222ed2e0e8619f168c80055b07063e4296b193c69e3c2a22af3"
+      "f2b36e1eff83bc0dbe8aeb7c12929280b32ca6d2ca7d82677faeeabd538aafff",
+      "f2b36e1eff83bc0dbe8aeb7c12929280b32ca6d2ca7d82677faeeabd538aafff"
     ],
     "status": "passed"
   },
@@ -514,12 +514,12 @@
     {
       "failureCode": "none",
       "metrics": {
-        "childCpuMs": 93,
-        "childMaxRssBytes": 124010496,
+        "childCpuMs": 75,
+        "childMaxRssBytes": 123060224,
         "decodedBytes": 0,
-        "durablePeakRssBytes": 123994112,
+        "durablePeakRssBytes": 123043840,
         "encodedBytes": 0,
-        "externalPeakRssBytes": 122355712,
+        "externalPeakRssBytes": 122896384,
         "externalRssSampleCount": 6,
         "externalRssSampleFailureCount": 0,
         "filesystem": {
@@ -528,12 +528,12 @@
           "sampledHighWaterBytes": 200864
         },
         "outputRecords": 27,
-        "parentElapsedMs": 245,
+        "parentElapsedMs": 220,
         "runCount": 2,
         "sourceBytes": 154645,
         "sourceFiles": 14,
         "stderrBytes": 169,
-        "stdoutBytes": 1072
+        "stdoutBytes": 1071
       },
       "name": "source_scan",
       "projectionSha256": "9a32d3d160adf2c4f0f900f4583abf8c4b37c5460377fcdd74447945cfa9acd7",
@@ -543,12 +543,12 @@
       "failureCode": "none",
       "metrics": {
         "childCpuMs": 53,
-        "childMaxRssBytes": 120389632,
+        "childMaxRssBytes": 120438784,
         "decodedBytes": 0,
-        "durablePeakRssBytes": 165511168,
+        "durablePeakRssBytes": 155648000,
         "encodedBytes": 0,
-        "externalPeakRssBytes": 97927168,
-        "externalRssSampleCount": 4,
+        "externalPeakRssBytes": 109019136,
+        "externalRssSampleCount": 5,
         "externalRssSampleFailureCount": 0,
         "filesystem": {
           "afterBytes": 401568,
@@ -556,7 +556,7 @@
           "sampledHighWaterBytes": 401568
         },
         "outputRecords": 27,
-        "parentElapsedMs": 193,
+        "parentElapsedMs": 208,
         "runCount": 2,
         "sourceBytes": 154645,
         "sourceFiles": 14,
@@ -570,49 +570,49 @@
     {
       "failureCode": "none",
       "metrics": {
-        "childCpuMs": 192,
-        "childMaxRssBytes": 131645440,
+        "childCpuMs": 142,
+        "childMaxRssBytes": 131547136,
         "decodedBytes": 109963,
-        "durablePeakRssBytes": 131432448,
-        "encodedBytes": 32463,
-        "externalPeakRssBytes": 131612672,
-        "externalRssSampleCount": 23,
+        "durablePeakRssBytes": 131448832,
+        "encodedBytes": 32469,
+        "externalPeakRssBytes": 130220032,
+        "externalRssSampleCount": 18,
         "externalRssSampleFailureCount": 0,
         "filesystem": {
-          "afterBytes": 554633,
+          "afterBytes": 554639,
           "beforeBytes": 401568,
-          "sampledHighWaterBytes": 554744
+          "sampledHighWaterBytes": 554639
         },
         "outputRecords": 27,
-        "parentElapsedMs": 1339,
+        "parentElapsedMs": 880,
         "runCount": 2,
         "sourceBytes": 154645,
         "sourceFiles": 14,
         "stderrBytes": 169,
-        "stdoutBytes": 1225
+        "stdoutBytes": 1222
       },
       "name": "export_set_materialize",
-      "projectionSha256": "28c1e6d7d0e2c968554c072fffab32a3990be8c75dd940c79ab9c59b1cefd03e",
+      "projectionSha256": "eca3282f17076c89b201b5348488e131c858f9e68e578e0ff970f6757321d3b2",
       "status": "completed"
     },
     {
       "failureCode": "none",
       "metrics": {
-        "childCpuMs": 43,
-        "childMaxRssBytes": 124157952,
+        "childCpuMs": 44,
+        "childMaxRssBytes": 124272640,
         "decodedBytes": 109963,
         "durablePeakRssBytes": 0,
-        "encodedBytes": 32463,
-        "externalPeakRssBytes": 92913664,
+        "encodedBytes": 32469,
+        "externalPeakRssBytes": 92389376,
         "externalRssSampleCount": 4,
         "externalRssSampleFailureCount": 0,
         "filesystem": {
-          "afterBytes": 554633,
-          "beforeBytes": 554633,
-          "sampledHighWaterBytes": 554633
+          "afterBytes": 554639,
+          "beforeBytes": 554639,
+          "sampledHighWaterBytes": 554639
         },
         "outputRecords": 27,
-        "parentElapsedMs": 182,
+        "parentElapsedMs": 177,
         "runCount": 2,
         "sourceBytes": 0,
         "sourceFiles": 0,
@@ -620,27 +620,27 @@
         "stdoutBytes": 997
       },
       "name": "export_set_verify",
-      "projectionSha256": "fee0a5a9fd13a89d161de25ba3eb37804d0efef223e6d45fd623639c9ea0423f",
+      "projectionSha256": "88e09e4eb59b93833ca1d9f95925647be0fa0e8dbc67661d5da29d7278242a37",
       "status": "completed"
     },
     {
       "failureCode": "none",
       "metrics": {
-        "childCpuMs": 151,
-        "childMaxRssBytes": 137838592,
+        "childCpuMs": 148,
+        "childMaxRssBytes": 135135232,
         "decodedBytes": 0,
         "durablePeakRssBytes": 0,
         "encodedBytes": 0,
-        "externalPeakRssBytes": 137478144,
+        "externalPeakRssBytes": 135086080,
         "externalRssSampleCount": 12,
         "externalRssSampleFailureCount": 0,
         "filesystem": {
           "afterBytes": 203384,
-          "beforeBytes": 556696,
-          "sampledHighWaterBytes": 556807
+          "beforeBytes": 556702,
+          "sampledHighWaterBytes": 556813
         },
         "outputRecords": 0,
-        "parentElapsedMs": 571,
+        "parentElapsedMs": 556,
         "runCount": 2,
         "sourceBytes": 0,
         "sourceFiles": 0,
@@ -648,27 +648,27 @@
         "stdoutBytes": 997
       },
       "name": "complete_set_delete",
-      "projectionSha256": "60f732f952e80497d873a4511e928e4ada204eed47dc29dd2838d3a4d516d3b4",
+      "projectionSha256": "eb286d149fc577693da5c6e766564d114f912b1578414d2dc3e8d60d2af1dd09",
       "status": "completed"
     },
     {
       "failureCode": "interruption_injected",
       "metrics": {
-        "childCpuMs": 36,
-        "childMaxRssBytes": 115032064,
+        "childCpuMs": 31,
+        "childMaxRssBytes": 114950144,
         "decodedBytes": 0,
         "durablePeakRssBytes": 0,
         "encodedBytes": 0,
-        "externalPeakRssBytes": 114950144,
+        "externalPeakRssBytes": 114917376,
         "externalRssSampleCount": 10,
         "externalRssSampleFailureCount": 0,
         "filesystem": {
-          "afterBytes": 556696,
-          "beforeBytes": 920780,
-          "sampledHighWaterBytes": 920780
+          "afterBytes": 556702,
+          "beforeBytes": 920792,
+          "sampledHighWaterBytes": 920792
         },
         "outputRecords": 0,
-        "parentElapsedMs": 488,
+        "parentElapsedMs": 430,
         "runCount": 2,
         "sourceBytes": 0,
         "sourceFiles": 0,
@@ -676,32 +676,32 @@
         "stdoutBytes": 1005
       },
       "name": "complete_set_delete_recovery",
-      "projectionSha256": "60f732f952e80497d873a4511e928e4ada204eed47dc29dd2838d3a4d516d3b4",
+      "projectionSha256": "eb286d149fc577693da5c6e766564d114f912b1578414d2dc3e8d60d2af1dd09",
       "status": "interrupted_recovered"
     },
     {
       "failureCode": "none",
       "metrics": {
-        "childCpuMs": 19,
-        "childMaxRssBytes": 115720192,
+        "childCpuMs": 17,
+        "childMaxRssBytes": 114753536,
         "decodedBytes": 0,
         "durablePeakRssBytes": 0,
         "encodedBytes": 0,
-        "externalPeakRssBytes": 115523584,
-        "externalRssSampleCount": 5,
+        "externalPeakRssBytes": 114753536,
+        "externalRssSampleCount": 6,
         "externalRssSampleFailureCount": 0,
         "filesystem": {
-          "afterBytes": 555166,
-          "beforeBytes": 722569,
-          "sampledHighWaterBytes": 722569
+          "afterBytes": 555172,
+          "beforeBytes": 722575,
+          "sampledHighWaterBytes": 722575
         },
         "outputRecords": 0,
-        "parentElapsedMs": 269,
+        "parentElapsedMs": 212,
         "runCount": 2,
         "sourceBytes": 0,
         "sourceFiles": 0,
         "stderrBytes": 169,
-        "stdoutBytes": 992
+        "stdoutBytes": 991
       },
       "name": "workspace_discard",
       "projectionSha256": "495426e69724d58733a4605ce62a0a9e61a094e67823671e64b872acf28bbea5",
@@ -710,26 +710,26 @@
     {
       "failureCode": "interruption_injected",
       "metrics": {
-        "childCpuMs": 14,
-        "childMaxRssBytes": 114589696,
+        "childCpuMs": 13,
+        "childMaxRssBytes": 115638272,
         "decodedBytes": 0,
         "durablePeakRssBytes": 0,
         "encodedBytes": 0,
-        "externalPeakRssBytes": 114065408,
+        "externalPeakRssBytes": 92553216,
         "externalRssSampleCount": 5,
         "externalRssSampleFailureCount": 0,
         "filesystem": {
-          "afterBytes": 555699,
-          "beforeBytes": 724330,
-          "sampledHighWaterBytes": 724330
+          "afterBytes": 555705,
+          "beforeBytes": 724336,
+          "sampledHighWaterBytes": 724336
         },
         "outputRecords": 0,
-        "parentElapsedMs": 247,
+        "parentElapsedMs": 204,
         "runCount": 2,
         "sourceBytes": 0,
         "sourceFiles": 0,
         "stderrBytes": 169,
-        "stdoutBytes": 1000
+        "stdoutBytes": 999
       },
       "name": "workspace_discard_recovery",
       "projectionSha256": "495426e69724d58733a4605ce62a0a9e61a094e67823671e64b872acf28bbea5",
@@ -739,20 +739,20 @@
       "failureCode": "none",
       "metrics": {
         "childCpuMs": 6,
-        "childMaxRssBytes": 111280128,
+        "childMaxRssBytes": 111706112,
         "decodedBytes": 0,
         "durablePeakRssBytes": 0,
         "encodedBytes": 0,
-        "externalPeakRssBytes": 92504064,
+        "externalPeakRssBytes": 92241920,
         "externalRssSampleCount": 4,
         "externalRssSampleFailureCount": 0,
         "filesystem": {
-          "afterBytes": 555969,
-          "beforeBytes": 556148,
-          "sampledHighWaterBytes": 556148
+          "afterBytes": 555975,
+          "beforeBytes": 556154,
+          "sampledHighWaterBytes": 556154
         },
         "outputRecords": 0,
-        "parentElapsedMs": 179,
+        "parentElapsedMs": 176,
         "runCount": 2,
         "sourceBytes": 0,
         "sourceFiles": 0,
@@ -767,20 +767,20 @@
       "failureCode": "interruption_injected",
       "metrics": {
         "childCpuMs": 5,
-        "childMaxRssBytes": 111280128,
+        "childMaxRssBytes": 111853568,
         "decodedBytes": 0,
         "durablePeakRssBytes": 0,
         "encodedBytes": 0,
-        "externalPeakRssBytes": 92684288,
+        "externalPeakRssBytes": 94175232,
         "externalRssSampleCount": 4,
         "externalRssSampleFailureCount": 0,
         "filesystem": {
-          "afterBytes": 556239,
-          "beforeBytes": 556427,
-          "sampledHighWaterBytes": 556427
+          "afterBytes": 556245,
+          "beforeBytes": 556433,
+          "sampledHighWaterBytes": 556433
         },
         "outputRecords": 0,
-        "parentElapsedMs": 166,
+        "parentElapsedMs": 167,
         "runCount": 2,
         "sourceBytes": 0,
         "sourceFiles": 0,
@@ -836,7 +836,7 @@
     "kind": "release_synthetic_semantics"
   },
   "protocolVersion": "g1-r7-release-evidence-v0.1",
-  "receiptSha256": "9a778ac5013f41a813f2e27a2a016b80ca3aa4c45c9413b721d58fe62983de10",
+  "receiptSha256": "cdfaa5d2e212bad434279dc04701da19695c7cf9f336a50de5feb42cfe50bbf1",
   "runtimeProvenance": {
     "architecture": "arm64",
     "elapsedClock": "parent_monotonic",

--- a/generated/r7-release-synthetic-semantics-node26.2.0-v0.1.json
+++ b/generated/r7-release-synthetic-semantics-node26.2.0-v0.1.json
@@ -482,7 +482,7 @@
     "resourcePolicyValuesSha256": "3cbe7853c8f75e96912885f64ba4ad1aeb13aff8a22e4ffbd51806b27c73b418",
     "schemaModuleSha256": "594d035e641e87b29db4027dca35157f8225fd5621816d67d5d9f25825468bbf",
     "workloadCodeFileCount": 359,
-    "workloadCodeSha256": "ea504fde37402622239d5405aa74c264b98a111c8da5b4031a0977fa5bd80741"
+    "workloadCodeSha256": "7a60f50547c7240e88357161542de2b6ceda3afecc004af776eaf6741e195772"
   },
   "determinism": {
     "comparisons": {
@@ -500,8 +500,8 @@
     "projectionVersion": "g1-r7-release-deterministic-projection-v0.1",
     "runCount": 2,
     "runProjectionSha256es": [
-      "524570722835ad060efe26b8e7819f4063bbbc0f641d545dd71bc0510699f2b8",
-      "524570722835ad060efe26b8e7819f4063bbbc0f641d545dd71bc0510699f2b8"
+      "4e0fe98fc0612ddeffd62d9f46c6157ff312e9f3f2027d79ff4f106a8ae1869b",
+      "4e0fe98fc0612ddeffd62d9f46c6157ff312e9f3f2027d79ff4f106a8ae1869b"
     ],
     "status": "passed"
   },
@@ -514,10 +514,10 @@
     {
       "failureCode": "none",
       "metrics": {
-        "childCpuMs": 77,
-        "childMaxRssBytes": 131055616,
+        "childCpuMs": 71,
+        "childMaxRssBytes": 130465792,
         "decodedBytes": 0,
-        "durablePeakRssBytes": 131055616,
+        "durablePeakRssBytes": 130449408,
         "encodedBytes": 0,
         "externalPeakRssBytes": 130449408,
         "externalRssSampleCount": 6,
@@ -525,15 +525,15 @@
         "filesystem": {
           "afterBytes": 200864,
           "beforeBytes": 160,
-          "sampledHighWaterBytes": 209742
+          "sampledHighWaterBytes": 200864
         },
         "outputRecords": 27,
-        "parentElapsedMs": 300,
+        "parentElapsedMs": 259,
         "runCount": 2,
         "sourceBytes": 154645,
         "sourceFiles": 14,
         "stderrBytes": 0,
-        "stdoutBytes": 1073
+        "stdoutBytes": 1072
       },
       "name": "source_scan",
       "projectionSha256": "9a32d3d160adf2c4f0f900f4583abf8c4b37c5460377fcdd74447945cfa9acd7",
@@ -542,13 +542,13 @@
     {
       "failureCode": "none",
       "metrics": {
-        "childCpuMs": 51,
-        "childMaxRssBytes": 130695168,
+        "childCpuMs": 48,
+        "childMaxRssBytes": 128942080,
         "decodedBytes": 0,
-        "durablePeakRssBytes": 161742848,
+        "durablePeakRssBytes": 169787392,
         "encodedBytes": 0,
-        "externalPeakRssBytes": 128565248,
-        "externalRssSampleCount": 5,
+        "externalPeakRssBytes": 107610112,
+        "externalRssSampleCount": 4,
         "externalRssSampleFailureCount": 0,
         "filesystem": {
           "afterBytes": 401568,
@@ -556,7 +556,7 @@
           "sampledHighWaterBytes": 401568
         },
         "outputRecords": 27,
-        "parentElapsedMs": 211,
+        "parentElapsedMs": 188,
         "runCount": 2,
         "sourceBytes": 154645,
         "sourceFiles": 14,
@@ -570,21 +570,21 @@
     {
       "failureCode": "none",
       "metrics": {
-        "childCpuMs": 162,
-        "childMaxRssBytes": 139657216,
+        "childCpuMs": 206,
+        "childMaxRssBytes": 139624448,
         "decodedBytes": 109963,
-        "durablePeakRssBytes": 139608064,
-        "encodedBytes": 32464,
+        "durablePeakRssBytes": 139591680,
+        "encodedBytes": 32469,
         "externalPeakRssBytes": 139591680,
-        "externalRssSampleCount": 22,
+        "externalRssSampleCount": 21,
         "externalRssSampleFailureCount": 0,
         "filesystem": {
-          "afterBytes": 554633,
+          "afterBytes": 554638,
           "beforeBytes": 401568,
-          "sampledHighWaterBytes": 554743
+          "sampledHighWaterBytes": 555905
         },
         "outputRecords": 27,
-        "parentElapsedMs": 1082,
+        "parentElapsedMs": 1060,
         "runCount": 2,
         "sourceBytes": 154645,
         "sourceFiles": 14,
@@ -592,27 +592,27 @@
         "stdoutBytes": 1223
       },
       "name": "export_set_materialize",
-      "projectionSha256": "d0604db98d792c5e10a057396c645bf6470b1ca812f52561b26dfcddbde2c196",
+      "projectionSha256": "27a05ec9f432a68cba3933063a1d1c834e6c42c8c1a0d1fa26fd9040e0205a99",
       "status": "completed"
     },
     {
       "failureCode": "none",
       "metrics": {
-        "childCpuMs": 42,
-        "childMaxRssBytes": 135069696,
+        "childCpuMs": 41,
+        "childMaxRssBytes": 134561792,
         "decodedBytes": 109963,
         "durablePeakRssBytes": 0,
-        "encodedBytes": 32464,
-        "externalPeakRssBytes": 100532224,
+        "encodedBytes": 32469,
+        "externalPeakRssBytes": 98549760,
         "externalRssSampleCount": 4,
         "externalRssSampleFailureCount": 0,
         "filesystem": {
-          "afterBytes": 554633,
-          "beforeBytes": 554633,
-          "sampledHighWaterBytes": 554633
+          "afterBytes": 554638,
+          "beforeBytes": 554638,
+          "sampledHighWaterBytes": 554638
         },
         "outputRecords": 27,
-        "parentElapsedMs": 174,
+        "parentElapsedMs": 171,
         "runCount": 2,
         "sourceBytes": 0,
         "sourceFiles": 0,
@@ -620,27 +620,27 @@
         "stdoutBytes": 997
       },
       "name": "export_set_verify",
-      "projectionSha256": "1d44bb7cf1841c949150c722d34718d53e435d50b82f57cd75599e4d553070f4",
+      "projectionSha256": "88e09e4eb59b93833ca1d9f95925647be0fa0e8dbc67661d5da29d7278242a37",
       "status": "completed"
     },
     {
       "failureCode": "none",
       "metrics": {
-        "childCpuMs": 146,
-        "childMaxRssBytes": 147423232,
+        "childCpuMs": 152,
+        "childMaxRssBytes": 145326080,
         "decodedBytes": 0,
         "durablePeakRssBytes": 0,
         "encodedBytes": 0,
-        "externalPeakRssBytes": 146980864,
+        "externalPeakRssBytes": 145211392,
         "externalRssSampleCount": 12,
         "externalRssSampleFailureCount": 0,
         "filesystem": {
           "afterBytes": 203384,
-          "beforeBytes": 556696,
-          "sampledHighWaterBytes": 556806
+          "beforeBytes": 556701,
+          "sampledHighWaterBytes": 556812
         },
         "outputRecords": 0,
-        "parentElapsedMs": 580,
+        "parentElapsedMs": 562,
         "runCount": 2,
         "sourceBytes": 0,
         "sourceFiles": 0,
@@ -648,27 +648,27 @@
         "stdoutBytes": 997
       },
       "name": "complete_set_delete",
-      "projectionSha256": "60f732f952e80497d873a4511e928e4ada204eed47dc29dd2838d3a4d516d3b4",
+      "projectionSha256": "4c80037bfcf4448a9089c6d0052ba1a6cc3dddf8617de764404773ef6fc20521",
       "status": "completed"
     },
     {
       "failureCode": "interruption_injected",
       "metrics": {
-        "childCpuMs": 33,
-        "childMaxRssBytes": 122617856,
+        "childCpuMs": 38,
+        "childMaxRssBytes": 121880576,
         "decodedBytes": 0,
         "durablePeakRssBytes": 0,
         "encodedBytes": 0,
-        "externalPeakRssBytes": 122486784,
+        "externalPeakRssBytes": 121815040,
         "externalRssSampleCount": 10,
         "externalRssSampleFailureCount": 0,
         "filesystem": {
-          "afterBytes": 556696,
-          "beforeBytes": 920780,
-          "sampledHighWaterBytes": 920780
+          "afterBytes": 556701,
+          "beforeBytes": 920790,
+          "sampledHighWaterBytes": 920790
         },
         "outputRecords": 0,
-        "parentElapsedMs": 438,
+        "parentElapsedMs": 433,
         "runCount": 2,
         "sourceBytes": 0,
         "sourceFiles": 0,
@@ -676,32 +676,32 @@
         "stdoutBytes": 1005
       },
       "name": "complete_set_delete_recovery",
-      "projectionSha256": "60f732f952e80497d873a4511e928e4ada204eed47dc29dd2838d3a4d516d3b4",
+      "projectionSha256": "4c80037bfcf4448a9089c6d0052ba1a6cc3dddf8617de764404773ef6fc20521",
       "status": "interrupted_recovered"
     },
     {
       "failureCode": "none",
       "metrics": {
-        "childCpuMs": 17,
-        "childMaxRssBytes": 122454016,
+        "childCpuMs": 15,
+        "childMaxRssBytes": 122355712,
         "decodedBytes": 0,
         "durablePeakRssBytes": 0,
         "encodedBytes": 0,
-        "externalPeakRssBytes": 122437632,
-        "externalRssSampleCount": 6,
+        "externalPeakRssBytes": 106708992,
+        "externalRssSampleCount": 4,
         "externalRssSampleFailureCount": 0,
         "filesystem": {
-          "afterBytes": 555166,
-          "beforeBytes": 722569,
-          "sampledHighWaterBytes": 722569
+          "afterBytes": 555171,
+          "beforeBytes": 722574,
+          "sampledHighWaterBytes": 722574
         },
         "outputRecords": 0,
-        "parentElapsedMs": 224,
+        "parentElapsedMs": 200,
         "runCount": 2,
         "sourceBytes": 0,
         "sourceFiles": 0,
         "stderrBytes": 0,
-        "stdoutBytes": 991
+        "stdoutBytes": 990
       },
       "name": "workspace_discard",
       "projectionSha256": "495426e69724d58733a4605ce62a0a9e61a094e67823671e64b872acf28bbea5",
@@ -711,20 +711,20 @@
       "failureCode": "interruption_injected",
       "metrics": {
         "childCpuMs": 13,
-        "childMaxRssBytes": 122290176,
+        "childMaxRssBytes": 122191872,
         "decodedBytes": 0,
         "durablePeakRssBytes": 0,
         "encodedBytes": 0,
-        "externalPeakRssBytes": 122273792,
-        "externalRssSampleCount": 5,
-        "externalRssSampleFailureCount": 1,
+        "externalPeakRssBytes": 106037248,
+        "externalRssSampleCount": 4,
+        "externalRssSampleFailureCount": 0,
         "filesystem": {
-          "afterBytes": 555699,
-          "beforeBytes": 724330,
-          "sampledHighWaterBytes": 724330
+          "afterBytes": 555704,
+          "beforeBytes": 724335,
+          "sampledHighWaterBytes": 724335
         },
         "outputRecords": 0,
-        "parentElapsedMs": 210,
+        "parentElapsedMs": 192,
         "runCount": 2,
         "sourceBytes": 0,
         "sourceFiles": 0,
@@ -739,20 +739,20 @@
       "failureCode": "none",
       "metrics": {
         "childCpuMs": 5,
-        "childMaxRssBytes": 120438784,
+        "childMaxRssBytes": 120193024,
         "decodedBytes": 0,
         "durablePeakRssBytes": 0,
         "encodedBytes": 0,
-        "externalPeakRssBytes": 103464960,
+        "externalPeakRssBytes": 107036672,
         "externalRssSampleCount": 4,
         "externalRssSampleFailureCount": 0,
         "filesystem": {
-          "afterBytes": 555969,
-          "beforeBytes": 556148,
-          "sampledHighWaterBytes": 556148
+          "afterBytes": 555974,
+          "beforeBytes": 556153,
+          "sampledHighWaterBytes": 556153
         },
         "outputRecords": 0,
-        "parentElapsedMs": 177,
+        "parentElapsedMs": 171,
         "runCount": 2,
         "sourceBytes": 0,
         "sourceFiles": 0,
@@ -767,20 +767,20 @@
       "failureCode": "interruption_injected",
       "metrics": {
         "childCpuMs": 5,
-        "childMaxRssBytes": 118276096,
+        "childMaxRssBytes": 118341632,
         "decodedBytes": 0,
         "durablePeakRssBytes": 0,
         "encodedBytes": 0,
-        "externalPeakRssBytes": 102498304,
+        "externalPeakRssBytes": 103153664,
         "externalRssSampleCount": 4,
         "externalRssSampleFailureCount": 0,
         "filesystem": {
-          "afterBytes": 556239,
-          "beforeBytes": 556427,
-          "sampledHighWaterBytes": 556427
+          "afterBytes": 556244,
+          "beforeBytes": 556432,
+          "sampledHighWaterBytes": 556432
         },
         "outputRecords": 0,
-        "parentElapsedMs": 168,
+        "parentElapsedMs": 162,
         "runCount": 2,
         "sourceBytes": 0,
         "sourceFiles": 0,
@@ -836,7 +836,7 @@
     "kind": "release_synthetic_semantics"
   },
   "protocolVersion": "g1-r7-release-evidence-v0.1",
-  "receiptSha256": "012565a67bc9bcb451eaaa0201e3027e628f1ab787700720c4dd69ce7762a0f5",
+  "receiptSha256": "b1649675c8d2ee1376250606efa84679cef3d438279e524c8e91dbf58656d296",
   "runtimeProvenance": {
     "architecture": "arm64",
     "elapsedClock": "parent_monotonic",

--- a/release-notes/0.1.17.md
+++ b/release-notes/0.1.17.md
@@ -1,17 +1,18 @@
 # TiboTattle 0.1.17
 
-**Status:** Candidate source notes for native dogfood. Integrated RC5 source
-produced signed, notarized, and installed build `1023.3`; physical testing then
-found that its five-minute ordinary refresh deadline stopped a legitimate full
-accounting-cache rebuild. Signed, notarized, and installed RC6 build `1023.4`
-proved that timeout correction, then exposed an inherited
-`recent_7d_indexing` legacy checkpoint suppressing otherwise-authoritative
-unified accounting. RC7 build `1023.5` is allocated to remove only that retired
-collector gate while preserving the fail-closed unified-generation authority
-check. RC7 still requires exact-source validation, protected R7 regeneration,
-signing, notarization, state-preserving installation, and installed native
-verification. No stable `v0.1.17` tag, GitHub release, published appcast, or RC7
-artifact is claimed yet.
+**Status:** Candidate source notes for native dogfood. RC7 source merge
+`87e07be350582713d815a21b4db470ed84aae037`, build `1023.5`, passed protected
+R7, the full source gate, Developer ID signing, notarization, stapling, and
+state-preserving installation. Its first installed refresh ingested unified
+index generation 44, then correctly withheld advanced accounting because the
+strict v0.14 cache validator found inconsistent fit metadata: an early
+diagnostic-only transition was excluded from the fit, but its eligibility was
+still projected onto a reset fitted from later eligible transitions. RC8 build
+`1023.6` is allocated for the narrow source
+correction. It keeps the strict validator and projects fit metadata from the
+first eligible row. RC8 has not yet completed fresh exact-source R7, artifact,
+installation, or physical verification. No stable `v0.1.17` tag, GitHub
+release, published appcast, or RC8 artifact is claimed yet.
 
 The native Mac app is easier to recover, clearer while it starts, and ready for
 the newer Codex history, plan, and quota formats already appearing in current
@@ -221,9 +222,9 @@ and Preview never opts into automatic updates.
 Internal dogfood is deliberately different: it keeps the stable bundle and
 local-state identity so it can test an in-place upgrade, while using its own
 update channel. Earlier 0.1.17 internal candidates used builds **1023**,
-**1023.1**, **1023.2**, **1023.3**, and **1023.4**. RC7 is allocated build
-**1023.5**, while **1024** remains reserved for the stable final, keeping stable
-ordered after the candidate. Signed tooling also requires a clean checkout and
+**1023.1**, **1023.2**, **1023.3**, **1023.4**, and **1023.5**. RC8 is
+allocated build **1023.6**, while **1024** remains reserved for the stable
+final, keeping stable ordered after the candidate. Signed tooling also requires a clean checkout and
 exactly one matching annotated source tag at `HEAD`: `v0.1.17` for stable, or
 the strict
 `tibotattle-internal-dogfood-0.1.17-rcN-source-YYYYMMDD` form for a dated
@@ -232,14 +233,16 @@ candidate.
 RC5 build `1023.3` is signed, notarized, and installed evidence only for its
 frozen source. It preserved schema-11 data and launched without an automatic
 Keychain prompt, but its full accounting-cache rebuild exceeded the ordinary
-five-minute refresh deadline. RC6 build `1023.4` then passed source, R7, signing,
-notarization, state-preserving replacement, and installed launch gates; its real
-refresh ran beyond five minutes and reached terminal success. That run exposed
-an older `recent_7d_indexing` checkpoint still withholding advanced accounting
-even though the unified generation itself was authoritative. RC7 removes only
-that retired checkpoint dependency. It does not relax
-`unifiedGenerationAuthoritative`, source completeness, generation matching, or
-atomic cache publication, and must repeat every exact-source and installed gate.
+five-minute refresh deadline. RC6 build `1023.4` then proved the extended
+deadline and exposed the retired `recent_7d_indexing` checkpoint. RC7 build
+`1023.5` removed that checkpoint and passed protected R7, the full source gate,
+signing, notarization, stapling, state-preserving replacement, and installed
+launch. Its first installed refresh ingested generation 44 before the v0.14
+cache validator rejected internally inconsistent fit metadata. RC8 keeps every
+fail-closed source, generation, resource, validation, and atomic-publication
+guard. It changes only fit-metadata projection to start at the first eligible
+row and must repeat every exact-source, R7, artifact, replacement, and installed
+gate.
 No 0.1.17 artifact has been published or made available through an updater.
 Browser rendering and compiled native tests do not prove physical popover
 interaction or thread-link handoff to Codex.

--- a/scripts/macos-bundle-version.js
+++ b/scripts/macos-bundle-version.js
@@ -20,11 +20,12 @@ export const MACOS_BUNDLE_VERSION_EPOCH = 2_000;
 // timestamp or environment-controlled counter.
 // The 0.1.17 RC2 used 1023, RC3 used 1023.1, installed startup-recovery RC4
 // used 1023.2, installed integrated RC5 used 1023.3, and installed accounting-
-// deadline RC6 used 1023.4. The retired-checkpoint correction uses monotonic
-// RC7 build 1023.5, preserving the allocated stable 1024 and upgrade ordering.
+// deadline RC6 used 1023.4, and the retired-checkpoint RC7 used 1023.5. The
+// fitted-transition correction uses monotonic RC8 build 1023.6, preserving the
+// allocated stable 1024 and upgrade ordering.
 export const SIGNED_MACOS_BUNDLE_VERSION_PLAN = Object.freeze({
   "0.1.17": Object.freeze({
-    "internal-dogfood": "1023.5",
+    "internal-dogfood": "1023.6",
     stable: "1024",
   }),
 });

--- a/src/reporting/weekly-calibration.js
+++ b/src/reporting/weekly-calibration.js
@@ -811,6 +811,7 @@ function summarizeResetGroup(rows) {
     observedSpanPp: percentages.length > 0 ? Math.max(...percentages) - Math.min(...percentages) : 0,
     interval: groupInterval(ordered),
     first: ordered[0],
+    firstEligible: eligible[0] ?? null,
   };
 }
 
@@ -1014,7 +1015,12 @@ export function analyzeWeeklyCalibration(
     (row.planType ?? "unknown") === selectedPlanType
   )));
   const resetFits = grouped.selected.map((group) => {
-    const first = group.first;
+    // A diagnostic-only transition may precede the clean observations that
+    // actually qualify this reset for a fit. Project the fit's identity and
+    // eligibility from its first admitted row; carrying metadata from the
+    // rejected row makes a valid estimate describe itself as diagnostic-only
+    // and correctly fail the bounded cache validator.
+    const first = group.firstEligible ?? group.first;
     const fits = Object.fromEntries(CANDIDATES.map((candidate) => [candidate.id, fitReset(group.rows, candidate)]));
     const lagFits = Object.fromEntries(LAG_CANDIDATES.map((candidate) => [candidate.id, fitReset(group.rows, candidate)]));
     return {

--- a/test/macos-app-bundle.test.js
+++ b/test/macos-app-bundle.test.js
@@ -4299,11 +4299,11 @@ test("development and preview builds treat the release-channel policy as optiona
 
 test("macOS release metadata validates versions, production mode, and Keychain references", async () => {
   assert.equal(normalizeMacOSBundleVersion(), DERIVED_MACOS_BUNDLE_VERSION);
-  assert.equal(INTERNAL_DOGFOOD_SIGNED_BUNDLE_VERSION, "1023.5");
+  assert.equal(INTERNAL_DOGFOOD_SIGNED_BUNDLE_VERSION, "1023.6");
   assert.equal(STABLE_SIGNED_BUNDLE_VERSION, "1024");
   assert.equal(
     normalizeMacOSBundleVersion(INTERNAL_DOGFOOD_SIGNED_BUNDLE_VERSION),
-    "1023.5",
+    "1023.6",
   );
   assert.equal(
     compareMacOSBundleVersions(
@@ -4338,13 +4338,18 @@ test("macOS release metadata validates versions, production mode, and Keychain r
     "the retired-checkpoint correction must be strictly newer than installed RC6",
   );
   assert.equal(
+    compareMacOSBundleVersions("1023.5", INTERNAL_DOGFOOD_SIGNED_BUNDLE_VERSION),
+    -1,
+    "the fitted-transition correction must be strictly newer than installed RC7",
+  );
+  assert.equal(
     compareMacOSBundleVersions(
       STABLE_SIGNED_BUNDLE_VERSION,
       INTERNAL_DOGFOOD_SIGNED_BUNDLE_VERSION,
     ) > 0,
     true,
   );
-  for (const unallocated of ["1023", "1023.0", "1023.1", "1023.1.0", "1023.2", "1023.2.0", "1023.3", "1023.3.0", "1023.4", "1023.4.0", "1023.5.0", "1024", "2000.1.17"]) {
+  for (const unallocated of ["1023", "1023.0", "1023.1", "1023.1.0", "1023.2", "1023.2.0", "1023.3", "1023.3.0", "1023.4", "1023.4.0", "1023.5", "1023.5.0", "1023.6.0", "1024", "2000.1.17"]) {
     assert.throws(
       () => readMacOSReleaseBuildConfiguration({
         USAGE_MONITOR_BUNDLE_VERSION: unallocated,

--- a/test/replay-safe-accounting-cache.test.js
+++ b/test/replay-safe-accounting-cache.test.js
@@ -1342,6 +1342,95 @@ test("the same lineage-aware scan produces a bounded weekly calibration summary"
   assert.equal(cache.weeklyCalibration.composition.capacityUsdByModel, null);
 });
 
+test("refresh publishes a fitted reset after an earlier diagnostic-only transition", async (t) => {
+  const directory = await mkdtemp(join(
+    tmpdir(),
+    "usage-monitor-diagnostic-first-calibration-",
+  ));
+  t.after(() => rm(directory, { recursive: true, force: true }));
+  const stateFile = join(directory, "local-collector-state-v1.sqlite");
+  const startMs = Date.parse("2026-08-01T00:00:00.000Z");
+  const stamp = (seconds) => new Date(startMs + seconds * 1_000).toISOString();
+  const resetsAt = Math.floor(
+    (startMs + 7 * 24 * 60 * 60 * 1_000) / 1_000,
+  );
+  const snapshots = [
+    weeklySnapshot({
+      timestamp: stamp(0),
+      usedPercent: 0,
+      planType: "pro",
+      resetsAt,
+    }),
+    weeklySnapshot({
+      timestamp: stamp(10),
+      usedPercent: 1,
+      planType: "pro",
+      resetsAt,
+    }),
+    ...Array.from({ length: 9 }, (_, boundary) => weeklySnapshot({
+      timestamp: stamp(20 + boundary * 10),
+      usedPercent: boundary,
+      planType: "plus",
+      resetsAt,
+    })),
+  ];
+  const events = Array.from({ length: 8 }, (_, index) => ({
+    ...usageEvent({
+      timestamp: stamp(25 + index * 10),
+      components: {
+        input_uncached_tokens: index === 0 ? 100_000_000 : 1_000_000,
+      },
+    }),
+    planAttribution: {
+      basis: "same_record",
+      planType: "plus",
+      planVariant: null,
+    },
+    // The first Plus quantity interval begins during the preceding Pro era,
+    // so the real transition miner makes only that row diagnostic. Every
+    // later interval starts inside the Plus era and remains fit-eligible.
+    usageIntervalStartedAt: stamp(index === 0 ? 9 : 21 + index * 10),
+    usageIntervalBasis: "previous_session_record",
+  }));
+
+  const written = await refreshReplaySafeAccountingCache({
+    cacheFile: stateFile,
+    now: () => startMs + 12 * 60 * 60 * 1_000,
+    windowDays: 365,
+    scan: async ({ onUsage, onRateLimitSnapshot }) => {
+      for (const event of events) onUsage(event);
+      for (const snapshot of snapshots) onRateLimitSnapshot(snapshot);
+      return { diagnostics: {} };
+    },
+  });
+
+  assert.doesNotThrow(() => assertReplaySafeAccountingCache(written));
+  const read = await readReplaySafeAccountingCache({
+    cacheFile: stateFile,
+    now: () => startMs + 12 * 60 * 60 * 1_000,
+  });
+  assert.equal(read.status, "available");
+  assert.equal(read.errorCode, null);
+  assert.deepEqual(read.cache, written);
+
+  const projections = [
+    written.weeklyCalibration,
+    ...Object.values(written.allowanceCapacityByScenario.scenarios)
+      .map((scenario) => scenario.calibration),
+  ];
+  for (const projection of projections) {
+    assert.equal(projection.selectedPlanType, "plus");
+    assert.equal(projection.status, "estimated");
+    assert.equal(projection.estimate.qualifyingResets, 1);
+    assert.equal(projection.recentResets.length, 1);
+    assert.equal(projection.recentResets[0].eligibleTransitions, 7);
+    assert.equal(
+      projection.recentResets[0].aggregationEligibility,
+      "primary_conditional",
+    );
+  }
+});
+
 test("a mix-varied corpus yields a fitted per-model composition that survives the cache round trip", async () => {
   const directory = await mkdtemp(join(tmpdir(), "composition-cache-"));
   const stateFile = join(directory, "collector-state-v1.sqlite");

--- a/test/weekly-calibration.test.js
+++ b/test/weekly-calibration.test.js
@@ -6,6 +6,7 @@ import {
   BOUNDED_WEEKLY_CALIBRATION_RESET_LIMIT,
   projectBoundedWeeklyCalibrationSummary,
   renderWeeklyCalibrationReport,
+  validWeeklyPlanPopulations,
 } from "../src/reporting/index.js";
 import { verifyWeeklyCalibration } from "../src/verify-weekly-calibration.js";
 
@@ -204,6 +205,53 @@ test("mixed-plan summaries retain legacy evidence without pooling plan medians",
   assert.equal(result.planAttribution.accountVerified, false);
   const selectedPro = projectBoundedWeeklyCalibrationSummary(dataset([...pro, ...plus]), { planType: "pro" });
   assert.equal(selectedPro.estimate.medianApiPriceEquivalentUsd, 1_600);
+});
+
+test("bounded summaries describe a fit from its first eligible transition", () => {
+  const reset = Math.floor(Date.parse("2026-08-20T00:00:00.000Z") / 1_000);
+  const diagnosticJumpUsd = 5_994;
+  const transitions = resetTransitions({ reset }).slice(0, 8).map((row, index) => ({
+    ...row,
+    // The rejected first interval contains a large attribution-uncertain
+    // cost jump. Later admitted intervals continue from that ledger value at
+    // the ordinary $600/100pp slope. If the first row ever leaks into the
+    // fit, its outlying boundary makes the counterfactual projection fail
+    // instead of coincidentally retaining the expected headline.
+    lastPriorCumulativeApiPricedUsd:
+      row.lastPriorCumulativeApiPricedUsd + (index === 0 ? 0 : diagnosticJumpUsd),
+    firstNextCumulativeApiPricedUsd:
+      row.firstNextCumulativeApiPricedUsd + diagnosticJumpUsd,
+    lastPriorCumulativeQuotaWeightedLowerUsd:
+      row.lastPriorCumulativeQuotaWeightedLowerUsd + (index === 0 ? 0 : diagnosticJumpUsd),
+    firstNextCumulativeQuotaWeightedLowerUsd:
+      row.firstNextCumulativeQuotaWeightedLowerUsd + diagnosticJumpUsd,
+    lastPriorCumulativeQuotaWeightedUpperUsd:
+      row.lastPriorCumulativeQuotaWeightedUpperUsd + (index === 0 ? 0 : diagnosticJumpUsd),
+    firstNextCumulativeQuotaWeightedUpperUsd:
+      row.firstNextCumulativeQuotaWeightedUpperUsd + diagnosticJumpUsd,
+    aggregationEligibility: index === 0
+      ? "diagnostic_only"
+      : "primary_conditional",
+  }));
+
+  const summary = projectBoundedWeeklyCalibrationSummary(dataset(transitions));
+
+  assert.equal(summary.status, "estimated");
+  assert.equal(summary.estimate.medianApiPriceEquivalentUsd, 600);
+  assert.equal(summary.recentResets[0].eligibleTransitions, 7);
+  assert.equal(
+    summary.recentResets[0].aggregationEligibility,
+    "primary_conditional",
+  );
+  assert.equal(validWeeklyPlanPopulations(summary), true);
+
+  const accidentallyAdmitted = projectBoundedWeeklyCalibrationSummary(dataset(
+    transitions.map((row, index) => index === 0
+      ? { ...row, aggregationEligibility: "primary_conditional" }
+      : row),
+  ));
+  assert.equal(accidentallyAdmitted.status, "insufficient_evidence");
+  assert.equal(accidentallyAdmitted.estimate, null);
 });
 
 test("a newly observed plan without a fit never borrows an older plan's headline", () => {


### PR DESCRIPTION
## Summary\n\n- project fitted reset metadata from the first eligible reset row, preserving diagnostic-only leading history without invalidating strict v0.14 accounting caches\n- add unit and end-to-end refresh -> SQLite -> strict-read regressions for the RC7 failure boundary\n- allocate internal-dogfood RC8 build 1023.6 and refresh maintained release records\n- regenerate and validate all ten protected R7 receipts on the frozen RC8 source\n\n## Validation\n\n- focused accounting/calibration: 88/88\n- documentation/preflight: 20/20\n- architecture: 382 production files, 1,538 imports, zero approved debt\n- protected R7: all synthetic/materialized phases passed on Node 24.14.0 and 26.2.0; paired real-history phase passed; retained freshness 2/2\n- R7 workload: 359 files, SHA-256 7a60f50547c7240e88357161542de2b6ceda3afecc004af776eaf6741e195772\n- exact-source full npm run check: exit 0\n- independent code-quality and test/documentation re-audits: no remaining findings\n\n## Release boundary\n\nThis prepares an internal 0.1.17 RC8 dogfood only. The formal PR #94 fixed-real-corpus before/after comparator remains **OPEN / NOT RUN** and continues to block stable/public qualification. R7 is not a substitute for that comparator.\n\nNo Worker deployment, hosted migration, contribution pairing, appcast publication, stable tag, GitHub release, Homebrew publication, or public release is authorized by this PR. Signed artifact construction, state-preserving installation, installed refresh validation, and physical two-limit popover QA remain post-merge gates.