### PR TITLE
Prepare native 0.1.17 qualification and packaging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,10 +34,24 @@ remains accountable for release wording, validation, signing, and publication.
 
 ## [Unreleased]
 
-**Candidate notes:** [0.1.17](./release-notes/0.1.17.md)
+Future changes will be recorded here.
 
-This candidate section combines direct post-v0.1.16 work with reviewed merged
-pull requests, including [PR #80](https://github.com/adamallcock/tibotattle/pull/80),
+## [0.1.17](./release-notes/0.1.17.md) - 2026-09-03
+
+**Provenance:** [GitHub release](https://github.com/adamallcock/tibotattle/releases/tag/v0.1.17) ·
+[annotated source tag](https://github.com/adamallcock/tibotattle/tree/v0.1.17) ·
+[changes since v0.1.16](https://github.com/adamallcock/tibotattle/compare/v0.1.16...v0.1.17) ·
+[accepted runtime basis](https://github.com/adamallcock/tibotattle/commit/394c8a03a986e0daadbe662679fd002202682e44)
+
+Stable product build `1024` uses accepted runtime basis
+`394c8a03a986e0daadbe662679fd002202682e44`; internal RC9 `1023.7` was the
+preceding dogfood allocation. PR #94 outcome is `passed_with_historical_artifact_refusal`; see the
+[qualification receipt](./docs/receipts/2026-09-03-pr94-account-plan-attribution-qualification.md).
+The manual clean-profile and physical Login Item matrix remains deferred; see
+the [native release plan](./docs/plans/2026-09-03-public-0.1.17-release.md).
+Hosted migrations and device pairing are not activated by the desktop release.
+
+This entry combines direct post-v0.1.16 work with reviewed merges in [PR #80](https://github.com/adamallcock/tibotattle/pull/80),
 [PR #83](https://github.com/adamallcock/tibotattle/pull/83),
 [PR #84](https://github.com/adamallcock/tibotattle/pull/84),
 [PR #85](https://github.com/adamallcock/tibotattle/pull/85),
@@ -50,19 +64,14 @@ pull requests, including [PR #80](https://github.com/adamallcock/tibotattle/pull
 [PR #94](https://github.com/adamallcock/tibotattle/pull/94),
 [PR #95](https://github.com/adamallcock/tibotattle/pull/95), and
 [PR #96](https://github.com/adamallcock/tibotattle/pull/96).
-PRs #73 and #74 are not part of this native macOS candidate. PR #75
-is not merged wholesale; a native subset of its menu-bar and weekly-pace work
-is ported without its Electron or multi-root changes. Separately, this candidate
-advances the local index to schema 11 only for the measured cleanup-index fix;
-it does not import PR #75's broader schema work. The candidate does not include
-the Electron application or unfinished Claude Code usage-monitoring integration
-work. Claude-related carryover is limited to dormant local/export compatibility
-scaffolding already on `main` and removal of the inactive quota route; 0.1.17
-does not collect, display, or claim Claude Code usage. The
-[merged-main comparison](https://github.com/adamallcock/tibotattle/compare/v0.1.16...main)
-is the public branch-history view; PR links identify reviewed merges, while
-unlinked items are direct commits. Nothing in this section is a
-published-release claim.
+PRs #73 and #74 are not part of this native macOS release. PR #75 is not
+merged wholesale; a native subset of its menu-bar and weekly-pace work is
+ported without its Electron or multi-root changes. The release does not
+include the Electron application or unfinished Claude Code usage-monitoring
+integration; 0.1.17 does not collect, display, or claim Claude Code usage.
+The [merged-main comparison](https://github.com/adamallcock/tibotattle/compare/v0.1.16...main)
+provides public branch-history context; PR links identify reviewed merges, while
+unlinked items are direct commits.
 
 ### Added
 
@@ -282,29 +291,14 @@ published-release claim.
 - Gives Preview its own app, bundle, semantic-open, local-state, Keychain,
   preferences, and Sparkle-feed identities, preventing preview installation or
   updates from replacing stable state.
-- Records builds 1023, 1023.1, 1023.2, 1023.3, 1023.4, and 1023.5 as earlier
-  0.1.17 internal dogfoods, records RC8 as build 1023.6, allocates build 1023.7
-  to corrective RC9, and retains build 1024 for stable.
-  Signed tooling requires a clean checkout with exactly one matching annotated
-  channel tag at `HEAD` before it can proceed. RC5 build 1023.3 is signed,
-  notarized, and installed evidence for its frozen source, but physical testing
-  found that its ordinary five-minute refresh deadline stopped a legitimate
-  full accounting-cache rebuild. RC6 build 1023.4 subsequently proved that
-  timeout correction in a signed, notarized, installed refresh, but exposed an
-  inherited `recent_7d_indexing` legacy checkpoint suppressing otherwise-
-  authoritative unified accounting. RC7 removes only that retired collector
-  gate and subsequently passed its protected R7, full source gate, Developer ID
-  signing, notarization, stapling, and state-preserving installation gates. Its
-  first installed refresh ingested unified-index generation 44, but the strict
-  v0.14 cache validator rejected accounting because the projection copied an
-  excluded diagnostic-only row's eligibility onto a reset fitted from later
-  eligible transitions. RC8 retains that strict validator and projects fit
-  metadata from the first eligible row. RC9 combines manual quota and detailed
-  accounting refresh in one action, keeps automatic quota checks light, bounds
-  automatic deep attempts to once per hour, restores
-  authoritative snapshot persistence, and supplies a scope-bound selected-plan
-  Trends lane. RC9 still requires fresh exact-source R7, artifact, install, and
-  physical verification; earlier candidates do not qualify these corrections.
+- Records the stable build-1024 release allocation and accepted runtime basis
+  `394c8a03a986e0daadbe662679fd002202682e44`; internal RC9 build `1023.7` was
+  the preceding dogfood allocation. Signed tooling requires a clean checkout
+  with exactly one matching annotated channel tag at `HEAD` before it can
+  proceed. The release retains the fail-closed source, generation, resource,
+  validation, atomic-publication, selected-plan Trends, and snapshot safeguards.
+  PR #94 outcome is `passed_with_historical_artifact_refusal` in the [qualification
+  receipt](./docs/receipts/2026-09-03-pr94-account-plan-attribution-qualification.md).
 - Establishes scoped, machine-checked repository guidance for coding agents and
   the root layout they may extend
   ([PR #77](https://github.com/adamallcock/tibotattle/pull/77)).

--- a/apps/macos/README.md
+++ b/apps/macos/README.md
@@ -430,38 +430,21 @@ a claim that Sparkle has updated the preview client.
 
 `CFBundleShortVersionString` remains the user-facing package version. The
 Sparkle ordering key, `CFBundleVersion`, is explicitly allocated for signed
-builds that retain the stable bundle identifier. The 0.1.17 internal-dogfood
-RC9 build allocation is `1023.7`; the 0.1.17 stable final remains `1024`. This
-candidate orders strictly after RC8 `1023.6`, installed RC7 `1023.5`, RC6 `1023.4`,
-integrated RC5 `1023.3`, startup-recovery RC4 `1023.2`, migration RC3
-`1023.1`, retained RC2 `1023`, and earlier shared-identity dogfood `1022`,
-while stable orders after the dogfood candidate.
-A future signed version/channel must add a reviewed
-monotonic allocation before release tooling will run.
+builds that retain the stable bundle identifier. The 0.1.17 stable allocation
+uses build `1024` and accepted runtime basis
+`394c8a03a986e0daadbe662679fd002202682e44`; internal RC9 build `1023.7` was the
+preceding dogfood allocation. The exact source provenance is the annotated
+[`v0.1.17` tag](https://github.com/adamallcock/tibotattle/tree/v0.1.17). A future
+signed version/channel must add a reviewed monotonic allocation before release
+tooling will run.
 
-Installed RC6 proved that the cold-accounting lifetime can safely exceed the
-ordinary five-minute refresh deadline. Its real refresh then exposed the
-inherited `recent_7d_indexing` legacy checkpoint suppressing otherwise-
-authoritative unified accounting. RC7 removed only that retired collector gate
-and passed protected R7, the full source gate, signing, notarization, stapling,
-and state-preserving installation. Its first installed refresh ingested
-generation 44, then the strict v0.14 cache validator rejected inconsistent fit
-metadata. The fit correctly excluded an early diagnostic-only transition, but
-the projection copied that rejected row's eligibility onto the reset fitted from
-later eligible transitions. RC8 source retains the strict validator and projects
-fit metadata from the first eligible row.
-
-RC9 source is under validation on base `35802d21ede67d362533f4e2be6b38041ece1cda`.
-It keeps startup and frequent automatic quota checks quick, makes the single
-manual Refresh action update detailed accounting too, bounds automatic detailed
-attempts to at most hourly, reconciles native refresh
-completion from the controller, and restores selected-plan Trends with matching
-plan-scoped usage plus retained authoritative snapshots across relaunch. The
-allocation is not artifact or installed-app evidence: exact-source gates,
-protected R7, signing, notarization, state-preserving replacement, installed
-refresh, and physical verification remain required. PR #94's real-corpus
-comparator remains **OPEN / NOT RUN**; compatible hosted migrations/deployment
-and end-to-end device pairing remain a separate open gate.
+Earlier RCs are historical qualification evidence only. The build-1024
+release retains the fail-closed source, generation, resource, validation,
+atomic-publication, selected-plan Trends, and snapshot safeguards. PR #94
+outcome is `passed_with_historical_artifact_refusal` in the
+[qualification receipt](../../docs/receipts/2026-09-03-pr94-account-plan-attribution-qualification.md).
+Hosted migrations and end-to-end device pairing are not activated by the
+desktop release.
 
 Release tooling accepts `USAGE_MONITOR_BUNDLE_VERSION` only when it exactly
 matches the checked-in channel allocation, and the signed stable path still
@@ -681,6 +664,14 @@ The automated validator proves the bundle and Gatekeeper contract on the build
 Mac with an empty temporary home. It also runs the packaged Login Item contract
 smoke against an injected fake manager; that check makes zero real
 ServiceManagement calls. It is not a substitute for a truly clean machine.
+The manual clean-profile and physical Login Item matrix remains deferred; see
+the [native release plan](../../docs/plans/2026-09-03-public-0.1.17-release.md).
+
+For Finder metadata, inspect the app directly on the final frozen DMG, read-only,
+after stapling. Derive the expected timestamp from the sealed source commit in
+`build-manifest.json`, then compare the outer bundle's creation and modification
+dates with that source-derived value. The isolated `ditto` copy used for
+clean-profile smoke is not evidence of mounted-volume Finder metadata.
 
 Before sending the DMG to any external user, perform a human clean-Mac or
 disposable-VM rehearsal:

--- a/apps/macos/README.md
+++ b/apps/macos/README.md
@@ -528,6 +528,13 @@ accepts only `vX.Y.Z` matching the short version. Internal dogfood accepts only
 non-zero-padded `N` and a real calendar date. Lightweight tags, aliases, wrong
 versions, and multiple matching channel tags at HEAD fail closed.
 
+External-release bundles set only the outer `.app` Finder creation and
+modification dates from the sealed source commit's Git committer timestamp.
+Payload files retain the fixed epoch used for reproducible inventories, and the
+DMG packager reapplies the same source-bound dates after staging. This
+filesystem metadata is outside the signed and inventoried payload; no build-host
+wall clock is used for it.
+
 ## Developer ID and notarization
 
 The release operator must first make a `Developer ID Application` identity

--- a/docs/current-status.md
+++ b/docs/current-status.md
@@ -1,10 +1,10 @@
 ---
 title: Current product and release status
-date: 2026-09-02
+date: 2026-09-03
 type: status
 status: current
-source_commit: 35802d21ede67d362533f4e2be6b38041ece1cda
-observation_date: 2026-09-02
+source_commit: 9494c0776892127284fca744a304cc3c0c58bdf3
+observation_date: 2026-09-03
 ---
 
 # Current product and release status
@@ -18,11 +18,11 @@ using this page for a later release or operational decision.
 
 | Boundary | Verified state |
 |---|---|
-| Documentation/source review | Base `35802d21ede67d362533f4e2be6b38041ece1cda`, reviewed 2026-09-02; local RC9 corrections and build `1023.7` allocation are under validation, not frozen or artifact-qualified |
-| Installed internal dogfood | App metadata observed 2026-09-02: version `0.1.17`, RC8 build `1023.6`. This read-only plist observation does not requalify its signature, source, or runtime. RC9 has not replaced it |
+| Documentation/source review | Release-preparation source `9494c0776892127284fca744a304cc3c0c58bdf3`, reviewed 2026-09-03; product runtime is unchanged from PR #102 merge `394c8a03a986e0daadbe662679fd002202682e44` |
+| Installed internal dogfood | Version `0.1.17`, RC9 build `1023.7`, source `394c8a03`; owner accepted the inspected apps on 2026-09-03. Plist version/build/minimum-OS were independently rechecked; this does not qualify every historical credential or clean-profile case |
 | Public service | Read-only `GET https://tibotattle.com/api/health`, HTTP 200, deployment source `304f3d736b6f9451d32a616bf3046ea628e828a3`, observed 2026-08-31 |
-| Public updater | Read-only `GET https://updates.tibotattle.com/appcast.xml`, observed 2026-08-27 |
-| Published release | GitHub release API for `adamallcock/tibotattle`, observed 2026-08-27 |
+| Public updater | Stable `0.1.16`; read-only feed check recorded 2026-09-03 in the release plan |
+| Published release | Immutable GitHub `v0.1.16`, exact five-asset set rechecked 2026-09-03; `v0.1.17` is not yet published at this snapshot |
 
 This is a snapshot, not an automatic monitor. A newer commit, deployment, feed,
 or release makes the corresponding row stale without changing the other rows.
@@ -109,74 +109,45 @@ point-in-time evidence only.
 The complete qualification matrix and rules for changing these claims are in
 [platform-support.md](./reference/platform-support.md).
 
-## Known boundaries
+## Release qualification and known boundaries
 
-- The checked-out source contains unreleased changes after `v0.1.16`; the
-  [changelog](../CHANGELOG.md) records them without claiming they shipped.
-- Integrated RC5 source `ff506dc3`, build `1023.3`, was signed, notarized and
-  installed on 2026-08-31. Its state-preserving replacement and first launch
-  passed, but its real full-accounting refresh did not: a healthy v0.14 rebuild
-  was terminated by the ordinary five-minute deadline. That evidence remains
-  specific to RC5.
-- RC6 source `e59115d41958f6b23496a65c9732a6a9944fdde0`, build `1023.4`,
-  subsequently passed its source gates, protected R7, Developer ID signing,
-  notarization, stapling, Gatekeeper, state-preserving replacement, and installed
-  launch without an observed Keychain prompt. Its real refresh ran past five
-  minutes and reached terminal success, proving the deadline correction. The
-  installed result then exposed an inherited `recent_7d_indexing` legacy
-  checkpoint suppressing otherwise-authoritative unified accounting. RC6 is
-  therefore not the final dogfood handoff.
-- RC7 source merge `87e07be350582713d815a21b4db470ed84aae037`, build
-  `1023.5`, removed only that retired collector checkpoint and subsequently
-  passed protected R7, the full source gate, Developer ID signing, notarization,
-  stapling, Gatekeeper, state-preserving replacement, and installation. Its
-  first installed refresh ingested unified-index generation 44, then correctly
-  withheld advanced accounting when the strict v0.14 cache validator found
-  inconsistent fit metadata. The fit correctly excluded an early
-  diagnostic-only transition, but the projection copied that rejected row's
-  eligibility onto the reset fitted from later eligible transitions.
-- RC8 source retains the strict validator and projects reset fit metadata from
-  the first eligible row. Its prior allocation was `1023.6`; the reviewed source
-  base for this update is `35802d21ede67d362533f4e2be6b38041ece1cda`.
-- RC9 reserves monotonic build `1023.7`, strictly after RC8 and before stable
-  `1024`. Its source is under validation: a single manual Refresh updates quota
-  and detailed accounting, while startup and frequent automatic checks collect
-  quick quota/headline evidence; automatic detailed attempts are at most hourly and count failed or
-  interrupted requests. Native polling uses controller mode/start receipts and
-  terminal-state fencing, so browser-started work shares the cadence and stale
-  pre-start replies cannot settle a new request. Trends pairs the selected
-  plan's fit with its source-bound usage, preserves established speed evidence
-  with the reviewed Standard fallback, and keeps all-plan accounting separate.
-  Authoritative dashboard snapshots use the current production shape so they
-  can be retained across relaunch. These are source changes, not evidence of a
-  built, installed, or passing RC9. Fresh exact-source R7, the complete source
-  gate, signed/notarized/stapled artifact, state-preserving replacement,
-  installed refresh, and physical native checks remain required.
-- The RC7 R7 workload-source closure has protected dual-runtime receipts for
-  359 files / workload SHA-256
-  `ea504fde37402622239d5405aa74c264b98a111c8da5b4031a0977fa5bd80741`.
-  Both decisions remain honestly `release_open`. Native UI and build-allocation
-  files remain subject to their separate macOS source, smoke, signed-artifact,
-  and installed-artifact gates.
-- The public service and release feed are remote state. Their health and
-  availability can change after this snapshot.
-- Public health is not proof that every admin, identity, contribution, deletion,
-  or updater path works end to end.
-- PR #94's fixed-real-corpus before/after coverage, diagnostic-distribution, and
-  resource comparator remains **OPEN / NOT RUN**. Current APIs cannot emit the
-  complete named fit-rejection reconciliation, so R7 cannot be used as a
-  substitute. An explicitly open-gate internal dogfood may proceed for testing,
-  but this blocks stable and public 0.1.17 qualification until it is closed or
-  deliberately resolved. The exact RC9 native artifact must separately pass
-  signing, notarization, state-preserving installation, updater, and physical
-  native checks. Pairing continuity needs compatible hosted Worker migrations
-  and deployment before the repaired desktop flow can be validated end to end.
-- An owner-only fixed-window attempt on 2026-08-31 failed closed before comparison:
-  the strict pre-PR scan reported `codex_rollout_content_invalid`. The supported
-  resource benchmark independently stopped at `benchmark_cold_rebuild_incomplete`
-  on both exact PR #94 revisions. No empirical comparison receipt was produced,
-  no source was excluded, and this does not constitute a run of the formal
-  comparator. Its **OPEN / NOT RUN** state remains a stable/public gate.
+- The [public-release plan](./plans/2026-09-03-public-0.1.17-release.md)
+  tracks final build `1024`, exact signed-artifact and prior-stable replacement
+  checks, immutable GitHub publication, Sparkle, and Homebrew independently.
+  Source preparation and a dated changelog are not publication evidence.
+- The accepted RC9 runtime has one manual Refresh for quota and detailed
+  accounting, quick startup/automatic checks, at-most-hourly automatic detailed
+  attempts, selected-plan Trends, retained authoritative snapshots, and the
+  measured accounting optimization. The
+  [performance receipt](./receipts/2026-09-03-optimized-rc9-accounting-comparison.md)
+  measures the accounting child, not end-to-end refresh latency.
+- PR #94's local qualification passed with the historical artifact refusal
+  explicitly recorded; the final candidate passes its strict cache validator. The
+  [local qualification receipt](./receipts/2026-09-03-pr94-account-plan-attribution-qualification.md)
+  binds the exact before, after, and final revisions to one immutable admitted
+  index. Its scope is accounting, attribution, calibration, and isolated-child
+  resources; it does not prove raw ingestion, account-exact identity, hosted
+  activation, or installed native lifecycle behavior.
+- The earlier 2026-08-31 raw-source attempt failed closed at
+  `codex_rollout_content_invalid` / `benchmark_cold_rebuild_incomplete` and
+  produced no comparison receipt. Later admitted-index qualification does not
+  relabel that attempt as passed or establish repair of its raw sources.
+- Retained dual-runtime R7 receipts bind workload SHA-256
+  `371af38d9066d4fd2d605efee1bc83a8618f20bb72403e4c9f80410d81b18299`.
+  Their decisions remain `release_open`, not a claim that every native or
+  publication gate passed. Release-tooling changes do not require regeneration
+  when the protected workload and freshness checks remain unchanged.
+- Following the owner's 2026-09-03 confidence-based release direction, the full
+  clean-profile/physical Login Item matrix is deferred for 0.1.17, not passed.
+  The release still stops for data loss, invalid signatures or updater bytes,
+  and unexpected Keychain prompts. Isolated-profile and fake-manager smokes
+  do not establish the deferred manual evidence.
+- Hosted migrations/deployment, plan-transport consent activation, and repaired
+  device pairing remain separate. Website validator backport/deployment is
+  separately held; publishing the desktop must not deploy current-main Worker
+  code or mutate hosted data.
+- Remote health and availability can change after this snapshot. Public health
+  is not proof of every admin, identity, contribution, deletion, or updater path.
 
 ## How to refresh this page
 

--- a/docs/plans/2026-09-03-public-0.1.17-release.md
+++ b/docs/plans/2026-09-03-public-0.1.17-release.md
@@ -272,3 +272,28 @@ before/after runtime and lock equality remains mandatory; final runtime, lock,
 source and filesystem identity digests must instead match its own two strict
 production probes. Add the missing final-runtime regression, commit the fix,
 and repeat the entire private run; the rejected assembly is not a receipt.
+
+Run 4 on `96c7487b` again completed all three semantic lanes and all six
+production-child runs, then refused the enclosing receipt. Independent review
+identified a different count-unit error: matrix cells combine multiple parents
+with the same per-parent outcome signature, but the validator compared that
+per-parent outcome count with the accumulated whole-cell primary-fit count.
+Require exact equality between the whole-cell primary count and the number of
+parents multiplied by the signature's primary-only count; diagnostic outcomes
+cannot justify a primary fit. Add multi-parent regressions and validate the
+same semantic projection before the expensive resource runs as well as in the
+final receipt. No product calculation or cache validator changes, and no
+failed assembly becomes release evidence.
+
+The owner reiterated that release confidence, not exhaustive validation
+perfection, is the objective. Keep this correction bounded, finish the existing
+data-conservation and signed-artifact/upgrade checks, and avoid adding
+speculative validation work. Following that direction, the coordinator's release
+basis is the owner's accepted dogfood runtime, targeted regressions, and fresh
+signed final-artifact/upgrade verification. The full clean-profile/physical
+Login Item matrix is explicitly deferred for 0.1.17, not passed; automated
+isolated-profile and fake-manager checks do not establish that manual evidence.
+This release-specific risk decision does not relax data-conservation, signature,
+updater-integrity, or unexpected-Keychain-prompt stop conditions, and does not
+authorize hosted migrations, protocol activation, or the separately held website
+validator backport/deployment.

--- a/docs/plans/2026-09-03-public-0.1.17-release.md
+++ b/docs/plans/2026-09-03-public-0.1.17-release.md
@@ -45,7 +45,7 @@ require freshly bound artifact evidence; never patch an already signed DMG.
   Finder inspection remains part of signed-artifact qualification.
 - [ ] Exact previous-stable compatibility fix and refusal tests reviewed and
   integrated; actual 0.1.16-to-final-stable replacement validation passes.
-- [ ] PR #94 fixed-real-corpus empirical gate closed. On 2026-09-03 the owner
+- [x] PR #94 fixed-real-corpus empirical gate closed. On 2026-09-03 the owner
   explicitly authorized building and running the comparison locally, then
   publishing 0.1.17 after it passes. There is no waiver. Use immutable private
   inputs and isolated derived state; emit only schema-validated aggregate
@@ -297,3 +297,32 @@ This release-specific risk decision does not relax data-conservation, signature,
 updater-integrity, or unexpected-Keychain-prompt stop conditions, and does not
 authorize hosted migrations, protocol activation, or the separately held website
 validator backport/deployment.
+
+### Completed local qualification and final freeze
+
+Run 5 on `9494c0776892127284fca744a304cc3c0c58bdf3` completed on
+2026-09-03 with exit zero and validated status
+`passed_with_historical_artifact_refusal`. The coordinator independently
+validated the closed receipt, and a second reviewer confirmed conservation,
+coverage changes and resource tradeoffs. The
+[content-free receipt](../receipts/2026-09-03-pr94-account-plan-attribution-qualification.md)
+binds the private JSON by exact bytes and SHA-256. All 707,889 positive usage
+records, 954,391 quota observations and 152 accepted candidate fits are
+preserved; no unexplained loss or duplicate primary representation remains.
+Final production runs take 39.57 and 40.75 seconds with identical strictly valid
+artifacts. Historical refusal is explicitly retained, never reported as a valid
+old artifact. The measured memory/artifact-size tradeoff is accepted under the
+unchanged resource bounds; no empirical release blocker remains.
+
+Final tracked changes after that measured head are release documentation only.
+Verify the runtime/dependency closure is unchanged before binding the final tag.
+The release-notes body is prepared for verbatim publication and uses immutable
+tagged documentation links; actual artifact/publication state remains here and
+in current-status rather than being guessed in advance.
+
+The documentation checker requires a stable tag before accepting the dated
+changelog. Freeze the final reviewed PR-head commit and create its local
+annotated `v0.1.17`; complete local/source/native/final-artifact checks before
+pushing branch and tag atomically. Require exact-head CI, then normal merge
+preserving the tagged head and identical tree. Build and publish from the
+tagged head, not the later untagged merge commit; do not rewrite a remote tag.

--- a/docs/plans/2026-09-03-public-0.1.17-release.md
+++ b/docs/plans/2026-09-03-public-0.1.17-release.md
@@ -179,3 +179,12 @@ unchanged after granting required process-observation permissions; the initial
 sandbox attempt could not gather RSS samples. No protected real-history receipts
 were regenerated. Comparator synthetic tests and its real-data run remain a
 separate gate until the complete reviewed receipt exists.
+
+The completed comparator/inventory owning suite passes 109 synthetic tests.
+The historical before/after pair requires identical runtime and lockfile; the
+final lane uses the same runtime but independently binds its reviewed lockfile
+(the later `fast-uri` 3.1.5-to-3.1.6 update). It is not represented as a pure
+PR #94-only comparison. An initial broad root attempt on `9901caa3` was stopped
+by the coordinator before correcting this overly restrictive final-lane check;
+that interrupted attempt is not a passing release gate. The full root gate
+remains required after the private comparison and final source freeze.

--- a/docs/plans/2026-09-03-public-0.1.17-release.md
+++ b/docs/plans/2026-09-03-public-0.1.17-release.md
@@ -1,0 +1,181 @@
+---
+title: Public 0.1.17 release preparation
+date: 2026-09-03
+type: plan
+status: in-progress
+---
+
+# Public 0.1.17 release
+
+The owner approved the inspected native apps and explicitly authorized
+publication on 2026-09-03. This authorizes the normal stable release sequence;
+it does not turn an incomplete qualification gate into passing evidence or
+authorize unrelated hosted data/protocol changes.
+
+The frozen starting point is main
+`394c8a03a986e0daadbe662679fd002202682e44` (PR #102). The inspected dogfood is
+0.1.17 build 1023.7; the stable inspection artifact is build 1024. GitHub still
+lists 0.1.16 as the latest published stable release at the read-only check on
+2026-09-03. No new public tag, release, feed or deployment has been made in
+this preparation step.
+
+Authority: the [macOS release runbook](../runbooks/macos-stable-release-runbook.md)
+and [publication runbook](../runbooks/2026-08-18-cross-platform-release-publication.md).
+Existing inspected DMGs and manifests remain immutable. Final source changes
+require freshly bound artifact evidence; never patch an already signed DMG.
+
+## Scope and ownership
+
+- Luna worker: fix the reproducibility epoch appearing as Finder creation and
+  modification dates. Preserve deterministic, source-bound packaging and
+  signing checks. Do not invent unavailable metadata.
+- Stable replacement worker: replace the broad legacy stable compatibility
+  seam with an exact, previous-artifact-only capability for the preserved
+  0.1.16 DMG and its historical Keytar normalization. Current candidates must
+  retain full validation; altered prior artifacts must fail.
+- Release coordinator: integrate and independently verify both fixes, finalize
+  release notes/metadata, freeze source, build/sign/validate, and publish in the
+  maintained order after all release decisions are resolved.
+- Other open PRs, Electron/Windows work, unrelated checkouts and installed user
+  state remain outside this final release scope.
+
+## Gate decisions
+
+- [x] Metadata source fix and focused tests reviewed and integrated. Final DMG
+  Finder inspection remains part of signed-artifact qualification.
+- [ ] Exact previous-stable compatibility fix and refusal tests reviewed and
+  integrated; actual 0.1.16-to-final-stable replacement validation passes.
+- [ ] PR #94 fixed-real-corpus empirical gate closed. On 2026-09-03 the owner
+  explicitly authorized building and running the comparison locally, then
+  publishing 0.1.17 after it passes. There is no waiver. Use immutable private
+  inputs and isolated derived state; emit only schema-validated aggregate
+  evidence. Preserve the separate hosted activation constraints.
+- [ ] Final root/native/release checks pass on the reviewed source. Revalidate
+  retained R7 provenance; regenerate only if its protected workload changed.
+  Existing `release_open` decisions must not be edited into passing receipts.
+- [ ] Exact signed clean-install/old-to-new and prompt-free native checks are
+  complete. Owner acceptance of dogfood UI is useful but not proof of every
+  old stable credential/upgrade case.
+
+## Publication sequence
+
+1. Finalize version lockstep and the dated, linked release notes/changelog;
+   confirm the actual package minimum macOS requirement and stable build
+   allocation. Review and merge only the release changes; obtain exact-head CI.
+2. Create the exact protected annotated stable tag on the reviewed source and
+   produce a fresh stable-channel signed/notarized/stapled DMG. Freeze its bytes.
+3. Generate the signed Sparkle appcast and canonical public manifest/checksums.
+   Use the supported native/checksum-only evidence path unless genuine hosted
+   attestations exist; absent SBOM/provenance remains explicitly null.
+4. Create a draft GitHub release with the complete reviewed asset set, including
+   appcast.xml. Download into a new directory and verify exact asset-set parity,
+   signatures, manifest, checksums and source identity.
+5. Publish the immutable release, redownload all public assets, verify GitHub's
+   immutable-release/asset evidence and confirm the published date/body.
+6. Only then publish the guarded stable Sparkle feed, update/verify Homebrew and
+   update the website's release availability. Verify delivered bytes, not just
+   version labels; test the actual older-client update path.
+
+Website publication must not silently roll out unqualified backend changes or
+apply remote migrations. Resolve the existing deployment/source boundary before
+that step. Hosted account/plan transport activation, private owner-erasure
+operations, migrations and live contribution tests remain separate gates.
+
+## Stop conditions
+
+Stop for unexpected Keychain prompts, invalid or altered artifacts, missing
+qualification/owner decisions, failed source or native gates, incomplete draft
+assets, non-immutable publication, or unverifiable live bytes. Preserve local
+state, credentials and rollback artifacts. Do not bypass a validator or infer
+permission to discard data or lower protections.
+
+## Execution checkpoint
+
+The exact previous-stable capability repair was independently reviewed and
+committed as `5db34878fcfda178ac39d227c34df0327419ce55`, then cherry-picked
+into this release branch as `1f4092a0`. Its 17 focused regression tests passed
+independently. The coordinator reran those tests together with retained R7
+freshness on the integrated source: 19 passed, no skips/failures/cancellations.
+Architecture passed with 380 production files, 1,536 imports and zero debt.
+The repair is outside the protected workload; current R7 provenance remains
+valid without another regeneration. Exact signed-pair validation against the
+preserved inspection artifact subsequently exited zero: published stable
+0.1.16 to stable inspection 1024, with the ordinary unmodified CLI. Both native
+signature/ticket/Gatekeeper and isolated smoke checks passed. No hosted mutation
+or installed-app replacement occurred. This qualifies the existing inspection
+pair; repeat against any newly built final artifact and keep existing-state/
+interactive credential migration as separate evidence.
+
+Read-only public checks on 2026-09-03 confirmed the existing v0.1.16 GitHub
+release is immutable and contains the complete five-asset set. The stable feed
+still names its exact published DMG hash; v0.1.17 has no remote tag. Public
+health reports deployed source
+`304f3d736b6f9451d32a616bf3046ea628e828a3`.
+
+The safe website lane must descend from that deployed source, preserving its
+Worker runtime/configuration, migrations and dependencies. Static review found
+that its native installer validator does not yet recognize the new migration
+helper in the 0.1.17 DMG. A narrow read-only validator backport, exact tooling
+allowlist/test update and genuine public release-copy change are needed before
+the maintained web-only lane can validate and deploy the new installer link.
+Canonical v1 manifest support already exists. This is a separate tooling-only
+follow-up; neither a dummy validator nor a full current-main Worker deployment
+is an acceptable shortcut. No such backport or deployment has occurred yet.
+
+After clarification, the owner authorized completing the empirical check locally
+and publishing only after it passes. The comparison isolates PR #94 first parent
+`a3c850360bc83c0e27bef2171aeb4a302b72f472` and merge result
+`20f449ff5c222989029fe343f219f02b497ae1d4`; final-source behavior must also be
+bound explicitly. The recent performance comparison uses two revisions that
+both already contain PR #94 and is not substituted for this check.
+
+The website validator backport was paused by the safety reviewer, which requires
+more specific owner approval for its cross-surface signature-validation scope.
+An explicit question is pending; incomplete website WIP is not integrated or
+used to validate an artifact. Local empirical and packaging work may continue.
+
+## Local comparator implementation
+
+The qualification entrypoint is `scripts/qualify-pr94-attribution.mjs`, requiring
+the explicit `--allow-private-attribution-comparison` flag, exact before/after/
+final clean revision roots, an immutable offline index, a new owner-only output
+directory, and canonical fixed start/end instants. It does not discover raw
+history, open live application state, access credentials, or upload data.
+
+The three lanes isolate the original attribution PR and then its subsequent
+release fixes. Each independently executes its own reader, public accounting
+kernel, miner and weekly reporter. Export-only instrumentation exposes the
+original reporter's helpers without replacing their bodies. Exact six-component
+ledger and quota-occurrence evidence uses per-comparison HMAC fingerprints in
+private sealed streams; only closed aggregate projections enter the receipt.
+Plan/basis/disposition populations are disjoint and must sum to that same
+ledger. Calibration reconciles raw parents, fragments, candidate votes, existing
+rejection reasons and primary-versus-diagnostic distributions. Counterfactual
+account checks alter only an unknown account label, never numerical inputs.
+
+The admitted-index scope is deliberate: PR #94 did not change extraction or
+admission semantics. Its physical index diff adds optional predecessor-query
+accelerators and read-only compatibility for those accelerators. The shared
+schema-11 input retains its exact generation and any tool-only provenance gap;
+it is never described as complete tool evidence. Raw-source export lifecycle
+qualification remains the separate R7 gate. Unified-index/cache lifecycle has
+its own source regressions; R7 does not exercise application refresh, relaunch,
+cancellation or SQLite query plans. Those must be evidenced separately and are
+not inferred from a successful child comparison. `legacy_zero` is explicitly recorded
+as the production cache's existing context-compatibility policy, not proof that
+missing input context was observed as zero.
+
+Resource measurements run the unmodified production accounting child twice per
+revision under the native time/RSS observer, with fresh isolated processes and
+unchanged production ceilings. Only same-revision repeatability requires
+byte-identical cache output: attribution intentionally changes cross-revision
+analysis. Observer timings, production child timings and retained application
+refresh/relaunch/cancellation evidence are not conflated.
+
+The integrated Finder fix is `af6d4b6c` (reviewed worker commit `01069a56`). Four
+focused Finder regressions and the full retained native gate passed: 101 tests,
+zero failures/skips/cancellations. Eight R7 synthetic/freshness checks passed
+unchanged after granting required process-observation permissions; the initial
+sandbox attempt could not gather RSS samples. No protected real-history receipts
+were regenerated. Comparator synthetic tests and its real-data run remain a
+separate gate until the complete reviewed receipt exists.

--- a/docs/plans/2026-09-03-public-0.1.17-release.md
+++ b/docs/plans/2026-09-03-public-0.1.17-release.md
@@ -314,7 +314,8 @@ artifacts. Historical refusal is explicitly retained, never reported as a valid
 old artifact. The measured memory/artifact-size tradeoff is accepted under the
 unchanged resource bounds; no empirical release blocker remains.
 
-Final tracked changes after that measured head are release documentation only.
+Final tracked changes after that measured head are release documentation and
+the release-notes test's tagged-versus-untagged lifecycle assertions only.
 Verify the runtime/dependency closure is unchanged before binding the final tag.
 The release-notes body is prepared for verbatim publication and uses immutable
 tagged documentation links; actual artifact/publication state remains here and
@@ -326,3 +327,19 @@ annotated `v0.1.17`; complete local/source/native/final-artifact checks before
 pushing branch and tag atomically. Require exact-head CI, then normal merge
 preserving the tagged head and identical tree. Build and publish from the
 tagged head, not the later untagged merge commit; do not rewrite a remote tag.
+
+The final broad root command on `a697ef28` completed 3,725 tests: 3,705 passed,
+17 platform skips and three failures. Two files could not start because the
+isolated checkout lacked the existing locked Worker `jsonc-parser` dependency;
+installing that lockfile without lifecycle scripts restored both unchanged
+files (7/7 passed). The third failure was the repository test assuming the
+current version must always be untagged, despite the release-notes checker
+correctly accepting the annotated tag and dated changelog. Correct that test
+to assert the exact inventory for either legitimate lifecycle state; retain
+the synthetic refusal checks. The broad command itself remains recorded as
+failed, with these focused reruns as the resolution rather than a fabricated
+green command. The separate updater tests passed 2/2; Codex release contracts,
+architecture, documentation and preflight passed. Retained R7 freshness passed
+in the root run. No app/runtime change or R7 regeneration is needed for these
+test-environment and lifecycle corrections. The corrected release-notes suite
+passes 11/11, including exact tagged-release and untagged-candidate inventories.

--- a/docs/plans/2026-09-03-public-0.1.17-release.md
+++ b/docs/plans/2026-09-03-public-0.1.17-release.md
@@ -188,3 +188,41 @@ PR #94-only comparison. An initial broad root attempt on `9901caa3` was stopped
 by the coordinator before correcting this overly restrictive final-lane check;
 that interrupted attempt is not a passing release gate. The full root gate
 remains required after the private comparison and final source freeze.
+
+### First private comparison attempt
+
+The first fixed-index run on `9efa3f92` exited one with
+`pr94_comparison_not_passed`; it produced no successful comparison receipt and
+did not start the production resource probes. All three lanes produced exactly
+identical private ledger bytes and aggregates: 707,889 positive usage records
+and 954,391 quota occurrences, with 18,851 zero-component indexed rows explicitly
+reconciled separately. All four calibration candidates retained 38 primary fits.
+
+The failed condition was one of 216 raw quota parents lacking an explained
+post-attribution transition outcome. It is a Plus parent with 13 raw snapshots;
+the baseline rejected its sole fragment for insufficient unique boundaries, so
+this is not an observed loss of an accepted fit. Before/after transition counts
+were 23,773/23,736; final matched after. Source review identified a missing
+harness disposition when individually matched snapshots lie in separate eras
+with no within-era percentage change. That hypothesis must be established by
+the original miner's group summaries and a synthetic regression, then a fresh
+complete private run; it is not permission to waive an unexplained parent.
+
+The synthetic Pro/Plus/Pro regression now establishes that disposition using
+the unchanged miner's own group summaries. The observer validates parent and
+era identity, unique snapshot totals, emitted transition counts and zero-change
+groups before admitting `no_within_era_percent_change`. Missing or inconsistent
+summaries still fail. The coordinator independently reran the worker,
+calibration and closed-receipt suites: 40 passed, no failures/skips/cancellations.
+This is observer qualification, not a successful replacement for the failed
+private run. Changed outcome signatures remain explicitly marked for coverage
+review even when the accepted-fit counts are unchanged.
+
+The completed follow-up owning suite passes 119/119 synthetic tests, with no
+skips or cancellations. It also observes the attribution reader's four original
+point-query plans through `EXPLAIN QUERY PLAN`, using synthetic bindings and
+emitting only search/scan/sort/other counts. No data SELECT executes in that
+probe. The first parent explicitly reports the absent feature as null; after
+and final must provide matching pre/post observations. This is not whole-reader
+query coverage or measured query-execution latency. No new product calculation,
+resource ceiling, private-data upload or generated R7 receipt changed.

--- a/docs/plans/2026-09-03-public-0.1.17-release.md
+++ b/docs/plans/2026-09-03-public-0.1.17-release.md
@@ -226,3 +226,37 @@ probe. The first parent explicitly reports the absent feature as null; after
 and final must provide matching pre/post observations. This is not whole-reader
 query coverage or measured query-execution latency. No new product calculation,
 resource ceiling, private-data upload or generated R7 receipt changed.
+
+### Second private comparison attempt and historical artifact refusal
+
+The second run on `e39efa9f` passed the exact ledger, calibration, population,
+reader-evidence and unknown-account checks in all three lanes. Both baseline
+production-child runs also passed. It then stopped at
+`pr94_production_artifact_invalid` while validating the first original PR #94
+merge artifact; no final comparison receipt was written and the final candidate
+production lane did not run.
+
+The historical revision's own strict cache assertion returned `cache_invalid`.
+Source inspection ties this to the already-recorded fitted-reset provenance
+defect: it copied metadata from the first, possibly diagnostic-only transition,
+while the later `1c51a50c` correction selects the first eligible transition.
+That correction is already in the frozen candidate. The child serializes its
+result before the production publication boundary asserts validity, explaining
+why a successful child process can yield an unshippable historical artifact.
+
+The v2 qualification contract keeps that failure explicit. Only the exact
+historical merge may record `historical_artifact_refused`, and only when two
+fresh production children return identical successful envelopes and artifact
+bytes, each original strict assertion returns exactly `cache_invalid`, and all
+source/index/dependency/clock/query-plan/resource bindings still pass. No cache
+projection is emitted for a refused artifact. Baseline and final candidate
+artifacts must still pass their unchanged strict validators. A receipt containing
+this historical outcome must use
+`passed_with_historical_artifact_refusal`, never the ordinary `passed` label.
+This characterizes the historical defect; it does not qualify that historical
+artifact, waive a failed candidate check, or change any product validator.
+The complete private run must be repeated against the committed v2 harness.
+The independent review identified and closed an artifact-context gap: even a
+refused artifact must match the exact requested clock, covered window and index
+generation fingerprint before the refusal can be recorded. This emits no cache
+projection. The integrated comparator/inventory suite now passes 124/124 tests.

--- a/docs/plans/2026-09-03-public-0.1.17-release.md
+++ b/docs/plans/2026-09-03-public-0.1.17-release.md
@@ -260,3 +260,15 @@ The independent review identified and closed an artifact-context gap: even a
 refused artifact must match the exact requested clock, covered window and index
 generation fingerprint before the refusal can be recorded. This emits no cache
 projection. The integrated comparator/inventory suite now passes 124/124 tests.
+
+The next complete run finished all semantic and production-child lanes, then
+the enclosing receipt validator refused the final assembly. The receipt's
+source validator still required the final lane's resolved runtime digest to
+equal the historical pair even though the runner and production-resource
+binding had already been corrected for the final lane's independently reviewed
+dependency update. The nearby comment described the intended independent
+binding, but the stale equality condition contradicted it. The exact historical
+before/after runtime and lock equality remains mandatory; final runtime, lock,
+source and filesystem identity digests must instead match its own two strict
+production probes. Add the missing final-runtime regression, commit the fix,
+and repeat the entire private run; the rejected assembly is not a receipt.

--- a/docs/receipts/2026-09-03-pr94-account-plan-attribution-qualification.md
+++ b/docs/receipts/2026-09-03-pr94-account-plan-attribution-qualification.md
@@ -1,0 +1,152 @@
+---
+title: PR94 account and plan attribution local qualification
+date: 2026-09-03
+type: receipt
+status: complete
+---
+
+# PR94 local attribution qualification
+
+The fixed-admitted-index comparison completed on 2026-09-03 with exit zero and
+validated status **`passed_with_historical_artifact_refusal`**. Accounting and
+calibration conservation passed. Both final-candidate production artifacts
+passed the unchanged strict cache validator and were byte-identical.
+
+The historical PR #94 merge still produces its known `cache_invalid` artifact;
+this is recorded as a refusal, not relabelled as valid. Its two fresh processes
+returned identical successful child envelopes and artifact bytes, each original
+strict assertion refused exactly `cache_invalid`, and source, clock, generation,
+dependency, query-plan and resource bindings passed. The later candidate fixes
+the fitted-reset metadata defect and passes strict validation. This receipt
+does not qualify the historical artifact for release.
+
+## Exact scope and custody
+
+- Before: `a3c850360bc83c0e27bef2171aeb4a302b72f472`, PR #94's first parent.
+- After: `20f449ff5c222989029fe343f219f02b497ae1d4`, PR #94's merge result.
+- Final measured source: `9494c0776892127284fca744a304cc3c0c58bdf3`.
+- Runtime: Node.js 26.2.0, macOS arm64. Historical before/after dependencies
+  match exactly; final dependencies are independently bound, including the
+  subsequently reviewed dependency update and accounting optimization.
+- Fixed interval: `2025-09-02T00:00:00.000Z` through
+  `2026-09-02T00:00:00.000Z`.
+- Immutable schema-11 index: generation 44, 1,508,540,416 bytes, SHA-256
+  `e9f477efc2c1ea50360509fe70681c8bd04b7b4a5b16a56b5d2855f69628b6ce`.
+- Closed JSON receipt: `pr94-admitted-index-comparison-v2`, 163,760 bytes,
+  SHA-256 `fdce799d5ea7af8d53430aaf44036afafba24f6d80ac7267b3f47fdec8aabead`.
+  It remains owner-only, mode 0600, regular file with one link. The coordinator
+  independently reran `validatePr94ComparisonReceipt` after completion.
+
+Only this content-free summary is committed. Private paths, source filenames,
+raw content, account/reset identities, detailed frames and accounting amounts
+are not published. The comparison neither scanned raw history nor accessed live
+app state, credentials, or hosted services. It used separate private processes
+and derived outputs, rechecked unchanged sources/dependencies/index, and did
+not modify the input index or protected R7 receipts.
+
+## Conservation and coverage review
+
+All three lanes retained the same 726,740 indexed usage rows: 707,889 positive
+usage records plus 18,851 explicitly reconciled zero-component rows. All
+954,391 admitted quota observations were preserved. Exact row-level ledger
+evidence, all six token components, decimal event-time amounts, pricing states,
+provenance and warning aggregates matched. Disjoint plan/basis/disposition
+populations sum to the original ledger; missing evidence remains explicit.
+
+The shared generation contains 7,708 sources and no skipped sources or threads.
+Its accounting coverage is complete. Its generic publication status remains
+`partial` / `tool_provenance_incomplete`, with 903,427 retained tool facts; this
+check does not promote incomplete tool provenance to complete evidence.
+
+The calibration comparison reconciled 216 raw reset parents across four
+candidates: all 864 parent/candidate pairs, with zero missing or added parents,
+unexplained residue, duplicate primary votes, or lost primary fits. All 152
+primary representations were retained (38 per candidate). Identical fit inputs
+produced identical arithmetic in all 140 before/after comparable fits and all
+152 after/final comparable fits.
+
+The attribution change intentionally changes the observation population:
+
+- 53 transitions move from eligible to aggregation-diagnostic-only; none is
+  dropped from the ledger.
+- 37 non-increasing cross-era transitions are no longer constructed. Eligible
+  transitions change from 13,544 to 13,491; non-increasing transitions from
+  9,884 to 9,847. The 341 no-usage and four pricing-warning rows are unchanged.
+- One formerly nonfitting parent now has no within-era percentage change;
+  its closed disposition explains the change from 136 to 135 parents with
+  transitions. It was not an accepted fit that disappeared.
+- Twelve retained primary representations have deliberately changed,
+  plan-scoped inputs; 16 parent/candidate outcome signatures change. Their
+  reasoned reconciliation is retained in the closed receipt. No fit with
+  identical inputs changes, and no accepted primary fit is lost.
+- The after-to-final comparison adds no calibration or population change.
+
+Each candidate retains 35 Pro, two Plus and one other-plan primary fit, with no
+unknown-plan primary. Only the Plus primary distribution changes with its
+plan-scoped inputs; Pro and other-plan primary distributions are unchanged.
+The closed receipt retains exact medians and central-80 ranges without
+publishing private accounting amounts here. Independent aggregate review
+confirmed the reconciliation and recommended closing this empirical gate.
+
+All 216 parents have unknown account identity. The original-fit-gate
+counterfactual checks found zero changed eligibility rows, point sets or fits
+solely from that unknown label, and zero unknown-account-only exclusions.
+This does not establish account-exact or same-login workspace attribution.
+Empty distributions remain unavailable; plan identity and account identity
+are not conflated.
+
+## Production resource measurements
+
+These are unmodified accounting-child processes, not the instrumented semantic
+observer or end-to-end application refresh. Each revision ran twice in fresh
+isolated processes under the same pinned clock and unchanged resource ceilings.
+
+| Revision / run | Wall ms | User CPU ms | System CPU ms | True peak RSS bytes | Artifact bytes |
+|---|---:|---:|---:|---:|---:|
+| Before / primary | 97,080 | 92,190 | 9,230 | 1,832,960,000 | 11,955,053 |
+| Before / repeat | 94,850 | 90,780 | 8,540 | 1,726,955,520 | 11,955,053 |
+| After / primary, refused artifact | 324,550 | 310,020 | 21,560 | 1,742,848,000 | 12,123,253 |
+| After / repeat, refused artifact | 322,700 | 309,050 | 20,860 | 1,967,374,336 | 12,123,253 |
+| Final / primary | 39,570 | 43,520 | 1,060 | 2,080,473,088 | 15,511,261 |
+| Final / repeat | 40,750 | 44,910 | 1,110 | 2,076,344,320 | 15,511,261 |
+
+Final median wall time is 40,160 ms: 55,805 ms lower than before (-58.15%) and
+283,465 ms lower than the historical after revision (-87.59%). Final median
+peak RSS is 2,078,408,704 bytes: 298,450,944 bytes higher than before (+16.77%)
+and 223,297,536 higher than after (+12.04%). All runs remain below the unchanged
+6,442,450,944-byte ceiling; no timeout or resource guard fired. This is a
+reviewed memory/time tradeoff, not an invented universal regression tolerance.
+The coordinator accepts it for this release given exact conservation, the
+substantial latency reduction and the retained resource headroom.
+
+The final cache SHA-256 is
+`bb90b9835fb786fdf1592ee18c6d1bcd5b84084a1d9a962c23d036bf15c7f61a`
+in both runs. Each revision is repeatable within itself; cross-revision cache
+bytes are not asserted equal because attribution and report structure change.
+The final artifact has 1,265,955 bytes of headroom below its unchanged 16 MiB
+limit. This is measured headroom, not a promise that arbitrarily larger future
+corpora will fit; the fail-closed size and retained-input bounds remain active.
+The receipt also retains query-plan classifications, cache/input/resource
+limits, retained-input counts/bytes, and per-phase observations.
+
+The separate instrumented semantic observer took 194,230 / 260,090 / 256,140 ms
+for before / after / final, with peak RSS 3,916,480,512 / 4,241,031,168 /
+4,508,811,264 bytes. Those measurements include evidence work and are not
+product refresh timings. Its phase and CPU measurements remain in the private
+receipt rather than being presented as the optimization result.
+
+## Release decision and limits
+
+The local PR #94 empirical gate is closed for this fixed admitted index. The
+result is not raw-ingestion, application no-change/relaunch, cancellation,
+installed-upgrade, end-to-end refresh, hosted deployment, consent activation or
+provider-billing proof. Those boundaries retain their separate evidence and
+decisions in the [release plan](../plans/2026-09-03-public-0.1.17-release.md).
+The earlier failed runs remain failed; none was reused as a successful receipt.
+
+The owner accepted the dogfood runtime and requested confidence-based release
+completion. The full clean-profile/physical Login Item matrix is explicitly
+deferred, not passed. Final signed-artifact/replacement, source and updater
+integrity gates remain required, and unexpected Keychain prompts still stop
+publication. Hosted migrations and the separately held website deployment are
+not authorized by this local result.

--- a/docs/runbooks/2026-08-18-cross-platform-release-publication.md
+++ b/docs/runbooks/2026-08-18-cross-platform-release-publication.md
@@ -210,7 +210,9 @@ only for an artifact claiming the attested v1 profile/path; a
 native/checksum-only artifact records explicit `null` evidence instead and may
 skip those attestation steps.
 
-1. Start from a clean checkout at the exact protected annotated version tag.
+1. Finalize the reviewed release notes and dated changelog before freezing the
+   source, then start from a clean checkout at the exact protected annotated
+   version tag. The macOS runbook explains the pre-tag documentation/CI order.
 2. Build on the native controlled runner with the committed lockfile.
 3. Run native tests and clean install/upgrade/uninstall checks.
 4. Complete all byte-changing operations: package, sign nested binaries,
@@ -226,10 +228,10 @@ skip those attestation steps.
    and `sbom.attestation` bundle outputs beside the final subject.
 9. Generate and validate release-manifest.json and SHA256SUMS with
    scripts/generate-release-evidence.js.
-10. Finalize the release notes and changelog: add release, annotated-tag, and
-    exact comparison provenance; include only verified public credits and mark
-    related open issues as open. Then create a draft GitHub release and upload
-    only reviewed public assets.
+10. Verify the already-frozen release notes and changelog contain release,
+    annotated-tag, and exact comparison provenance, verified public credits,
+    and explicit open-issue boundaries. Do not edit the tagged build source
+    here. Create a draft GitHub release and upload only reviewed public assets.
 11. Copy every draft asset from the reviewed staging area into a fresh
     verification directory. Validate the manifest and SHA256SUMS and source
     identity there. For the attested v1 profile/path, also verify both
@@ -247,7 +249,10 @@ or evidence need to change.
 ## 5. Draft and immutable release publication
 
 The public asset set for a direct subject always includes the final platform
-artifact, `release-manifest.json`, `SHA256SUMS`, and `verify-release.md`. Include
+artifact, `release-manifest.json`, `SHA256SUMS`, and `verify-release.md`. When
+`updater.enabled` is true, also include its exact metadata file; macOS Sparkle
+uses `appcast.xml`. Its checksum entry must have a corresponding uploaded asset.
+Include
 the following only when the artifact's manifest fields are non-null:
 
 - the SPDX JSON SBOM when `artifact.sbom` is non-null;
@@ -301,6 +306,8 @@ gh release create "$TAG" --repo "$REPO" --verify-tag --draft \
 gh release upload "$TAG" --repo "$REPO" \
   "$ARTIFACT" \
   "$RELEASE_MANIFEST" "$SHA256SUMS" "$VERIFY_GUIDE"
+# For a macOS direct subject with Sparkle enabled, also upload the exact feed:
+gh release upload "$TAG" --repo "$REPO" "<staging-directory>/appcast.xml"
 ~~~
 
 For the attested v1 profile/path, produce and verify the final SPDX file and
@@ -318,6 +325,8 @@ SBOM_BUNDLE="$EVIDENCE_DIRECTORY/$ARTIFACT_NAME.sbom.bundle.json"
 gh release upload "$TAG" --repo "$REPO" \
   "$ARTIFACT" "$SPDX" "$PROVENANCE_BUNDLE" "$SBOM_BUNDLE" \
   "$RELEASE_MANIFEST" "$SHA256SUMS" "$VERIFY_GUIDE"
+# For a macOS direct subject with Sparkle enabled, also upload the exact feed:
+gh release upload "$TAG" --repo "$REPO" "<staging-directory>/appcast.xml"
 ~~~
 
 Before publication, validate the exact draft staging directory locally. This

--- a/docs/runbooks/macos-stable-release-runbook.md
+++ b/docs/runbooks/macos-stable-release-runbook.md
@@ -107,7 +107,21 @@ but it cannot read or migrate stable state. The signed same-identity
 the live stable database into Preview, relabel `PRAGMA user_version`, delete the
 index, or reopen a migrated schema-10 or schema-11 index with shipped 0.1.16.
 
-The replacement validator has one closed previous-only exception for the
+The replacement validator has a closed previous-only exception for published
+stable `0.1.16` / bundle version `0.1.16`: SHA-256
+`5e3e60402ffa3c61d8279f5f759548a8b48084f1ae567eeb1b30156c7f30a9fe`,
+49,341,389 bytes, source `4f30508eff55c122e73025ad06d73b33cadbc508`
+at `v0.1.16`. Its exact receipt, source/payload digests, updater key/framework,
+and normalized Keytar tuple are pinned. Only the checksum-verified previous
+artifact receives short-lived compatibility for the absent source seal,
+migration helper, and both Keychain identity plist fields. A version match or
+public boolean cannot authorize it. The capability expires before candidate
+validation, including when previous validation fails. Native signature,
+notarization, Gatekeeper, and isolated-smoke checks remain required; the old
+manifest and artifact are never rewritten. This is replacement-artifact proof,
+not existing-state rollback or prompt-free installed-upgrade proof.
+
+A separate closed previous-only exception covers the
 pre-policy internal-dogfood `0.1.16` / build `1022` DMG: SHA-256
 `2b32964c8b3bc2912620dbbe078aaf4e2fd49f1725a4e94a62dff184cdc9f8c1`,
 49,341,249 bytes, source `5adaca5fdc8f981c391144e0d29b6f4c764f0f96`
@@ -165,7 +179,7 @@ implementation and synthetic reset evidence are recorded in the
 and do not authorize resetting real credentials during qualification. An
 unsigned smoke or a blocked signed probe is not signed-upgrade evidence.
 
-A second closed previous-only exception accepts the retained 0.1.17 / build
+Another closed previous-only exception accepts the retained 0.1.17 / build
 1023 RC2 DMG, SHA-256
 `125a15da9b0e260ec3797527d6b98e15aa1172e8b6fc8e7942d2a799cc2b29b0`,
 49,574,961 bytes, source `3d9055fc8e58c84f8ba71feb5deb58b52c532138`.

--- a/docs/runbooks/macos-stable-release-runbook.md
+++ b/docs/runbooks/macos-stable-release-runbook.md
@@ -51,7 +51,11 @@ A version bump is **not** just package.json. Bump or regenerate all of:
    boundaries explicitly, and move shipped items out of `Unreleased`. Do not
    reconstruct claims or attribution that were not validated.
 
-Run the release preflight before tagging:
+Run candidate preflight while untagged work remains under `Unreleased`. The
+documentation checker requires a stable tag for a dated release entry: finalize
+and commit the release text, create the local annotated tag as described in
+section 1, then run the final preflight below before pushing that tag. Do not
+weaken the checker or edit tracked release text after freezing the tag.
 
 ~~~bash
 node scripts/check-release-notes.mjs
@@ -203,7 +207,9 @@ the new constant.
 
 The macOS finalizer requires an empty tree (including untracked files) and an
 exact annotated tag. The tag must identify the reviewed release commit and be
-protected by the repository's version-tag rules.
+protected by the repository's version-tag rules. It may identify the frozen,
+reviewed PR head; it need not identify the later main merge commit. Build only
+with HEAD at that exact tagged commit.
 
 The sole historical exception is the pre-policy `v0.1.10` published ref. It is
 a protected lightweight tag at
@@ -215,10 +221,35 @@ lightweight tag: every new stable tag must remain annotated and protected.
 
 ~~~bash
 git status --porcelain=v1 --untracked-files=all   # must print nothing
-git describe --exact-match --tags HEAD             # must print vX.Y.Z
-git tag -a vX.Y.Z <reviewed-commit> -m "TiboTattle X.Y.Z ..."
-git push origin vX.Y.Z
+git tag -a vX.Y.Z HEAD -m "TiboTattle X.Y.Z ..."  # final reviewed commit
+git describe --exact-match --tags HEAD           # must print vX.Y.Z
 ~~~
+
+For a tagged PR head, complete local checks and final-artifact validation from
+that frozen checkout before atomically pushing its branch and tag. Set
+`RELEASE_BRANCH` to the actual reviewed branch; do not push directly to main:
+
+~~~bash
+git push --atomic origin "refs/heads/$RELEASE_BRANCH" "refs/tags/vX.Y.Z"
+~~~
+
+Require passing CI for the frozen PR head after the remote tag is available.
+The release-trust PR job uses the PR merge checkout and fetches full history;
+the tag need not point at that synthetic merge. Merge normally, without squash
+or rebase, preserving the tagged head as an ancestor and an identical tree.
+Resolve `MERGE_COMMIT` to the actual resulting merge commit and verify:
+
+~~~bash
+git merge-base --is-ancestor "vX.Y.Z^{}" "$MERGE_COMMIT"
+git diff --exit-code "vX.Y.Z^{tree}" "$MERGE_COMMIT^{tree}"
+~~~
+
+Only then proceed to public release publication. Keep artifact provenance at
+the tagged PR-head commit, not the later merge commit. Do not rewrite tags or
+shared history; if CI or merge changes require different source bytes, stop and
+resolve the release identity before continuing. Final notes and changelog must
+already be committed before the local tag; later publication steps verify and
+upload that frozen text rather than changing it.
 
 Do not sign from a branch that is ahead of or different from the tag. The
 source identity later recorded in the release evidence descriptor must be the
@@ -268,23 +299,27 @@ The separate `TiboTattle Preview.app` identity may use the deterministic
 preview epoch (`2000.1.17` for 0.1.17); it does not participate in stable
 Sparkle ordering.
 
-RC7 source merge `87e07be350582713d815a21b4db470ed84aae037` passed its
-protected R7, full source, signing, notarization, stapling, and installation
-gates. Its first installed refresh ingested generation 44 but the strict v0.14
-cache validator rejected inconsistent fit metadata. RC8 source retains that
-validator and projects fit metadata from the first eligible row. RC9 source is
-under validation on base `35802d21ede67d362533f4e2be6b38041ece1cda`: one manual
-Refresh for quota and accounting, quick startup/automatic checks,
-at-most-hourly automatic detailed attempts,
-native terminal-state reconciliation, selected-plan Trends, and last-good
-snapshot persistence. Its `1023.7` allocation does not establish a built or
-installed artifact. Before RC9 is treated as installed dogfood evidence, repeat
-exact-source R7, full source, artifact, state-preserving install, installed
-refresh, and physical native checks. The formal PR #94 real-corpus comparator
-remains **OPEN / NOT RUN** and blocks stable or public qualification; an
-explicitly open-gate internal dogfood does not close it. Compatible hosted
-Worker migrations/deployment and end-to-end device pairing also remain open,
-separate gates; a desktop installation cannot qualify them.
+The owner accepted the runtime from source
+`394c8a03a986e0daadbe662679fd002202682e44` in dogfood `1023.7` and inspected
+stable build `1024`. That acceptance is the retained runtime basis, not proof
+of newly finalized bytes. The final `0.1.17`/`1024` artifact must bind the
+reviewed release tag and pass fresh signed-artifact and exact previous-stable
+replacement validation. Formal PR #94 local qualification completed with
+`passed_with_historical_artifact_refusal`; the final candidate passes its strict
+cache validator. The
+[qualification receipt](../receipts/2026-09-03-pr94-account-plan-attribution-qualification.md)
+records exact data conservation, coverage review, and resource measurements.
+Failed or partial earlier comparison runs remain historical failures, not
+qualification evidence.
+
+For 0.1.17 only, the full clean-profile/physical Login Item matrix is explicitly
+deferred, not passed, under the
+[owner's release-specific decision](../plans/2026-09-03-public-0.1.17-release.md).
+Automated isolated-profile and fake-manager checks do not establish those
+manual results. Data conservation, signatures, updater integrity, and the
+unexpected-Keychain-prompt stop condition remain unchanged. Hosted migrations,
+protocol activation, live contribution tests, and website publication remain
+separate; this release decision does not authorize them.
 
 Signing-key access on the release machine is a separate owner provisioning
 step, not an end-user permission requirement. If signing requests approval,
@@ -299,12 +334,34 @@ the final arm64 DMG at:
 .release-build/macos-release/TiboTattle-X.Y.Z-macOS-arm64.dmg
 ~~~
 
-Read the minimum OS out of the bundle now, and use only this value afterwards:
+Read the minimum OS and Finder dates from the app inside the final DMG, not
+the retained review candidate (the finalizer signs a separate staged app).
+After final validation, mount the DMG read-only without launching the app.
+Compare the outer `.app` directory's birth time and modification time against
+the committer timestamp of its sealed source commit:
 
 ~~~bash
-/usr/libexec/PlistBuddy -c "Print :LSMinimumSystemVersion" \
-  .release-build/macos-production/TiboTattle.app/Contents/Info.plist
+(
+  set -e
+  FINDER_DMG="$PWD/.release-build/macos-release/TiboTattle-X.Y.Z-macOS-arm64.dmg"
+  FINDER_MOUNT="$(mktemp -d /private/tmp/tibotattle-final-finder.XXXXXX)"
+  /usr/bin/hdiutil attach -readonly -nobrowse -mountpoint "$FINDER_MOUNT" "$FINDER_DMG"
+  trap '/usr/bin/hdiutil detach "$FINDER_MOUNT"' EXIT
+  FINDER_APP="$FINDER_MOUNT/TiboTattle.app"
+  FINDER_COMMIT="$(/usr/bin/plutil -extract release.source.commit raw -o - \
+    "$FINDER_APP/Contents/Resources/build-manifest.json")"
+  FINDER_EPOCH="$(git show -s --format=%ct "$FINDER_COMMIT^{commit}")"
+  test "$(/usr/bin/stat -f %B "$FINDER_APP")" = "$FINDER_EPOCH"
+  test "$(/usr/bin/stat -f %m "$FINDER_APP")" = "$FINDER_EPOCH"
+  /usr/libexec/PlistBuddy -c "Print :LSMinimumSystemVersion" \
+    "$FINDER_APP/Contents/Info.plist"
+)
 ~~~
+
+Both timestamp comparisons must pass. This checks only the outer bundle's
+Finder metadata; internal payload timestamps remain normalized. Never repair
+dates inside a mounted or signed artifact. Use the printed minimum OS value
+afterwards.
 
 It is typed by hand in two places later — the "Requires macOS N or later" line
 in `release-notes/X.Y.Z.md`, and `--minimum-macos` in the release-site command
@@ -342,13 +399,14 @@ npm run product:macos:appcast -- \
   --channel stable \
   --app ".release-build/macos-production/TiboTattle.app" \
   --dmg ".release-build/macos-release/TiboTattle-X.Y.Z-macOS-arm64.dmg" \
-  --bundle-version "X.Y.Z" \
+  --bundle-version "1024" \
   --sparkle-public-ed-key "jhgPwmvWLMr7TGURJUoi6sXias7YP1F+hejZawKVTGw="
 ~~~
 
 This uses the pinned generate_appcast and embeds the feed signature required by
 the installed client's SURequireSignedFeed=true. A hand-built minimal appcast
-is not a valid updater subject.
+is not a valid updater subject. `1024` is the reviewed 0.1.17 bundle build, not
+the marketing version; future releases must use their reviewed allocation.
 
 Do **not** run the publishing command yet. The appcast is carried as updater
 metadata in the release evidence descriptor and is published only after the
@@ -544,12 +602,14 @@ gh release create "$TAG" --repo "$REPO" --verify-tag --draft \
   --title "TiboTattle X.Y.Z" --notes-file "$NOTES_FILE"
 # Use this baseline upload for a native/checksum-only manifest (null evidence):
 gh release upload "$TAG" --repo "$REPO" \
-  "$DMG" "$RELEASE_MANIFEST" "$SHA256SUMS" "$VERIFY_GUIDE"
+  "$DMG" "$RELEASE_MANIFEST" "$SHA256SUMS" "$VERIFY_GUIDE" \
+  "$RELEASE_DIR/appcast.xml"
 
 # For the attested v1 profile/path, use this command instead:
 gh release upload "$TAG" --repo "$REPO" \
   "$DMG" "$SPDX" "$PROVENANCE" "$SBOM_ATTESTATION" \
-  "$RELEASE_MANIFEST" "$SHA256SUMS" "$VERIFY_GUIDE"
+  "$RELEASE_MANIFEST" "$SHA256SUMS" "$VERIFY_GUIDE" \
+  "$RELEASE_DIR/appcast.xml"
 ~~~
 
 Download every asset into a fresh directory. During the draft phase, verify the
@@ -647,6 +707,7 @@ gh release verify-asset "$TAG" "$PUBLISHED_VERIFY_DIR/$ARTIFACT_NAME" --repo "$R
 gh release verify-asset "$TAG" "$PUBLISHED_VERIFY_DIR/release-manifest.json" --repo "$REPO"
 gh release verify-asset "$TAG" "$PUBLISHED_VERIFY_DIR/SHA256SUMS" --repo "$REPO"
 gh release verify-asset "$TAG" "$PUBLISHED_VERIFY_DIR/verify-release.md" --repo "$REPO"
+gh release verify-asset "$TAG" "$PUBLISHED_VERIFY_DIR/appcast.xml" --repo "$REPO"
 ~~~
 
 For an attested v1 profile/path, also verify each published evidence asset:
@@ -705,11 +766,23 @@ Verify content by **downloading the bytes and hashing them**, not by reading a
 field that says what you expect:
 
 ~~~bash
-curl -s -o /tmp/live.dmg "https://updates.tibotattle.com/releases/X.Y.Z/$SHA/TiboTattle-X.Y.Z-macOS-arm64.dmg"
-shasum -a 256 /tmp/live.dmg     # must equal $SHA
-gh release download "$TAG" --repo "$REPO" --dir /tmp/gh --pattern '*.dmg' --clobber
-shasum -a 256 /tmp/gh/*.dmg     # must equal $SHA
+(
+  set -e -o pipefail
+  LIVE_VERIFY_DIR="$(mktemp -d /private/tmp/tibotattle-live-update.XXXXXX)"
+  SPARKLE_DOWNLOAD_URL="$(/usr/bin/xmllint --xpath \
+    'string(/rss/channel/item/enclosure/@url)' "$RELEASE_DIR/appcast.xml")"
+  test -n "$SPARKLE_DOWNLOAD_URL"
+  curl --fail --show-error --location \
+    --output "$LIVE_VERIFY_DIR/$ARTIFACT_NAME" "$SPARKLE_DOWNLOAD_URL"
+  LIVE_SHA="$(shasum -a 256 "$LIVE_VERIFY_DIR/$ARTIFACT_NAME" | awk '{print $1}')"
+  EXPECTED_SHA="$(shasum -a 256 "$DMG" | awk '{print $1}')"
+  test "$LIVE_SHA" = "$EXPECTED_SHA"
+)
 ~~~
+
+Use the actual generated enclosure URL: its content-addressed namespace is the
+bundle build (`releases/1024/...` for 0.1.17), not the marketing version. The
+fresh GitHub-download validation in section 6 separately verifies those bytes.
 
 **A 200 from a hash-named R2 URL is evidence of publication, not of content.**
 The digest in that key is a naming convention; R2 serves whatever bytes live at

--- a/release-notes/0.1.17.md
+++ b/release-notes/0.1.17.md
@@ -1,16 +1,14 @@
 # TiboTattle 0.1.17
 
-**Status:** Candidate source notes for native dogfood, updated 2026-09-03. RC9
-build `1023.7` is allocated on source base
-`35802d21ede67d362533f4e2be6b38041ece1cda`; its refresh-policy, current-plan
-Trends, last-good snapshot corrections, and accounting optimizations are
-recorded in the [integration plan](../docs/plans/2026-08-30-native-dogfood-integration.md).
-These source notes alone are not evidence of a built or installed RC9.
-Exact-source R7, the complete source gate, signed/notarized/stapled artifact,
-state-preserving installation, and physical verification remain separate
-requirements. PR #94's real-corpus comparator and
-compatible hosted device-pairing validation remain open. No stable `v0.1.17`
-tag, public GitHub release, or published appcast is claimed by these notes.
+**Provenance:** Stable product build `1024` uses accepted runtime basis
+`394c8a03a986e0daadbe662679fd002202682e44`; the exact source provenance is the
+annotated [`v0.1.17` tag](https://github.com/adamallcock/tibotattle/tree/v0.1.17).
+Internal RC9 build `1023.7` was the preceding dogfood allocation. PR #94
+outcome: `passed_with_historical_artifact_refusal`; see the [qualification
+receipt](https://github.com/adamallcock/tibotattle/blob/v0.1.17/docs/receipts/2026-09-03-pr94-account-plan-attribution-qualification.md).
+Artifact and operational evidence are tracked separately in the [release
+plan](https://github.com/adamallcock/tibotattle/blob/v0.1.17/docs/plans/2026-09-03-public-0.1.17-release.md) and [current
+status matrix](https://github.com/adamallcock/tibotattle/blob/v0.1.17/docs/current-status.md).
 
 The native Mac app is easier to recover, clearer while it starts, and ready for
 the newer Codex history, plan, and quota formats already appearing in current
@@ -29,20 +27,21 @@ readiness arrives after the initial wait, the native app now keeps observing the
 same fenced document generation, refreshes once, and replaces the timeout page
 after the late primary result succeeds rather than requiring a manual reload.
 
-RC9 source has one manual **Refresh** action for quota, history, and detailed
+The app has one manual **Refresh** action for quota, history, and detailed
 accounting, with reuse of valid cached work. Startup and frequent automatic
-checks remain quota/headline-only; foreground automatic checks may attempt detailed accounting at most hourly
+checks remain quota/headline-only; foreground automatic checks may attempt
+detailed accounting at most hourly
 when no refresh is active. Failed, cancelled, or interrupted detailed attempts
 also count against that interval. Native controls follow the controller's
 actual terminal receipt, and browser-started detailed work shares the same
-cadence. These corrections are under validation, not installed-RC9 proof.
+cadence.
 
 The accounting rebuild also removes redundant attribution queries, repeated
 sorting and full-history scans, while preserving exact event-time accounting.
 A fixed private-index comparison measured median accounting-child time falling
 from 321.86 seconds to 39.25 seconds, with eight byte-identical outputs across
 the two revisions. Median peak memory rose 5.3%, within the unchanged resource
-ceiling. The [comparison receipt](../docs/receipts/2026-09-03-optimized-rc9-accounting-comparison.md)
+ceiling. The [comparison receipt](https://github.com/adamallcock/tibotattle/blob/v0.1.17/docs/receipts/2026-09-03-optimized-rc9-accounting-comparison.md)
 records the inputs, raw measurements, and limitations; this is not an end-to-end
 installed refresh measurement or a substitute for artifact qualification.
 
@@ -110,7 +109,7 @@ result from a different plan. Useful retained history survives when account
 identity is missing, while conflicting or unsupported attribution remains
 explicitly unavailable.
 
-RC9 source corrects Trends for mixed-plan history by pairing the selected
+The Trends view now corrects mixed-plan history by pairing the selected
 plan's fit with only that plan's source-bound usage, without changing the
 all-plan accounting totals. It retains established speed determinations and
 the reviewed Standard fallback for unresolved speed. Missing price, plan, or
@@ -160,13 +159,14 @@ The internal partial-tool-history warning no longer appears as a dashboard
 warning. Its coverage state is preserved, and missing tool totals are still
 withheld rather than shown as zero.
 
-RC9 source repairs last-good snapshot persistence to validate the actual
+Last-good snapshot persistence now validates the actual
 production dashboard shape rather than require a retired report field. This
 allows the native dashboard to retain its most recently verified figures across
 relaunch, clearly labelled as retained while a fresh analysis catches up. If
 neither the current index nor a compatible snapshot can support a figure, it
-stays unavailable rather than becoming a confident zero. Installed-RC9
-verification remains outstanding.
+stays unavailable rather than becoming a confident zero. The manual clean-profile
+and physical Login Item matrix remains deferred; see the [native release
+plan](https://github.com/adamallcock/tibotattle/blob/v0.1.17/docs/plans/2026-09-03-public-0.1.17-release.md).
 
 ## Clearer costs and cache-drop details
 
@@ -206,14 +206,14 @@ not block the accounting view.
 
 0.1.17 introduces local unified-index schema 11. The shipped 0.1.16 app created
 schema 8; newer development and dogfood code may have created schema 9 or
-schema 10. This candidate checks each supported predecessor read-only first.
+schema 10. This release checks each supported predecessor read-only first.
 Schema 8 and 9 predate the current source-identity contract, so the normal app
 path rebuilds a validated schema-11 stage from readable raw history. Schema 10
 already has the current physical identity contract and is cloned and migrated
 additively. The separate parser v10-to-v11 upgrade still reprocesses readable
 sources; only an unchanged source with current parser and source provenance can
-be reused without rescanning. Neither path replaces the live index until its
-candidate passes validation. Schema 11 adds the two usage lookup indexes
+be reused without rescanning. Neither path replaces the live index until
+validation succeeds. Schema 11 adds the two usage lookup indexes
 required for bounded source quarantine and orphan quota cleanup. Parser v11
 separately retains valid source facts when one quota window is malformed and
 accepts Codex's segment-start paginated lineage reset without inheriting
@@ -244,30 +244,20 @@ and Preview never opts into automatic updates.
 
 Internal dogfood is deliberately different: it keeps the stable bundle and
 local-state identity so it can test an in-place upgrade, while using its own
-update channel. Earlier 0.1.17 internal candidates used builds **1023**,
-**1023.1**, **1023.2**, **1023.3**, **1023.4**, **1023.5**, and RC8
-**1023.6**. RC9 is allocated build **1023.7**, while **1024** remains reserved for the stable
-final, keeping stable ordered after the candidate. Signed tooling also requires a clean checkout and
-exactly one matching annotated source tag at `HEAD`: `v0.1.17` for stable, or
-the strict
-`tibotattle-internal-dogfood-0.1.17-rcN-source-YYYYMMDD` form for a dated
-candidate.
+update channel. The 0.1.17 stable allocation uses the same product identity at
+build **1024** and accepted runtime basis
+`394c8a03a986e0daadbe662679fd002202682e44`; RC9 build **1023.7** was the
+preceding internal dogfood. The exact source provenance is the annotated
+[`v0.1.17` tag](https://github.com/adamallcock/tibotattle/tree/v0.1.17).
 
-RC5 build `1023.3` is signed, notarized, and installed evidence only for its
-frozen source. It preserved schema-11 data and launched without an automatic
-Keychain prompt, but its full accounting-cache rebuild exceeded the ordinary
-five-minute refresh deadline. RC6 build `1023.4` then proved the extended
-deadline and exposed the retired `recent_7d_indexing` checkpoint. RC7 build
-`1023.5` removed that checkpoint and passed protected R7, the full source gate,
-signing, notarization, stapling, state-preserving replacement, and installed
-launch. Its first installed refresh ingested generation 44 before the v0.14
-cache validator rejected internally inconsistent fit metadata. RC8 source
-corrected fit-metadata projection to start at the first eligible row. RC9 keeps
-the fail-closed source, generation, resource, validation, and atomic-publication
-guards while separating refresh modes, correcting selected-plan Trends, and
-repairing snapshot persistence. Its allocation does not qualify an artifact;
-every exact-source, R7, artifact, replacement, and installed gate must be met.
-No 0.1.17 artifact has been published or made available through an updater.
+Earlier RCs are historical qualification evidence only. Build 1024 carries the
+fail-closed source, generation, resource, validation, and atomic-publication
+guards, plus the selected-plan Trends and snapshot fixes. The PR #94 result is
+`passed_with_historical_artifact_refusal` in the [qualification
+receipt](https://github.com/adamallcock/tibotattle/blob/v0.1.17/docs/receipts/2026-09-03-pr94-account-plan-attribution-qualification.md);
+artifact and installation evidence are recorded separately in the [release
+plan](https://github.com/adamallcock/tibotattle/blob/v0.1.17/docs/plans/2026-09-03-public-0.1.17-release.md) and [current
+status matrix](https://github.com/adamallcock/tibotattle/blob/v0.1.17/docs/current-status.md).
 Browser rendering and compiled native tests do not prove physical popover
 interaction or thread-link handoff to Codex.
 
@@ -300,13 +290,13 @@ change retention periods or erase previously accepted data.
 The desktop update and hosted service deployment are separate. The merged
 Worker source makes `DELETE /api/v1/me` return `404 NOT_FOUND` without participant
 mutation, but that endpoint retirement has **not been deployed by this release
-work**. Installing the candidate changes its desktop controls, not the live
+work**. Installing this release changes its desktop controls, not the live
 Worker endpoint or controls in older installed apps.
 
 Before a separate hosted cutover, the owner must verify independent owner
 access, account for unfinished deletions, resolve private privacy-request
 intake and identity verification, and verify retention/backup disclosures.
-Those requirements remain open; this candidate establishes no new contact
+Those requirements remain open; this release establishes no new contact
 channel, response deadline, or conclusion about applicable privacy rights.
 
 ## Public community view
@@ -333,16 +323,15 @@ desktop source build or installation is not evidence that pairing works against
 the live service.
 
 The fixed-real-corpus, before/after attribution comparison required by the PR
-#94 plan remains **OPEN / NOT RUN** and has not been represented as passed by
-R7. Existing tools provide partial content-free aggregates but no reviewed,
-schema-validated cross-revision comparator with the required reconciliation and
-resource receipt. An explicitly open-gate internal dogfood may be used for
-testing, but this empirical gate must be closed or deliberately resolved before
-stable or public qualification.
+#94 plan is tracked in the [qualification receipt](https://github.com/adamallcock/tibotattle/blob/v0.1.17/docs/receipts/2026-09-03-pr94-account-plan-attribution-qualification.md).
+**Outcome:** `passed_with_historical_artifact_refusal`. The result is limited to the measured local
+comparator and does not establish hosted deployment, provider-authoritative
+billing, account-exact or cross-device identity, or general R7/native
+qualification.
 
 ## Known limitations
 
-This candidate remains the native macOS app. It does not include the new
+This release remains the native macOS app. It does not include the new
 Electron application, and Windows and Linux desktop support are not claimed by
 0.1.17.
 Unfinished Claude Code usage-monitoring integration work is also excluded.

--- a/scripts/build-macos-app.js
+++ b/scripts/build-macos-app.js
@@ -121,6 +121,12 @@ const DISTRIBUTION_CHANNEL_PRODUCTION = "production";
 const MACOS_BUILD_PROFILE_RELEASE = "release";
 const MACOS_BUILD_PROFILE_TEST = "test";
 const FIXED_EPOCH_SECONDS = 946_684_800;
+const GIT_PATH = "/usr/bin/git";
+const SET_FILE_PATH = "/usr/bin/SetFile";
+const MACOS_TOOL_ENV = Object.freeze({
+  PATH: "/usr/bin:/bin:/usr/sbin:/sbin",
+  TZ: "UTC",
+});
 const MAXIMUM_BUNDLE_BYTES = 512 * 1024 * 1024;
 const MANIFEST_SCHEMA = "usage-monitor-macos-app-build-v0.1";
 const CODESIGN_PATH = "/usr/bin/codesign";
@@ -1968,6 +1974,93 @@ function run(command, args, options = {}) {
   return result.stdout.trim();
 }
 
+function macOSFinderDate(timestampSeconds, label) {
+  if (!Number.isSafeInteger(timestampSeconds) || timestampSeconds < 0) {
+    fail(`${label} must be a non-negative integer timestamp`);
+  }
+  const date = new Date(timestampSeconds * 1_000);
+  if (!Number.isFinite(date.getTime())
+      || date.getUTCFullYear() < 1904
+      || date.getUTCFullYear() > 9999) {
+    fail(`${label} is outside the supported macOS file-date range`);
+  }
+  const pad = (value) => String(value).padStart(2, "0");
+  return [
+    `${pad(date.getUTCMonth() + 1)}/${pad(date.getUTCDate())}/${date.getUTCFullYear()}`,
+    `${pad(date.getUTCHours())}:${pad(date.getUTCMinutes())}:${pad(date.getUTCSeconds())}`,
+  ].join(" ");
+}
+
+/**
+ * Read the source commit's timestamp for external builds. The commit is
+ * already authenticated by the release-core preflight; reading it here keeps
+ * Finder metadata tied to that same immutable source revision without adding
+ * a wall-clock input or changing the public build manifest.
+ */
+export function readMacOSReleaseSourceTimestamp(source) {
+  if (!source || typeof source !== "object"
+      || typeof source.commit !== "string"
+      || !/^[0-9a-f]{40,64}$/u.test(source.commit)) {
+    fail(
+      "Release source commit is required for Finder metadata",
+      "MACOS_RELEASE_SOURCE_INVALID",
+    );
+  }
+  const output = run(GIT_PATH, [
+    "-C",
+    REPOSITORY_ROOT,
+    "show",
+    "-s",
+    "--format=%ct",
+    `${source.commit}^{commit}`,
+  ], { env: MACOS_TOOL_ENV });
+  if (!/^\d+$/u.test(output)) {
+    fail(
+      "Release source commit timestamp is invalid",
+      "MACOS_RELEASE_SOURCE_TIMESTAMP_INVALID",
+    );
+  }
+  const timestampSeconds = Number(output);
+  if (!Number.isSafeInteger(timestampSeconds) || timestampSeconds < 0) {
+    fail(
+      "Release source commit timestamp is outside the supported range",
+      "MACOS_RELEASE_SOURCE_TIMESTAMP_INVALID",
+    );
+  }
+  return timestampSeconds;
+}
+
+/**
+ * Set only the outer bundle directory's Finder birth/modify dates. Payload
+ * files retain the fixed normalization above; this filesystem metadata is not
+ * part of the signed or inventoried payload bytes.
+ */
+export function setMacOSBundleFinderMetadata(path, {
+  birthTimeSeconds,
+  modificationTimeSeconds = birthTimeSeconds,
+  commandRunner = run,
+} = {}) {
+  if (typeof path !== "string" || path.length === 0 || path.includes("\0")) {
+    fail("macOS bundle path is invalid for Finder metadata");
+  }
+  const birthDate = macOSFinderDate(birthTimeSeconds, "Finder birth time");
+  const modificationDate = macOSFinderDate(
+    modificationTimeSeconds,
+    "Finder modification time",
+  );
+  commandRunner(SET_FILE_PATH, [
+    "-d",
+    birthDate,
+    "-m",
+    modificationDate,
+    path,
+  ], { env: MACOS_TOOL_ENV });
+  return Object.freeze({
+    birthTimeSeconds,
+    modificationTimeSeconds,
+  });
+}
+
 function assertBuildPlatform() {
   if (process.platform !== "darwin"
       || process.arch !== PINNED_NODE_ARCHITECTURE) {
@@ -3269,7 +3362,15 @@ export async function assertMacOSExternalBuildOutputIsFresh(output) {
   );
 }
 
-export async function installMacOSExternalBuildOutput(stagedApp, output) {
+export async function installMacOSExternalBuildOutput(stagedApp, output, {
+  finderMetadata = null,
+} = {}) {
+  // Validate and apply Finder metadata while the bundle is still isolated.
+  // If SetFile is unavailable or rejects the staged bundle, no final output
+  // path has been claimed yet.
+  if (finderMetadata !== null) {
+    setMacOSBundleFinderMetadata(stagedApp, finderMetadata);
+  }
   try {
     // Claim the final bundle path without replacement. If an output appears
     // after the pre-build check, mkdir fails and the existing target remains.
@@ -3283,8 +3384,34 @@ export async function installMacOSExternalBuildOutput(stagedApp, output) {
     }
     throw error;
   }
-  for (const entry of await readdir(stagedApp)) {
-    await rename(join(stagedApp, entry), join(output, entry));
+  try {
+    // mkdir above claims the path; set its root metadata before moving any
+    // payload entries so a metadata failure cannot expose a final bundle.
+    if (finderMetadata !== null) {
+      setMacOSBundleFinderMetadata(output, finderMetadata);
+    }
+    for (const entry of await readdir(stagedApp)) {
+      await rename(join(stagedApp, entry), join(output, entry));
+    }
+    if (finderMetadata !== null) {
+      // Moving entries updates the claimed directory's mtime. Restore only
+      // that root field after the move; the source-bound SetFile preflight
+      // above already established the Finder birth date before installation.
+      const modificationTimeSeconds = finderMetadata.modificationTimeSeconds
+        ?? finderMetadata.birthTimeSeconds;
+      await utimes(
+        output,
+        modificationTimeSeconds,
+        modificationTimeSeconds,
+      );
+    }
+  } catch (error) {
+    try {
+      await rm(output, { recursive: true, force: false });
+    } catch (cleanupError) {
+      error.message = `${error.message}; failed to remove incomplete external output: ${cleanupError.message}`;
+    }
+    throw error;
   }
 }
 
@@ -3936,6 +4063,9 @@ export async function buildMacOSApp({
     })
     : resolve(output);
   assertBuildPlatform();
+  const releaseFinderTimestamp = externalDistribution
+    ? readMacOSReleaseSourceTimestamp(sealedReleaseSource)
+    : null;
   const iconAssets = await loadIconAssets({
     required: distribution.externalDistribution || distribution.previewDistribution,
   });
@@ -3966,7 +4096,11 @@ export async function buildMacOSApp({
     });
     signApplicationBundle(stagedApp);
     if (externalDistribution) {
-      await installMacOSExternalBuildOutput(stagedApp, selectedOutput);
+      await installMacOSExternalBuildOutput(stagedApp, selectedOutput, {
+        finderMetadata: {
+          birthTimeSeconds: releaseFinderTimestamp,
+        },
+      });
     } else {
       let legacyPreviewArchive = null;
       if (await verifyExistingBuildTarget(selectedOutput, productBrand)) {

--- a/scripts/lib/pr94-analysis-worker.mjs
+++ b/scripts/lib/pr94-analysis-worker.mjs
@@ -144,12 +144,55 @@ function bound(values, target, inclusive) {
   return low;
 }
 
+// These are the original miner's groups, not a second implementation of its
+// era or transition policy. Bind every summary to its input parent and emitted
+// rows before retaining only bounded, content-free counts for reconciliation.
+function originalDerivationEvidence(result, identity, attributed) {
+  if (!Array.isArray(result.groupSummaries) || result.groupSummaries.length > MAX_QUOTA
+      || result.windowGroupCount !== result.groupSummaries.length) fail("pr94_derivation_invalid");
+  const expectedParent = parentKey(identity);
+  const rowCounts = new Map();
+  for (const row of result.transitions) {
+    if (parentKey(row) !== expectedParent) fail("pr94_derivation_invalid");
+    const era = attributed ? row.planEraKey : "legacy";
+    if (typeof era !== "string" || era.length === 0 || era.length > 4096) fail("pr94_derivation_invalid");
+    rowCounts.set(era, (rowCounts.get(era) ?? 0) + 1);
+  }
+  const seen = new Set();
+  const evidence = { groupCount: result.groupSummaries.length, snapshotCount: 0,
+    transitionCount: 0, zeroTransitionGroupCount: 0 };
+  for (const summary of result.groupSummaries) {
+    if (!summary || parentKey(summary) !== expectedParent
+        || !["primary", "secondary"].includes(summary.slot)
+        || !integer(summary.snapshotCount) || summary.snapshotCount < 1 || summary.snapshotCount > MAX_QUOTA
+        || !integer(summary.transitionCount) || summary.transitionCount >= summary.snapshotCount
+        || !integer(summary.monotonicTransitionCount) || !integer(summary.regressionTransitionCount)
+        || summary.monotonicTransitionCount + summary.regressionTransitionCount !== summary.transitionCount) {
+      fail("pr94_derivation_invalid");
+    }
+    const era = attributed ? summary.planEraKey : "legacy";
+    if (typeof era !== "string" || era.length === 0 || era.length > 4096 || seen.has(era)
+        || (rowCounts.get(era) ?? 0) !== summary.transitionCount) fail("pr94_derivation_invalid");
+    seen.add(era);
+    rowCounts.delete(era);
+    evidence.snapshotCount += summary.snapshotCount;
+    evidence.transitionCount += summary.transitionCount;
+    evidence.zeroTransitionGroupCount += Number(summary.transitionCount === 0);
+    if (evidence.snapshotCount > MAX_QUOTA || evidence.transitionCount > MAX_TRANSITIONS) fail("pr94_derivation_invalid");
+  }
+  if (rowCounts.size !== 0 || evidence.snapshotCount !== result.deduplicatedSnapshotCount
+      || evidence.transitionCount !== result.transitions.length) fail("pr94_derivation_invalid");
+  return Object.freeze(evidence);
+}
+
 export async function derivePr94BatchedTransitions({ modules, usage, grouped, startAt, endAt,
   resourceCheck = checkResource }) {
   const transitions = [];
   let deduplicatedSnapshotCount = 0;
   let maximumUsageSlice = 0;
   let maximumQuotaSlice = 0;
+  const rawParents = new Map(grouped.rawParents.map((parent) => [parentKey(parent), parent]));
+  if (rawParents.size !== grouped.rawParents.length || rawParents.size !== grouped.groups.length) fail("pr94_derivation_invalid");
   for (const group of grouped.groups) {
     resourceCheck();
     const windowStart = (group.identity.resetsAt - WEEKLY * 60) * 1000;
@@ -165,13 +208,20 @@ export async function derivePr94BatchedTransitions({ modules, usage, grouped, st
       includeNormalizedInputs: false, consumeInputs: true,
       resourceCheck, ...(grouped.attribution ? { planAttributionIndex: grouped.attribution } : {}),
     });
-    if (!integer(result.deduplicatedSnapshotCount) || !Array.isArray(result.transitions)) {
+    if (!integer(result.deduplicatedSnapshotCount) || result.deduplicatedSnapshotCount > group.snapshots.length
+        || !Array.isArray(result.transitions) || result.transitions.length > MAX_TRANSITIONS) {
       fail("pr94_derivation_invalid");
     }
+    const parent = rawParents.get(parentKey(group.identity));
+    const derivationEvidence = originalDerivationEvidence(result, group.identity, grouped.attribution !== null);
+    if (!parent || derivationEvidence.snapshotCount !== parent.matchedUniqueSnapshotCount) fail("pr94_derivation_invalid");
+    parent.derivationEvidence = derivationEvidence;
+    rawParents.delete(parentKey(group.identity));
     deduplicatedSnapshotCount += result.deduplicatedSnapshotCount;
     if (transitions.length + result.transitions.length > MAX_TRANSITIONS) fail("pr94_resource_limit");
     for (const row of result.transitions) transitions.push(row);
   }
+  if (rawParents.size !== 0) fail("pr94_derivation_invalid");
   transitions.sort((a, b) => a.eventTime.localeCompare(b.eventTime)
     || a.resetIdentity.localeCompare(b.resetIdentity)
     || a.windowDurationMins - b.windowDurationMins || a.slot.localeCompare(b.slot));

--- a/scripts/lib/pr94-analysis-worker.mjs
+++ b/scripts/lib/pr94-analysis-worker.mjs
@@ -1,0 +1,370 @@
+import { createHash } from "node:crypto";
+import { once } from "node:events";
+import { createWriteStream } from "node:fs";
+import { lstat, realpath, writeFile } from "node:fs/promises";
+import { join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { loadPr94Revision } from "./pr94-revision-loader.mjs";
+import { buildPr94PopulationEvidence } from "./pr94-population-evidence.mjs";
+import { inspectDetailedAccountingBenchmarkIndex,
+  projectDetailedAccountingBenchmarkGeneration } from "../benchmark-detailed-accounting.mjs";
+import {
+  createPr94LedgerEvidence,
+  iteratePr94LedgerEvidencePrivate,
+  disposePr94LedgerEvidencePrivate,
+} from "./pr94-ledger-evidence.mjs";
+import {
+  buildPr94CalibrationEvidence,
+  iteratePr94CalibrationPrivateFrames,
+  disposePr94CalibrationEvidencePrivate,
+} from "./pr94-calibration-evidence.mjs";
+
+const MAX_RSS = 6_442_450_944;
+const MAX_USAGE = 1_000_000;
+const MAX_QUOTA = 1_000_000;
+const MAX_TRANSITIONS = 200_000;
+const WEEKLY = 10_080;
+export const PR94_ANALYSIS_ERROR_CODES = Object.freeze([
+  "pr94_resource_limit", "pr94_inputs_invalid", "pr94_attribution_index_incomplete", "pr94_derivation_invalid",
+  "pr94_private_artifact_limit", "pr94_private_artifact_write_failed", "pr94_inventory_invalid", "pr94_path_invalid",
+  "pr94_generation_incomplete", "pr94_inventory_mismatch", "pr94_reader_incomplete", "pr94_result_limit",
+  "pr94_runtime_invalid", "pr94_request_invalid", "pr94_population_invalid", "pr94_instrumentation_invalid",
+  "transition_derivation_input_limit_exceeded", "transition_derivation_row_limit_exceeded", "transition_derivation_work_limit_exceeded",
+  "pr94_ledger_row_rejected", "pr94_ledger_invalid", "pr94_ledger_state", "pr94_ledger_private_evidence_required",
+  "pr94_analysis_failed",
+  ...["aggregate_invalid", "baseline_population_mismatch", "candidates_invalid", "count_invalid", "diagnostic_multiplied",
+    "duplicate_parent", "eligibility_drift", "evidence_untrusted", "fit_gate_drift", "fit_source_unrecognized",
+    "fragment_limit", "fragment_multiplied", "fragment_reason_unknown", "group_multiplied", "group_unreconciled",
+    "hmac_key_invalid", "identity_invalid", "input_invalid", "internal_missing", "parent_candidate_missing",
+    "parent_invalid", "parent_multiplied", "parent_out_of_scope", "primary_multiplied", "private_frames_invalid",
+    "report_count_mismatch", "report_distribution_mismatch", "report_fit_mismatch", "report_fragment_mismatch",
+    "report_group_mismatch", "report_rejected_fit", "report_suppressed_fit", "scope_invalid", "seal_invalid",
+    "snapshot_partition_invalid", "suppression_unknown", "transition_parent_missing"].map((name) => `pr94_calibration_${name}`),
+]);
+const TOKEN_COLUMNS = Object.freeze([
+  "tokens_in_uncached", "tokens_in_cache_read", "tokens_in_cache_write",
+  "tokens_out_text", "tokens_out_reasoning", "tokens_out_combined",
+]);
+function fail(code) { throw Object.assign(new Error(code), { code }); }
+function checkResource() {
+  if (process.memoryUsage.rss() > MAX_RSS) fail("pr94_resource_limit");
+}
+function integer(value) { return Number.isSafeInteger(value) && value >= 0; }
+function parentKey(row) {
+  return JSON.stringify([row.accountScopeId ?? "unattributed", row.provider,
+    row.planType ?? "unknown", row.limitId, row.windowDurationMins, row.resetsAt]);
+}
+function quotaIdentity(snapshot) {
+  return { accountScopeId: snapshot.accountScopeId ?? null,
+    provider: snapshot.window.provider, planType: snapshot.window.planType ?? "unknown",
+    planVariant: snapshot.window.planVariant ?? "unknown", limitId: snapshot.window.limitId,
+    windowDurationMins: snapshot.window.windowDurationMins, resetsAt: snapshot.window.resetsAt };
+}
+
+export function buildPr94QuotaGroups(snapshots, { quota, revisionKind }) {
+  if (!Array.isArray(snapshots) || snapshots.length > MAX_QUOTA
+      || !["before", "after", "final"].includes(revisionKind)) fail("pr94_inputs_invalid");
+  let attribution = null;
+  if (revisionKind !== "before") {
+    attribution = quota.buildPlanAttributionIndex(snapshots.map((snapshot) => ({
+      contextKey: quota.planAttributionContextKey(snapshot.window.provider, snapshot.window.limitId),
+      observedAtMs: snapshot.timestampMs,
+      planType: snapshot.window.planType,
+      planVariant: snapshot.window.planVariant ?? "unknown",
+      accountScopeId: snapshot.accountScopeId ?? null,
+    })));
+    // Unknown-plan anchors intentionally contribute to ignoredObservationCount;
+    // the original owner retains their conditional era. They are not malformed
+    // input and must not be relabelled as a failed/incomplete discovery.
+    if (attribution.status !== "ready") {
+      fail("pr94_attribution_index_incomplete");
+    }
+  }
+  const groups = new Map();
+  let latestMs = -Infinity;
+  let latestPlans = new Set();
+  for (const snapshot of snapshots) {
+    if (snapshot.window.provider !== "openai_codex" || snapshot.window.limitId !== "codex") continue;
+    const plan = snapshot.window.planType;
+    if (typeof plan === "string" && plan !== "unknown") {
+      if (snapshot.timestampMs > latestMs) { latestMs = snapshot.timestampMs; latestPlans = new Set(); }
+      if (snapshot.timestampMs === latestMs) latestPlans.add(plan);
+    }
+    if (snapshot.window.windowDurationMins !== WEEKLY) continue;
+    const identity = quotaIdentity(snapshot);
+    const key = parentKey(identity);
+    let group = groups.get(key);
+    if (!group) {
+      group = { identity, snapshots: [], unique: new Set(), percents: new Set(),
+        matchedUnique: new Set(), matchedPercents: new Set(), matched: 0,
+        conflicted: 0, unavailable: 0 };
+      groups.set(key, group);
+    }
+    group.snapshots.push(snapshot);
+    const observationKey = `${snapshot.timestampMs}|${snapshot.window.usedPercent}`;
+    group.unique.add(observationKey);
+    group.percents.add(snapshot.window.usedPercent);
+    const lookup = attribution === null ? null : quota.planEraForInterval(attribution, {
+      contextKey: quota.planAttributionContextKey(snapshot.window.provider, snapshot.window.limitId),
+      observedAtMs: snapshot.timestampMs, accountScopeId: snapshot.accountScopeId ?? null,
+    });
+    const matched = attribution === null
+      || (lookup.status === "matched" && lookup.era.planType === snapshot.window.planType);
+    if (matched) {
+      group.matched += 1;
+      group.matchedUnique.add(observationKey);
+      group.matchedPercents.add(snapshot.window.usedPercent);
+    } else if (lookup.status === "conflicted") group.conflicted += 1;
+    else group.unavailable += 1;
+  }
+  const rawParents = [...groups.values()].map((group) => ({
+    ...group.identity, snapshotCount: group.snapshots.length,
+    uniqueSnapshotCount: group.unique.size, distinctPercentCount: group.percents.size,
+    matchedSnapshotCount: group.matched,
+    matchedUniqueSnapshotCount: group.matchedUnique.size,
+    matchedDistinctPercentCount: group.matchedPercents.size,
+    conflictedSnapshotCount: group.conflicted, unavailableSnapshotCount: group.unavailable,
+  }));
+  for (const group of groups.values()) {
+    delete group.unique; delete group.percents;
+    delete group.matchedUnique; delete group.matchedPercents;
+  }
+  return { attribution, rawParents, groups: [...groups.values()],
+    selectedPlanType: latestPlans.size === 1 ? [...latestPlans][0] : "unknown" };
+}
+
+function bound(values, target, inclusive) {
+  let low = 0; let high = values.length;
+  while (low < high) {
+    const middle = Math.floor((low + high) / 2);
+    if (values[middle].timestampMs < target
+        || (inclusive && values[middle].timestampMs === target)) low = middle + 1;
+    else high = middle;
+  }
+  return low;
+}
+
+export async function derivePr94BatchedTransitions({ modules, usage, grouped, startAt, endAt,
+  resourceCheck = checkResource }) {
+  const transitions = [];
+  let deduplicatedSnapshotCount = 0;
+  let maximumUsageSlice = 0;
+  let maximumQuotaSlice = 0;
+  for (const group of grouped.groups) {
+    resourceCheck();
+    const windowStart = (group.identity.resetsAt - WEEKLY * 60) * 1000;
+    const lastObserved = group.snapshots.at(-1).timestampMs;
+    const low = bound(usage, Math.max(Date.parse(startAt), windowStart), false);
+    const high = bound(usage, lastObserved, true);
+    const slice = usage.slice(low, high);
+    maximumUsageSlice = Math.max(maximumUsageSlice, slice.length);
+    maximumQuotaSlice = Math.max(maximumQuotaSlice, group.snapshots.length);
+    const result = await modules.miner.deriveCodexTransitionSeriesCooperatively({
+      startAt, endAt, rawUsageEvents: slice, rateLimitSnapshots: group.snapshots.slice(),
+      diagnostics: {}, includeSnapshotIntervals: false, windowDurationMins: WEEKLY,
+      includeNormalizedInputs: false, consumeInputs: true,
+      resourceCheck, ...(grouped.attribution ? { planAttributionIndex: grouped.attribution } : {}),
+    });
+    if (!integer(result.deduplicatedSnapshotCount) || !Array.isArray(result.transitions)) {
+      fail("pr94_derivation_invalid");
+    }
+    deduplicatedSnapshotCount += result.deduplicatedSnapshotCount;
+    if (transitions.length + result.transitions.length > MAX_TRANSITIONS) fail("pr94_resource_limit");
+    for (const row of result.transitions) transitions.push(row);
+  }
+  transitions.sort((a, b) => a.eventTime.localeCompare(b.eventTime)
+    || a.resetIdentity.localeCompare(b.resetIdentity)
+    || a.windowDurationMins - b.windowDurationMins || a.slot.localeCompare(b.slot));
+  return { transitions, deduplicatedSnapshotCount,
+    batchMetrics: { batches: grouped.groups.length, maximumUsageSlice, maximumQuotaSlice } };
+}
+
+async function writePrivateFrames(path, frames) {
+  const output = createWriteStream(path, { flags: "wx", mode: 0o600 });
+  // Observe asynchronous errors even before the next drain/end wait.
+  let streamError = null;
+  output.on("error", (error) => { streamError = error; });
+  let bytes = 0;
+  try {
+    for (const frame of frames) {
+      if (streamError) throw streamError;
+      const line = `${JSON.stringify(frame)}\n`;
+      bytes += Buffer.byteLength(line);
+      if (bytes > 512 * 1024 * 1024) fail("pr94_private_artifact_limit");
+      if (!output.write(line)) await once(output, "drain");
+    }
+    output.end();
+    await once(output, "close");
+    if (streamError) throw streamError;
+    return bytes;
+  } catch {
+    output.destroy();
+    fail("pr94_private_artifact_write_failed");
+  }
+}
+
+function indexInventory(database, generation, startMs, endMs) {
+  const totals = database.prepare(`SELECT COUNT(*) AS count,
+    SUM(CASE WHEN ${TOKEN_COLUMNS.map((column) => `COALESCE(${column},0)`).join("+")}=0
+      THEN 1 ELSE 0 END) AS zeroCount FROM usage_event
+    WHERE observed_at_ms >= ? AND observed_at_ms <= ?`).get(startMs, endMs);
+  const quota = { admitted: 0, held: 0, suppressed: 0 };
+  for (const row of database.prepare(`SELECT admission,COUNT(*) AS count FROM quota_occurrence
+    WHERE observed_at_ms >= ? AND observed_at_ms <= ? GROUP BY admission`).all(startMs, endMs)) {
+    if (!Object.hasOwn(quota, row.admission) || !integer(row.count)) fail("pr94_inventory_invalid");
+    quota[row.admission] = row.count;
+  }
+  if (!integer(totals.count) || !integer(totals.zeroCount)
+      || totals.zeroCount > totals.count) fail("pr94_inventory_invalid");
+  return { indexedUsageRows: totals.count, zeroComponentUsageRows: totals.zeroCount, quota,
+    generationUsageRows: generation.usageEvents, generationQuotaRows: generation.quotaOccurrences };
+}
+
+function safeCoverage(result) {
+  if (result?.coverage?.status !== "complete") fail("pr94_reader_incomplete");
+  // Complete accounting coverage is not complete tool provenance. The exact
+  // generation descriptor is independently projected by the coordinator.
+  return { accountingStatus: "complete",
+    diagnosticsSha256: createHash("sha256").update(JSON.stringify(result.diagnostics)).digest("hex"),
+    compatibilitySha256: createHash("sha256").update(JSON.stringify(result.compatibility)).digest("hex") };
+}
+
+export function validatePr94WorkerOptions(options) {
+  const keys = ["root", "indexFile", "outputDirectory", "startAt", "endAt", "revisionKind"];
+  if (!options || typeof options !== "object" || Array.isArray(options)
+      || Object.keys(options).sort().join("|") !== keys.sort().join("|")) fail("pr94_request_invalid");
+  for (const name of ["root", "indexFile", "outputDirectory"]) {
+    if (typeof options[name] !== "string" || options[name].includes("\0")
+        || resolve(options[name]) !== options[name]) fail("pr94_request_invalid");
+  }
+  for (const name of ["startAt", "endAt"]) {
+    if (typeof options[name] !== "string" || !Number.isSafeInteger(Date.parse(options[name]))
+        || new Date(options[name]).toISOString() !== options[name]) fail("pr94_request_invalid");
+  }
+  if (options.startAt >= options.endAt || !["before", "after", "final"].includes(options.revisionKind)) {
+    fail("pr94_request_invalid");
+  }
+  return options;
+}
+
+export async function runPr94AnalysisWorker(options, hmacKey) {
+  validatePr94WorkerOptions(options);
+  const { root, indexFile, outputDirectory, startAt, endAt, revisionKind } = options;
+  const directory = await lstat(outputDirectory);
+  if (!directory.isDirectory() || directory.isSymbolicLink()
+      || directory.uid !== process.getuid() || (directory.mode & 0o077)
+      || await realpath(outputDirectory) !== outputDirectory) fail("pr94_path_invalid");
+  await inspectDetailedAccountingBenchmarkIndex(indexFile);
+  const modules = await loadPr94Revision(root);
+  const database = modules.index.openLocalUnifiedIndex(indexFile, { readOnly: true });
+  let generation; let inventory;
+  try {
+    generation = modules.index.readUnifiedIndexGenerationDescriptor(database);
+    inventory = indexInventory(database, generation, Date.parse(startAt), Date.parse(endAt));
+  } finally { database.close(); }
+  if (generation.skippedSourceCount !== 0 || generation.skippedThreadCount !== 0
+      || !generation.discoveryComplete || !generation.usageProvenanceComplete
+      || !generation.quotaProvenanceComplete) fail("pr94_generation_incomplete");
+  const generationEvidence = projectDetailedAccountingBenchmarkGeneration(generation);
+  const ledger = createPr94LedgerEvidence({ hmacKey, maxRows: 2_000_000 });
+  const usage = []; const snapshots = []; const costs = [];
+  let lastUsage = -Infinity; let lastQuota = -Infinity;
+  const phaseMs = {};
+  let started = performance.now();
+  const scanResult = await modules.reader.createLocalUnifiedAccountingSource({
+    indexFile, requireComplete: true, expectedGeneration: generation,
+    verifyPublishedGeneration: true, contextBehavior: "legacy_zero",
+  })({ startAt, endAt,
+    onUsage(event) {
+      if (usage.length >= MAX_USAGE || event.timestampMs < lastUsage) fail("pr94_inputs_invalid");
+      lastUsage = event.timestampMs;
+      const price = modules.accounting.priceCodexUsageEvent(event);
+      ledger.consumeUsage(event, price);
+      usage.push(event);
+      costs.push(price.totalUsd);
+      if (usage.length % 2048 === 0) checkResource();
+    },
+    onRateLimitSnapshot(snapshot) {
+      if (snapshots.length >= MAX_QUOTA || snapshot.timestampMs < lastQuota) fail("pr94_inputs_invalid");
+      lastQuota = snapshot.timestampMs;
+      ledger.consumeQuota(snapshot);
+      snapshots.push({ timestamp: snapshot.timestamp, timestampMs: snapshot.timestampMs,
+        window: snapshot.window, ...(snapshot.accountScopeId ? { accountScopeId: snapshot.accountScopeId } : {}) });
+      if (snapshots.length % 2048 === 0) checkResource();
+    },
+  });
+  phaseMs.readAndLedger = Math.round(performance.now() - started);
+  if (usage.length + inventory.zeroComponentUsageRows !== inventory.indexedUsageRows
+      || snapshots.length !== inventory.quota.admitted) fail("pr94_inventory_mismatch");
+  const coverage = safeCoverage(scanResult);
+  const ledgerEvidence = ledger.finish();
+  const privateLedgerBytes = await writePrivateFrames(join(outputDirectory, "ledger.ndjson"),
+    iteratePr94LedgerEvidencePrivate(ledgerEvidence));
+  disposePr94LedgerEvidencePrivate(ledgerEvidence);
+  started = performance.now();
+  const grouped = buildPr94QuotaGroups(snapshots, { quota: modules.quota, revisionKind });
+  snapshots.length = 0;
+  checkResource();
+  const populationEvidence = buildPr94PopulationEvidence({ usage, costs, ledger: ledgerEvidence,
+    quota: modules.quota, attribution: grouped.attribution, revisionKind, resourceCheck: checkResource });
+  costs.length = 0;
+  const derived = await derivePr94BatchedTransitions({ modules, usage, grouped, startAt, endAt });
+  phaseMs.attributionAndDerivation = Math.round(performance.now() - started);
+  usage.length = 0;
+  started = performance.now();
+  const calibration = buildPr94CalibrationEvidence({
+    internals: modules.reporting.__pr94CalibrationInternals,
+    analyzeWeeklyCalibration: modules.reporting.analyzeWeeklyCalibration,
+    candidates: modules.reporting.WEEKLY_CALIBRATION_CANDIDATES,
+    transitions: derived.transitions, rawParents: grouped.rawParents,
+    revisionKind, hmacKey, scope: { startAt, endAt }, selectedPlanType: grouped.selectedPlanType,
+  });
+  phaseMs.calibrationAndReconciliation = Math.round(performance.now() - started);
+  const privateCalibrationBytes = await writePrivateFrames(join(outputDirectory, "calibration.ndjson"),
+    iteratePr94CalibrationPrivateFrames(calibration));
+  disposePr94CalibrationEvidencePrivate(calibration);
+  checkResource();
+  const result = { schema: "pr94-analysis-worker-v1", revisionKind,
+    // This is the shipped detailed-accounting policy, not a claim that unknown
+    // source-native context was actually observed as zero.
+    contextBehavior: "legacy_zero", generation: generationEvidence,
+    attributionIndex: grouped.attribution === null ? null : {
+      observationCount: grouped.attribution.observationCount,
+      ignoredObservationCount: grouped.attribution.ignoredObservationCount,
+      eras: grouped.attribution.eras.length, conflicts: grouped.attribution.conflicts.length,
+      contexts: grouped.attribution.contexts.size,
+    },
+    instrumentation: modules.instrumentation, inventory, coverage,
+    ledger: ledgerEvidence, calibration, populationEvidence, batchMetrics: derived.batchMetrics,
+    deduplicatedWeeklySnapshots: derived.deduplicatedSnapshotCount, phaseMs,
+    privateArtifactBytes: { ledger: privateLedgerBytes, calibration: privateCalibrationBytes } };
+  const body = JSON.stringify(result);
+  if (Buffer.byteLength(body) > 4 * 1024 * 1024) fail("pr94_result_limit");
+  await writeFile(join(outputDirectory, "analysis.json"), body, { flag: "wx", mode: 0o600 });
+  return { status: "ok", resultBytes: Buffer.byteLength(body),
+    resultSha256: createHash("sha256").update(body).digest("hex") };
+}
+
+if (process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  try {
+    if (process.version !== "v26.2.0" || process.platform !== "darwin" || process.arch !== "arm64") {
+      fail("pr94_runtime_invalid");
+    }
+    const chunks = []; let requestBytes = 0;
+    for await (const chunk of process.stdin) {
+      requestBytes += chunk.length;
+      if (requestBytes > 32 * 1024) fail("pr94_request_invalid");
+      chunks.push(chunk);
+    }
+    const input = Buffer.concat(chunks).toString("utf8");
+    const { hmacKey: key, ...options } = JSON.parse(input);
+    if (typeof key !== "string" || !/^[0-9a-f]{64}$/u.test(key)) fail("pr94_request_invalid");
+    const envelope = await runPr94AnalysisWorker(options, Buffer.from(key, "hex"));
+    process.stdout.write(`${JSON.stringify(envelope)}\n`);
+  } catch (error) {
+    // A lower-level Error may contain private paths or input. Do not print it.
+    const codes = new Set(PR94_ANALYSIS_ERROR_CODES);
+    process.stdout.write(`${JSON.stringify({ status: "error",
+      code: codes.has(error?.code ?? error?.message) ? error.code ?? error.message : "pr94_analysis_failed" })}\n`);
+  }
+}

--- a/scripts/lib/pr94-calibration-evidence.mjs
+++ b/scripts/lib/pr94-calibration-evidence.mjs
@@ -22,7 +22,7 @@ const OUTCOMES = Object.freeze([
   "aggregation_diagnostic_only", "insufficient_unique_boundaries", "insufficient_percent_span",
   "training_capacity_unavailable", "insufficient_training_pairs", "full_capacity_unavailable",
   "relative_width_unavailable", "relative_width_exceeded", "insufficient_snapshots",
-  "no_percent_change", "all_snapshot_attribution_withheld", "unexplained_no_transition",
+  "no_percent_change", "no_within_era_percent_change", "all_snapshot_attribution_withheld", "unexplained_no_transition",
 ]);
 const ROW_REASONS = Object.freeze([
   "eligible", "aggregation_diagnostic_only", "non_increasing_percent", "no_usage",
@@ -215,15 +215,31 @@ function noTransitionReason(raw) {
       || matched + conflicted + unavailable !== total) {
     fail("pr94_calibration_snapshot_partition_invalid");
   }
-  if (matched === 0 && total > 0) return "all_snapshot_attribution_withheld";
   const matchedUnique = raw.matchedUniqueSnapshotCount ?? (matched === total ? unique : null);
   const matchedDistinct = raw.matchedDistinctPercentCount ?? (matched === total ? distinct : null);
   if (matchedUnique !== null && (count(matchedUnique) > matched
       || (matchedDistinct !== null && count(matchedDistinct) > matchedUnique))) {
     fail("pr94_calibration_snapshot_partition_invalid");
   }
+  const derived = raw.derivationEvidence;
+  if (derived !== undefined) {
+    const keys = ["groupCount", "snapshotCount", "transitionCount", "zeroTransitionGroupCount"];
+    if (!equal(recordKeys(derived).sort(), [...keys].sort())) fail("pr94_calibration_snapshot_partition_invalid");
+    for (const key of keys) if (count(derived[key]) > 1_000_000) fail("pr94_calibration_snapshot_partition_invalid");
+    if (matchedUnique === null || derived.snapshotCount !== matchedUnique
+        || derived.groupCount > derived.snapshotCount
+        || (derived.groupCount === 0) !== (derived.snapshotCount === 0)
+        || derived.transitionCount > derived.snapshotCount - derived.groupCount
+        || derived.zeroTransitionGroupCount > derived.groupCount
+        || (derived.transitionCount === 0) !== (derived.zeroTransitionGroupCount === derived.groupCount)) {
+      fail("pr94_calibration_snapshot_partition_invalid");
+    }
+  }
+  if (matched === 0 && total > 0) return "all_snapshot_attribution_withheld";
   if (matchedUnique !== null && matchedUnique < 2) return "insufficient_snapshots";
   if (matchedDistinct !== null && matchedDistinct < 2) return "no_percent_change";
+  if (derived && derived.groupCount > 1 && derived.transitionCount === 0
+      && matchedDistinct !== null && matchedDistinct >= 2) return "no_within_era_percent_change";
   return "unexplained_no_transition";
 }
 
@@ -263,7 +279,7 @@ export function buildPr94CalibrationEvidence(options) {
     const id = parentKey(raw, hmacKey);
     if (parents.has(id)) fail("pr94_calibration_duplicate_parent");
     const reason = noTransitionReason(raw); // Validate every raw partition, not only empty parents.
-    parents.set(id, { raw, reason, frames: candidates.map((candidate) => ({
+    parents.set(id, { raw, reason, transitionRows: 0, frames: candidates.map((candidate) => ({
       kind: "parent", parentKey: id, candidateId: candidate.id, planType: plan(raw.planType),
       accountKnown: accountKnown(raw.accountScopeId),
       snapshotCount: raw.snapshotCount, fragments: [], noTransitionReason: null,
@@ -273,12 +289,20 @@ export function buildPr94CalibrationEvidence(options) {
   const groupedRows = new Map();
   const rowReasons = emptyCounts(ROW_REASONS);
   for (const row of weekly) {
-    if (!parents.has(parentKey(row, hmacKey))) fail("pr94_calibration_transition_parent_missing");
+    const parent = parents.get(parentKey(row, hmacKey));
+    if (!parent) fail("pr94_calibration_transition_parent_missing");
+    parent.transitionRows += 1;
     const group = groupKey(row, internals);
     const rows = groupedRows.get(group) ?? [];
     rows.push(row);
     groupedRows.set(group, rows);
     rowReasons[eligibleReason(row, internals)] += 1;
+  }
+  for (const parent of parents.values()) {
+    if (parent.raw.derivationEvidence !== undefined
+        && parent.raw.derivationEvidence.transitionCount !== parent.transitionRows) {
+      fail("pr94_calibration_snapshot_partition_invalid");
+    }
   }
   if (groupedRows.size > LIMITS.fragments) fail("pr94_calibration_fragment_limit");
   const actualPlans = [...new Set(rawParents.map((row) => row.planType ?? "unknown"))].sort();

--- a/scripts/lib/pr94-calibration-evidence.mjs
+++ b/scripts/lib/pr94-calibration-evidence.mjs
@@ -1,0 +1,672 @@
+import { createHash, createHmac, timingSafeEqual } from "node:crypto";
+
+// The runner authenticates the revision and its export-only loader. Pin the
+// unchanged fit body as well: the explanatory branches below must never become
+// a second, silently drifting calibration policy. All numerical fits are still
+// evaluated by the original revision's helpers and public reporter.
+const FIT_RESET_SHA256 = "c35467f3159d5c1d4188a8534b9dd8e4e93a2ca7316c7e1a81d9004dbf71c8b3";
+const SCHEMA = "pr94-calibration-evidence-v2";
+const LIMITS = Object.freeze({ parents: 10_000, transitions: 200_000, fragments: 40_000 });
+const CANDIDATES = Object.freeze([
+  ["standard_api", "standard"], ["speed_lower", "lower"],
+  ["speed_midpoint", "midpoint"], ["speed_upper", "upper"],
+]);
+const PLANS = new Set(["free", "plus", "pro", "pro_lite", "team", "business", "enterprise", "edu", "unknown"]);
+const SUPPRESSIONS = Object.freeze([
+  "simultaneous_slot_conflict", "near_duplicate_reset_identity_with_less_evidence",
+  "overlapping_observation_window",
+]);
+const OUTCOMES = Object.freeze([
+  "selected_plan_primary", "alternate_plan_primary", "unselected_plan_primary",
+  "losing_qualifying_fragment", ...SUPPRESSIONS,
+  "aggregation_diagnostic_only", "insufficient_unique_boundaries", "insufficient_percent_span",
+  "training_capacity_unavailable", "insufficient_training_pairs", "full_capacity_unavailable",
+  "relative_width_unavailable", "relative_width_exceeded", "insufficient_snapshots",
+  "no_percent_change", "all_snapshot_attribution_withheld", "unexplained_no_transition",
+]);
+const ROW_REASONS = Object.freeze([
+  "eligible", "aggregation_diagnostic_only", "non_increasing_percent", "no_usage",
+  "partial_elapsed_coverage", "pricing_warning", "attribution_warning",
+]);
+const ACCOUNT_CHECK_COUNTS = Object.freeze([
+  "fragmentCandidatesChecked", "rowsChecked", "changedEligibilityRows", "changedPointSets",
+  "changedFits", "unknownOnlyFitExclusions",
+]);
+const PRIVATE = new WeakMap();
+const HEX = /^[a-f0-9]{64}$/u;
+
+function fail(code) {
+  const error = new Error(code);
+  error.code = code;
+  throw error;
+}
+
+function count(value) {
+  if (!Number.isSafeInteger(value) || value < 0 || Object.is(value, -0)) fail("pr94_calibration_count_invalid");
+  return value;
+}
+
+function text(value, fallback = null) {
+  if (value === undefined || value === null) return fallback;
+  if (typeof value !== "string" || value.length > 512) fail("pr94_calibration_identity_invalid");
+  return value;
+}
+
+function keyBytes(value) {
+  if (!(value instanceof Uint8Array) || value.byteLength < 32 || value.byteLength > 64) {
+    fail("pr94_calibration_hmac_key_invalid");
+  }
+  return value;
+}
+
+function digest(key, domain, value) {
+  return createHmac("sha256", key).update(domain).update("\0").update(JSON.stringify(value)).digest("hex");
+}
+
+function freeze(value) {
+  if (value && typeof value === "object" && !Object.isFrozen(value)) {
+    for (const item of Object.values(value)) freeze(item);
+    Object.freeze(value);
+  }
+  return value;
+}
+
+function clone(value) {
+  return structuredClone(value);
+}
+
+function recordKeys(value) {
+  if (!value || typeof value !== "object" || Array.isArray(value)
+      || ![Object.prototype, null].includes(Object.getPrototypeOf(value))) fail("pr94_calibration_private_frames_invalid");
+  const descriptors = Object.getOwnPropertyDescriptors(value);
+  if (Reflect.ownKeys(value).some((key) => typeof key !== "string"
+      || !descriptors[key].enumerable || !Object.hasOwn(descriptors[key], "value"))) {
+    fail("pr94_calibration_private_frames_invalid");
+  }
+  return Object.keys(value);
+}
+
+function equal(left, right) {
+  return JSON.stringify(left) === JSON.stringify(right);
+}
+
+// Public receipt ordering is code-unit lexical, independent of host locale.
+// JSON punctuation and prefix plans (pro/pro_lite) collate differently in ICU.
+function compareReceiptKeys(left, right) {
+  return left < right ? -1 : left > right ? 1 : 0;
+}
+
+function plan(value) {
+  return PLANS.has(value) ? value : value === null || value === undefined ? "unknown" : "other";
+}
+
+function accountKnown(value) {
+  return ![null, undefined, "unknown", "unattributed", "unavailable", ""].includes(value);
+}
+
+function parentIdentity(row) {
+  if (!row || typeof row !== "object") fail("pr94_calibration_parent_invalid");
+  return [text(row.accountScopeId, "unattributed"), text(row.provider), text(row.planType, "unknown"),
+    text(row.limitId), count(row.windowDurationMins), count(row.resetsAt)];
+}
+
+function parentKey(row, key) { return digest(key, "parent", parentIdentity(row)); }
+function groupKey(row, internals) {
+  return `${internals.partitionKey(row, { includeSlot: false })}|${row.resetsAt}`;
+}
+function actualParentKey(row, internals, key) {
+  return digest(key, "actual-parent", internals.resetParentKey
+    ? internals.resetParentKey(row) : groupKey(row, internals));
+}
+
+function round(value) {
+  return Number.isFinite(value) ? Math.round((value + Number.EPSILON) * 1e6) / 1e6 : null;
+}
+
+// Receipt statistics only, not a replacement for any calibration calculation.
+function distribution(values) {
+  const ordered = values.filter(Number.isFinite).sort((a, b) => a - b);
+  const quantile = (p) => {
+    if (ordered.length === 0) return null;
+    const at = (ordered.length - 1) * p;
+    const low = Math.floor(at);
+    return round(low === Math.ceil(at) ? ordered[low]
+      : ordered[low] * (1 - (at - low)) + ordered[Math.ceil(at)] * (at - low));
+  };
+  return { count: ordered.length, median: quantile(0.5), central80: { lower: quantile(0.1), upper: quantile(0.9) } };
+}
+
+function emptyCounts(names) { return Object.fromEntries(names.map((name) => [name, 0])); }
+
+function eligibleReason(row, internals) {
+  let reason = "eligible";
+  if (row.aggregationEligibility === "diagnostic_only" && !internals.isEligible(row)) reason = "aggregation_diagnostic_only";
+  else if (!(row.nextUsedPercent > row.priorUsedPercent)) reason = "non_increasing_percent";
+  else if (!(row.marginalUsageEventCount > 0)) reason = "no_usage";
+  else if (row.quality?.localCoverage?.elapsedTimeCoverageFraction !== 1) reason = "partial_elapsed_coverage";
+  else if ((row.quality?.pricingWarnings?.length ?? 0) !== 0) reason = "pricing_warning";
+  else if ((row.quality?.attributionWarnings?.length ?? 0) !== 0) reason = "attribution_warning";
+  if ((reason === "eligible") !== internals.isEligible(row)) fail("pr94_calibration_eligibility_drift");
+  return reason;
+}
+
+function fitDecision(rows, candidate, internals) {
+  const fit = internals.fitReset(rows, candidate);
+  const points = internals.uniquePoints(rows, candidate);
+  let reason = null;
+  if (points.length < 8) reason = rows.length > 0
+      && rows.every((row) => row.aggregationEligibility === "diagnostic_only" && !internals.isEligible(row))
+    ? "aggregation_diagnostic_only" : "insufficient_unique_boundaries";
+  else if (points.at(-1).percent - points[0].percent < 5) reason = "insufficient_percent_span";
+  else {
+    const cutoff = points[0].percent + (points.at(-1).percent - points[0].percent) * 0.7;
+    let train = points.filter((point) => point.percent <= cutoff);
+    const holdout = points.filter((point) => point.percent > cutoff);
+    if (train.length < 5 || holdout.length < 2) {
+      const split = Math.max(5, Math.min(points.length - 2, Math.floor(points.length * 0.7)));
+      train = points.slice(0, split);
+    }
+    const training = internals.capacityFit(train);
+    if (!Number.isFinite(training.capacityUsd)) reason = "training_capacity_unavailable";
+    else if (training.pairCount < 6) reason = "insufficient_training_pairs";
+    else {
+      const full = internals.capacityFit(points);
+      if (!Number.isFinite(full.capacityUsd)) reason = "full_capacity_unavailable";
+      else {
+        const width = internals.fitRelativeCentral80Width(full);
+        if (!Number.isFinite(width)) reason = "relative_width_unavailable";
+        else if (width > 1) reason = "relative_width_exceeded";
+      }
+    }
+  }
+  if ((fit === null) !== (reason !== null)) fail("pr94_calibration_fit_gate_drift");
+  return { fit, points, reason };
+}
+
+function checkUnknownAccountFit(rows, candidate, internals, actualFit, actualPoints) {
+  const result = emptyCounts(ACCOUNT_CHECK_COUNTS);
+  result.rowsChecked = rows.filter((row) => !accountKnown(row.accountScopeId)).length;
+  if (result.rowsChecked === 0) return result;
+  result.fragmentCandidatesChecked = 1;
+  // A diagnostic counterfactual only: preserve every numeric/plan/eligibility
+  // field, changing only unknown account identity within the existing group.
+  // It proves direct fit-gate independence, NOT upstream quantity attribution
+  // or that this synthetic scope is an observed real billing identity.
+  const known = rows.map((row) => accountKnown(row.accountScopeId) ? row
+    : { ...row, accountScopeId: "pr94-counterfactual-known-account" });
+  result.changedEligibilityRows = rows.filter((row, index) => internals.isEligible(row)
+    !== internals.isEligible(known[index])).length;
+  const points = internals.uniquePoints(known, candidate);
+  const fit = internals.fitReset(known, candidate);
+  result.changedPointSets = Number(!equal(actualPoints, points));
+  result.changedFits = Number(!equal(actualFit, fit));
+  result.unknownOnlyFitExclusions = Number(actualFit === null && fit !== null);
+  return result;
+}
+
+function noTransitionReason(raw) {
+  const total = count(raw.snapshotCount);
+  const unique = count(raw.uniqueSnapshotCount);
+  const distinct = count(raw.distinctPercentCount);
+  const matched = count(raw.matchedSnapshotCount);
+  const conflicted = count(raw.conflictedSnapshotCount);
+  const unavailable = count(raw.unavailableSnapshotCount);
+  if (total === 0 || unique === 0 || unique > total || distinct === 0 || distinct > unique
+      || matched + conflicted + unavailable !== total) {
+    fail("pr94_calibration_snapshot_partition_invalid");
+  }
+  if (matched === 0 && total > 0) return "all_snapshot_attribution_withheld";
+  const matchedUnique = raw.matchedUniqueSnapshotCount ?? (matched === total ? unique : null);
+  const matchedDistinct = raw.matchedDistinctPercentCount ?? (matched === total ? distinct : null);
+  if (matchedUnique !== null && (count(matchedUnique) > matched
+      || (matchedDistinct !== null && count(matchedDistinct) > matchedUnique))) {
+    fail("pr94_calibration_snapshot_partition_invalid");
+  }
+  if (matchedUnique !== null && matchedUnique < 2) return "insufficient_snapshots";
+  if (matchedDistinct !== null && matchedDistinct < 2) return "no_percent_change";
+  return "unexplained_no_transition";
+}
+
+function validateInputs(options) {
+  const { internals, candidates, transitions, rawParents, revisionKind, analyzeWeeklyCalibration } = options;
+  if (!["before", "after", "final"].includes(revisionKind)
+      || typeof analyzeWeeklyCalibration !== "function"
+      || !Array.isArray(transitions) || transitions.length > LIMITS.transitions
+      || !Array.isArray(rawParents) || rawParents.length > LIMITS.parents
+      || !Array.isArray(candidates) || candidates.length !== 4) fail("pr94_calibration_input_invalid");
+  for (const name of ["selectResetGroups", "fitReset", "uniquePoints", "capacityFit", "fitRelativeCentral80Width", "isEligible", "partitionKey"]) {
+    if (typeof internals?.[name] !== "function") fail("pr94_calibration_internal_missing");
+  }
+  if (createHash("sha256").update(Function.prototype.toString.call(internals.fitReset)).digest("hex") !== FIT_RESET_SHA256) {
+    fail("pr94_calibration_fit_source_unrecognized");
+  }
+  for (const [at, [id, kind]] of CANDIDATES.entries()) {
+    if (candidates[at]?.id !== id || candidates[at]?.kind !== kind) fail("pr94_calibration_candidates_invalid");
+  }
+  if (revisionKind !== "before" && typeof internals.resetParentKey !== "function") fail("pr94_calibration_internal_missing");
+  for (const field of ["startAt", "endAt"]) {
+    const value = options.scope?.[field];
+    if (typeof value !== "string" || !Number.isFinite(Date.parse(value))
+        || new Date(value).toISOString() !== value) fail("pr94_calibration_scope_invalid");
+  }
+  if (options.scope.startAt > options.scope.endAt) fail("pr94_calibration_scope_invalid");
+  keyBytes(options.hmacKey);
+}
+
+export function buildPr94CalibrationEvidence(options) {
+  validateInputs(options);
+  const { internals, candidates, transitions, rawParents, revisionKind, hmacKey, scope } = options;
+  const selectedPlanType = options.selectedPlanType ?? null;
+  const parents = new Map();
+  for (const raw of rawParents) {
+    if (raw.windowDurationMins !== 10_080 || raw.limitId !== "codex") fail("pr94_calibration_parent_out_of_scope");
+    const id = parentKey(raw, hmacKey);
+    if (parents.has(id)) fail("pr94_calibration_duplicate_parent");
+    const reason = noTransitionReason(raw); // Validate every raw partition, not only empty parents.
+    parents.set(id, { raw, reason, frames: candidates.map((candidate) => ({
+      kind: "parent", parentKey: id, candidateId: candidate.id, planType: plan(raw.planType),
+      accountKnown: accountKnown(raw.accountScopeId),
+      snapshotCount: raw.snapshotCount, fragments: [], noTransitionReason: null,
+    })) });
+  }
+  const weekly = transitions.filter((row) => row.windowDurationMins === 10_080 && row.limitId === "codex");
+  const groupedRows = new Map();
+  const rowReasons = emptyCounts(ROW_REASONS);
+  for (const row of weekly) {
+    if (!parents.has(parentKey(row, hmacKey))) fail("pr94_calibration_transition_parent_missing");
+    const group = groupKey(row, internals);
+    const rows = groupedRows.get(group) ?? [];
+    rows.push(row);
+    groupedRows.set(group, rows);
+    rowReasons[eligibleReason(row, internals)] += 1;
+  }
+  if (groupedRows.size > LIMITS.fragments) fail("pr94_calibration_fragment_limit");
+  const actualPlans = [...new Set(rawParents.map((row) => row.planType ?? "unknown"))].sort();
+  const reports = [];
+  const observedGroups = new Set();
+  for (const population of actualPlans) {
+    const input = weekly.filter((row) => (row.planType ?? "unknown") === population);
+    const grouped = internals.selectResetGroups(input);
+    const selected = new Set(grouped.selected.map((group) => groupKey(group.first, internals)));
+    const suppressed = new Map();
+    for (const item of grouped.suppressed) {
+      if (!SUPPRESSIONS.includes(item.reason)) fail("pr94_calibration_suppression_unknown");
+      const id = `${item.partition}|${item.resetsAt}`;
+      if (suppressed.has(id) || selected.has(id)) fail("pr94_calibration_group_multiplied");
+      suppressed.set(id, item.reason);
+    }
+    for (const candidate of candidates) {
+      const report = options.analyzeWeeklyCalibration({ transitions: input, scope }, {
+        planType: population, forcedCandidateId: candidate.id,
+      });
+      const populationParents = new Set(rawParents.filter((row) => (row.planType ?? "unknown") === population)
+        .map((row) => parentKey(row, hmacKey)));
+      reports.push({ populationParents, candidateId: candidate.id, report });
+      if (!equal(report.duplicateResetGroupsSuppressed, grouped.suppressed)
+          || report.quality?.exactResetGroups !== grouped.exactGroupCount
+          || report.quality?.selectedResetGroups !== grouped.selected.length) fail("pr94_calibration_report_group_mismatch");
+      const primary = new Map();
+      for (const reset of report.resetValues) {
+        const id = `${reset.continuityTrack}|${reset.resetsAt}`;
+        if (primary.has(id)) fail("pr94_calibration_primary_multiplied");
+        primary.set(id, reset);
+      }
+      const diagnostics = new Map();
+      for (const item of report.fragmentDiagnostics ?? []) {
+        if (item.candidateId !== candidate.id) continue;
+        if (item.reason !== "another_qualifying_fragment_represents_reset") fail("pr94_calibration_fragment_reason_unknown");
+        const id = JSON.stringify([item.resetParentKey, item.planEraKey]);
+        if (diagnostics.has(id)) fail("pr94_calibration_diagnostic_multiplied");
+        diagnostics.set(id, item);
+      }
+      let primaryCount = 0;
+      let diagnosticCount = 0;
+      for (const [id, rows] of groupedRows) {
+        const first = rows[0];
+        if ((first.planType ?? "unknown") !== population) continue;
+        observedGroups.add(id);
+        if (selected.has(id) === suppressed.has(id)) fail("pr94_calibration_group_unreconciled");
+        const frame = parents.get(parentKey(first, hmacKey)).frames.find((item) => item.candidateId === candidate.id);
+        const fragment = {
+          fragmentKey: digest(hmacKey, "fragment", id),
+          actualParentKey: actualParentKey(first, internals, hmacKey),
+          outcome: suppressed.get(id) ?? null, inputDigest: null,
+          capacity: null, span: null, boundaries: null,
+          accountCheck: emptyCounts(ACCOUNT_CHECK_COUNTS),
+        };
+        if (selected.has(id)) {
+          const decision = fitDecision(rows, candidate, internals);
+          fragment.accountCheck = checkUnknownAccountFit(rows, candidate, internals, decision.fit, decision.points);
+          fragment.inputDigest = digest(hmacKey, "fit-input", decision.points);
+          fragment.boundaries = decision.points.length;
+          fragment.span = decision.points.length ? decision.points.at(-1).percent - decision.points[0].percent : null;
+          fragment.outcome = decision.reason;
+          if (decision.fit !== null) {
+            fragment.capacity = decision.fit.fullCapacityUsd;
+            const actual = primary.get(id);
+            if (actual) {
+              if (actual.apiPriceEquivalentUsd !== round(fragment.capacity)
+                  || actual.pointCount !== decision.fit.pointCount
+                  || actual.percentSpan !== round(decision.fit.percentSpan)) fail("pr94_calibration_report_fit_mismatch");
+              fragment.outcome = selectedPlanType === null ? "unselected_plan_primary"
+                : population === selectedPlanType ? "selected_plan_primary" : "alternate_plan_primary";
+              primaryCount += 1;
+            } else {
+              const item = diagnostics.get(JSON.stringify([internals.resetParentKey?.(first), first.planEraKey ?? "legacy"]));
+              if (!item || item.apiPriceEquivalentUsd !== round(fragment.capacity)
+                  || item.uniqueBoundaries !== fragment.boundaries
+                  || item.observedSpanPercentagePoints !== round(fragment.span)) fail("pr94_calibration_report_fragment_mismatch");
+              fragment.outcome = "losing_qualifying_fragment";
+              diagnosticCount += 1;
+            }
+          } else if (primary.has(id)) fail("pr94_calibration_report_rejected_fit");
+        } else if (primary.has(id)) fail("pr94_calibration_report_suppressed_fit");
+        frame.fragments.push(fragment);
+      }
+      const score = report.selection?.candidateScores?.find((item) => item.id === candidate.id);
+      if (primaryCount !== primary.size || primaryCount !== score?.qualifyingResets
+          || diagnosticCount !== diagnostics.size) fail("pr94_calibration_report_count_mismatch");
+    }
+  }
+  if (observedGroups.size !== groupedRows.size) fail("pr94_calibration_group_unreconciled");
+  const frames = [...parents.values()].flatMap(({ frames: items, reason }) => items.map((frame) => {
+    if (frame.fragments.length === 0) frame.noTransitionReason = reason;
+    frame.fragments.sort((a, b) => a.fragmentKey.localeCompare(b.fragmentKey));
+    return frame;
+  })).sort((a, b) => a.parentKey.localeCompare(b.parentKey) || a.candidateId.localeCompare(b.candidateId));
+  assertFrames(frames);
+  // Independently reconcile the original reporter's distribution, not only its counts.
+  for (const { populationParents, candidateId, report } of reports) {
+    const relevant = frames.filter((frame) => populationParents.has(frame.parentKey) && frame.candidateId === candidateId);
+    const primary = relevant.flatMap((frame) => frame.fragments.filter(isPrimary).map((item) => item.capacity));
+    const calculated = distribution(primary);
+    const summary = report.weeklyValueSummary;
+    if (summary === null ? calculated.count !== 0
+      : summary.resetCount !== calculated.count || summary.medianApiPriceEquivalentUsd !== calculated.median
+        || summary.central80AcrossResetsUsd.lower !== calculated.central80.lower
+        || summary.central80AcrossResetsUsd.upper !== calculated.central80.upper) fail("pr94_calibration_report_distribution_mismatch");
+    const fragmentSummary = report.quality?.fragmentSelection?.find((item) => item.candidateId === candidateId);
+    if (revisionKind !== "before") {
+      const diagnostic = distribution(relevant.flatMap((frame) => frame.fragments
+        .filter((item) => item.outcome === "losing_qualifying_fragment").map((item) => round(item.capacity))));
+      const projected = (value) => ({ count: value.count, medianApiPriceEquivalentUsd: value.median,
+        central80ApiPriceEquivalentUsd: value.central80 });
+      if (!equal(fragmentSummary?.primary, projected(calculated))
+          || !equal(fragmentSummary?.diagnosticOnly, projected(diagnostic))) fail("pr94_calibration_report_distribution_mismatch");
+    }
+  }
+  if (revisionKind === "before") {
+    // The old public reporter has no plan selector. Per-plan diagnostic reads
+    // must add back to its native all-plan result, not silently replace it.
+    for (const candidate of candidates) {
+      const report = options.analyzeWeeklyCalibration({ transitions: weekly, scope }, { forcedCandidateId: candidate.id });
+      const expected = new Set(frames.filter((frame) => frame.candidateId === candidate.id)
+        .flatMap((frame) => frame.fragments.filter(isPrimary).map((item) => item.fragmentKey)));
+      const observed = new Set(report.resetValues.map((row) => digest(hmacKey, "fragment", `${row.continuityTrack}|${row.resetsAt}`)));
+      if (observed.size !== report.resetValues.length || observed.size !== expected.size
+          || [...observed].some((id) => !expected.has(id))) fail("pr94_calibration_baseline_population_mismatch");
+      const score = report.selection?.candidateScores?.find((item) => item.id === candidate.id);
+      if (score?.qualifyingResets !== expected.size) fail("pr94_calibration_baseline_population_mismatch");
+    }
+  }
+  const aggregate = aggregateFrames(frames, { revisionKind, selectedPlanType: plan(selectedPlanType), transitionRows: weekly.length, rowReasons });
+  PRIVATE.set(aggregate, { frames: freeze(frames), key: Buffer.from(hmacKey) });
+  return aggregate;
+}
+
+function isPrimary(fragment) { return fragment.outcome.endsWith("_plan_primary"); }
+
+function assertFrames(frames) {
+  if (!Array.isArray(frames) || frames.length > LIMITS.parents * 4) fail("pr94_calibration_private_frames_invalid");
+  const identities = new Set();
+  const fragments = new Set();
+  const votes = new Set();
+  let fragmentCount = 0;
+  for (const frame of frames) {
+    if (!equal(recordKeys(frame).sort(), ["kind", "parentKey", "candidateId", "planType", "accountKnown", "snapshotCount", "fragments", "noTransitionReason"].sort())
+        || frame.kind !== "parent" || !HEX.test(frame.parentKey)
+        || !CANDIDATES.some(([id]) => id === frame.candidateId)
+        || ![...PLANS, "other"].includes(frame.planType) || typeof frame.accountKnown !== "boolean"
+        || !Array.isArray(frame.fragments) || frame.fragments.length > LIMITS.fragments
+        || (frame.noTransitionReason !== null && !OUTCOMES.includes(frame.noTransitionReason))) fail("pr94_calibration_private_frames_invalid");
+    count(frame.snapshotCount);
+    const identity = `${frame.parentKey}|${frame.candidateId}`;
+    if (identities.has(identity) || (frame.fragments.length === 0) !== (frame.noTransitionReason !== null)) fail("pr94_calibration_parent_multiplied");
+    identities.add(identity);
+    for (const item of frame.fragments) {
+      fragmentCount += 1;
+      if (fragmentCount > LIMITS.fragments * 4) fail("pr94_calibration_fragment_limit");
+      if (!equal(recordKeys(item).sort(), ["fragmentKey", "actualParentKey", "outcome", "inputDigest", "capacity", "span", "boundaries", "accountCheck"].sort())
+          || !HEX.test(item.fragmentKey) || !HEX.test(item.actualParentKey)
+          || !OUTCOMES.includes(item.outcome) || (item.inputDigest !== null && !HEX.test(item.inputDigest))
+          || (item.capacity !== null && (!Number.isFinite(item.capacity) || item.capacity <= 0))
+          || (item.span !== null && !Number.isFinite(item.span))
+          || (item.boundaries !== null && (!Number.isSafeInteger(item.boundaries) || item.boundaries < 0))) fail("pr94_calibration_private_frames_invalid");
+      if (!equal(recordKeys(item.accountCheck).sort(), [...ACCOUNT_CHECK_COUNTS].sort())) fail("pr94_calibration_private_frames_invalid");
+      for (const field of ACCOUNT_CHECK_COUNTS) count(item.accountCheck[field]);
+      if (item.accountCheck.fragmentCandidatesChecked > 1
+          || item.accountCheck.rowsChecked > LIMITS.transitions
+          || (item.accountCheck.fragmentCandidatesChecked === 0) !== (item.accountCheck.rowsChecked === 0)
+          || item.accountCheck.changedEligibilityRows > item.accountCheck.rowsChecked
+          || ["changedPointSets", "changedFits", "unknownOnlyFitExclusions"].some((field) => item.accountCheck[field] > item.accountCheck.fragmentCandidatesChecked)
+          || item.accountCheck.unknownOnlyFitExclusions > item.accountCheck.changedFits) fail("pr94_calibration_private_frames_invalid");
+      const fragment = `${frame.candidateId}|${item.fragmentKey}`;
+      if (fragments.has(fragment)) fail("pr94_calibration_fragment_multiplied");
+      fragments.add(fragment);
+      if (isPrimary(item)) {
+        const vote = `${frame.candidateId}|${item.actualParentKey}`;
+        if (votes.has(vote) || item.capacity === null) fail("pr94_calibration_primary_multiplied");
+        votes.add(vote);
+      }
+    }
+  }
+  const parentCounts = new Map();
+  for (const frame of frames) parentCounts.set(frame.parentKey, (parentCounts.get(frame.parentKey) ?? 0) + 1);
+  if ([...parentCounts.values()].some((value) => value !== 4)) fail("pr94_calibration_parent_candidate_missing");
+}
+
+function aggregateFrames(frames, metadata) {
+  const parents = frames.filter((frame) => frame.candidateId === "standard_api");
+  const summarize = (items) => {
+    const outcomes = emptyCounts(OUTCOMES);
+    const primary = [];
+    const diagnostic = [];
+    const spans = [];
+    const boundaries = [];
+    for (const frame of items) {
+      if (frame.noTransitionReason !== null) outcomes[frame.noTransitionReason] += 1;
+      for (const item of frame.fragments) {
+        outcomes[item.outcome] += 1;
+        if (isPrimary(item)) primary.push(item.capacity);
+        if (item.outcome === "losing_qualifying_fragment") diagnostic.push(item.capacity);
+        if (item.span !== null) spans.push(item.span);
+        if (item.boundaries !== null) boundaries.push(item.boundaries);
+      }
+    }
+    return { parentCandidates: items.length, outcomes, primary: distribution(primary), diagnostic: distribution(diagnostic), spans: distribution(spans), boundaries: distribution(boundaries) };
+  };
+  const unexplained = parents.filter((frame) => frame.noTransitionReason === "unexplained_no_transition").length;
+  const unknownAccountCheck = { scope: "original_fit_gate_only", ...emptyCounts(ACCOUNT_CHECK_COUNTS) };
+  for (const frame of frames) for (const fragment of frame.fragments) {
+    for (const field of ACCOUNT_CHECK_COUNTS) unknownAccountCheck[field] += fragment.accountCheck[field];
+  }
+  const accountViolation = ACCOUNT_CHECK_COUNTS.slice(2).some((field) => unknownAccountCheck[field] !== 0);
+  return freeze({
+    schemaVersion: SCHEMA, revisionKind: metadata.revisionKind, selectedPlanType: metadata.selectedPlanType,
+    status: unexplained === 0 && !accountViolation ? "pass" : "fail",
+    counts: { rawParents: parents.length, parentCandidates: frames.length, transitionRows: metadata.transitionRows,
+      parentsWithTransitions: parents.filter((frame) => frame.fragments.length > 0).length,
+      knownAccountParents: parents.filter((frame) => frame.accountKnown).length,
+      unknownAccountParents: parents.filter((frame) => !frame.accountKnown).length, unexplainedParents: unexplained },
+    rowReasons: metadata.rowReasons, unknownAccountCheck,
+    candidates: CANDIDATES.map(([candidateId]) => ({ candidateId, ...summarize(frames.filter((frame) => frame.candidateId === candidateId)) })),
+    plans: [...new Set(frames.map((frame) => frame.planType))].sort().map((planType) => ({
+      planType, candidates: CANDIDATES.map(([candidateId]) => ({ candidateId, ...summarize(frames.filter((frame) => frame.planType === planType && frame.candidateId === candidateId)) })),
+    })),
+  });
+}
+
+/** Owner-only transport. These HMAC frames are NEVER a public receipt. */
+export function* iteratePr94CalibrationPrivateFrames(evidence) {
+  const state = PRIVATE.get(evidence);
+  if (!state) fail("pr94_calibration_evidence_untrusted");
+  for (const frame of state.frames) {
+    if (PRIVATE.get(evidence) !== state) fail("pr94_calibration_evidence_untrusted");
+    yield clone(frame);
+  }
+  if (PRIVATE.get(evidence) !== state) fail("pr94_calibration_evidence_untrusted");
+  yield { kind: "seal", digest: digest(state.key, "sealed-calibration", [evidence, state.frames]) };
+}
+
+export function disposePr94CalibrationEvidencePrivate(evidence) {
+  const state = PRIVATE.get(evidence);
+  if (!state) fail("pr94_calibration_evidence_untrusted");
+  state.key.fill(0);
+  state.frames = null;
+  PRIVATE.delete(evidence);
+}
+
+export async function importPr94CalibrationEvidence({ aggregate, frames, hmacKey }) {
+  keyBytes(hmacKey);
+  if (!frames || (typeof frames[Symbol.iterator] !== "function" && typeof frames[Symbol.asyncIterator] !== "function")) {
+    fail("pr94_calibration_private_frames_invalid");
+  }
+  const received = [];
+  for await (const frame of frames) {
+    if (received.length >= LIMITS.parents * 4 + 1) fail("pr94_calibration_private_frames_invalid");
+    recordKeys(frame);
+    if (Array.isArray(frame.fragments)) for (const item of frame.fragments) {
+      recordKeys(item);
+      recordKeys(item.accountCheck);
+    }
+    received.push(clone(frame));
+  }
+  if (received.length === 0) fail("pr94_calibration_private_frames_invalid");
+  const items = received.slice(0, -1);
+  assertFrames(items);
+  const seal = received.at(-1);
+  if (!equal(recordKeys(seal).sort(), ["digest", "kind"]) || seal.kind !== "seal" || !HEX.test(seal.digest)) fail("pr94_calibration_seal_invalid");
+  const expected = digest(hmacKey, "sealed-calibration", [aggregate, items]);
+  if (!timingSafeEqual(Buffer.from(expected, "hex"), Buffer.from(seal.digest, "hex"))) fail("pr94_calibration_seal_invalid");
+  if (!["before", "after", "final"].includes(aggregate?.revisionKind)
+      || ![...PLANS, "other"].includes(aggregate.selectedPlanType)
+      || !equal(Object.keys(aggregate.rowReasons ?? {}).sort(), [...ROW_REASONS].sort())) fail("pr94_calibration_aggregate_invalid");
+  for (const value of Object.values(aggregate.rowReasons)) count(value);
+  const rebuilt = aggregateFrames(items, { revisionKind: aggregate.revisionKind, selectedPlanType: aggregate.selectedPlanType,
+    transitionRows: count(aggregate.counts?.transitionRows), rowReasons: clone(aggregate.rowReasons) });
+  if (!equal(aggregate, rebuilt)) fail("pr94_calibration_aggregate_invalid");
+  PRIVATE.set(rebuilt, { frames: freeze(items), key: Buffer.from(hmacKey) });
+  return rebuilt;
+}
+
+export function comparePr94CalibrationEvidence(before, after) {
+  const left = PRIVATE.get(before);
+  const right = PRIVATE.get(after);
+  if (!left || !right || left.key.length !== right.key.length
+      || !timingSafeEqual(left.key, right.key)) fail("pr94_calibration_evidence_untrusted");
+  const prior = new Map(left.frames.map((frame) => [`${frame.parentKey}|${frame.candidateId}`, frame]));
+  const next = new Map(right.frames.map((frame) => [`${frame.parentKey}|${frame.candidateId}`, frame]));
+  let missing = 0;
+  let added = 0;
+  let unchangedFitInputs = 0;
+  let changedIdenticalInputFits = 0;
+  let rejectedIdenticalInputFits = 0;
+  let changedRawParentInventory = 0;
+  let baselinePrimaryFits = 0;
+  let retainedPrimaryFits = 0;
+  let lostPrimaryFits = 0;
+  let newPrimaryFits = 0;
+  let changedInputPrimaryLosses = 0;
+  let unexplainedPrimaryLosses = 0;
+  let retainedPrimaryInputChanges = 0;
+  let changedOutcomeParentCandidates = 0;
+  const matrix = new Map();
+  const outcomes = (frame) => {
+    const counts = new Map();
+    if (!frame) counts.set("missing_parent", 1);
+    else if (frame.noTransitionReason !== null) counts.set(frame.noTransitionReason, 1);
+    else for (const fragment of frame.fragments) counts.set(fragment.outcome, (counts.get(fragment.outcome) ?? 0) + 1);
+    return [...counts].sort(([a], [b]) => compareReceiptKeys(a, b)).map(([outcome, count]) => ({ outcome, count }));
+  };
+  const addMatrix = (frame, following) => {
+    const baseline = frame?.fragments.filter(isPrimary) ?? [];
+    const current = following?.fragments.filter(isPrimary) ?? [];
+    const retained = Math.min(baseline.length, current.length);
+    const lost = baseline.length - retained;
+    const gained = current.length - retained;
+    const afterOutcomes = outcomes(following);
+    const transition = !following ? "missing_parent" : baseline.length > 0
+      ? current.length > 0 ? "retained_primary" : "lost_primary"
+      : current.length > 0 ? "new_primary" : "no_primary";
+    // A changed-input rejection is evidence of changed fit inputs, not proof
+    // that the change is acceptable. Preserve every exact downstream reason
+    // and make every coverage change require review; no loss tolerance exists.
+    const selectedAfter = following?.fragments.filter((item) => item.inputDigest !== null) ?? [];
+    const inputsChanged = lost > 0 && selectedAfter.length > 0
+      && baseline.every((previous) => selectedAfter.every((item) => item.inputDigest !== previous.inputDigest));
+    const namedOtherDisposition = following && (following.noTransitionReason !== null
+      && following.noTransitionReason !== "unexplained_no_transition"
+      || following.fragments.some((item) => SUPPRESSIONS.includes(item.outcome)
+        || item.outcome === "losing_qualifying_fragment"));
+    const unexplained = lost > 0 && (!following || (!inputsChanged && !namedOtherDisposition));
+    const primaryInputsChanged = retained > 0 && !equal(baseline.map((item) => item.inputDigest).sort(),
+      current.map((item) => item.inputDigest).sort());
+    if (primaryInputsChanged) retainedPrimaryInputChanges += 1;
+    if (frame && following && !equal(outcomes(frame), afterOutcomes)) changedOutcomeParentCandidates += 1;
+    baselinePrimaryFits += baseline.length;
+    retainedPrimaryFits += retained;
+    lostPrimaryFits += lost;
+    newPrimaryFits += gained;
+    if (inputsChanged) changedInputPrimaryLosses += lost;
+    if (unexplained) unexplainedPrimaryLosses += lost;
+    const identity = frame ?? following;
+    const key = JSON.stringify([identity.candidateId, identity.planType, identity.accountKnown, transition, afterOutcomes]);
+    let cell = matrix.get(key);
+    if (!cell) {
+      cell = { candidateId: identity.candidateId, planType: identity.planType, accountKnown: identity.accountKnown,
+        transition, afterOutcomes, parentCandidates: 0, baselinePrimaryFits: 0, afterPrimaryFits: 0,
+        retainedPrimaryFits: 0, lostPrimaryFits: 0, newPrimaryFits: 0, changedInputPrimaryLosses: 0 };
+      matrix.set(key, cell);
+    }
+    cell.parentCandidates += 1;
+    cell.baselinePrimaryFits += baseline.length;
+    cell.afterPrimaryFits += current.length;
+    cell.retainedPrimaryFits += retained;
+    cell.lostPrimaryFits += lost;
+    cell.newPrimaryFits += gained;
+    if (inputsChanged) cell.changedInputPrimaryLosses += lost;
+  };
+  for (const [id, frame] of prior) {
+    const following = next.get(id);
+    addMatrix(frame, following);
+    if (!following) { missing += 1; continue; }
+    if (frame.snapshotCount !== following.snapshotCount || frame.accountKnown !== following.accountKnown
+        || frame.planType !== following.planType) changedRawParentInventory += 1;
+    const priorFits = new Map(frame.fragments.filter((item) => item.capacity !== null).map((item) => [item.inputDigest, item.capacity]));
+    for (const item of following.fragments.filter((fragment) => fragment.inputDigest !== null)) {
+      if (!priorFits.has(item.inputDigest)) continue;
+      unchangedFitInputs += 1;
+      if (item.capacity === null) rejectedIdenticalInputFits += 1;
+      else if (priorFits.get(item.inputDigest) !== item.capacity) changedIdenticalInputFits += 1;
+    }
+  }
+  for (const [id, frame] of next) if (!prior.has(id)) { added += 1; addMatrix(null, frame); }
+  return freeze({ schemaVersion: "pr94-calibration-comparison-v2",
+    status: before.status === "pass" && after.status === "pass" && missing === 0 && added === 0
+      && changedIdenticalInputFits === 0 && rejectedIdenticalInputFits === 0
+      && unexplainedPrimaryLosses === 0 && changedRawParentInventory === 0
+      && before.selectedPlanType === after.selectedPlanType ? "pass" : "fail",
+    beforeParentCandidates: prior.size, afterParentCandidates: next.size,
+    missingParentCandidates: missing, addedParentCandidates: added,
+    reconciledParentCandidates: prior.size - missing, identicalFitInputsCompared: unchangedFitInputs,
+    changedIdenticalInputFits, unexplainedParents: before.counts.unexplainedParents + after.counts.unexplainedParents,
+    changedRawParentInventory, selectedPopulationMatches: before.selectedPlanType === after.selectedPlanType,
+    duplicatePrimaryVotes: 0,
+    baselinePrimaryFits, retainedPrimaryFits, lostPrimaryFits, newPrimaryFits,
+    changedInputPrimaryLosses, rejectedIdenticalInputFits, unexplainedPrimaryLosses,
+    retainedPrimaryInputChanges, changedOutcomeParentCandidates,
+    requiresCoverageReview: lostPrimaryFits > 0 || newPrimaryFits > 0
+      || retainedPrimaryInputChanges > 0 || changedOutcomeParentCandidates > 0,
+    primaryOutcomeMatrix: [...matrix.entries()].sort(([a], [b]) => compareReceiptKeys(a, b)).map(([, value]) => value),
+  });
+}

--- a/scripts/lib/pr94-ledger-evidence.mjs
+++ b/scripts/lib/pr94-ledger-evidence.mjs
@@ -1,0 +1,533 @@
+import { createHmac, timingSafeEqual } from "node:crypto";
+import { addUsdStrings } from "@app-usagemonitor/accounting";
+
+// This is an evidence comparator, not a reader or pricing implementation. Feed
+// each admitted reader occurrence exactly once, with its public accounting
+// result. Never feed overlapping calibration slices back into this ledger.
+// Public finishes contain aggregates only. PRIVATE frames are ephemeral,
+// owner-only transport between isolated revision processes, never a receipt.
+export const PR94_LEDGER_COMPONENTS = Object.freeze([
+  "input_uncached_tokens", "input_cache_read_tokens", "input_cache_write_tokens",
+  "output_text_tokens", "output_reasoning_tokens", "output_combined_tokens",
+]);
+const COVERAGE = ["fully_priced", "partially_priced", "unpriced"];
+const WARNING_CODES = Object.freeze([
+  "unknown_provider", "unknown_surface", "unknown_model", "price_not_found",
+  "component_unpriced", "tool_component_unpriced", "source_capability_unsupported",
+  "service_tier_unsupported", "long_context_rule_missing", "historical_price_missing",
+  "historical_price_timestamp_missing", "pricing_period_required",
+  "pricing_period_unsupported", "billing_schedule_unsupported",
+  "duplicate_component_conflict", "unknown_zero_component", "unknown_component",
+  "unsupported_provider", "service_tier_exact_card_missing", "component_price_missing",
+  "component_observation_unavailable", "alias_inferred", "price_stale",
+  "usage_field_ignored", "usage_missing", "inclusive_usage_ambiguous",
+  "discount_not_applied", "provider_reported_cost_mismatch", "provider_reported_cost_used",
+  "price_source_disagreement",
+]);
+const VERSION = "pr94-ledger-evidence-v1";
+const PRIVATE_VERSION = "pr94-ledger-evidence-private-v1";
+const MAX_ROWS = 10_000_000;
+const DEFAULT_MAX_ROWS = 2_000_000;
+const FINISHES = new WeakMap();
+const COUNTERS = ["observedEvents", "missingEvents", "unavailableEvents", "zeroEvents"];
+const COMPONENT_COUNTERS = [...COUNTERS, "pricedEvents", "unpricedEvents", "unavailablePricingEvents"];
+const COMPONENT_DECIMALS = ["quantity", "pricedQuantity", "unpricedQuantity", "costUsd"];
+const ID_FIELDS = ["sourceLocal", "sourceRolloutOrdinal", "sourceRecordOrdinal"];
+const OPTIONAL_ORDER_FIELDS = ["sourceOrdinal", "sourceOffset", "sequence"];
+const SURFACE_FIELDS = ["surface", "threadSource", "agentScope", "lineageDisposition"];
+const TIER_FIELDS = ["billingSurface", "codexSpeedMode", "apiServiceTier", "tierSource", "tierObservedAt"];
+const ATTRIBUTION_FIELDS = ["planAttribution", "usageIntervalStartedAt", "usageIntervalBasis"];
+
+function fail(code = "invalid") {
+  // Fixed errors must not interpolate private field names, values, paths or IDs.
+  const error = new TypeError(`pr94_ledger_${code}`);
+  error.code = `pr94_ledger_${code}`;
+  throw error;
+}
+
+function record(value) {
+  if (!value || typeof value !== "object" || Array.isArray(value)
+      || ![Object.prototype, null].includes(Object.getPrototypeOf(value))) fail();
+  const descriptors = Object.getOwnPropertyDescriptors(value);
+  if (Reflect.ownKeys(value).some((key) => typeof key !== "string"
+      || !descriptors[key].enumerable || !Object.hasOwn(descriptors[key], "value"))) fail();
+  return value;
+}
+
+function closed(value, required, optional = []) {
+  record(value);
+  const allowed = new Set([...required, ...optional]);
+  if (required.some((key) => !Object.hasOwn(value, key))
+      || Object.keys(value).some((key) => !allowed.has(key))) fail();
+  return value;
+}
+
+function count(value) {
+  if (!Number.isSafeInteger(value) || value < 0 || Object.is(value, -0)) fail();
+  return value;
+}
+
+function sumCount(...values) { return count(values.reduce((sum, value) => sum + count(value), 0)); }
+function member(value, values) { if (!values.includes(value)) fail(); return value; }
+function atom(value, nullable = false) {
+  if (nullable && value === null) return null;
+  if (typeof value !== "string" || !/^[A-Za-z0-9._:-]{1,256}$/.test(value)) fail();
+  return value;
+}
+
+function decimal(value, integer = false) {
+  if (typeof value !== "string" || value.length > 128
+      || !(integer ? /^(?:0|[1-9]\d*)$/ : /^(?:0|[1-9]\d*)(?:\.\d*[1-9])?$/).test(value)) fail();
+  return value;
+}
+
+function add(...values) { return decimal(addUsdStrings(...values)); }
+function decimalGreaterThanInteger(value, limit) {
+  const [whole, fraction = ""] = decimal(value).split(".");
+  return BigInt(whole + fraction) > limit * 10n ** BigInt(fraction.length);
+}
+function instant(value, nullable = false) {
+  if (nullable && value === null) return null;
+  if (typeof value !== "string" || value.length !== 24 || !Number.isFinite(Date.parse(value))
+      || new Date(value).toISOString() !== value) fail();
+  return value;
+}
+
+function canonical(value) {
+  if (Array.isArray(value)) return `[${value.map(canonical).join(",")}]`;
+  if (value !== null && typeof value === "object") {
+    return `{${Object.keys(value).sort().map((key) => `${JSON.stringify(key)}:${canonical(value[key])}`).join(",")}}`;
+  }
+  return JSON.stringify(value);
+}
+
+function freeze(value) {
+  if (value && typeof value === "object") {
+    Object.values(value).forEach(freeze);
+    Object.freeze(value);
+  }
+  return value;
+}
+
+function keyed(key, domain, value) {
+  return createHmac("sha256", key).update(`${VERSION}\0${domain}\0`).update(canonical(value)).digest("hex");
+}
+
+function digest(value) { if (typeof value !== "string" || !/^[a-f0-9]{64}$/.test(value)) fail(); return value; }
+function sameDigest(left, right) {
+  return timingSafeEqual(Buffer.from(digest(left), "hex"), Buffer.from(digest(right), "hex"));
+}
+
+function options(value) {
+  closed(value, ["hmacKey"], ["maxRows"]);
+  if (!(value.hmacKey instanceof Uint8Array) || value.hmacKey.byteLength !== 32) fail();
+  const maxRows = count(Object.hasOwn(value, "maxRows") ? value.maxRows : DEFAULT_MAX_ROWS);
+  if (maxRows < 1 || maxRows > MAX_ROWS) fail();
+  return { key: Buffer.from(value.hmacKey), maxRows };
+}
+
+function identity(row, quota = false) {
+  if (!(row.sourceLocal instanceof Uint8Array) || row.sourceLocal.byteLength !== 32) fail();
+  count(row.sourceRolloutOrdinal);
+  count(row.sourceRecordOrdinal);
+  if (Object.hasOwn(row, "sourceOrdinal") && count(row.sourceOrdinal) !== row.sourceRolloutOrdinal) fail();
+  if (Object.hasOwn(row, "sourceOffset") && count(row.sourceOffset) !== row.sourceRecordOrdinal) fail();
+  if (Object.hasOwn(row, "sequence")) count(row.sequence);
+  return [Buffer.from(row.sourceLocal).toString("hex"), row.sourceRolloutOrdinal,
+    row.sourceRecordOrdinal, ...(quota ? [count(row.slotOrder)] : [])];
+}
+
+function semantics(row) {
+  instant(row.timestamp);
+  if (!Number.isSafeInteger(row.timestampMs) || Date.parse(row.timestamp) !== row.timestampMs) fail();
+  closed(row.surfaceClassification, SURFACE_FIELDS);
+  SURFACE_FIELDS.forEach((key) => atom(row.surfaceClassification[key]));
+  return { timestamp: row.timestamp, surfaceClassification: { ...row.surfaceClassification } };
+}
+
+function observation(values, name, availability = {}) {
+  const present = Object.hasOwn(values, name);
+  const value = present ? values[name] : null;
+  if (present && value !== null) count(value);
+  const available = Object.hasOwn(availability, name) ? availability[name] : null;
+  if (available !== null && typeof available !== "boolean") fail();
+  return { state: available === false || (present && value === null)
+    ? "unavailable" : present ? "observed" : "missing", present, value, availability: available };
+}
+
+function rawUsage(row) {
+  closed(row, ["timestamp", "timestampMs", "model", "components", "tierSemantics",
+    "surfaceClassification", ...ID_FIELDS],
+  [...OPTIONAL_ORDER_FIELDS, ...ATTRIBUTION_FIELDS, "totalInputContextTokens", "componentAvailability"]);
+  const semantic = semantics(row);
+  atom(row.model);
+  closed(row.components, [], PR94_LEDGER_COMPONENTS);
+  if (Object.hasOwn(row, "componentAvailability")) closed(row.componentAvailability, [], PR94_LEDGER_COMPONENTS);
+  const components = Object.fromEntries(PR94_LEDGER_COMPONENTS.map((name) =>
+    [name, observation(row.components, name, row.componentAvailability)]));
+  const context = observation(row, "totalInputContextTokens");
+  closed(row.tierSemantics, TIER_FIELDS);
+  TIER_FIELDS.filter((key) => key !== "tierObservedAt").forEach((key) => atom(row.tierSemantics[key]));
+  instant(row.tierSemantics.tierObservedAt, true);
+  // These are the intentional PR94 attribution delta, not conserved usage.
+  if (Object.hasOwn(row, "planAttribution")) {
+    closed(row.planAttribution, ["basis", "planType", "planVariant"]);
+    member(row.planAttribution.basis, ["unavailable", "same_record", "conflicted"]);
+    atom(row.planAttribution.planType, true);
+    atom(row.planAttribution.planVariant, true);
+  }
+  if (Object.hasOwn(row, "usageIntervalStartedAt")) instant(row.usageIntervalStartedAt, true);
+  if (Object.hasOwn(row, "usageIntervalBasis")) {
+    member(row.usageIntervalBasis, ["unavailable", "previous_session_record", "previous_source_record"]);
+  }
+  return { identity: identity(row), semantic: { ...semantic, model: row.model,
+    components, context, tierSemantics: { ...row.tierSemantics } } };
+}
+
+function pricedUsage(result, raw) {
+  closed(result, ["schemaVersion", "basis", "provider", "model", "surface", "pricingContext",
+    "coverageStatus", "coverageCounts", "totalUsd", "components", "priceCardBreakdown",
+    "selectedPriceCardId", "selectedPriceCardIds", "warnings", "ledger"], ["methodVersion", "registry"]);
+  if (result.schemaVersion !== "0.1" || result.basis !== "api_price_equivalent_not_subscription_allowance"
+      || result.provider !== "openai" || result.surface !== "openai.responses" || result.model !== raw.model) fail();
+  closed(result.pricingContext, ["serviceTier", "tierSource", "pricedAt", "region", "priceEpochBasis"],
+    ["historicalPriceReasonCode"]);
+  const context = result.pricingContext;
+  atom(context.serviceTier); atom(context.tierSource); atom(context.priceEpochBasis);
+  atom(context.region, true); instant(context.pricedAt, true);
+  if (Object.hasOwn(context, "historicalPriceReasonCode")) member(context.historicalPriceReasonCode, WARNING_CODES);
+  member(result.coverageStatus, COVERAGE);
+  decimal(result.totalUsd);
+  closed(result.coverageCounts, ["pricedComponents", "unpricedComponents", "unavailableComponents"]);
+  Object.values(result.coverageCounts).forEach(count);
+  if (!Array.isArray(result.components) || result.components.length > PR94_LEDGER_COMPONENTS.length) fail();
+  const components = {};
+  const coverage = { pricedComponents: 0, unpricedComponents: 0, unavailableComponents: 0 };
+  const cards = new Map();
+  let total = "0";
+  for (const component of result.components) {
+    closed(component, ["name", "pricedAs", "quantity", "unit", "pricingStatus", "unitPriceUsd", "costUsd", "priceCardId"],
+      ["reasonCode", "metadata"]);
+    const name = member(component.name, PR94_LEDGER_COMPONENTS);
+    if (Object.hasOwn(components, name) || component.unit !== "token") fail();
+    const status = member(component.pricingStatus, ["priced", "unpriced", "unavailable"]);
+    const observed = raw.components[name];
+    if (status === "unavailable") {
+      if (observed.state !== "unavailable" || component.quantity !== null) fail();
+      coverage.unavailableComponents += 1;
+    } else {
+      decimal(component.quantity, true);
+      if (observed.state !== "observed" || component.quantity !== String(observed.value) || observed.value === 0) fail();
+      coverage[status === "priced" ? "pricedComponents" : "unpricedComponents"] += 1;
+    }
+    if (status === "priced") {
+      if (component.pricedAs !== name || Object.hasOwn(component, "reasonCode")) fail();
+      decimal(component.unitPriceUsd); decimal(component.costUsd); atom(component.priceCardId);
+      total = add(total, component.costUsd);
+      cards.set(component.priceCardId, add(cards.get(component.priceCardId) ?? "0", component.costUsd));
+    } else {
+      if (component.unitPriceUsd !== null || component.costUsd !== null || component.priceCardId !== null) fail();
+      if (component.pricedAs !== null && component.pricedAs !== name) fail();
+      member(component.reasonCode, WARNING_CODES);
+      if (status === "unavailable" && component.reasonCode !== "component_observation_unavailable") fail();
+    }
+    // Deliberately omit accounting diagnostic messages and arbitrary metadata.
+    components[name] = { name, pricedAs: component.pricedAs, quantity: component.quantity,
+      pricingStatus: status, unitPriceUsd: component.unitPriceUsd, costUsd: component.costUsd,
+      priceCardId: component.priceCardId, reasonCode: component.reasonCode ?? null };
+  }
+  for (const name of PR94_LEDGER_COMPONENTS) {
+    const observed = raw.components[name];
+    // OpenAI's public kernel has no combined-output unavailable mapping. It
+    // remains explicitly unavailable in raw evidence, not an invented zero.
+    const expected = (observed.state === "observed" && observed.value > 0)
+      || (observed.state === "unavailable" && name !== "output_combined_tokens");
+    if (Object.hasOwn(components, name) !== expected) fail();
+  }
+  const status = coverage.unpricedComponents === 0 && coverage.unavailableComponents === 0
+    ? "fully_priced" : coverage.pricedComponents > 0 ? "partially_priced" : "unpriced";
+  if (canonical(coverage) !== canonical(result.coverageCounts) || result.totalUsd !== total
+      || result.coverageStatus !== status) fail("cost_conservation");
+  if (!Array.isArray(result.selectedPriceCardIds) || !Array.isArray(result.priceCardBreakdown)
+      || result.selectedPriceCardIds.length > 6 || result.priceCardBreakdown.length > 6) fail();
+  const selected = [...cards.keys()].sort();
+  if (canonical(result.selectedPriceCardIds) !== canonical(selected)
+      || result.selectedPriceCardId !== (selected.length === 1 ? selected[0] : null)) fail();
+  const breakdown = result.priceCardBreakdown.map((item) => {
+    closed(item, ["priceCardId", "events", "costUsd"]);
+    atom(item.priceCardId); decimal(item.costUsd);
+    if (item.events !== 1) fail();
+    return item;
+  });
+  if (canonical(breakdown) !== canonical(selected.map((priceCardId) => ({ priceCardId, events: 1, costUsd: cards.get(priceCardId) })))) fail();
+  closed(result.warnings, ["coverage", "informational"]);
+  const warnings = {};
+  for (const kind of ["coverage", "informational"]) {
+    if (!Array.isArray(result.warnings[kind]) || result.warnings[kind].length > 128) fail();
+    warnings[kind] = result.warnings[kind].map((item) => {
+      closed(item, ["code", "message", "metadata"]);
+      return member(item.code, WARNING_CODES);
+    }).sort();
+  }
+  let registry = null;
+  if (Object.hasOwn(result, "registry")) {
+    closed(result.registry, ["version", "sha256", "observedAt", "priceBasis", "historicalDefault", "sources"]);
+    registry = { version: atom(result.registry.version), sha256: result.registry.sha256 === null ? null : digest(result.registry.sha256) };
+  }
+  const methodVersion = Object.hasOwn(result, "methodVersion") ? atom(result.methodVersion) : null;
+  return { components, coverageStatus: result.coverageStatus, totalUsd: total,
+    pricingContext: { ...context }, warnings, registry, methodVersion };
+}
+
+function emptyObservation() { return { observedEvents: 0, missingEvents: 0, unavailableEvents: 0, zeroEvents: 0, quantity: "0" }; }
+function emptyAggregate() {
+  return { schemaVersion: VERSION, usage: { events: 0, totalUsd: "0",
+    components: Object.fromEntries(PR94_LEDGER_COMPONENTS.map((name) => [name, {
+      ...emptyObservation(), pricedEvents: 0, unpricedEvents: 0, unavailablePricingEvents: 0,
+      pricedQuantity: "0", unpricedQuantity: "0", costUsd: "0",
+    }])), context: emptyObservation(), coverage: Object.fromEntries(COVERAGE.map((status) => [status, 0])),
+    warnings: Object.fromEntries(["coverage", "informational"].map((kind) => [kind,
+      Object.fromEntries(WARNING_CODES.map((code) => [code, 0]))])) },
+  quota: { events: 0, slots: { primary: 0, secondary: 0 }, usedPercentTotal: "0", windowDurationMinsTotal: "0" } };
+}
+
+function accumulateObservation(target, observation) {
+  const field = `${observation.state}Events`;
+  target[field] = sumCount(target[field], 1);
+  if (observation.state === "observed") {
+    target.quantity = add(target.quantity, String(observation.value));
+    if (observation.value === 0) target.zeroEvents = sumCount(target.zeroEvents, 1);
+  }
+}
+
+function validateObservation(value, events, component = false) {
+  closed(value, component ? [...COMPONENT_COUNTERS, ...COMPONENT_DECIMALS] : [...COUNTERS, "quantity"]);
+  (component ? COMPONENT_COUNTERS : COUNTERS).forEach((key) => count(value[key]));
+  decimal(value.quantity, true);
+  if (sumCount(value.observedEvents, value.missingEvents, value.unavailableEvents) !== events
+      || value.zeroEvents > value.observedEvents
+      || (value.observedEvents === value.zeroEvents && value.quantity !== "0")
+      || BigInt(value.quantity) > BigInt(value.observedEvents) * BigInt(Number.MAX_SAFE_INTEGER)
+      || (value.observedEvents > value.zeroEvents && BigInt(value.quantity) < BigInt(value.observedEvents - value.zeroEvents))) fail();
+  if (component) {
+    decimal(value.pricedQuantity, true); decimal(value.unpricedQuantity, true); decimal(value.costUsd);
+    if (sumCount(value.pricedEvents, value.unpricedEvents, value.zeroEvents) !== value.observedEvents
+        || value.unavailablePricingEvents > value.unavailableEvents
+        || add(value.pricedQuantity, value.unpricedQuantity) !== value.quantity
+        || (value.pricedEvents === 0 && (value.pricedQuantity !== "0" || value.costUsd !== "0"))
+        || (value.unpricedEvents === 0 && value.unpricedQuantity !== "0")
+        || BigInt(value.pricedQuantity) < BigInt(value.pricedEvents)
+        || BigInt(value.unpricedQuantity) < BigInt(value.unpricedEvents)
+        || BigInt(value.pricedQuantity) > BigInt(value.pricedEvents) * BigInt(Number.MAX_SAFE_INTEGER)
+        || BigInt(value.unpricedQuantity) > BigInt(value.unpricedEvents) * BigInt(Number.MAX_SAFE_INTEGER)) fail();
+  }
+}
+
+/** Validate the complete PUBLIC schema. A valid aggregate alone is not row proof. */
+export function validatePr94LedgerEvidenceAggregate(value) {
+  closed(value, ["schemaVersion", "usage", "quota"]);
+  if (value.schemaVersion !== VERSION) fail();
+  const { usage, quota } = value;
+  closed(usage, ["events", "totalUsd", "components", "context", "coverage", "warnings"]);
+  count(usage.events); decimal(usage.totalUsd);
+  closed(usage.components, PR94_LEDGER_COMPONENTS);
+  for (const name of PR94_LEDGER_COMPONENTS) {
+    const component = usage.components[name];
+    validateObservation(component, usage.events, true);
+    if (component.unavailablePricingEvents !== (name === "output_combined_tokens" ? 0 : component.unavailableEvents)) fail();
+  }
+  validateObservation(usage.context, usage.events);
+  if (add(...PR94_LEDGER_COMPONENTS.map((name) => usage.components[name].costUsd)) !== usage.totalUsd) fail();
+  closed(usage.coverage, COVERAGE);
+  if (sumCount(...Object.values(usage.coverage)) !== usage.events) fail();
+  closed(usage.warnings, ["coverage", "informational"]);
+  for (const kind of ["coverage", "informational"]) {
+    closed(usage.warnings[kind], WARNING_CODES);
+    for (const value of Object.values(usage.warnings[kind])) {
+      if (BigInt(count(value)) > BigInt(usage.events) * 128n) fail();
+    }
+  }
+  closed(quota, ["events", "slots", "usedPercentTotal", "windowDurationMinsTotal"]);
+  count(quota.events); decimal(quota.usedPercentTotal); decimal(quota.windowDurationMinsTotal, true);
+  closed(quota.slots, ["primary", "secondary"]);
+  if (sumCount(quota.slots.primary, quota.slots.secondary) !== quota.events
+      || (quota.events === 0 && (quota.usedPercentTotal !== "0" || quota.windowDurationMinsTotal !== "0"))
+      || decimalGreaterThanInteger(quota.usedPercentTotal, BigInt(quota.events) * 100n)
+      || BigInt(quota.windowDurationMinsTotal) > BigInt(quota.events) * BigInt(Number.MAX_SAFE_INTEGER)
+      || BigInt(quota.windowDurationMinsTotal) < BigInt(quota.events)) fail();
+  return value;
+}
+
+function finish(aggregate, state) {
+  validatePr94LedgerEvidenceAggregate(aggregate);
+  freeze(aggregate);
+  FINISHES.set(aggregate, state);
+  return aggregate;
+}
+
+/** All errors poison the accumulator; a caught invalid row cannot become a pass. */
+export function createPr94LedgerEvidence(configuration) {
+  const { key, maxRows } = options(configuration);
+  const state = { key, keyCheck: keyed(key, "same-key", null), usage: new Map(), quota: new Map() };
+  const aggregate = emptyAggregate();
+  let phase = "open";
+  function consume(kind, callback) {
+    if (phase !== "open") fail("state");
+    try {
+      if (state.usage.size + state.quota.size >= maxRows) fail("row_limit");
+      const { id, semantic, apply } = callback();
+      const rowIdentity = keyed(key, `${kind}-identity`, id);
+      if (state[kind].has(rowIdentity)) fail("duplicate");
+      const fingerprint = keyed(key, `${kind}-semantic`, semantic);
+      apply();
+      state[kind].set(rowIdentity, fingerprint);
+    } catch {
+      phase = "failed";
+      state.usage.clear(); state.quota.clear(); key.fill(0);
+      fail("row_rejected");
+    }
+  }
+  return Object.freeze({
+    consumeUsage(row, priced) {
+      consume("usage", () => {
+        const raw = rawUsage(row);
+        const price = pricedUsage(priced, raw.semantic);
+        return { id: raw.identity, semantic: { ...raw.semantic, price }, apply() {
+          aggregate.usage.events = sumCount(aggregate.usage.events, 1);
+          aggregate.usage.totalUsd = add(aggregate.usage.totalUsd, price.totalUsd);
+          accumulateObservation(aggregate.usage.context, raw.semantic.context);
+          for (const name of PR94_LEDGER_COMPONENTS) {
+            const target = aggregate.usage.components[name];
+            accumulateObservation(target, raw.semantic.components[name]);
+            const component = price.components[name];
+            if (!component) continue;
+            const status = component.pricingStatus;
+            const counter = status === "unavailable" ? "unavailablePricingEvents" : `${status}Events`;
+            target[counter] = sumCount(target[counter], 1);
+            if (status !== "unavailable") target[`${status}Quantity`] = add(target[`${status}Quantity`], component.quantity);
+            if (status === "priced") target.costUsd = add(target.costUsd, component.costUsd);
+          }
+          aggregate.usage.coverage[price.coverageStatus] = sumCount(aggregate.usage.coverage[price.coverageStatus], 1);
+          for (const kind of ["coverage", "informational"]) for (const code of price.warnings[kind]) {
+            aggregate.usage.warnings[kind][code] = sumCount(aggregate.usage.warnings[kind][code], 1);
+          }
+        } };
+      });
+    },
+    consumeQuota(row) {
+      consume("quota", () => {
+        closed(row, ["timestamp", "timestampMs", "window", "surfaceClassification", "slotOrder", ...ID_FIELDS], OPTIONAL_ORDER_FIELDS);
+        const semantic = semantics(row);
+        closed(row.window, ["provider", "planType", "limitId", "slot", "usedPercent", "windowDurationMins", "resetsAt"]);
+        const window = row.window;
+        atom(window.provider); atom(window.planType, true); atom(window.limitId);
+        member(window.slot, ["primary", "secondary"]);
+        if (typeof window.usedPercent !== "number" || !Number.isFinite(window.usedPercent)
+            || window.usedPercent < 0 || window.usedPercent > 100 || Object.is(window.usedPercent, -0)
+            || count(window.windowDurationMins) === 0 || count(window.resetsAt) === 0) fail();
+        return { id: identity(row, true), semantic: { ...semantic, window: { ...window } }, apply() {
+          aggregate.quota.events = sumCount(aggregate.quota.events, 1);
+          aggregate.quota.slots[window.slot] = sumCount(aggregate.quota.slots[window.slot], 1);
+          aggregate.quota.usedPercentTotal = add(aggregate.quota.usedPercentTotal, String(window.usedPercent));
+          aggregate.quota.windowDurationMinsTotal = add(aggregate.quota.windowDurationMinsTotal, String(window.windowDurationMins));
+        } };
+      });
+    },
+    finish() {
+      if (phase !== "open") fail("state");
+      phase = "finished";
+      return finish(aggregate, state);
+    },
+  });
+}
+
+function authentic(value) {
+  const state = FINISHES.get(value);
+  if (!state) fail("private_evidence_required");
+  return state;
+}
+
+/** Release private memory/key after comparison and transport have completed. */
+export function disposePr94LedgerEvidencePrivate(value) {
+  const state = authentic(value);
+  state.key.fill(0);
+  state.usage.clear();
+  state.quota.clear();
+  FINISHES.delete(value);
+}
+
+/** PRIVATE streaming frames: never include these in public JSON or diagnostics. */
+export function* iteratePr94LedgerEvidencePrivate(value) {
+  const state = authentic(value);
+  const mac = createHmac("sha256", state.key).update(`${PRIVATE_VERSION}\0stream\0`);
+  const header = { type: "header", schemaVersion: PRIVATE_VERSION, keyCheck: state.keyCheck, aggregate: value };
+  mac.update(canonical(header)).update("\n");
+  yield header;
+  for (const type of ["usage", "quota"]) for (const [identity, fingerprint] of state[type]) {
+    authentic(value);
+    const frame = { type, identity, fingerprint };
+    mac.update(canonical(frame)).update("\n");
+    yield frame;
+  }
+  authentic(value);
+  yield { type: "seal", hmac: mac.digest("hex") };
+}
+
+/** Import parsed PRIVATE frames from a bounded owner-only NDJSON reader. */
+export async function importPr94LedgerEvidencePrivate(frames, configuration) {
+  const { key, maxRows } = options(configuration);
+  const state = { key, keyCheck: keyed(key, "same-key", null), usage: new Map(), quota: new Map() };
+  const mac = createHmac("sha256", key).update(`${PRIVATE_VERSION}\0stream\0`);
+  let aggregate;
+  let sealed = false;
+  try {
+    for await (const frame of frames) {
+      if (sealed) fail();
+      if (!aggregate) {
+        closed(frame, ["type", "schemaVersion", "keyCheck", "aggregate"]);
+        if (frame.type !== "header" || frame.schemaVersion !== PRIVATE_VERSION || !sameDigest(frame.keyCheck, state.keyCheck)) fail();
+        validatePr94LedgerEvidenceAggregate(frame.aggregate);
+        if (sumCount(frame.aggregate.usage.events, frame.aggregate.quota.events) > maxRows) fail();
+        aggregate = JSON.parse(canonical(frame.aggregate));
+      } else if (frame?.type === "seal") {
+        closed(frame, ["type", "hmac"]);
+        if (!sameDigest(frame.hmac, mac.digest("hex")) || state.usage.size !== aggregate.usage.events
+            || state.quota.size !== aggregate.quota.events) fail();
+        sealed = true;
+        continue;
+      } else {
+        closed(frame, ["type", "identity", "fingerprint"]);
+        member(frame.type, ["usage", "quota"]);
+        digest(frame.identity); digest(frame.fingerprint);
+        if (state.usage.size + state.quota.size >= maxRows || state[frame.type].has(frame.identity)) fail();
+        state[frame.type].set(frame.identity, frame.fingerprint);
+      }
+      mac.update(canonical(frame)).update("\n");
+    }
+    if (!sealed) fail();
+    return finish(aggregate, state);
+  } catch {
+    state.usage.clear(); state.quota.clear(); key.fill(0);
+    fail("private_evidence_rejected");
+  }
+}
+
+/** Aggregate equality is necessary but never sufficient for conservation. */
+export function comparePr94LedgerEvidence(before, after) {
+  const left = authentic(before);
+  const right = authentic(after);
+  if (!sameDigest(left.keyCheck, right.keyCheck)) fail("key_mismatch");
+  const rows = {};
+  for (const kind of ["usage", "quota"]) {
+    const result = { before: left[kind].size, after: right[kind].size, unchanged: 0, changed: 0, missing: 0, added: 0 };
+    for (const [id, fingerprint] of left[kind]) {
+      const counterpart = right[kind].get(id);
+      result[counterpart === undefined ? "missing" : fingerprint === counterpart ? "unchanged" : "changed"] += 1;
+    }
+    for (const id of right[kind].keys()) if (!left[kind].has(id)) result.added += 1;
+    rows[kind] = result;
+  }
+  const aggregateEqual = canonical(before) === canonical(after);
+  const equal = aggregateEqual && Object.values(rows).every((row) => row.changed === 0 && row.missing === 0 && row.added === 0);
+  return freeze({ schemaVersion: "pr94-ledger-comparison-v1", status: equal ? "equal" : "different", aggregateEqual, rows });
+}

--- a/scripts/lib/pr94-population-evidence.mjs
+++ b/scripts/lib/pr94-population-evidence.mjs
@@ -1,0 +1,118 @@
+import { addUsdStrings } from "@app-usagemonitor/accounting";
+import { PR94_LEDGER_COMPONENTS } from "./pr94-ledger-evidence.mjs";
+
+const PLANS = ["free", "plus", "pro", "pro_lite", "team", "business", "enterprise", "edu", "unknown", "other"];
+const BASIS = ["not_recorded", "unavailable", "same_record", "conflicted"];
+const DISPOSITIONS = ["legacy_unseparated", "compatible", "legacy_conditional", "unresolved", "incompatible"];
+const REASONS = ["legacy_unseparated", "no_plan_evidence", "usage_interval_unresolved", "outside_observed_history",
+  "plan_transition_interval", "conflicting_quota_evidence", "usage_plan_conflict", "usage_quantity_plan_unresolved",
+  "account_unresolved", "plan_unresolved", "different_context", "different_account", "different_plan", "different_era",
+  "explicit_usage_attribution", "source_record_conflicted"];
+const DECIMAL = /^(?:0|[1-9]\d*)(?:\.\d*[1-9])?$/u;
+function fail() { throw Object.assign(new Error("pr94_population_invalid"), { code: "pr94_population_invalid" }); }
+function count(value) { if (!Number.isSafeInteger(value) || value < 0 || Object.is(value, -0)) fail(); return value; }
+function decimal(value) { if (typeof value !== "string" || value.length > 100 || !DECIMAL.test(value)) fail(); return value; }
+function closed(value, keys) {
+  if (!value || typeof value !== "object" || Array.isArray(value)
+      || ![Object.prototype, null].includes(Object.getPrototypeOf(value))) fail();
+  const descriptors = Object.getOwnPropertyDescriptors(value);
+  if (Reflect.ownKeys(value).length !== keys.length || keys.some((key) => !descriptors[key]?.enumerable
+      || !Object.hasOwn(descriptors[key], "value"))) fail();
+}
+function empty() {
+  return { events: 0, totalUsd: "0", components: Object.fromEntries(PR94_LEDGER_COMPONENTS.map((name) => [name,
+    { quantity: "0", observedEvents: 0, missingEvents: 0, unavailableEvents: 0 }])) };
+}
+function sum(target, source) {
+  target.events = count(target.events + count(source.events));
+  target.totalUsd = addUsdStrings(target.totalUsd, decimal(source.totalUsd));
+  for (const name of PR94_LEDGER_COMPONENTS) {
+    const item = source.components[name]; const out = target.components[name];
+    out.quantity = addUsdStrings(out.quantity, decimal(item.quantity));
+    for (const key of ["observedEvents", "missingEvents", "unavailableEvents"]) out[key] = count(out[key] + count(item[key]));
+  }
+}
+function checkTotals(value) {
+  closed(value, ["events", "totalUsd", "components"]); count(value.events); decimal(value.totalUsd);
+  closed(value.components, PR94_LEDGER_COMPONENTS);
+  for (const item of Object.values(value.components)) {
+    closed(item, ["quantity", "observedEvents", "missingEvents", "unavailableEvents"]);
+    decimal(item.quantity);
+    if (count(item.observedEvents) + count(item.missingEvents) + count(item.unavailableEvents) !== value.events) fail();
+    if (!/^(?:0|[1-9]\d*)$/u.test(item.quantity)
+        || BigInt(item.quantity) > BigInt(item.observedEvents) * BigInt(Number.MAX_SAFE_INTEGER)) fail();
+  }
+}
+export function validatePr94PopulationEvidence(value) {
+  closed(value, ["schema", "context", "revisionKind", "totals", "populations", "unknownAccountOnlyWithheldEvents"]);
+  if (value.schema !== "pr94-population-evidence-v1" || value.context !== "openai_codex|codex"
+      || !["before", "after", "final"].includes(value.revisionKind)) fail();
+  checkTotals(value.totals); count(value.unknownAccountOnlyWithheldEvents);
+  if (!Array.isArray(value.populations) || value.populations.length > 2000) fail();
+  const sumOfPopulations = empty(); const keys = new Set();
+  for (const item of value.populations) {
+    closed(item, ["planType", "basis", "disposition", "reason", "accountKnown", "totals"]);
+    if (!PLANS.includes(item.planType) || !BASIS.includes(item.basis)
+        || !DISPOSITIONS.includes(item.disposition) || !REASONS.includes(item.reason)
+        || typeof item.accountKnown !== "boolean") fail();
+    const key = JSON.stringify([item.planType, item.basis, item.disposition, item.reason, item.accountKnown]);
+    if (keys.has(key)) fail(); keys.add(key);
+    checkTotals(item.totals); sum(sumOfPopulations, item.totals);
+  }
+  if (JSON.stringify(sumOfPopulations) !== JSON.stringify(value.totals)) fail();
+  const withheld = value.populations.filter((item) => !item.accountKnown && item.disposition === "unresolved"
+    && item.reason === "account_unresolved").reduce((total, item) => total + item.totals.events, 0);
+  if (withheld !== value.unknownAccountOnlyWithheldEvents) fail();
+  return value;
+}
+
+// Each admitted usage event is classified once with the same public arguments
+// as the original transition miner. This is a disjoint diagnostic projection,
+// never a second priced ledger or a per-reset sum of overlapping usage slices.
+export function buildPr94PopulationEvidence({ usage, costs, ledger, quota, attribution, revisionKind, resourceCheck = () => {} }) {
+  if (!Array.isArray(usage) || usage.length > 1_000_000 || !Array.isArray(costs)
+      || costs.length !== usage.length || ledger?.usage?.events !== usage.length) fail();
+  const populations = new Map(); const totals = empty();
+  for (let at = 0; at < usage.length; at += 1) {
+    if (at % 2048 === 0) resourceCheck();
+    const event = usage[at]; const scope = event.accountScopeId;
+    const accountKnown = typeof scope === "string" && scope.length <= 512
+      && !["", "unknown", "unattributed", "unavailable"].includes(scope);
+    const basis = event.planAttribution?.basis ?? "not_recorded";
+    let classification = { disposition: "legacy_unseparated", reason: "legacy_unseparated", planType: "unknown" };
+    if (revisionKind !== "before") {
+      const intervalStartMs = Date.parse(event.usageIntervalStartedAt ?? "");
+      classification = quota.classifyUsageAttribution(attribution, {
+        contextKey: quota.planAttributionContextKey("openai_codex", "codex"), observedAtMs: event.timestampMs,
+        ...(Number.isSafeInteger(intervalStartMs) ? { intervalStartMs } : {}),
+        observedPlanType: basis === "same_record" ? event.planAttribution.planType : null,
+        observedPlanVariant: event.planAttribution?.planVariant ?? "unknown", accountScopeId: scope ?? null,
+      });
+      if (basis === "conflicted") classification = { ...classification, disposition: "unresolved", reason: "source_record_conflicted" };
+      if (classification.disposition !== "unresolved" && !classification.era) fail();
+    }
+    const planType = classification.planType == null ? "unknown"
+      : PLANS.includes(classification.planType) ? classification.planType : "other";
+    const metadata = { planType, basis, disposition: classification.disposition, reason: classification.reason, accountKnown };
+    const key = JSON.stringify(metadata);
+    if (!populations.has(key)) populations.set(key, { ...metadata, totals: empty() });
+    const item = empty(); item.events = 1; item.totalUsd = decimal(costs[at]);
+    for (const name of PR94_LEDGER_COMPONENTS) {
+      const present = Object.hasOwn(event.components, name); const value = event.components[name];
+      const unavailable = event.componentAvailability?.[name] === false || (present && value === null);
+      const component = item.components[name];
+      if (unavailable) component.unavailableEvents = 1;
+      else if (!present) component.missingEvents = 1;
+      else { component.observedEvents = 1; component.quantity = String(count(value)); }
+    }
+    sum(populations.get(key).totals, item); sum(totals, item);
+  }
+  const expected = { events: ledger.usage.events, totalUsd: ledger.usage.totalUsd,
+    components: Object.fromEntries(PR94_LEDGER_COMPONENTS.map((name) => [name,
+      Object.fromEntries(["quantity", "observedEvents", "missingEvents", "unavailableEvents"].map((key) => [key, ledger.usage.components[name][key]]))])) };
+  if (JSON.stringify(totals) !== JSON.stringify(expected)) fail();
+  const rows = [...populations.entries()].sort(([a], [b]) => a.localeCompare(b)).map(([, value]) => value);
+  return validatePr94PopulationEvidence({ schema: "pr94-population-evidence-v1", context: "openai_codex|codex", revisionKind,
+    totals, populations: rows, unknownAccountOnlyWithheldEvents: rows.filter((item) => !item.accountKnown
+      && item.disposition === "unresolved" && item.reason === "account_unresolved").reduce((n, item) => n + item.totals.events, 0) });
+}

--- a/scripts/lib/pr94-production-resource-worker.mjs
+++ b/scripts/lib/pr94-production-resource-worker.mjs
@@ -28,6 +28,12 @@ const POLICY_KEYS = ["maximumRssBytes", "rssDeltaBudgetBytes", "rebuildChildOldS
 const INPUT_LIMITS = ["usageEvents", "weeklySnapshots", "combinedInputs", "retainedBytes"];
 const CACHE_ARRAYS = ["periods", "timeline", "sparkUsageTimeline", "quotaTimeline", "sparkQuotaTimeline"];
 const RUN_KINDS = ["primary", "fresh_process_repeat"];
+const BEFORE_REVISION = "a3c850360bc83c0e27bef2171aeb4a302b72f472";
+const QUERY_PLAN_SCHEMA = "pr94-attribution-query-plans-v1";
+const QUERY_ROLES = ["membership", "same_record_plans", "source_predecessor", "session_predecessor"];
+const QUERY_METHODS = ["get", "all", "get", "get"];
+const QUERY_ARITIES = [2, 5, 3, 5];
+const QUERY_COUNTS = ["steps", "search", "scan", "tempSort", "other"];
 const MODULE_FILE = fileURLToPath(import.meta.url);
 const SAFE_FAILURES = new Set([
   "invalid", "approval_required", "runtime_invalid", "window_invalid", "policy_invalid", "path_invalid",
@@ -36,6 +42,7 @@ const SAFE_FAILURES = new Set([
   "command_failed", "command_timeout", "command_output_limit", "command_aborted", "command_termination_unconfirmed",
   "metrics_invalid", "envelope_invalid", "child_refused", "artifact_invalid", "artifact_mismatch", "index_invalid",
   "resource_limit_exceeded", "dependency_invalid", "dependency_changed", "dependency_limit_exceeded", "refused",
+  "query_plan_invalid", "query_plan_changed",
 ]);
 export const PR94_PRODUCTION_ERROR_CODES = Object.freeze([...SAFE_FAILURES].map((code) => `pr94_production_${code}`));
 
@@ -68,6 +75,88 @@ function sameFile(left, right) {
     .every((key) => left[key] === right[key]);
 }
 function same(left, right) { return JSON.stringify(left) === JSON.stringify(right); }
+
+export function validatePr94AttributionQueryPlans(value, revision) {
+  exact(value, ["schema", "scope", "binding", "status", "statements"]);
+  if (typeof revision !== "string" || !REVISION.test(revision)
+      || value.schema !== QUERY_PLAN_SCHEMA || value.scope !== "attribution_point_queries_explain_only"
+      || value.binding !== "synthetic") fail("query_plan_invalid");
+  if (revision === BEFORE_REVISION) {
+    if (value.status !== "feature_absent" || value.statements !== null) fail("query_plan_invalid");
+    return value;
+  }
+  if (value.status !== "observed") fail("query_plan_invalid");
+  exact(value.statements, QUERY_ROLES);
+  for (const role of QUERY_ROLES) {
+    const counts = exact(value.statements[role], QUERY_COUNTS);
+    QUERY_COUNTS.forEach((key) => integer(counts[key]));
+    if (counts.steps < 1 || integer(counts.search + counts.scan + counts.tempSort + counts.other) !== counts.steps) {
+      fail("query_plan_invalid");
+    }
+  }
+  return value;
+}
+
+// Compile the selected reader's original four point-query statements against
+// the real read-only schema, using only synthetic bind values. The adapter
+// NEVER steps a data SELECT. Its synthetic membership drives the public
+// reader's branches, not a claim that an index row exists. Statement order,
+// method and arity are a closed contract of the reviewed after/final readers.
+// This excludes full scans, optional precomputation and query execution cost.
+export function collectPr94AttributionQueryPlans({ readerModule, database, generationId, observedAtMs, revision }) {
+  try {
+    if (typeof revision !== "string" || !REVISION.test(revision)
+        || typeof database?.prepare !== "function") fail("query_plan_invalid");
+    integer(generationId, 1);
+    integer(observedAtMs, -8_640_000_000_000_000, 8_640_000_000_000_000);
+    const createReader = readerModule?.createLocalUnifiedUsageAttributionReader;
+    const evidence = { schema: QUERY_PLAN_SCHEMA, scope: "attribution_point_queries_explain_only",
+      binding: "synthetic", status: "feature_absent", statements: null };
+    if (revision === BEFORE_REVISION) {
+      if (createReader !== undefined) fail("query_plan_invalid");
+      return validatePr94AttributionQueryPlans(evidence, revision);
+    }
+    if (typeof createReader !== "function") fail("query_plan_invalid");
+    const source = Buffer.alloc(32, 17); const session = Buffer.alloc(32, 29);
+    const prepared = []; const statements = {};
+    const explainOnly = {
+      prepare(sql) {
+        const index = prepared.length;
+        if (index >= QUERY_ROLES.length || typeof sql !== "string" || !/^\s*SELECT\b/u.test(sql)) fail("query_plan_invalid");
+        const state = { used: false }; prepared.push(state);
+        function explain(method, parameters) {
+          if (state.used || method !== QUERY_METHODS[index] || parameters.length !== QUERY_ARITIES[index]) fail("query_plan_invalid");
+          state.used = true;
+          const counts = { steps: 0, search: 0, scan: 0, tempSort: 0, other: 0 };
+          // Iteration bounds retained memory independently of plan length;
+          // the surrounding untimed probe keeps its existing 30-second bound.
+          for (const row of database.prepare(`EXPLAIN QUERY PLAN ${sql}`).iterate(...parameters)) {
+            exact(row, ["id", "parent", "notused", "detail"]);
+            integer(row.id); integer(row.parent); integer(row.notused);
+            if (typeof row.detail !== "string" || row.detail.length === 0) fail("query_plan_invalid");
+            const kind = /^SEARCH\b/u.test(row.detail) ? "search"
+              : /^SCAN\b/u.test(row.detail) ? "scan"
+                : /^USE TEMP B-TREE\b/u.test(row.detail) ? "tempSort" : "other";
+            counts.steps = integer(counts.steps + 1);
+            counts[kind] = integer(counts[kind] + 1);
+          }
+          statements[QUERY_ROLES[index]] = counts;
+          if (index === 0) return { source_ordinal: 0, session_local: session, scanned_bytes: 1 };
+          return index === 1 ? [] : undefined;
+        }
+        return { get: (...parameters) => explain("get", parameters), all: (...parameters) => explain("all", parameters) };
+      },
+    };
+    const reader = createReader({ database: explainOnly, generationId });
+    reader.read({ source_local: source, source_ordinal: 0, source_offset: 1,
+      session_local: session, observed_at_ms: observedAtMs });
+    if (prepared.length !== QUERY_ROLES.length || prepared.some((state) => !state.used)) fail("query_plan_invalid");
+    return validatePr94AttributionQueryPlans({ ...evidence, status: "observed", statements }, revision);
+  } catch {
+    // SQLite errors can contain SQL, schema names or private bindings.
+    fail("query_plan_invalid");
+  }
+}
 
 function windowFor(startAt, endAt) {
   instant(startAt); instant(endAt);
@@ -183,15 +272,23 @@ function validateSource(value, expectedRevision) {
 async function probeRevision({ root, stage, path, context, command, environment, signal, cwd }) {
   const cacheUrl = JSON.stringify(pathToFileURL(join(root, "src/replay-safe-accounting-cache.js")).href);
   const indexUrl = JSON.stringify(pathToFileURL(join(root, "src/local-unified-index.js")).href);
+  const readerUrl = JSON.stringify(pathToFileURL(join(root, "src/local-unified-accounting-source.js")).href);
   const projectionUrl = JSON.stringify(pathToFileURL(MODULE_FILE).href);
   const program = `import { readFile } from 'node:fs/promises';
 import { REPLAY_SAFE_ACCOUNTING_MEMORY_POLICY as policy, REPLAY_SAFE_ACCOUNTING_REBUILD_REQUEST_VERSION as requestVersion, assertReplaySafeAccountingCache } from ${cacheUrl};
 import { openLocalUnifiedIndex, readUnifiedIndexGenerationDescriptor } from ${indexUrl};
-import { projectPr94ProductionCache } from ${projectionUrl};
+import * as readerModule from ${readerUrl};
+import { projectPr94ProductionCache, collectPr94AttributionQueryPlans } from ${projectionUrl};
 try {
  if (process.argv[1] === 'metadata') {
   const db = openLocalUnifiedIndex(process.argv[2], { readOnly: true });
-  try { process.stdout.write(JSON.stringify({ policy, requestVersion, generation: readUnifiedIndexGenerationDescriptor(db) })); } finally { db.close(); }
+  try {
+   const generation = readUnifiedIndexGenerationDescriptor(db);
+   const context = JSON.parse(process.argv[3]);
+   const queryPlans = collectPr94AttributionQueryPlans({ readerModule, database: db, generationId: generation.id,
+    observedAtMs: context.observedAtMs, revision: context.revision });
+   process.stdout.write(JSON.stringify({ policy, requestVersion, generation, queryPlans }));
+  } finally { db.close(); }
  } else {
   const cache = JSON.parse(await readFile(process.argv[2], 'utf8'));
   assertReplaySafeAccountingCache(cache);
@@ -211,7 +308,7 @@ try {
 
 export function validatePr94ProductionResourceEvidence(value) {
   exact(value, ["schema", "scope", "revision", "dependencies", "clock", "index", "generation", "policy",
-    "limits", "runs", "exactRepeatOutput", "indexUnchanged", "sourceUnchanged", "dependenciesUnchanged", "notMeasured"]);
+    "limits", "runs", "queryPlans", "exactRepeatOutput", "indexUnchanged", "sourceUnchanged", "dependenciesUnchanged", "notMeasured"]);
   if (value.schema !== SCHEMA || value.scope !== "isolated_child_repeatability" || !REVISION.test(value.revision)) fail();
   validateSource({ revision: value.revision, dependencies: value.dependencies }, value.revision);
   exact(value.clock, ["startAt", "endAt", "nowMs", "windowDays"]);
@@ -221,6 +318,7 @@ export function validatePr94ProductionResourceEvidence(value) {
   integer(value.generation.id, 1); integer(value.generation.usageEvents); integer(value.generation.quotaOccurrences);
   if (!["complete", "partial"].includes(value.generation.publicationStatus) || typeof value.generation.toolProvenanceComplete !== "boolean") fail();
   validatePolicy(value.policy);
+  validatePr94AttributionQueryPlans(value.queryPlans, value.revision);
   exact(value.limits, ["envelopeBytes", "transportBytes", "durableCacheBytes"]);
   if (!same(value.limits, { envelopeBytes: 64 * 1024, transportBytes: TRANSPORT_BYTES, durableCacheBytes: CACHE_BYTES })) fail();
   if (!Array.isArray(value.runs) || value.runs.length !== 2) fail();
@@ -273,9 +371,11 @@ async function runWorker(options, {
   await mkdir(temporary, { mode: 0o700 });
   const environment = { TMPDIR: temporary, LC_ALL: "C" };
   const probeOptions = { root: options.root, command, environment, signal, cwd: options.outputDirectory };
-  const initial = await probe({ ...probeOptions, stage: "metadata", path: options.indexFile });
-  exact(initial, ["policy", "requestVersion", "generation"]);
+  const metadataContext = { revision: options.expectedRevision, observedAtMs: clock.nowMs };
+  const initial = await probe({ ...probeOptions, stage: "metadata", path: options.indexFile, context: metadataContext });
+  exact(initial, ["policy", "requestVersion", "generation", "queryPlans"]);
   validatePolicy(initial.policy);
+  validatePr94AttributionQueryPlans(initial.queryPlans, options.expectedRevision);
   const generation = projectDetailedAccountingBenchmarkGeneration(initial.generation);
   if (generation.id !== options.expectedIndex.generationId) fail("generation_mismatch");
   const request = buildPr94ProductionResourceRequest({ ...clock, indexFile: options.indexFile, codexHome, ...initial });
@@ -308,7 +408,11 @@ async function runWorker(options, {
   if (!sameFile(indexStat, await inspectDetailedAccountingBenchmarkIndex(options.indexFile))
       || await digestDetailedAccountingBenchmarkFile(options.indexFile, indexStat, { signal }) !== indexSha256) fail("index_changed");
   if (!same(beforeSource, validateSource(await inspectSource(options.root, { signal, command }), options.expectedRevision))) fail("source_changed");
-  if (!same(initial, await probe({ ...probeOptions, stage: "metadata", path: options.indexFile }))) fail("generation_changed");
+  const finalMetadata = await probe({ ...probeOptions, stage: "metadata", path: options.indexFile, context: metadataContext });
+  exact(finalMetadata, ["policy", "requestVersion", "generation", "queryPlans"]);
+  validatePr94AttributionQueryPlans(finalMetadata.queryPlans, options.expectedRevision);
+  if (!same(initial.queryPlans, finalMetadata.queryPlans)) fail("query_plan_changed");
+  if (!same(initial, finalMetadata)) fail("generation_changed");
   const finalOutputStat = await privateDirectory(options.outputDirectory);
   if (outputStat.dev !== finalOutputStat.dev || outputStat.ino !== finalOutputStat.ino) fail("path_invalid");
   cancelled(signal);
@@ -317,7 +421,7 @@ async function runWorker(options, {
     index: { sha256: indexSha256, bytes: indexStat.size },
     generation: { id: generation.id, publicationStatus: generation.publicationStatus,
       toolProvenanceComplete: generation.toolProvenanceComplete, usageEvents: generation.usageEvents,
-      quotaOccurrences: generation.quotaOccurrences }, policy: initial.policy,
+      quotaOccurrences: generation.quotaOccurrences }, policy: initial.policy, queryPlans: initial.queryPlans,
     limits: { envelopeBytes: 64 * 1024, transportBytes: TRANSPORT_BYTES, durableCacheBytes: CACHE_BYTES }, runs,
     exactRepeatOutput: true, indexUnchanged: true, sourceUnchanged: true, dependenciesUnchanged: true,
     notMeasured: ["app_no_change_cache_hit", "app_relaunch", "end_to_end_refresh", "cancellation", "evidence_observer_overhead"] });

--- a/scripts/lib/pr94-production-resource-worker.mjs
+++ b/scripts/lib/pr94-production-resource-worker.mjs
@@ -1,0 +1,354 @@
+import { lstat, mkdir, realpath, writeFile } from "node:fs/promises";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+import {
+  digestDetailedAccountingBenchmarkFile,
+  inspectDetailedAccountingBenchmarkIndex,
+  parseMacOsTimeMetrics,
+  parseSuccessfulAccountingEnvelope,
+  projectDetailedAccountingBenchmarkGeneration,
+  runBoundedBenchmarkCommand,
+  snapshotDetailedAccountingDependencies,
+  verifyAccountingBenchmarkArtifact,
+} from "../benchmark-detailed-accounting.mjs";
+
+// Production child resource evidence only. No ledger observer, instrumentation,
+// ingestion, installed-app work, cache publication or application refresh runs
+// in the timed process. Repeated fresh processes prove child repeatability, not
+// an app-level no-change cache hit, relaunch, refresh or cancellation outcome.
+const SCHEMA = "pr94-production-resource-v1";
+const DAY_MS = 86_400_000;
+const HASH = /^[a-f0-9]{64}$/u;
+const REVISION = /^[a-f0-9]{40}$/u;
+const TRANSPORT_BYTES = 64 * 1024 * 1024;
+const CACHE_BYTES = 16 * 1024 * 1024;
+const MAX_RSS_BYTES = 6_442_450_944;
+const POLICY_KEYS = ["maximumRssBytes", "rssDeltaBudgetBytes", "rebuildChildOldSpaceMib",
+  "archiveMaximumRssBytes", "archiveRssDeltaBudgetBytes"];
+const INPUT_LIMITS = ["usageEvents", "weeklySnapshots", "combinedInputs", "retainedBytes"];
+const CACHE_ARRAYS = ["periods", "timeline", "sparkUsageTimeline", "quotaTimeline", "sparkQuotaTimeline"];
+const RUN_KINDS = ["primary", "fresh_process_repeat"];
+const MODULE_FILE = fileURLToPath(import.meta.url);
+const SAFE_FAILURES = new Set([
+  "invalid", "approval_required", "runtime_invalid", "window_invalid", "policy_invalid", "path_invalid",
+  "source_invalid", "source_changed", "index_mismatch", "index_changed", "generation_invalid", "generation_mismatch", "generation_changed",
+  "request_version_invalid", "cache_context_mismatch", "probe_invalid", "artifact_changed", "repeat_mismatch", "cancelled",
+  "command_failed", "command_timeout", "command_output_limit", "command_aborted", "command_termination_unconfirmed",
+  "metrics_invalid", "envelope_invalid", "child_refused", "artifact_invalid", "artifact_mismatch", "index_invalid",
+  "resource_limit_exceeded", "dependency_invalid", "dependency_changed", "dependency_limit_exceeded", "refused",
+]);
+export const PR94_PRODUCTION_ERROR_CODES = Object.freeze([...SAFE_FAILURES].map((code) => `pr94_production_${code}`));
+
+function fail(code = "invalid") { throw Object.assign(new Error(`pr94_production_${code}`), { code: `pr94_production_${code}` }); }
+function safeFailureCode(error) {
+  const code = typeof error?.code === "string" ? error.code.replace(/^pr94_production_/u, "") : "refused";
+  return SAFE_FAILURES.has(code) ? code : "refused";
+}
+function exact(value, keys) {
+  if (!value || typeof value !== "object" || Array.isArray(value)
+      || ![Object.prototype, null].includes(Object.getPrototypeOf(value))) fail();
+  const descriptors = Object.getOwnPropertyDescriptors(value);
+  if (Reflect.ownKeys(value).length !== keys.length || keys.some((key) => !Object.hasOwn(descriptors, key)
+      || !descriptors[key].enumerable || !Object.hasOwn(descriptors[key], "value"))) fail();
+  return value;
+}
+function integer(value, minimum = 0, maximum = Number.MAX_SAFE_INTEGER) {
+  if (!Number.isSafeInteger(value) || value < minimum || value > maximum || Object.is(value, -0)) fail();
+  return value;
+}
+function digest(value) { if (typeof value !== "string" || !HASH.test(value)) fail(); return value; }
+function cancelled(signal) { if (signal?.aborted) fail("cancelled"); }
+function instant(value) {
+  if (typeof value !== "string" || value.length !== 24 || !Number.isSafeInteger(Date.parse(value))
+      || new Date(value).toISOString() !== value) fail();
+  return value;
+}
+function sameFile(left, right) {
+  return ["dev", "ino", "size", "mtimeMs", "ctimeMs", "mode", "uid", "nlink"]
+    .every((key) => left[key] === right[key]);
+}
+function same(left, right) { return JSON.stringify(left) === JSON.stringify(right); }
+
+function windowFor(startAt, endAt) {
+  instant(startAt); instant(endAt);
+  const duration = Date.parse(endAt) - Date.parse(startAt);
+  if (!Number.isSafeInteger(duration) || duration % DAY_MS !== 0) fail("window_invalid");
+  // Exact production range: never round or widen the caller's comparison.
+  const windowDays = integer(duration / DAY_MS, 365, 3653);
+  return { startAt, endAt, nowMs: Date.parse(endAt), windowDays };
+}
+
+function validatePolicy(policy) {
+  exact(policy, POLICY_KEYS);
+  POLICY_KEYS.forEach((key) => integer(policy[key], 1));
+  if (policy.maximumRssBytes > MAX_RSS_BYTES) fail("policy_invalid");
+  if (integer(policy.rebuildChildOldSpaceMib * 1024 * 1024, 1) < policy.maximumRssBytes) fail("policy_invalid");
+  return policy;
+}
+
+function validateProjection(value) {
+  exact(value, ["schemaVersion", "source", "weeklyInput", "rows"]);
+  if (!["local-replay-safe-accounting-v0.13", "local-replay-safe-accounting-v0.14",
+    "local-replay-safe-accounting-v0.15"].includes(value.schemaVersion)) fail();
+  exact(value.source, ["mode", "contextBehavior", "accountingCoverage", "generationMatched", "readsRawSources"]);
+  if (value.source.mode !== "unified" || value.source.contextBehavior !== "legacy_zero"
+      || value.source.accountingCoverage !== "complete" || value.source.generationMatched !== true
+      || value.source.readsRawSources !== false) fail();
+  const input = value.weeklyInput;
+  exact(input, ["status", "encoding", "source", "retainedUsageEvents", "retainedWeeklySnapshots", "estimatedRetainedBytes", "limits"]);
+  if (input.status !== "complete" || input.source !== "unified_index"
+      || !["accounting_compact_v2", "accounting_compact_v3"].includes(input.encoding)) fail();
+  exact(input.limits, INPUT_LIMITS);
+  INPUT_LIMITS.forEach((key) => integer(input.limits[key], 1));
+  integer(input.retainedUsageEvents, 0, input.limits.usageEvents);
+  integer(input.retainedWeeklySnapshots, 0, input.limits.weeklySnapshots);
+  integer(input.estimatedRetainedBytes, 0, input.limits.retainedBytes);
+  integer(input.retainedUsageEvents + input.retainedWeeklySnapshots, 0, input.limits.combinedInputs);
+  // Each revision's public validator owns its retained-byte formula: v2 and
+  // v3 intentionally charge different per-usage retained sizes.
+  exact(value.rows, CACHE_ARRAYS);
+  CACHE_ARRAYS.forEach((key) => integer(value.rows[key]));
+  return value;
+}
+
+/** Call only after the selected revision's assertReplaySafeAccountingCache. */
+export function projectPr94ProductionCache(cache, { startAt, endAt, generationId, generationFingerprint }) {
+  windowFor(startAt, endAt);
+  integer(generationId, 1);
+  if (!/^generation-v2-[a-f0-9]{64}$/u.test(generationFingerprint)) fail();
+  if (cache?.generatedAt !== endAt || cache?.coveredAt?.startAt !== startAt || cache.coveredAt.endAt !== endAt
+      || cache?.sourceDescriptor?.generation !== String(generationId)
+      || cache.sourceDescriptor.generationFingerprint !== generationFingerprint) fail("cache_context_mismatch");
+  const input = cache.weeklyCalibrationInput;
+  if (!input || !input.coveredAt) fail();
+  instant(input.coveredAt.startAt); instant(input.coveredAt.endAt);
+  if (input.coveredAt.startAt > input.coveredAt.endAt || input.coveredAt.endAt > endAt) fail();
+  const projection = {
+    schemaVersion: cache.schemaVersion,
+    source: { mode: cache.sourceDescriptor.mode, contextBehavior: cache.sourceDescriptor.contextBehavior,
+      accountingCoverage: cache.sourceDescriptor.coverageStatus,
+      generationMatched: cache.sourceDescriptor.generationMatched,
+      readsRawSources: cache.sourceDescriptor.capabilities?.readsRawSources },
+    weeklyInput: { status: input.status, encoding: input.encoding, source: input.source,
+      retainedUsageEvents: input.retainedUsageEvents, retainedWeeklySnapshots: input.retainedWeeklySnapshots,
+      estimatedRetainedBytes: input.estimatedRetainedBytes,
+      limits: Object.fromEntries(INPUT_LIMITS.map((key) => [key, input.limits?.[key]])) },
+    rows: Object.fromEntries(CACHE_ARRAYS.map((key) => {
+      if (!Array.isArray(cache[key])) fail();
+      return [key, cache[key].length];
+    })),
+  };
+  return validateProjection(projection);
+}
+
+/** Exact production request; no scan/rss hooks or PR94 export instrumentation. */
+export function buildPr94ProductionResourceRequest({ startAt, endAt, indexFile, codexHome, generation, policy, requestVersion }) {
+  const clock = windowFor(startAt, endAt);
+  validatePolicy(policy);
+  projectDetailedAccountingBenchmarkGeneration(generation);
+  if (requestVersion !== "replay-safe-accounting-rebuild-request-v1") fail("request_version_invalid");
+  for (const path of [indexFile, codexHome]) if (typeof path !== "string" || resolve(path) !== path) fail("path_invalid");
+  return { version: requestVersion, nowMs: clock.nowMs, windowDays: clock.windowDays,
+    codexHome, sourceMode: "unified", contextBehavior: "legacy_zero", expectedGeneration: generation,
+    unifiedIndexFile: indexFile, declaredSpeedBaselines: [], transitionResourceLimits: null,
+    maximumRssBytes: policy.maximumRssBytes };
+}
+
+async function privateDirectory(path) {
+  const metadata = await lstat(path);
+  if (!metadata.isDirectory() || metadata.isSymbolicLink() || metadata.uid !== process.getuid()
+      || (metadata.mode & 0o077) !== 0 || await realpath(path) !== path) fail("path_invalid");
+  return metadata;
+}
+
+async function sourceIdentity(root, { signal, command }) {
+  if (await realpath(root) !== root) fail("source_invalid");
+  const git = (args) => command("/usr/bin/git", ["-C", root, ...args], { signal });
+  const revision = (await git(["rev-parse", "--verify", "HEAD"])).stdout.trim();
+  if (!REVISION.test(revision)
+      || (await git(["status", "--porcelain=v1", "--untracked-files=all"])).stdout !== "") fail("source_invalid");
+  return { revision, dependencies: await snapshotDetailedAccountingDependencies(root, { signal }) };
+}
+
+function validateSource(value, expectedRevision) {
+  exact(value, ["revision", "dependencies"]);
+  if (value.revision !== expectedRevision) fail("source_changed");
+  exact(value.dependencies, ["sourceSha256", "runtimeSha256", "lockSha256", "identitySha256"]);
+  Object.values(value.dependencies).forEach(digest);
+  return value;
+}
+
+// Static public owners selected beneath the authenticated revision. The
+// projection helper is observer code, loaded only in this untimed probe.
+async function probeRevision({ root, stage, path, context, command, environment, signal, cwd }) {
+  const cacheUrl = JSON.stringify(pathToFileURL(join(root, "src/replay-safe-accounting-cache.js")).href);
+  const indexUrl = JSON.stringify(pathToFileURL(join(root, "src/local-unified-index.js")).href);
+  const projectionUrl = JSON.stringify(pathToFileURL(MODULE_FILE).href);
+  const program = `import { readFile } from 'node:fs/promises';
+import { REPLAY_SAFE_ACCOUNTING_MEMORY_POLICY as policy, REPLAY_SAFE_ACCOUNTING_REBUILD_REQUEST_VERSION as requestVersion, assertReplaySafeAccountingCache } from ${cacheUrl};
+import { openLocalUnifiedIndex, readUnifiedIndexGenerationDescriptor } from ${indexUrl};
+import { projectPr94ProductionCache } from ${projectionUrl};
+try {
+ if (process.argv[1] === 'metadata') {
+  const db = openLocalUnifiedIndex(process.argv[2], { readOnly: true });
+  try { process.stdout.write(JSON.stringify({ policy, requestVersion, generation: readUnifiedIndexGenerationDescriptor(db) })); } finally { db.close(); }
+ } else {
+  const cache = JSON.parse(await readFile(process.argv[2], 'utf8'));
+  assertReplaySafeAccountingCache(cache);
+  process.stdout.write(JSON.stringify(projectPr94ProductionCache(cache, JSON.parse(process.argv[3]))));
+ }
+} catch { process.exitCode = 1; }`;
+  let output;
+  try {
+    output = await command(process.execPath, ["--input-type=module", "--eval", program,
+      stage, path, JSON.stringify(context ?? null)], { cwd, env: environment, signal, timeoutMs: 30_000 });
+  } catch (error) {
+    if (error?.code === "command_failed") fail(stage === "artifact" ? "artifact_invalid" : "generation_invalid");
+    throw error;
+  }
+  try { return JSON.parse(output.stdout); } catch { fail("probe_invalid"); }
+}
+
+export function validatePr94ProductionResourceEvidence(value) {
+  exact(value, ["schema", "scope", "revision", "dependencies", "clock", "index", "generation", "policy",
+    "limits", "runs", "exactRepeatOutput", "indexUnchanged", "sourceUnchanged", "dependenciesUnchanged", "notMeasured"]);
+  if (value.schema !== SCHEMA || value.scope !== "isolated_child_repeatability" || !REVISION.test(value.revision)) fail();
+  validateSource({ revision: value.revision, dependencies: value.dependencies }, value.revision);
+  exact(value.clock, ["startAt", "endAt", "nowMs", "windowDays"]);
+  if (!same(value.clock, windowFor(value.clock.startAt, value.clock.endAt))) fail();
+  exact(value.index, ["sha256", "bytes"]); digest(value.index.sha256); integer(value.index.bytes, 1);
+  exact(value.generation, ["id", "publicationStatus", "toolProvenanceComplete", "usageEvents", "quotaOccurrences"]);
+  integer(value.generation.id, 1); integer(value.generation.usageEvents); integer(value.generation.quotaOccurrences);
+  if (!["complete", "partial"].includes(value.generation.publicationStatus) || typeof value.generation.toolProvenanceComplete !== "boolean") fail();
+  validatePolicy(value.policy);
+  exact(value.limits, ["envelopeBytes", "transportBytes", "durableCacheBytes"]);
+  if (!same(value.limits, { envelopeBytes: 64 * 1024, transportBytes: TRANSPORT_BYTES, durableCacheBytes: CACHE_BYTES })) fail();
+  if (!Array.isArray(value.runs) || value.runs.length !== 2) fail();
+  value.runs.forEach((run, index) => {
+    exact(run, ["kind", "metrics", "envelope", "artifact", "cache"]);
+    if (run.kind !== RUN_KINDS[index]) fail();
+    exact(run.metrics, ["wallMs", "userCpuMs", "systemCpuMs", "peakRssBytes"]);
+    Object.values(run.metrics).forEach((measurement) => integer(measurement));
+    integer(run.metrics.peakRssBytes, 1, value.policy.maximumRssBytes);
+    const envelope = parseSuccessfulAccountingEnvelope(JSON.stringify(run.envelope));
+    exact(run.artifact, ["sha256", "bytes"]); digest(run.artifact.sha256); integer(run.artifact.bytes, 2, CACHE_BYTES);
+    if (envelope.resultBytes !== run.artifact.bytes || envelope.resultSha256 !== run.artifact.sha256) fail();
+    validateProjection(run.cache);
+  });
+  if (!same(value.runs[0].artifact, value.runs[1].artifact) || !same(value.runs[0].cache, value.runs[1].cache)
+      || value.exactRepeatOutput !== true || value.indexUnchanged !== true || value.sourceUnchanged !== true
+      || value.dependenciesUnchanged !== true
+      || !same(value.notMeasured, ["app_no_change_cache_hit", "app_relaunch", "end_to_end_refresh", "cancellation", "evidence_observer_overhead"])) fail();
+  return value;
+}
+
+async function runWorker(options, {
+  signal = null, command = runBoundedBenchmarkCommand, inspectSource = sourceIdentity,
+  probe = probeRevision, runtime = { version: process.version, platform: process.platform, arch: process.arch },
+} = {}) {
+  if (options?.privateOperationApproved !== true) fail("approval_required");
+  const required = ["privateOperationApproved", "root", "expectedRevision", "indexFile", "expectedIndex", "outputDirectory", "startAt", "endAt"];
+  exact(options, Object.hasOwn(options, "timeoutSeconds") ? [...required, "timeoutSeconds"] : required);
+  if (runtime.version !== "v26.2.0" || runtime.platform !== "darwin" || runtime.arch !== "arm64") fail("runtime_invalid");
+  const clock = windowFor(options.startAt, options.endAt);
+  const timeoutSeconds = integer(options.timeoutSeconds ?? 1800, 1, 3600);
+  if (!REVISION.test(options.expectedRevision)) fail();
+  exact(options.expectedIndex, ["sha256", "bytes", "generationId"]);
+  digest(options.expectedIndex.sha256); integer(options.expectedIndex.bytes, 1); integer(options.expectedIndex.generationId, 1);
+  for (const key of ["root", "indexFile", "outputDirectory"]) {
+    if (typeof options[key] !== "string" || resolve(options[key]) !== options[key]) fail("path_invalid");
+  }
+  cancelled(signal);
+  const beforeSource = validateSource(await inspectSource(options.root, { signal, command }), options.expectedRevision);
+  if (await realpath(options.indexFile) !== options.indexFile) fail("path_invalid");
+  const indexStat = await inspectDetailedAccountingBenchmarkIndex(options.indexFile);
+  const indexSha256 = await digestDetailedAccountingBenchmarkFile(options.indexFile, indexStat, { signal });
+  if (indexStat.size !== options.expectedIndex.bytes || indexSha256 !== options.expectedIndex.sha256) fail("index_mismatch");
+  await privateDirectory(dirname(options.outputDirectory));
+  await mkdir(options.outputDirectory, { mode: 0o700 });
+  const outputStat = await privateDirectory(options.outputDirectory);
+  const codexHome = join(options.outputDirectory, "empty-codex-home");
+  const temporary = join(options.outputDirectory, "temporary");
+  await mkdir(codexHome, { mode: 0o700 });
+  await mkdir(temporary, { mode: 0o700 });
+  const environment = { TMPDIR: temporary, LC_ALL: "C" };
+  const probeOptions = { root: options.root, command, environment, signal, cwd: options.outputDirectory };
+  const initial = await probe({ ...probeOptions, stage: "metadata", path: options.indexFile });
+  exact(initial, ["policy", "requestVersion", "generation"]);
+  validatePolicy(initial.policy);
+  const generation = projectDetailedAccountingBenchmarkGeneration(initial.generation);
+  if (generation.id !== options.expectedIndex.generationId) fail("generation_mismatch");
+  const request = buildPr94ProductionResourceRequest({ ...clock, indexFile: options.indexFile, codexHome, ...initial });
+  const context = { startAt: clock.startAt, endAt: clock.endAt, generationId: generation.id,
+    generationFingerprint: initial.generation.fingerprint };
+  const runs = [];
+  for (const kind of RUN_KINDS) {
+    cancelled(signal);
+    if (!sameFile(indexStat, await inspectDetailedAccountingBenchmarkIndex(options.indexFile))) fail("index_changed");
+    const directory = join(options.outputDirectory, kind);
+    await mkdir(directory, { mode: 0o700 });
+    const requestFile = join(directory, "request.json");
+    const resultFile = join(directory, "result.json");
+    await writeFile(requestFile, JSON.stringify(request), { flag: "wx", mode: 0o600 });
+    const output = await command("/usr/bin/time", ["-l", process.execPath,
+      `--max-old-space-size=${initial.policy.rebuildChildOldSpaceMib}`,
+      join(options.root, "src/replay-safe-accounting-rebuild-child.js"), requestFile, resultFile],
+    { cwd: directory, env: environment, signal, timeoutMs: timeoutSeconds * 1000 });
+    const envelope = parseSuccessfulAccountingEnvelope(output.stdout);
+    const metrics = parseMacOsTimeMetrics(output.stderr);
+    if (metrics.peakRssBytes > initial.policy.maximumRssBytes) fail("resource_limit_exceeded");
+    const artifact = await verifyAccountingBenchmarkArtifact(resultFile, envelope, { signal });
+    const cache = validateProjection(await probe({ ...probeOptions, stage: "artifact", path: resultFile, context }));
+    // Bind the exact file validated by the selected revision's public facade.
+    if (!same(artifact, await verifyAccountingBenchmarkArtifact(resultFile, envelope, { signal }))) fail("artifact_changed");
+    if (runs.length && (!same(runs[0].artifact, artifact) || !same(runs[0].cache, cache))) fail("repeat_mismatch");
+    runs.push({ kind, metrics, envelope, artifact, cache });
+  }
+  cancelled(signal);
+  if (!sameFile(indexStat, await inspectDetailedAccountingBenchmarkIndex(options.indexFile))
+      || await digestDetailedAccountingBenchmarkFile(options.indexFile, indexStat, { signal }) !== indexSha256) fail("index_changed");
+  if (!same(beforeSource, validateSource(await inspectSource(options.root, { signal, command }), options.expectedRevision))) fail("source_changed");
+  if (!same(initial, await probe({ ...probeOptions, stage: "metadata", path: options.indexFile }))) fail("generation_changed");
+  const finalOutputStat = await privateDirectory(options.outputDirectory);
+  if (outputStat.dev !== finalOutputStat.dev || outputStat.ino !== finalOutputStat.ino) fail("path_invalid");
+  cancelled(signal);
+  return validatePr94ProductionResourceEvidence({ schema: SCHEMA, scope: "isolated_child_repeatability",
+    revision: beforeSource.revision, dependencies: beforeSource.dependencies, clock,
+    index: { sha256: indexSha256, bytes: indexStat.size },
+    generation: { id: generation.id, publicationStatus: generation.publicationStatus,
+      toolProvenanceComplete: generation.toolProvenanceComplete, usageEvents: generation.usageEvents,
+      quotaOccurrences: generation.quotaOccurrences }, policy: initial.policy,
+    limits: { envelopeBytes: 64 * 1024, transportBytes: TRANSPORT_BYTES, durableCacheBytes: CACHE_BYTES }, runs,
+    exactRepeatOutput: true, indexUnchanged: true, sourceUnchanged: true, dependenciesUnchanged: true,
+    notMeasured: ["app_no_change_cache_hit", "app_relaunch", "end_to_end_refresh", "cancellation", "evidence_observer_overhead"] });
+}
+
+/** Characterization adapters are function-only seams, never CLI input. */
+export async function runPr94ProductionResourceWorker(options, adapters = {}) {
+  try { return await runWorker(options, adapters); }
+  catch (error) {
+    // Filesystem, subprocess and selected-revision exceptions may hold private
+    // paths or diagnostics. No arbitrary exception crosses this public seam.
+    fail(safeFailureCode(error));
+  }
+}
+
+if (process.argv[1] && resolve(process.argv[1]) === MODULE_FILE) {
+  const controller = new AbortController();
+  const abort = () => controller.abort();
+  process.once("SIGINT", abort); process.once("SIGTERM", abort);
+  try {
+    let request = "";
+    for await (const chunk of process.stdin) {
+      request += chunk;
+      if (Buffer.byteLength(request) > 64 * 1024) fail();
+    }
+    const result = await runPr94ProductionResourceWorker(JSON.parse(request), { signal: controller.signal });
+    process.stdout.write(`${JSON.stringify({ status: "ok", result })}\n`);
+  } catch (error) {
+    process.stdout.write(`${JSON.stringify({ status: "error", code: `pr94_production_${safeFailureCode(error)}` })}\n`);
+    process.exitCode = 1;
+  } finally {
+    process.removeListener("SIGINT", abort); process.removeListener("SIGTERM", abort);
+  }
+}

--- a/scripts/lib/pr94-production-resource-worker.mjs
+++ b/scripts/lib/pr94-production-resource-worker.mjs
@@ -16,7 +16,7 @@ import {
 // ingestion, installed-app work, cache publication or application refresh runs
 // in the timed process. Repeated fresh processes prove child repeatability, not
 // an app-level no-change cache hit, relaunch, refresh or cancellation outcome.
-const SCHEMA = "pr94-production-resource-v1";
+const SCHEMA = "pr94-production-resource-v2";
 const DAY_MS = 86_400_000;
 const HASH = /^[a-f0-9]{64}$/u;
 const REVISION = /^[a-f0-9]{40}$/u;
@@ -29,6 +29,7 @@ const INPUT_LIMITS = ["usageEvents", "weeklySnapshots", "combinedInputs", "retai
 const CACHE_ARRAYS = ["periods", "timeline", "sparkUsageTimeline", "quotaTimeline", "sparkQuotaTimeline"];
 const RUN_KINDS = ["primary", "fresh_process_repeat"];
 const BEFORE_REVISION = "a3c850360bc83c0e27bef2171aeb4a302b72f472";
+const AFTER_REVISION = "20f449ff5c222989029fe343f219f02b497ae1d4";
 const QUERY_PLAN_SCHEMA = "pr94-attribution-query-plans-v1";
 const QUERY_ROLES = ["membership", "same_record_plans", "source_predecessor", "session_predecessor"];
 const QUERY_METHODS = ["get", "all", "get", "get"];
@@ -200,14 +201,20 @@ function validateProjection(value) {
   return value;
 }
 
-/** Call only after the selected revision's assertReplaySafeAccountingCache. */
-export function projectPr94ProductionCache(cache, { startAt, endAt, generationId, generationFingerprint }) {
+/** Bind even a refused historical artifact without treating it as valid. */
+export function assertPr94ProductionCacheContext(cache, { startAt, endAt, generationId, generationFingerprint }) {
   windowFor(startAt, endAt);
   integer(generationId, 1);
   if (!/^generation-v2-[a-f0-9]{64}$/u.test(generationFingerprint)) fail();
   if (cache?.generatedAt !== endAt || cache?.coveredAt?.startAt !== startAt || cache.coveredAt.endAt !== endAt
       || cache?.sourceDescriptor?.generation !== String(generationId)
       || cache.sourceDescriptor.generationFingerprint !== generationFingerprint) fail("cache_context_mismatch");
+}
+
+/** Call only after the selected revision's assertReplaySafeAccountingCache. */
+export function projectPr94ProductionCache(cache, context) {
+  assertPr94ProductionCacheContext(cache, context);
+  const { endAt } = context;
   const input = cache.weeklyCalibrationInput;
   if (!input || !input.coveredAt) fail();
   instant(input.coveredAt.startAt); instant(input.coveredAt.endAt);
@@ -278,7 +285,7 @@ async function probeRevision({ root, stage, path, context, command, environment,
 import { REPLAY_SAFE_ACCOUNTING_MEMORY_POLICY as policy, REPLAY_SAFE_ACCOUNTING_REBUILD_REQUEST_VERSION as requestVersion, assertReplaySafeAccountingCache } from ${cacheUrl};
 import { openLocalUnifiedIndex, readUnifiedIndexGenerationDescriptor } from ${indexUrl};
 import * as readerModule from ${readerUrl};
-import { projectPr94ProductionCache, collectPr94AttributionQueryPlans } from ${projectionUrl};
+import { assertPr94ProductionCacheContext, projectPr94ProductionCache, collectPr94AttributionQueryPlans } from ${projectionUrl};
 try {
  if (process.argv[1] === 'metadata') {
   const db = openLocalUnifiedIndex(process.argv[2], { readOnly: true });
@@ -291,8 +298,17 @@ try {
   } finally { db.close(); }
  } else {
   const cache = JSON.parse(await readFile(process.argv[2], 'utf8'));
-  assertReplaySafeAccountingCache(cache);
-  process.stdout.write(JSON.stringify(projectPr94ProductionCache(cache, JSON.parse(process.argv[3]))));
+  const context = JSON.parse(process.argv[3]);
+  assertPr94ProductionCacheContext(cache, context);
+  let assertionRefused = false;
+  try {
+   assertReplaySafeAccountingCache(cache);
+  } catch (error) {
+   if (context?.revision !== '${AFTER_REVISION}' || error?.code !== 'cache_invalid') throw error;
+   assertionRefused = true;
+  }
+  if (assertionRefused) process.stdout.write(JSON.stringify({ status: 'refused', code: 'cache_invalid' }));
+  else process.stdout.write(JSON.stringify(projectPr94ProductionCache(cache, context)));
  }
 } catch { process.exitCode = 1; }`;
   let output;
@@ -340,6 +356,63 @@ export function validatePr94ProductionResourceEvidence(value) {
   return value;
 }
 
+function validateHistoricalCacheAssertion(value) {
+  exact(value, ["status", "code"]);
+  if (value.status !== "refused" || value.code !== "cache_invalid") fail();
+  return value;
+}
+
+function historicalCacheAssertion(value) {
+  try { return validateHistoricalCacheAssertion(value); }
+  catch { return null; }
+}
+
+function validateHistoricalArtifactRefusal(value) {
+  exact(value, ["schema", "scope", "status", "revision", "dependencies", "clock", "index", "generation", "policy",
+    "limits", "runs", "queryPlans", "exactRepeatOutput", "indexUnchanged", "sourceUnchanged", "dependenciesUnchanged", "notMeasured"]);
+  if (value.schema !== SCHEMA || value.scope !== "isolated_child_repeatability"
+      || value.status !== "historical_artifact_refused" || value.revision !== AFTER_REVISION) fail();
+  validateSource({ revision: value.revision, dependencies: value.dependencies }, AFTER_REVISION);
+  exact(value.clock, ["startAt", "endAt", "nowMs", "windowDays"]);
+  if (!same(value.clock, windowFor(value.clock.startAt, value.clock.endAt))) fail();
+  exact(value.index, ["sha256", "bytes"]); digest(value.index.sha256); integer(value.index.bytes, 1);
+  exact(value.generation, ["id", "publicationStatus", "toolProvenanceComplete", "usageEvents", "quotaOccurrences"]);
+  integer(value.generation.id, 1); integer(value.generation.usageEvents); integer(value.generation.quotaOccurrences);
+  if (!["complete", "partial"].includes(value.generation.publicationStatus)
+      || typeof value.generation.toolProvenanceComplete !== "boolean") fail();
+  validatePolicy(value.policy);
+  validatePr94AttributionQueryPlans(value.queryPlans, AFTER_REVISION);
+  exact(value.limits, ["envelopeBytes", "transportBytes", "durableCacheBytes"]);
+  if (!same(value.limits, { envelopeBytes: 64 * 1024, transportBytes: TRANSPORT_BYTES, durableCacheBytes: CACHE_BYTES })) fail();
+  if (!Array.isArray(value.runs) || value.runs.length !== 2) fail();
+  value.runs.forEach((run, index) => {
+    exact(run, ["kind", "metrics", "envelope", "artifact", "cacheAssertion"]);
+    if (run.kind !== RUN_KINDS[index]) fail();
+    exact(run.metrics, ["wallMs", "userCpuMs", "systemCpuMs", "peakRssBytes"]);
+    Object.values(run.metrics).forEach((measurement) => integer(measurement));
+    integer(run.metrics.peakRssBytes, 1, value.policy.maximumRssBytes);
+    const envelope = parseSuccessfulAccountingEnvelope(JSON.stringify(run.envelope));
+    exact(run.artifact, ["sha256", "bytes"]); digest(run.artifact.sha256); integer(run.artifact.bytes, 2, CACHE_BYTES);
+    if (envelope.resultBytes !== run.artifact.bytes || envelope.resultSha256 !== run.artifact.sha256) fail();
+    validateHistoricalCacheAssertion(run.cacheAssertion);
+  });
+  if (!same(value.runs[0].envelope, value.runs[1].envelope)
+      || !same(value.runs[0].artifact, value.runs[1].artifact)
+      || !same(value.runs[0].cacheAssertion, value.runs[1].cacheAssertion)
+      || value.exactRepeatOutput !== true || value.indexUnchanged !== true || value.sourceUnchanged !== true
+      || value.dependenciesUnchanged !== true
+      || !same(value.notMeasured, ["app_no_change_cache_hit", "app_relaunch", "end_to_end_refresh", "cancellation", "evidence_observer_overhead"])) fail();
+  return value;
+}
+
+/** Strict production evidence, or the one pinned historical refusal outcome. */
+export function validatePr94ProductionResourceOutcome(value) {
+  const status = value && typeof value === "object"
+    ? Object.getOwnPropertyDescriptor(value, "status") : null;
+  if (status && Object.hasOwn(status, "value")) return validateHistoricalArtifactRefusal(value);
+  return validatePr94ProductionResourceEvidence(value);
+}
+
 async function runWorker(options, {
   signal = null, command = runBoundedBenchmarkCommand, inspectSource = sourceIdentity,
   probe = probeRevision, runtime = { version: process.version, platform: process.platform, arch: process.arch },
@@ -380,7 +453,7 @@ async function runWorker(options, {
   if (generation.id !== options.expectedIndex.generationId) fail("generation_mismatch");
   const request = buildPr94ProductionResourceRequest({ ...clock, indexFile: options.indexFile, codexHome, ...initial });
   const context = { startAt: clock.startAt, endAt: clock.endAt, generationId: generation.id,
-    generationFingerprint: initial.generation.fingerprint };
+    generationFingerprint: initial.generation.fingerprint, revision: options.expectedRevision };
   const runs = [];
   for (const kind of RUN_KINDS) {
     cancelled(signal);
@@ -398,11 +471,19 @@ async function runWorker(options, {
     const metrics = parseMacOsTimeMetrics(output.stderr);
     if (metrics.peakRssBytes > initial.policy.maximumRssBytes) fail("resource_limit_exceeded");
     const artifact = await verifyAccountingBenchmarkArtifact(resultFile, envelope, { signal });
-    const cache = validateProjection(await probe({ ...probeOptions, stage: "artifact", path: resultFile, context }));
+    const probed = await probe({ ...probeOptions, stage: "artifact", path: resultFile, context });
+    const cacheAssertion = historicalCacheAssertion(probed);
+    const cache = cacheAssertion === null ? validateProjection(probed) : null;
+    if (cacheAssertion !== null && options.expectedRevision !== AFTER_REVISION) fail("artifact_invalid");
     // Bind the exact file validated by the selected revision's public facade.
     if (!same(artifact, await verifyAccountingBenchmarkArtifact(resultFile, envelope, { signal }))) fail("artifact_changed");
-    if (runs.length && (!same(runs[0].artifact, artifact) || !same(runs[0].cache, cache))) fail("repeat_mismatch");
-    runs.push({ kind, metrics, envelope, artifact, cache });
+    const priorCache = runs.length && Object.hasOwn(runs[0], "cache") ? runs[0].cache : null;
+    const priorAssertion = runs.length && Object.hasOwn(runs[0], "cacheAssertion") ? runs[0].cacheAssertion : null;
+    if (runs.length && (!same(runs[0].envelope, envelope) || !same(runs[0].artifact, artifact)
+        || !same(priorCache, cache) || !same(priorAssertion, cacheAssertion))) fail("repeat_mismatch");
+    runs.push(cacheAssertion === null
+      ? { kind, metrics, envelope, artifact, cache }
+      : { kind, metrics, envelope, artifact, cacheAssertion });
   }
   cancelled(signal);
   if (!sameFile(indexStat, await inspectDetailedAccountingBenchmarkIndex(options.indexFile))
@@ -416,7 +497,7 @@ async function runWorker(options, {
   const finalOutputStat = await privateDirectory(options.outputDirectory);
   if (outputStat.dev !== finalOutputStat.dev || outputStat.ino !== finalOutputStat.ino) fail("path_invalid");
   cancelled(signal);
-  return validatePr94ProductionResourceEvidence({ schema: SCHEMA, scope: "isolated_child_repeatability",
+  const shared = { schema: SCHEMA, scope: "isolated_child_repeatability",
     revision: beforeSource.revision, dependencies: beforeSource.dependencies, clock,
     index: { sha256: indexSha256, bytes: indexStat.size },
     generation: { id: generation.id, publicationStatus: generation.publicationStatus,
@@ -424,7 +505,12 @@ async function runWorker(options, {
       quotaOccurrences: generation.quotaOccurrences }, policy: initial.policy, queryPlans: initial.queryPlans,
     limits: { envelopeBytes: 64 * 1024, transportBytes: TRANSPORT_BYTES, durableCacheBytes: CACHE_BYTES }, runs,
     exactRepeatOutput: true, indexUnchanged: true, sourceUnchanged: true, dependenciesUnchanged: true,
-    notMeasured: ["app_no_change_cache_hit", "app_relaunch", "end_to_end_refresh", "cancellation", "evidence_observer_overhead"] });
+    notMeasured: ["app_no_change_cache_hit", "app_relaunch", "end_to_end_refresh", "cancellation", "evidence_observer_overhead"] };
+  if (runs.every((run) => Object.hasOwn(run, "cacheAssertion"))) {
+    if (options.expectedRevision !== AFTER_REVISION) fail("artifact_invalid");
+    return validatePr94ProductionResourceOutcome({ ...shared, status: "historical_artifact_refused" });
+  }
+  return validatePr94ProductionResourceOutcome(shared);
 }
 
 /** Characterization adapters are function-only seams, never CLI input. */

--- a/scripts/lib/pr94-receipt-validation.mjs
+++ b/scripts/lib/pr94-receipt-validation.mjs
@@ -34,6 +34,9 @@ const CANDIDATES = Object.freeze([
 const PRIMARY_TRANSITIONS = Object.freeze([
   "retained_primary", "lost_primary", "new_primary", "no_primary", "missing_parent",
 ]);
+const PRIMARY_OUTCOMES = Object.freeze([
+  "selected_plan_primary", "alternate_plan_primary", "unselected_plan_primary",
+]);
 const PLANS = new Set([
   "free", "plus", "pro", "pro_lite", "team", "business", "enterprise", "edu", "unknown", "other",
 ]);
@@ -490,7 +493,7 @@ function validateCalibrationComparison(value, before = null, after = null) {
         || cell.retainedPrimaryFits + cell.newPrimaryFits !== cell.afterPrimaryFits
         || cell.changedInputPrimaryLosses > cell.lostPrimaryFits) reject();
     list(cell.afterOutcomes, OUTCOMES.length + 1);
-    let outcomeTotal = 0;
+    let primaryOutcomesPerParent = 0;
     let previousOutcome = null;
     for (const outcome of cell.afterOutcomes) {
       exact(outcome, ["outcome", "count"]);
@@ -498,7 +501,7 @@ function validateCalibrationComparison(value, before = null, after = null) {
       integer(outcome.count, 1, MAX_CALIBRATION_ITEMS);
       if (previousOutcome !== null && outcome.outcome <= previousOutcome) reject();
       previousOutcome = outcome.outcome;
-      outcomeTotal += outcome.count;
+      if (PRIMARY_OUTCOMES.includes(outcome.outcome)) primaryOutcomesPerParent += outcome.count;
     }
     if (cell.afterOutcomes.length === 0
         || (cell.transition === "missing_parent"
@@ -510,7 +513,10 @@ function validateCalibrationComparison(value, before = null, after = null) {
     if (cell.transition === "new_primary" && (cell.baselinePrimaryFits !== 0 || cell.afterPrimaryFits === 0)) reject();
     if (cell.transition === "no_primary" && (cell.baselinePrimaryFits !== 0 || cell.afterPrimaryFits !== 0)) reject();
     if (cell.transition === "missing_parent" && cell.afterPrimaryFits !== 0) reject();
-    if (cell.transition !== "missing_parent" && outcomeTotal < cell.afterPrimaryFits) reject();
+    // The cell key contains a shared per-parent outcome shape, while fit
+    // counts are summed over every parent represented by the cell. Diagnostic
+    // and rejection outcomes must never justify a primary fit.
+    if (cell.afterPrimaryFits !== cell.parentCandidates * primaryOutcomesPerParent) reject();
     const key = JSON.stringify([cell.candidateId, cell.planType, cell.accountKnown, cell.transition, cell.afterOutcomes]);
     if (seen.has(key) || (previousKey !== null && key <= previousKey)) reject();
     seen.add(key); previousKey = key;
@@ -603,6 +609,19 @@ function validateEvidence(value) {
   return value;
 }
 
+function validateComparisonEvidenceLocal(value) {
+  exact(value, ["comparison", "evidence"]);
+  validateEvidence(value.evidence);
+  validateComparison(value.comparison, value.evidence);
+  return value;
+}
+
+/** Validate the semantic pair before running the separate production probes. */
+export function validatePr94ComparisonEvidence(value) {
+  try { return validateComparisonEvidenceLocal(value); }
+  catch { throw publicError("comparison"); }
+}
+
 function validateProductionResources(value, receipt, evidence) {
   exact(value, ["before", "after", "final"]);
   for (const side of ["before", "after", "final"]) {
@@ -640,8 +659,7 @@ function validateReceiptLocal(value) {
   validateIndex(value.index);
   validateWindow(value.window);
   validateMeasurements(value.measurements);
-  validateEvidence(value.evidence);
-  validateComparison(value.comparison, value.evidence);
+  validateComparisonEvidenceLocal({ comparison: value.comparison, evidence: value.evidence });
   validateProductionResources(value.productionResources, value, value.evidence);
   return value;
 }

--- a/scripts/lib/pr94-receipt-validation.mjs
+++ b/scripts/lib/pr94-receipt-validation.mjs
@@ -398,7 +398,6 @@ function validateSources(value) {
   if (value.before.revision !== PR94_COMPARISON_REVISIONS.before
       || value.after.revision !== PR94_COMPARISON_REVISIONS.after) reject();
   if (value.before.dependencies.runtimeSha256 !== value.after.dependencies.runtimeSha256
-      || value.before.dependencies.runtimeSha256 !== value.final.dependencies.runtimeSha256
       || value.before.dependencies.lockSha256 !== value.after.dependencies.lockSha256) reject();
   // Only before/after isolate PR94. The separately identified final lane also
   // includes subsequent reviewed dependency updates; bind those to its own

--- a/scripts/lib/pr94-receipt-validation.mjs
+++ b/scripts/lib/pr94-receipt-validation.mjs
@@ -1,12 +1,12 @@
 import { PR94_LEDGER_COMPONENTS, validatePr94LedgerEvidenceAggregate } from "./pr94-ledger-evidence.mjs";
-import { validatePr94ProductionResourceEvidence } from "./pr94-production-resource-worker.mjs";
+import { validatePr94ProductionResourceEvidence, validatePr94ProductionResourceOutcome } from "./pr94-production-resource-worker.mjs";
 import { validatePr94PopulationEvidence } from "./pr94-population-evidence.mjs";
 
 // This module validates only the content-free public projections. Private
 // frame files remain the authority for row-level comparison and are never
 // accepted by these functions.
 const ANALYSIS_SCHEMA = "pr94-analysis-worker-v1";
-const RECEIPT_SCHEMA = "pr94-admitted-index-comparison-v1";
+const RECEIPT_SCHEMA = "pr94-admitted-index-comparison-v2";
 const CALIBRATION_SCHEMA = "pr94-calibration-evidence-v2";
 const CALIBRATION_COMPARISON_SCHEMA = "pr94-calibration-comparison-v2";
 const LEDGER_COMPARISON_SCHEMA = "pr94-ledger-comparison-v1";
@@ -608,7 +608,12 @@ function validateProductionResources(value, receipt, evidence) {
   exact(value, ["before", "after", "final"]);
   for (const side of ["before", "after", "final"]) {
     const resource = value[side];
-    try { validatePr94ProductionResourceEvidence(resource); } catch { reject(); }
+    try {
+      // Only the original merge may record its known unshippable artifact.
+      // Baseline and final candidate still require the strict success shape.
+      if (side === "after") validatePr94ProductionResourceOutcome(resource);
+      else validatePr94ProductionResourceEvidence(resource);
+    } catch { reject(); }
     if (resource.revision !== receipt.sources[side].revision
         || !same(resource.dependencies, receipt.sources[side].dependencies)
         || !same(resource.index, receipt.index)
@@ -621,12 +626,16 @@ function validateProductionResources(value, receipt, evidence) {
         || resource.generation.usageEvents !== generation.usageEvents
         || resource.generation.quotaOccurrences !== generation.quotaOccurrences) reject();
   }
+  const historicalRefusal = value.after.status === "historical_artifact_refused";
+  if (receipt.status !== (historicalRefusal
+    ? "passed_with_historical_artifact_refusal" : "passed")) reject();
   return value;
 }
 
 function validateReceiptLocal(value) {
   exact(value, RECEIPT_KEYS);
-  if (value.schema !== RECEIPT_SCHEMA || value.status !== "passed"
+  if (value.schema !== RECEIPT_SCHEMA
+      || !["passed", "passed_with_historical_artifact_refusal"].includes(value.status)
       || value.scope !== "fixed_admitted_index_analysis_not_raw_ingestion_or_hosted_activation") reject();
   validateSources(value.sources);
   validateIndex(value.index);

--- a/scripts/lib/pr94-receipt-validation.mjs
+++ b/scripts/lib/pr94-receipt-validation.mjs
@@ -44,7 +44,7 @@ const OUTCOMES = Object.freeze([
   "aggregation_diagnostic_only", "insufficient_unique_boundaries", "insufficient_percent_span",
   "training_capacity_unavailable", "insufficient_training_pairs", "full_capacity_unavailable",
   "relative_width_unavailable", "relative_width_exceeded", "insufficient_snapshots",
-  "no_percent_change", "all_snapshot_attribution_withheld", "unexplained_no_transition",
+  "no_percent_change", "no_within_era_percent_change", "all_snapshot_attribution_withheld", "unexplained_no_transition",
 ]);
 const ROW_REASONS = Object.freeze([
   "eligible", "aggregation_diagnostic_only", "non_increasing_percent", "no_usage",

--- a/scripts/lib/pr94-receipt-validation.mjs
+++ b/scripts/lib/pr94-receipt-validation.mjs
@@ -397,10 +397,12 @@ function validateSources(value) {
   for (const side of ["before", "after", "final"]) validateSource(value[side]);
   if (value.before.revision !== PR94_COMPARISON_REVISIONS.before
       || value.after.revision !== PR94_COMPARISON_REVISIONS.after) reject();
-  for (const key of ["runtimeSha256", "lockSha256"]) {
-    if (value.before.dependencies[key] !== value.after.dependencies[key]
-        || value.before.dependencies[key] !== value.final.dependencies[key]) reject();
-  }
+  if (value.before.dependencies.runtimeSha256 !== value.after.dependencies.runtimeSha256
+      || value.before.dependencies.runtimeSha256 !== value.final.dependencies.runtimeSha256
+      || value.before.dependencies.lockSha256 !== value.after.dependencies.lockSha256) reject();
+  // Only before/after isolate PR94. The separately identified final lane also
+  // includes subsequent reviewed dependency updates; bind those to its own
+  // production probes instead of pretending it is the historical PR94 tree.
   return value;
 }
 

--- a/scripts/lib/pr94-receipt-validation.mjs
+++ b/scripts/lib/pr94-receipt-validation.mjs
@@ -1,0 +1,642 @@
+import { PR94_LEDGER_COMPONENTS, validatePr94LedgerEvidenceAggregate } from "./pr94-ledger-evidence.mjs";
+import { validatePr94ProductionResourceEvidence } from "./pr94-production-resource-worker.mjs";
+import { validatePr94PopulationEvidence } from "./pr94-population-evidence.mjs";
+
+// This module validates only the content-free public projections. Private
+// frame files remain the authority for row-level comparison and are never
+// accepted by these functions.
+const ANALYSIS_SCHEMA = "pr94-analysis-worker-v1";
+const RECEIPT_SCHEMA = "pr94-admitted-index-comparison-v1";
+const CALIBRATION_SCHEMA = "pr94-calibration-evidence-v2";
+const CALIBRATION_COMPARISON_SCHEMA = "pr94-calibration-comparison-v2";
+const LEDGER_COMPARISON_SCHEMA = "pr94-ledger-comparison-v1";
+const HASH = /^[a-f0-9]{64}$/u;
+const REVISION = /^[a-f0-9]{40}$/u;
+const INSTANT_LENGTH = 24;
+const MAX_RSS = 6_442_450_944;
+const MAX_PHASE_MS = 3_600_000;
+const MAX_USAGE = 1_000_000;
+const MAX_QUOTA = 1_000_000;
+const MAX_TRANSITIONS = 200_000;
+const MAX_LEDGER_ROWS = 2_000_000;
+const MAX_CALIBRATION_PARENTS = 10_000;
+const MAX_CALIBRATION_FRAGMENTS = 40_000;
+const MAX_CALIBRATION_ITEMS = MAX_CALIBRATION_FRAGMENTS * 4;
+const MAX_INDEX_BYTES = 32 * 1024 * 1024 * 1024;
+const PR94_COMPARISON_REVISIONS = Object.freeze({
+  before: "a3c850360bc83c0e27bef2171aeb4a302b72f472",
+  after: "20f449ff5c222989029fe343f219f02b497ae1d4",
+});
+
+const CANDIDATES = Object.freeze([
+  "standard_api", "speed_lower", "speed_midpoint", "speed_upper",
+]);
+const PRIMARY_TRANSITIONS = Object.freeze([
+  "retained_primary", "lost_primary", "new_primary", "no_primary", "missing_parent",
+]);
+const PLANS = new Set([
+  "free", "plus", "pro", "pro_lite", "team", "business", "enterprise", "edu", "unknown", "other",
+]);
+const OUTCOMES = Object.freeze([
+  "selected_plan_primary", "alternate_plan_primary", "unselected_plan_primary",
+  "losing_qualifying_fragment", "simultaneous_slot_conflict",
+  "near_duplicate_reset_identity_with_less_evidence", "overlapping_observation_window",
+  "aggregation_diagnostic_only", "insufficient_unique_boundaries", "insufficient_percent_span",
+  "training_capacity_unavailable", "insufficient_training_pairs", "full_capacity_unavailable",
+  "relative_width_unavailable", "relative_width_exceeded", "insufficient_snapshots",
+  "no_percent_change", "all_snapshot_attribution_withheld", "unexplained_no_transition",
+]);
+const ROW_REASONS = Object.freeze([
+  "eligible", "aggregation_diagnostic_only", "non_increasing_percent", "no_usage",
+  "partial_elapsed_coverage", "pricing_warning", "attribution_warning",
+]);
+const GENERATION_COUNTS = Object.freeze([
+  "indexedSourceCount", "indexedSourceBytes", "skippedSourceCount", "skippedSourceBytes",
+  "skippedThreadCount", "usageEvents", "quotaOccurrences", "toolFacts",
+]);
+const ACCOUNT_CHECK_COUNTS = Object.freeze([
+  "fragmentCandidatesChecked", "rowsChecked", "changedEligibilityRows", "changedPointSets",
+  "changedFits", "unknownOnlyFitExclusions",
+]);
+const CALIBRATION_COMPARISON_COUNTS = Object.freeze([
+  "beforeParentCandidates", "afterParentCandidates", "missingParentCandidates", "addedParentCandidates",
+  "reconciledParentCandidates", "identicalFitInputsCompared", "changedIdenticalInputFits", "unexplainedParents",
+  "changedRawParentInventory", "baselinePrimaryFits", "retainedPrimaryFits", "lostPrimaryFits", "newPrimaryFits",
+  "changedInputPrimaryLosses", "rejectedIdenticalInputFits", "unexplainedPrimaryLosses",
+  "retainedPrimaryInputChanges", "changedOutcomeParentCandidates",
+]);
+const ANALYSIS_KEYS = Object.freeze([
+  "schema", "revisionKind", "contextBehavior", "generation", "attributionIndex",
+  "instrumentation", "inventory", "coverage", "ledger", "calibration", "populationEvidence", "batchMetrics",
+  "deduplicatedWeeklySnapshots", "phaseMs", "privateArtifactBytes",
+]);
+const RECEIPT_KEYS = Object.freeze([
+  "schema", "status", "scope", "sources", "index", "window", "comparison",
+  "measurements", "productionResources", "evidence",
+]);
+
+function reject() {
+  throw new Error("invalid_pr94_receipt_value");
+}
+
+function publicError(kind) {
+  const code = `pr94_receipt_${kind}_invalid`;
+  return Object.assign(new Error(code), { code });
+}
+
+function exact(value, keys) {
+  if (!value || typeof value !== "object" || Array.isArray(value)
+      || ![Object.prototype, null].includes(Object.getPrototypeOf(value))) reject();
+  const expected = new Set(keys);
+  const ownKeys = Reflect.ownKeys(value);
+  if (ownKeys.length !== expected.size) reject();
+  for (const key of ownKeys) {
+    if (typeof key !== "string" || !expected.has(key)) reject();
+    const descriptor = Object.getOwnPropertyDescriptor(value, key);
+    if (!descriptor?.enumerable || !Object.hasOwn(descriptor, "value")) reject();
+  }
+  return value;
+}
+
+function list(value, maximum) {
+  if (!Array.isArray(value) || !Number.isSafeInteger(value.length) || value.length > maximum) reject();
+  const keys = Reflect.ownKeys(value);
+  if (keys.length !== value.length + 1 || !keys.includes("length")) reject();
+  for (let index = 0; index < value.length; index += 1) {
+    const key = String(index);
+    if (!keys.includes(key)) reject();
+    const descriptor = Object.getOwnPropertyDescriptor(value, key);
+    if (!descriptor?.enumerable || !Object.hasOwn(descriptor, "value")) reject();
+  }
+  return value;
+}
+
+function integer(value, minimum = 0, maximum = Number.MAX_SAFE_INTEGER) {
+  if (!Number.isSafeInteger(value) || value < minimum || value > maximum || Object.is(value, -0)) reject();
+  return value;
+}
+
+function finite(value, minimum = -Infinity, maximum = Infinity) {
+  if (typeof value !== "number" || !Number.isFinite(value) || value < minimum || value > maximum
+      || Object.is(value, -0)) reject();
+  return value;
+}
+
+function boolean(value) {
+  if (typeof value !== "boolean") reject();
+  return value;
+}
+
+function member(value, values) {
+  if (!values.includes(value)) reject();
+  return value;
+}
+
+function hash(value) {
+  if (typeof value !== "string" || !HASH.test(value)) reject();
+  return value;
+}
+
+function revision(value) {
+  if (typeof value !== "string" || !REVISION.test(value)) reject();
+  return value;
+}
+
+function instant(value) {
+  if (typeof value !== "string" || value.length !== INSTANT_LENGTH
+      || !Number.isSafeInteger(Date.parse(value)) || new Date(value).toISOString() !== value) reject();
+  return value;
+}
+
+function same(left, right) {
+  return JSON.stringify(left) === JSON.stringify(right);
+}
+
+function validateGeneration(value) {
+  exact(value, ["id", "fingerprintSha256", "publicationStatus", "publicationBlockReason",
+    "toolProvenanceComplete", ...GENERATION_COUNTS]);
+  integer(value.id, 1);
+  hash(value.fingerprintSha256);
+  member(value.publicationStatus, ["complete", "partial"]);
+  member(value.publicationBlockReason, [null, "tool_provenance_incomplete", "codex_rollout_sources_quarantined"]);
+  boolean(value.toolProvenanceComplete);
+  for (const key of GENERATION_COUNTS) integer(value[key]);
+  return value;
+}
+
+function validateAttributionIndex(value, revisionKind) {
+  if (revisionKind === "before") {
+    if (value !== null) reject();
+    return value;
+  }
+  exact(value, ["observationCount", "ignoredObservationCount", "eras", "conflicts", "contexts"]);
+  for (const key of ["observationCount", "ignoredObservationCount", "eras", "conflicts", "contexts"]) {
+    integer(value[key], 0, MAX_QUOTA);
+  }
+  if (value.ignoredObservationCount > value.observationCount
+      || value.eras > value.observationCount || value.conflicts > value.observationCount
+      || value.contexts > value.observationCount) reject();
+  return value;
+}
+
+function validateInstrumentation(value) {
+  exact(value, ["sourceSha256", "instrumentationSha256", "transformation"]);
+  hash(value.sourceSha256); hash(value.instrumentationSha256);
+  if (value.transformation !== "append_exports_only") reject();
+  return value;
+}
+
+function validateInventory(value, generation) {
+  exact(value, ["indexedUsageRows", "zeroComponentUsageRows", "quota",
+    "generationUsageRows", "generationQuotaRows"]);
+  integer(value.indexedUsageRows, 0, MAX_USAGE);
+  integer(value.zeroComponentUsageRows, 0, MAX_USAGE);
+  if (value.zeroComponentUsageRows > value.indexedUsageRows) reject();
+  exact(value.quota, ["admitted", "held", "suppressed"]);
+  for (const key of ["admitted", "held", "suppressed"]) integer(value.quota[key], 0, MAX_QUOTA);
+  if (value.quota.admitted + value.quota.held + value.quota.suppressed > generation.quotaOccurrences) reject();
+  integer(value.generationUsageRows);
+  integer(value.generationQuotaRows);
+  if (value.generationUsageRows !== generation.usageEvents
+      || value.generationQuotaRows !== generation.quotaOccurrences) reject();
+  return value;
+}
+
+function validateCoverage(value) {
+  exact(value, ["accountingStatus", "diagnosticsSha256", "compatibilitySha256"]);
+  if (value.accountingStatus !== "complete") reject();
+  hash(value.diagnosticsSha256); hash(value.compatibilitySha256);
+  return value;
+}
+
+function validatePopulation(value, ledger, revisionKind) {
+  try { validatePr94PopulationEvidence(value); } catch { reject(); }
+  if (value.revisionKind !== revisionKind || value.totals.events !== ledger.usage.events
+      || value.totals.totalUsd !== ledger.usage.totalUsd) reject();
+  for (const name of PR94_LEDGER_COMPONENTS) {
+    const population = value.totals.components[name];
+    const ledgerComponent = ledger.usage.components[name];
+    for (const key of ["quantity", "observedEvents", "missingEvents", "unavailableEvents"]) {
+      if (population[key] !== ledgerComponent[key]) reject();
+    }
+  }
+  return value;
+}
+
+function validateCalibrationDistribution(value, kind) {
+  exact(value, ["count", "median", "central80"]);
+  integer(value.count, 0, MAX_CALIBRATION_ITEMS);
+  exact(value.central80, ["lower", "upper"]);
+  if (value.count === 0) {
+    if (value.median !== null || value.central80.lower !== null || value.central80.upper !== null) reject();
+    return value;
+  }
+  const minimum = kind === "capacity" ? Number.MIN_VALUE : 0;
+  finite(value.median, minimum);
+  finite(value.central80.lower, minimum);
+  finite(value.central80.upper, minimum);
+  if (value.central80.lower > value.central80.upper) reject();
+  return value;
+}
+
+function validateCalibrationCandidate(value, parentMaximum) {
+  exact(value, ["candidateId", "parentCandidates", "outcomes", "primary", "diagnostic", "spans", "boundaries"]);
+  member(value.candidateId, CANDIDATES);
+  integer(value.parentCandidates, 0, parentMaximum);
+  exact(value.outcomes, OUTCOMES);
+  for (const outcome of OUTCOMES) integer(value.outcomes[outcome], 0, MAX_CALIBRATION_ITEMS);
+  validateCalibrationDistribution(value.primary, "capacity");
+  validateCalibrationDistribution(value.diagnostic, "capacity");
+  validateCalibrationDistribution(value.spans, "span");
+  validateCalibrationDistribution(value.boundaries, "boundaries");
+  return value;
+}
+
+function validateCalibrationCandidateList(value, parentMaximum) {
+  list(value, 4);
+  if (value.length !== CANDIDATES.length) reject();
+  const seen = new Set();
+  value.forEach((candidate, index) => {
+    validateCalibrationCandidate(candidate, parentMaximum);
+    if (candidate.candidateId !== CANDIDATES[index] || seen.has(candidate.candidateId)) reject();
+    seen.add(candidate.candidateId);
+  });
+  return value;
+}
+
+function validateCalibrationAggregateLocal(value) {
+  exact(value, ["schemaVersion", "revisionKind", "selectedPlanType", "status", "counts",
+    "rowReasons", "unknownAccountCheck", "candidates", "plans"]);
+  if (value.schemaVersion !== CALIBRATION_SCHEMA) reject();
+  member(value.revisionKind, ["before", "after", "final"]);
+  member(value.selectedPlanType, [...PLANS]);
+  member(value.status, ["pass", "fail"]);
+  exact(value.counts, ["rawParents", "parentCandidates", "transitionRows", "parentsWithTransitions",
+    "knownAccountParents", "unknownAccountParents", "unexplainedParents"]);
+  integer(value.counts.rawParents, 0, MAX_CALIBRATION_PARENTS);
+  integer(value.counts.parentCandidates, 0, MAX_CALIBRATION_PARENTS * 4);
+  integer(value.counts.transitionRows, 0, MAX_TRANSITIONS);
+  for (const key of ["parentsWithTransitions", "knownAccountParents", "unknownAccountParents", "unexplainedParents"]) {
+    integer(value.counts[key], 0, MAX_CALIBRATION_PARENTS);
+  }
+  if (value.counts.parentCandidates !== value.counts.rawParents * 4
+      || value.counts.parentsWithTransitions > value.counts.rawParents
+      || value.counts.knownAccountParents + value.counts.unknownAccountParents !== value.counts.rawParents
+      || value.counts.unexplainedParents > value.counts.rawParents) reject();
+
+  exact(value.rowReasons, ROW_REASONS);
+  let reasonTotal = 0;
+  for (const reason of ROW_REASONS) {
+    integer(value.rowReasons[reason], 0, MAX_TRANSITIONS);
+    reasonTotal += value.rowReasons[reason];
+  }
+  if (reasonTotal !== value.counts.transitionRows) reject();
+
+  exact(value.unknownAccountCheck, ["scope", ...ACCOUNT_CHECK_COUNTS]);
+  if (value.unknownAccountCheck.scope !== "original_fit_gate_only") reject();
+  for (const key of ACCOUNT_CHECK_COUNTS) {
+    integer(value.unknownAccountCheck[key], 0,
+      key === "rowsChecked" ? MAX_TRANSITIONS * 4 : MAX_CALIBRATION_ITEMS);
+  }
+  if (value.unknownAccountCheck.changedEligibilityRows > value.unknownAccountCheck.rowsChecked
+      || value.unknownAccountCheck.changedPointSets > value.unknownAccountCheck.fragmentCandidatesChecked
+      || value.unknownAccountCheck.changedFits > value.unknownAccountCheck.fragmentCandidatesChecked
+      || value.unknownAccountCheck.unknownOnlyFitExclusions > value.unknownAccountCheck.changedFits
+      || (value.unknownAccountCheck.fragmentCandidatesChecked === 0)
+        !== (value.unknownAccountCheck.rowsChecked === 0)) reject();
+  if (value.status !== (value.counts.unexplainedParents === 0
+      && ACCOUNT_CHECK_COUNTS.slice(2).every((key) => value.unknownAccountCheck[key] === 0) ? "pass" : "fail")) reject();
+
+  validateCalibrationCandidateList(value.candidates, value.counts.rawParents);
+  list(value.plans, PLANS.size);
+  const planCounts = Object.fromEntries(CANDIDATES.map((candidate) => [candidate, 0]));
+  const seenPlans = new Set();
+  let previousPlan = null;
+  for (const plan of value.plans) {
+    exact(plan, ["planType", "candidates"]);
+    member(plan.planType, [...PLANS]);
+    if (seenPlans.has(plan.planType) || (previousPlan !== null && plan.planType <= previousPlan)) reject();
+    previousPlan = plan.planType;
+    seenPlans.add(plan.planType);
+    validateCalibrationCandidateList(plan.candidates, value.counts.rawParents);
+    for (const candidate of plan.candidates) planCounts[candidate.candidateId] += candidate.parentCandidates;
+  }
+  for (const candidate of value.candidates) {
+    if (planCounts[candidate.candidateId] !== candidate.parentCandidates) reject();
+  }
+  if ((value.counts.rawParents === 0) !== (value.plans.length === 0)) reject();
+  return value;
+}
+
+/** Validate the public calibration projection owned by this receipt schema. */
+export function validatePr94CalibrationAggregate(value) {
+  return validateCalibrationAggregateLocal(value);
+}
+
+function validateBatchMetrics(value) {
+  exact(value, ["batches", "maximumUsageSlice", "maximumQuotaSlice"]);
+  integer(value.batches, 0, MAX_QUOTA);
+  integer(value.maximumUsageSlice, 0, MAX_USAGE);
+  integer(value.maximumQuotaSlice, 0, MAX_QUOTA);
+  return value;
+}
+
+function validatePhaseMs(value) {
+  exact(value, ["readAndLedger", "attributionAndDerivation", "calibrationAndReconciliation"]);
+  for (const key of ["readAndLedger", "attributionAndDerivation", "calibrationAndReconciliation"]) {
+    integer(value[key], 0, MAX_PHASE_MS);
+  }
+  return value;
+}
+
+function validatePrivateArtifactBytes(value) {
+  exact(value, ["ledger", "calibration"]);
+  integer(value.ledger, 1, 512 * 1024 * 1024);
+  integer(value.calibration, 1, 512 * 1024 * 1024);
+  return value;
+}
+
+function validateAnalysisLocal(value) {
+  exact(value, ANALYSIS_KEYS);
+  if (value.schema !== ANALYSIS_SCHEMA) reject();
+  member(value.revisionKind, ["before", "after", "final"]);
+  if (value.contextBehavior !== "legacy_zero") reject();
+  const generation = validateGeneration(value.generation);
+  validateAttributionIndex(value.attributionIndex, value.revisionKind);
+  validateInstrumentation(value.instrumentation);
+  const inventory = validateInventory(value.inventory, generation);
+  validateCoverage(value.coverage);
+  try { validatePr94LedgerEvidenceAggregate(value.ledger); } catch { reject(); }
+  try { validatePr94CalibrationAggregate(value.calibration); } catch { reject(); }
+  if (value.calibration.revisionKind !== value.revisionKind) reject();
+  validatePopulation(value.populationEvidence, value.ledger, value.revisionKind);
+  validateBatchMetrics(value.batchMetrics);
+  integer(value.deduplicatedWeeklySnapshots, 0, MAX_USAGE);
+  validatePhaseMs(value.phaseMs);
+  validatePrivateArtifactBytes(value.privateArtifactBytes);
+  if (value.ledger.usage.events !== inventory.indexedUsageRows - inventory.zeroComponentUsageRows
+      || value.ledger.quota.events !== inventory.quota.admitted) reject();
+  return value;
+}
+
+export function validatePr94AnalysisResult(value) {
+  try { return validateAnalysisLocal(value); }
+  catch { throw publicError("analysis"); }
+}
+
+function validateSource(value) {
+  exact(value, ["revision", "dependencies"]);
+  revision(value.revision);
+  exact(value.dependencies, ["sourceSha256", "runtimeSha256", "lockSha256", "identitySha256"]);
+  for (const digest of Object.values(value.dependencies)) hash(digest);
+  return value;
+}
+
+function validateSources(value) {
+  exact(value, ["before", "after", "final"]);
+  for (const side of ["before", "after", "final"]) validateSource(value[side]);
+  if (value.before.revision !== PR94_COMPARISON_REVISIONS.before
+      || value.after.revision !== PR94_COMPARISON_REVISIONS.after) reject();
+  for (const key of ["runtimeSha256", "lockSha256"]) {
+    if (value.before.dependencies[key] !== value.after.dependencies[key]
+        || value.before.dependencies[key] !== value.final.dependencies[key]) reject();
+  }
+  return value;
+}
+
+function validateIndex(value) {
+  exact(value, ["sha256", "bytes"]);
+  hash(value.sha256);
+  integer(value.bytes, 1, MAX_INDEX_BYTES);
+  return value;
+}
+
+function validateWindow(value) {
+  exact(value, ["startAt", "endAt"]);
+  instant(value.startAt); instant(value.endAt);
+  if (value.startAt >= value.endAt) reject();
+  return value;
+}
+
+function validateLedgerComparisonShape(value) {
+  exact(value, ["schemaVersion", "status", "aggregateEqual", "rows"]);
+  if (value.schemaVersion !== LEDGER_COMPARISON_SCHEMA) reject();
+  member(value.status, ["equal", "different"]);
+  boolean(value.aggregateEqual);
+  exact(value.rows, ["usage", "quota"]);
+  for (const kind of ["usage", "quota"]) {
+    const row = value.rows[kind];
+    exact(row, ["before", "after", "unchanged", "changed", "missing", "added"]);
+    for (const key of ["before", "after", "unchanged", "changed", "missing", "added"]) {
+      integer(row[key], 0, MAX_LEDGER_ROWS);
+    }
+    if (row.unchanged + row.changed + row.missing !== row.before
+        || row.unchanged + row.changed + row.added !== row.after) reject();
+  }
+  const unchanged = ["usage", "quota"].every((kind) => {
+    const row = value.rows[kind];
+    return row.changed === 0 && row.missing === 0 && row.added === 0;
+  });
+  if (value.status === "equal" && (!value.aggregateEqual || !unchanged)) reject();
+  return value;
+}
+
+function primaryFitCount(calibration) {
+  return calibration.candidates.reduce((total, candidate) => total + candidate.primary.count, 0);
+}
+
+function validateCalibrationComparison(value, before = null, after = null) {
+  exact(value, ["schemaVersion", "status", ...CALIBRATION_COMPARISON_COUNTS,
+    "selectedPopulationMatches", "duplicatePrimaryVotes", "requiresCoverageReview", "primaryOutcomeMatrix"]);
+  if (value.schemaVersion !== CALIBRATION_COMPARISON_SCHEMA) reject();
+  member(value.status, ["pass", "fail"]);
+  for (const key of CALIBRATION_COMPARISON_COUNTS) integer(value[key], 0, MAX_CALIBRATION_ITEMS);
+  if (value.beforeParentCandidates % 4 !== 0 || value.afterParentCandidates % 4 !== 0
+      || value.missingParentCandidates % 4 !== 0 || value.addedParentCandidates % 4 !== 0
+      || value.reconciledParentCandidates % 4 !== 0) reject();
+  boolean(value.selectedPopulationMatches);
+  boolean(value.requiresCoverageReview);
+  if (value.missingParentCandidates + value.reconciledParentCandidates !== value.beforeParentCandidates
+      || value.addedParentCandidates + value.reconciledParentCandidates !== value.afterParentCandidates
+      || value.changedIdenticalInputFits + value.rejectedIdenticalInputFits > value.identicalFitInputsCompared
+      || value.changedIdenticalInputFits > value.identicalFitInputsCompared
+      || value.changedInputPrimaryLosses > value.lostPrimaryFits
+      || value.unexplainedPrimaryLosses > value.lostPrimaryFits
+      || value.lostPrimaryFits + value.retainedPrimaryFits !== value.baselinePrimaryFits
+      || value.changedRawParentInventory > value.reconciledParentCandidates
+      || value.changedOutcomeParentCandidates > value.reconciledParentCandidates
+      || value.retainedPrimaryInputChanges > value.reconciledParentCandidates) reject();
+
+  list(value.primaryOutcomeMatrix, MAX_CALIBRATION_ITEMS);
+  const matrixTotals = { parentCandidates: 0, baselinePrimaryFits: 0, afterPrimaryFits: 0,
+    retainedPrimaryFits: 0, lostPrimaryFits: 0, newPrimaryFits: 0, changedInputPrimaryLosses: 0 };
+  const seen = new Set();
+  let previousKey = null;
+  for (const cell of value.primaryOutcomeMatrix) {
+    exact(cell, ["candidateId", "planType", "accountKnown", "transition", "afterOutcomes",
+      "parentCandidates", "baselinePrimaryFits", "afterPrimaryFits", "retainedPrimaryFits",
+      "lostPrimaryFits", "newPrimaryFits", "changedInputPrimaryLosses"]);
+    member(cell.candidateId, CANDIDATES);
+    member(cell.planType, [...PLANS]);
+    boolean(cell.accountKnown);
+    member(cell.transition, PRIMARY_TRANSITIONS);
+    for (const key of ["parentCandidates", "baselinePrimaryFits", "afterPrimaryFits", "retainedPrimaryFits",
+      "lostPrimaryFits", "newPrimaryFits", "changedInputPrimaryLosses"]) {
+      integer(cell[key], 0, MAX_CALIBRATION_ITEMS);
+      matrixTotals[key] += cell[key];
+    }
+    if (cell.parentCandidates < 1 || cell.lostPrimaryFits + cell.retainedPrimaryFits !== cell.baselinePrimaryFits
+        || cell.retainedPrimaryFits + cell.newPrimaryFits !== cell.afterPrimaryFits
+        || cell.changedInputPrimaryLosses > cell.lostPrimaryFits) reject();
+    list(cell.afterOutcomes, OUTCOMES.length + 1);
+    let outcomeTotal = 0;
+    let previousOutcome = null;
+    for (const outcome of cell.afterOutcomes) {
+      exact(outcome, ["outcome", "count"]);
+      member(outcome.outcome, [...OUTCOMES, "missing_parent"]);
+      integer(outcome.count, 1, MAX_CALIBRATION_ITEMS);
+      if (previousOutcome !== null && outcome.outcome <= previousOutcome) reject();
+      previousOutcome = outcome.outcome;
+      outcomeTotal += outcome.count;
+    }
+    if (cell.afterOutcomes.length === 0
+        || (cell.transition === "missing_parent"
+          ? !(cell.afterOutcomes.length === 1 && cell.afterOutcomes[0].outcome === "missing_parent"
+            && cell.afterOutcomes[0].count === 1)
+          : cell.afterOutcomes.some((outcome) => outcome.outcome === "missing_parent"))) reject();
+    if (cell.transition === "retained_primary" && (cell.baselinePrimaryFits === 0 || cell.afterPrimaryFits === 0)) reject();
+    if (cell.transition === "lost_primary" && (cell.baselinePrimaryFits === 0 || cell.afterPrimaryFits !== 0)) reject();
+    if (cell.transition === "new_primary" && (cell.baselinePrimaryFits !== 0 || cell.afterPrimaryFits === 0)) reject();
+    if (cell.transition === "no_primary" && (cell.baselinePrimaryFits !== 0 || cell.afterPrimaryFits !== 0)) reject();
+    if (cell.transition === "missing_parent" && cell.afterPrimaryFits !== 0) reject();
+    if (cell.transition !== "missing_parent" && outcomeTotal < cell.afterPrimaryFits) reject();
+    const key = JSON.stringify([cell.candidateId, cell.planType, cell.accountKnown, cell.transition, cell.afterOutcomes]);
+    if (seen.has(key) || (previousKey !== null && key <= previousKey)) reject();
+    seen.add(key); previousKey = key;
+  }
+  if (matrixTotals.parentCandidates !== value.beforeParentCandidates + value.addedParentCandidates
+      || matrixTotals.baselinePrimaryFits !== value.baselinePrimaryFits
+      || matrixTotals.afterPrimaryFits !== value.retainedPrimaryFits + value.newPrimaryFits
+      || matrixTotals.retainedPrimaryFits !== value.retainedPrimaryFits
+      || matrixTotals.lostPrimaryFits !== value.lostPrimaryFits
+      || matrixTotals.newPrimaryFits !== value.newPrimaryFits
+      || matrixTotals.changedInputPrimaryLosses !== value.changedInputPrimaryLosses) reject();
+  const expectedReview = value.lostPrimaryFits > 0 || value.newPrimaryFits > 0
+    || value.retainedPrimaryInputChanges > 0 || value.changedOutcomeParentCandidates > 0;
+  if (value.requiresCoverageReview !== expectedReview) reject();
+  if (value.status === "pass"
+      && (value.missingParentCandidates !== 0 || value.addedParentCandidates !== 0
+        || value.changedIdenticalInputFits !== 0 || value.rejectedIdenticalInputFits !== 0
+        || value.unexplainedPrimaryLosses !== 0 || value.changedRawParentInventory !== 0
+        || value.unexplainedParents !== 0 || value.duplicatePrimaryVotes !== 0
+        || !value.selectedPopulationMatches)) reject();
+  if (before !== null && after !== null) {
+    if (value.beforeParentCandidates !== before.calibration.counts.parentCandidates
+        || value.afterParentCandidates !== after.calibration.counts.parentCandidates
+        || value.unexplainedParents !== before.calibration.counts.unexplainedParents
+          + after.calibration.counts.unexplainedParents
+        || value.baselinePrimaryFits !== primaryFitCount(before.calibration)
+        || value.retainedPrimaryFits + value.newPrimaryFits !== primaryFitCount(after.calibration)
+        || value.selectedPopulationMatches !== (before.calibration.selectedPlanType === after.calibration.selectedPlanType)) reject();
+  }
+  return value;
+}
+
+function validateLedgerComparison(value, before = null, after = null) {
+  validateLedgerComparisonShape(value);
+  if (before !== null && after !== null) {
+    for (const kind of ["usage", "quota"]) {
+      if (value.rows[kind].before !== before.ledger[kind].events
+          || value.rows[kind].after !== after.ledger[kind].events) reject();
+    }
+  }
+  return value;
+}
+
+function validateComparison(value, evidence) {
+  exact(value, ["attributionLedger", "finalLedger", "attributionCalibration", "finalCalibration",
+    "readerEvidenceUnchanged"]);
+  boolean(value.readerEvidenceUnchanged);
+  if (!value.readerEvidenceUnchanged) reject();
+  const ledgerComparisons = [
+    [value.attributionLedger, evidence.before, evidence.after],
+    [value.finalLedger, evidence.after, evidence.final],
+  ];
+  const calibrationComparisons = [
+    [value.attributionCalibration, evidence.before, evidence.after],
+    [value.finalCalibration, evidence.after, evidence.final],
+  ];
+  ledgerComparisons.forEach(([comparison, before, after]) => validateLedgerComparison(comparison, before, after));
+  calibrationComparisons.forEach(([comparison, before, after]) => validateCalibrationComparison(comparison, before, after));
+  if (ledgerComparisons.some(([comparison]) => comparison.status !== "equal" || !comparison.aggregateEqual)
+      || calibrationComparisons.some(([comparison]) => comparison.status !== "pass")) reject();
+  return value;
+}
+
+function validateMetrics(value) {
+  exact(value, ["wallMs", "userCpuMs", "systemCpuMs", "peakRssBytes"]);
+  integer(value.wallMs, 0, MAX_PHASE_MS);
+  integer(value.userCpuMs, 0);
+  integer(value.systemCpuMs, 0);
+  integer(value.peakRssBytes, 1, MAX_RSS);
+  return value;
+}
+
+function validateMeasurements(value) {
+  exact(value, ["before", "after", "final"]);
+  for (const side of ["before", "after", "final"]) validateMetrics(value[side]);
+  return value;
+}
+
+function validateEvidence(value) {
+  exact(value, ["before", "after", "final"]);
+  for (const side of ["before", "after", "final"]) {
+    validateAnalysisLocal(value[side]);
+    if (value[side].revisionKind !== side || value[side].calibration.status !== "pass"
+        || value[side].populationEvidence.unknownAccountOnlyWithheldEvents !== 0) reject();
+  }
+  for (const key of ["inventory", "coverage", "generation"]) {
+    if (!same(value.before[key], value.after[key]) || !same(value.before[key], value.final[key])) reject();
+  }
+  if (!same(value.before.ledger, value.after.ledger) || !same(value.after.ledger, value.final.ledger)) reject();
+  return value;
+}
+
+function validateProductionResources(value, receipt, evidence) {
+  exact(value, ["before", "after", "final"]);
+  for (const side of ["before", "after", "final"]) {
+    const resource = value[side];
+    try { validatePr94ProductionResourceEvidence(resource); } catch { reject(); }
+    if (resource.revision !== receipt.sources[side].revision
+        || !same(resource.dependencies, receipt.sources[side].dependencies)
+        || !same(resource.index, receipt.index)
+        || resource.clock.startAt !== receipt.window.startAt
+        || resource.clock.endAt !== receipt.window.endAt) reject();
+    const generation = evidence[side].generation;
+    if (resource.generation.id !== generation.id
+        || resource.generation.publicationStatus !== generation.publicationStatus
+        || resource.generation.toolProvenanceComplete !== generation.toolProvenanceComplete
+        || resource.generation.usageEvents !== generation.usageEvents
+        || resource.generation.quotaOccurrences !== generation.quotaOccurrences) reject();
+  }
+  return value;
+}
+
+function validateReceiptLocal(value) {
+  exact(value, RECEIPT_KEYS);
+  if (value.schema !== RECEIPT_SCHEMA || value.status !== "passed"
+      || value.scope !== "fixed_admitted_index_analysis_not_raw_ingestion_or_hosted_activation") reject();
+  validateSources(value.sources);
+  validateIndex(value.index);
+  validateWindow(value.window);
+  validateMeasurements(value.measurements);
+  validateEvidence(value.evidence);
+  validateComparison(value.comparison, value.evidence);
+  validateProductionResources(value.productionResources, value, value.evidence);
+  return value;
+}
+
+export function validatePr94ComparisonReceipt(value) {
+  try { return validateReceiptLocal(value); }
+  catch { throw publicError("comparison"); }
+}

--- a/scripts/lib/pr94-revision-loader.mjs
+++ b/scripts/lib/pr94-revision-loader.mjs
@@ -1,0 +1,72 @@
+import { createHash } from "node:crypto";
+import { readFile } from "node:fs/promises";
+import { registerHooks } from "node:module";
+import { join, resolve } from "node:path";
+import { pathToFileURL } from "node:url";
+
+// Qualification-only, export-only instrumentation. Original function bodies,
+// branches and returned production objects are not changed. The coordinator
+// authenticates the clean revision and dependencies before invoking this seam.
+// The exact original bytes and appended instrumentation are bound separately.
+const REPORT_PATH = "src/reporting/weekly-calibration.js";
+const REQUIRED_FUNCTIONS = Object.freeze([
+  "selectResetGroups", "fitReset", "uniquePoints", "capacityFit",
+  "fitRelativeCentral80Width", "isEligible", "partitionKey",
+]);
+
+function fail() { throw new Error("pr94_instrumentation_invalid"); }
+function hash(bytes) { return createHash("sha256").update(bytes).digest("hex"); }
+
+export function instrumentPr94CalibrationSource(source) {
+  if (typeof source !== "string" || source.length > 512 * 1024
+      || source.includes("__pr94CalibrationInternals")) fail();
+  for (const name of REQUIRED_FUNCTIONS) {
+    if ([...source.matchAll(new RegExp(`^function ${name}\\(`, "gm"))].length !== 1) fail();
+  }
+  if ([...source.matchAll(/^const CANDIDATES = \[/gmu)].length !== 1) fail();
+  const names = [...REQUIRED_FUNCTIONS];
+  if (/^function resetParentKey\(/mu.test(source)) names.push("resetParentKey");
+  const suffix = `\nexport const __pr94CalibrationInternals = Object.freeze({ ${names.join(", ")} });\n`
+    + "export { CANDIDATES as WEEKLY_CALIBRATION_CANDIDATES };\n";
+  return Object.freeze({
+    source: source + suffix,
+    sourceSha256: hash(source),
+    instrumentationSha256: hash(suffix),
+  });
+}
+
+export async function loadPr94Revision(root) {
+  if (typeof root !== "string" || resolve(root) !== root) fail();
+  const reportUrl = pathToFileURL(join(root, REPORT_PATH)).href;
+  const source = await readFile(join(root, REPORT_PATH), "utf8");
+  const instrumented = instrumentPr94CalibrationSource(source);
+  let calls = 0;
+  const hook = registerHooks({
+    load(url, context, nextLoad) {
+      const loaded = nextLoad(url, context);
+      if (url !== reportUrl) return loaded;
+      const original = typeof loaded.source === "string"
+        ? loaded.source : Buffer.from(loaded.source).toString("utf8");
+      if (hash(original) !== instrumented.sourceSha256 || ++calls !== 1) fail();
+      return { ...loaded, source: instrumented.source };
+    },
+  });
+  try {
+    const reporting = await import(reportUrl);
+    if (calls !== 1) fail();
+    const [reader, index, miner, accounting, quota, cache] = await Promise.all([
+      import(pathToFileURL(join(root, "src/local-unified-accounting-source.js")).href),
+      import(pathToFileURL(join(root, "src/local-unified-index.js")).href),
+      import(pathToFileURL(join(root, "src/codex-transition-miner.js")).href),
+      import(pathToFileURL(join(root, "packages/accounting/index.js")).href),
+      import(pathToFileURL(join(root, "packages/quota-analysis/index.js")).href),
+      import(pathToFileURL(join(root, "src/replay-safe-accounting-cache.js")).href),
+    ]);
+    return { reader, index, miner, accounting, quota, cache, reporting,
+      instrumentation: {
+        sourceSha256: instrumented.sourceSha256,
+        instrumentationSha256: instrumented.instrumentationSha256,
+        transformation: "append_exports_only",
+      } };
+  } finally { hook.deregister(); }
+}

--- a/scripts/macos-release-core.js
+++ b/scripts/macos-release-core.js
@@ -56,6 +56,8 @@ import {
   assertMacOSKeychainMigrationManifest,
   buildMacOSAppForRelease,
   buildMacOSReleaseCandidate,
+  readMacOSReleaseSourceTimestamp,
+  setMacOSBundleFinderMetadata,
   validateMacOSPreviewApp,
 } from "./build-macos-app.js";
 import {
@@ -2692,14 +2694,21 @@ export async function packageMacOSDMG({
   replace = false,
   distribution,
   channel = STABLE_RELEASE_CHANNEL,
-}) {
+}, {
+  inspectInput = inspectMacOSDMGInput,
+  commandRunner = runMacOSReleaseCommand,
+  finderMetadataSetter = setMacOSBundleFinderMetadata,
+} = {}) {
   if (!Object.values(DMG_DISTRIBUTIONS).includes(distribution)) {
     fail(
       "DMG packaging requires an explicit development, preview, or release distribution",
       "MACOS_DMG_DISTRIBUTION_REQUIRED",
     );
   }
-  const inspected = await inspectMacOSDMGInput(appPath, distribution, channel);
+  const inspected = await inspectInput(appPath, distribution, channel);
+  const releaseFinderTimestamp = distribution === DMG_DISTRIBUTIONS.release
+    ? readMacOSReleaseSourceTimestamp(inspected.source)
+    : null;
   const selectedOutput = resolve(output);
   if (basename(selectedOutput).startsWith(".")
       || !selectedOutput.endsWith(".dmg")) {
@@ -2735,7 +2744,7 @@ export async function packageMacOSDMG({
   );
   try {
     await mkdir(staging, { recursive: true, mode: 0o755 });
-    runMacOSReleaseCommand("/usr/bin/ditto", [
+    commandRunner("/usr/bin/ditto", [
       "--noqtn",
       inspected.appPath,
       stagedApp,
@@ -2756,8 +2765,17 @@ export async function packageMacOSDMG({
         await utimes(current, FIXED_EPOCH_SECONDS, FIXED_EPOCH_SECONDS);
       }
     }
+    if (releaseFinderTimestamp !== null) {
+      // The payload tree remains normalized to the fixed epoch. Restore the
+      // source-bound outer bundle dates so Finder does not expose that
+      // reproducibility sentinel as a release date.
+      finderMetadataSetter(stagedApp, {
+        birthTimeSeconds: releaseFinderTimestamp,
+        modificationTimeSeconds: releaseFinderTimestamp,
+      });
+    }
     await symlink("/Applications", join(staging, "Applications"));
-    runMacOSReleaseCommand("/usr/bin/hdiutil", [
+    commandRunner("/usr/bin/hdiutil", [
       "create",
       "-ov",
       "-srcfolder",
@@ -2778,7 +2796,7 @@ export async function packageMacOSDMG({
       failureMessage: "DMG creation failed",
       timeout: 300_000,
     });
-    runMacOSReleaseCommand("/usr/bin/hdiutil", [
+    commandRunner("/usr/bin/hdiutil", [
       "verify",
       temporaryDMG,
     ], {

--- a/scripts/macos-release-core.js
+++ b/scripts/macos-release-core.js
@@ -167,6 +167,37 @@ const VERIFIED_LEGACY_DOGFOOD_PREVIOUS_ARTIFACT = Symbol(
   "verified legacy dogfood previous artifact",
 );
 const VERIFIED_LEGACY_DOGFOOD_CAPABILITIES = new WeakSet();
+// The published stable 0.1.16 has the same pre-policy payload shape, but its
+// distinct source, updater key, build digests and DMG bytes must all match.
+const LEGACY_STABLE_PREVIOUS_RELEASE = Object.freeze({
+  artifactSha256:
+    "5e3e60402ffa3c61d8279f5f759548a8b48084f1ae567eeb1b30156c7f30a9fe",
+  artifactBytes: 49_341_389,
+  artifactFileName: "TiboTattle-0.1.16-macOS-arm64.dmg",
+  bundleVersion: "0.1.16",
+  shortVersion: "0.1.16",
+  sourceCommit: "4f30508eff55c122e73025ad06d73b33cadbc508",
+  sourceTag: "v0.1.16",
+  sourceSha256:
+    "95de0721e5a29ab0988535a55935e516012e9230185bab79d1504b24fc59513a",
+  payloadSha256:
+    "23f41a17bc6f4fede452e53f61972999b7ea144e732cd59807d77aca2ada20e5",
+  publicEdKeySha256:
+    "ae8a8e00311a4cfc1e7e7f2eedcf7fa53d6bc197997c912a0b8f908e54a28fbf",
+  frameworkSha256:
+    "2a43f8c41a29b195982354d7580036c178ed89e3b3e5dc0d8ab295290d91a0ac",
+  keytar: Object.freeze({
+    path: "Contents/Resources/app/node_modules/@github/keytar/prebuilds/darwin-arm64/keytar.node",
+    bytes: 98_544,
+    mode: "555",
+    sha256:
+      "dd24fba62f187f494e86ab5c4d499dcb8cb2c5bd7345079651297aecb9c6f049",
+  }),
+});
+const VERIFIED_LEGACY_STABLE_PREVIOUS_ARTIFACT = Symbol(
+  "verified legacy stable previous artifact",
+);
+const VERIFIED_LEGACY_STABLE_CAPABILITIES = new WeakSet();
 // This immutable rc2 was installed before the migration helper existed. Only
 // the checksum-verified previous side of a replacement may omit that helper;
 // every newly built/signable/public candidate must carry the current contract.
@@ -242,6 +273,17 @@ function validatePreMigrationPreviousCapability(capability) {
     fail(
       "Pre-migration helper compatibility requires a verified previous-artifact capability",
       "MACOS_KEYCHAIN_MIGRATION_COMPATIBILITY_INVALID",
+    );
+  }
+  return true;
+}
+
+function validateLegacyStablePreviousCapability(capability) {
+  if (capability === null) return false;
+  if (!VERIFIED_LEGACY_STABLE_CAPABILITIES.has(capability)) {
+    fail(
+      "Legacy stable compatibility requires a verified previous-artifact capability",
+      "MACOS_LEGACY_SOURCE_COMPATIBILITY_INVALID",
     );
   }
   return true;
@@ -826,7 +868,7 @@ async function verifyMacOSBuildPayload(
   manifest,
   legacyDogfoodPreviousCapability = null,
   preMigrationPreviousCapability = null,
-  legacyStablePrevious = false,
+  legacyStablePreviousCapability = null,
 ) {
   const legacyDogfoodPrevious = validateLegacyDogfoodPreviousCapability(
     legacyDogfoodPreviousCapability,
@@ -834,6 +876,12 @@ async function verifyMacOSBuildPayload(
   const preMigrationPrevious = validatePreMigrationPreviousCapability(
     preMigrationPreviousCapability,
   );
+  const legacyStablePrevious = validateLegacyStablePreviousCapability(
+    legacyStablePreviousCapability,
+  );
+  const legacyKeytarContract = legacyDogfoodPrevious
+    ? LEGACY_DOGFOOD_PREVIOUS_RELEASE.keytar
+    : legacyStablePrevious ? LEGACY_STABLE_PREVIOUS_RELEASE.keytar : null;
   const helperRequired = !legacyDogfoodPrevious
     && !preMigrationPrevious && !legacyStablePrevious;
   if (helperRequired) {
@@ -874,8 +922,7 @@ async function verifyMacOSBuildPayload(
       );
     }
     previousPath = entry.path;
-    const legacyKeytar = legacyDogfoodPrevious
-      && entry.path === LEGACY_DOGFOOD_PREVIOUS_RELEASE.keytar.path;
+    const legacyKeytar = entry.path === legacyKeytarContract?.path;
     const expectedNormalization = (NORMALIZED_MACH_O_PATHS.has(entry.path)
         || legacyKeytar)
       ? "mach_o_without_code_signature"
@@ -888,7 +935,7 @@ async function verifyMacOSBuildPayload(
         || !/^[a-f0-9]{64}$/u.test(entry.sha256)
         || entry.normalization !== expectedNormalization
         || (legacyKeytar && ["bytes", "mode", "sha256"].some((key) =>
-          entry[key] !== LEGACY_DOGFOOD_PREVIOUS_RELEASE.keytar[key]))
+          entry[key] !== legacyKeytarContract[key]))
         || expected.has(entry.path)
         || [BUILD_MANIFEST_PATH, CODE_RESOURCES_PATH].includes(entry.path)) {
       fail(
@@ -908,8 +955,8 @@ async function verifyMacOSBuildPayload(
     : selectedBaseMachOPaths;
   for (const required of [
     ...requiredMachOPaths,
-    ...(legacyDogfoodPrevious
-      ? [LEGACY_DOGFOOD_PREVIOUS_RELEASE.keytar.path]
+    ...(legacyKeytarContract !== null
+      ? [legacyKeytarContract.path]
       : []),
   ]) {
     if (!expected.has(required)) {
@@ -1095,14 +1142,21 @@ function hasAppOpenScheme(plist) {
       && entry.CFBundleURLSchemes.includes(APP_OPEN_SCHEME));
 }
 
-function hasExpectedProductBrand(plist, legacyDogfoodPreviousCapability = null) {
+function hasExpectedProductBrand(
+  plist,
+  legacyDogfoodPreviousCapability = null,
+  legacyStablePreviousCapability = null,
+) {
   const legacyDogfoodPrevious = validateLegacyDogfoodPreviousCapability(
     legacyDogfoodPreviousCapability,
+  );
+  const legacyStablePrevious = validateLegacyStablePreviousCapability(
+    legacyStablePreviousCapability,
   );
   // The pinned old app used the same identity constants in code, before these
   // two fields were added to its plist. Do not exempt new candidates or accept
   // a partially specified/different identity on the historical artifact.
-  const expectedKeychainIdentity = legacyDogfoodPrevious
+  const expectedKeychainIdentity = legacyDogfoodPrevious || legacyStablePrevious
     ? !Object.hasOwn(plist, "UsageMonitorKeychainNamespace")
       && !Object.hasOwn(plist, "UsageMonitorKeychainAccount")
     : plist.UsageMonitorKeychainNamespace === PRODUCT_BRAND.keychainNamespace
@@ -1216,6 +1270,7 @@ export async function inspectMacOSApp(appPath, {
   allowLegacyUnsealedSource = false,
   [VERIFIED_LEGACY_DOGFOOD_PREVIOUS_ARTIFACT]: legacyDogfoodPreviousCapability = null,
   [VERIFIED_PRE_MIGRATION_PREVIOUS_ARTIFACT]: preMigrationPreviousCapability = null,
+  [VERIFIED_LEGACY_STABLE_PREVIOUS_ARTIFACT]: legacyStablePreviousCapability = null,
   channel = "stable",
   requireExternalDistribution = false,
 } = {}) {
@@ -1225,8 +1280,12 @@ export async function inspectMacOSApp(appPath, {
   const preMigrationPrevious = validatePreMigrationPreviousCapability(
     preMigrationPreviousCapability,
   );
+  const legacyStablePrevious = validateLegacyStablePreviousCapability(
+    legacyStablePreviousCapability,
+  );
   if (typeof allowLegacyUnsealedSource !== "boolean"
-      || ((allowLegacyUnsealedSource || legacyDogfoodPrevious || preMigrationPrevious)
+      || (allowLegacyUnsealedSource && !legacyStablePrevious)
+      || ((legacyStablePrevious || legacyDogfoodPrevious || preMigrationPrevious)
         && !requireExternalDistribution)) {
     fail(
       "Legacy unsealed source compatibility requires external artifact validation",
@@ -1253,11 +1312,21 @@ export async function inspectMacOSApp(appPath, {
       || manifest.application?.bundleIdentifier !== BUNDLE_IDENTIFIER) {
     fail("Application build manifest has an unexpected identity");
   }
-  const exactLegacyStablePrevious = allowLegacyUnsealedSource
+  const exactLegacyStablePrevious = legacyStablePrevious
     && channel === STABLE_RELEASE_CHANNEL
-    && manifest.application?.bundleVersion === LEGACY_STABLE_MACOS_BUNDLE_VERSION
-    && manifest.application?.shortVersion === LEGACY_STABLE_MACOS_BUNDLE_VERSION
-    && manifest.release?.source === undefined;
+    && manifest.application?.bundleVersion === LEGACY_STABLE_PREVIOUS_RELEASE.bundleVersion
+    && manifest.application?.shortVersion === LEGACY_STABLE_PREVIOUS_RELEASE.shortVersion
+    && manifest.release?.source === undefined
+    && manifest.inputs?.sourceSha256 === LEGACY_STABLE_PREVIOUS_RELEASE.sourceSha256
+    && manifest.payload?.payloadSha256 === LEGACY_STABLE_PREVIOUS_RELEASE.payloadSha256
+    && manifest.release?.updater?.publicEdKeySha256 === LEGACY_STABLE_PREVIOUS_RELEASE.publicEdKeySha256
+    && manifest.release?.updater?.frameworkSha256 === LEGACY_STABLE_PREVIOUS_RELEASE.frameworkSha256;
+  if (legacyStablePrevious && !exactLegacyStablePrevious) {
+    fail(
+      "Legacy stable compatibility does not match the exact previous build",
+      "MACOS_LEGACY_SOURCE_COMPATIBILITY_INVALID",
+    );
+  }
   if (preMigrationPrevious
       && (channel !== INTERNAL_DOGFOOD_RELEASE_CHANNEL
         || manifest.application?.bundleVersion !== PRE_MIGRATION_DOGFOOD_PREVIOUS_RELEASE.bundleVersion
@@ -1280,7 +1349,7 @@ export async function inspectMacOSApp(appPath, {
     manifest,
     legacyDogfoodPreviousCapability,
     preMigrationPreviousCapability,
-    exactLegacyStablePrevious,
+    legacyStablePreviousCapability,
   );
   const plistPath = join(selected, "Contents", "Info.plist");
   await regularPath(plistPath);
@@ -1288,7 +1357,9 @@ export async function inspectMacOSApp(appPath, {
   if (plist.CFBundleIdentifier !== BUNDLE_IDENTIFIER
       || plist.CFBundleExecutable !== PRODUCT_BRAND.executableName
       || !hasAppOpenScheme(plist)
-      || !hasExpectedProductBrand(plist, legacyDogfoodPreviousCapability)) {
+      || !hasExpectedProductBrand(
+        plist, legacyDogfoodPreviousCapability, legacyStablePreviousCapability,
+      )) {
     fail("Application bundle metadata is incomplete");
   }
   await validateUpdaterBoundary(selected, plist, manifest, {
@@ -1306,12 +1377,12 @@ export async function inspectMacOSApp(appPath, {
   }
   if (requireExternalDistribution) {
     const releaseChannel = resolveOperationalReleaseChannel(channel);
-    const exactLegacyUnsealedSource = allowLegacyUnsealedSource
+    const exactLegacyUnsealedSource = exactLegacyStablePrevious
       && releaseChannel.name === STABLE_RELEASE_CHANNEL
       && plist.CFBundleVersion === LEGACY_STABLE_MACOS_BUNDLE_VERSION
       && plist.CFBundleShortVersionString
         === LEGACY_STABLE_MACOS_BUNDLE_VERSION;
-    if (allowLegacyUnsealedSource && !exactLegacyUnsealedSource) {
+    if (legacyStablePrevious && !exactLegacyUnsealedSource) {
       fail(
         "Legacy unsealed source compatibility applies only to the exact 0.1.16 stable rollback artifact",
         "MACOS_LEGACY_SOURCE_COMPATIBILITY_INVALID",
@@ -1696,6 +1767,14 @@ function validateSignedReleaseManifest(manifest, label, {
     : validateSignedReleaseChannel(manifest, label);
   const legacyDogfoodPreviousSource = allowLegacyDogfoodPreviousSource
     && isExactLegacyDogfoodPreviousRelease(manifest);
+  if (manifest.artifact.sha256 === LEGACY_STABLE_PREVIOUS_RELEASE.artifactSha256
+      && (!allowLegacyStableMigrationSource
+        || !isExactLegacyStablePreviousRelease(manifest))) {
+    fail(
+      "The historical stable artifact is allowed only as its exact previous release",
+      "MACOS_LEGACY_SOURCE_COMPATIBILITY_INVALID",
+    );
+  }
   if (manifest.artifact.sha256 === LEGACY_DOGFOOD_PREVIOUS_RELEASE.artifactSha256
       && !legacyDogfoodPreviousSource) {
     fail(
@@ -1751,6 +1830,26 @@ function validateSignedReleaseManifest(manifest, label, {
 function isExactLegacyDogfoodPreviousRelease(manifest) {
   const legacy = LEGACY_DOGFOOD_PREVIOUS_RELEASE;
   return manifest?.channel?.name === INTERNAL_DOGFOOD_RELEASE_CHANNEL
+    && manifest.application?.bundleIdentifier === BUNDLE_IDENTIFIER
+    && manifest.application?.bundleVersion === legacy.bundleVersion
+    && manifest.application?.shortVersion === legacy.shortVersion
+    && manifest.artifact?.sha256 === legacy.artifactSha256
+    && manifest.artifact?.bytes === legacy.artifactBytes
+    && manifest.artifact?.fileName === legacy.artifactFileName
+    && manifest.source?.repository === PUBLIC_RELEASE_SOURCE_REPOSITORY
+    && manifest.source?.commit === legacy.sourceCommit
+    && manifest.source?.tag === legacy.sourceTag
+    && manifest.build?.sourceSha256 === legacy.sourceSha256
+    && manifest.build?.payloadSha256 === legacy.payloadSha256
+    && manifest.updater?.appcastURL === manifest.channel.sparkle.appcastURL
+    && manifest.updater?.publicEdKeySha256 === legacy.publicEdKeySha256
+    && manifest.updater?.frameworkSha256 === legacy.frameworkSha256
+    && manifest.updater?.verifyBeforeExtraction === true;
+}
+
+function isExactLegacyStablePreviousRelease(manifest) {
+  const legacy = LEGACY_STABLE_PREVIOUS_RELEASE;
+  return manifest?.channel?.name === STABLE_RELEASE_CHANNEL
     && manifest.application?.bundleIdentifier === BUNDLE_IDENTIFIER
     && manifest.application?.bundleVersion === legacy.bundleVersion
     && manifest.application?.shortVersion === legacy.shortVersion
@@ -1985,6 +2084,13 @@ export function validateMacOSSignedReplacementPair({
     candidateManifest,
     "Candidate release",
   );
+  if (previous.application.bundleVersion === LEGACY_STABLE_MACOS_BUNDLE_VERSION
+      && !isExactLegacyStablePreviousRelease(previous)) {
+    fail(
+      "Legacy stable replacement compatibility requires the exact previous release",
+      "MACOS_LEGACY_SOURCE_COMPATIBILITY_INVALID",
+    );
+  }
   const previousChannelName = validateSignedReleaseChannel(
     previous,
     "Previous release",
@@ -2155,12 +2261,12 @@ export async function validateMacOSSignedReplacementArtifacts({
     previousManifest: previous.manifest,
     candidateManifest: candidate.manifest,
   });
-  const previousIsExactLegacyStable =
-    previous.manifest.channel.name === STABLE_RELEASE_CHANNEL
-    && previous.manifest.application.bundleVersion
-      === LEGACY_STABLE_MACOS_BUNDLE_VERSION
-    && previous.manifest.application.shortVersion
-      === LEGACY_STABLE_MACOS_BUNDLE_VERSION;
+  const legacyStablePreviousCapability = isExactLegacyStablePreviousRelease(
+    previous.manifest,
+  ) ? Object.freeze({}) : null;
+  if (legacyStablePreviousCapability !== null) {
+    VERIFIED_LEGACY_STABLE_CAPABILITIES.add(legacyStablePreviousCapability);
+  }
   const previousArtifactCapability = isExactLegacyDogfoodPreviousRelease(
     previous.manifest,
   ) ? Object.freeze({}) : null;
@@ -2175,7 +2281,10 @@ export async function validateMacOSSignedReplacementArtifacts({
   }
   try {
     await validateArtifact(previous.artifact, {
-      allowLegacyUnsealedSource: previousIsExactLegacyStable,
+      allowLegacyUnsealedSource: legacyStablePreviousCapability !== null,
+      ...(legacyStablePreviousCapability !== null ? {
+        [VERIFIED_LEGACY_STABLE_PREVIOUS_ARTIFACT]: legacyStablePreviousCapability,
+      } : {}),
       ...(previousArtifactCapability !== null ? {
         [VERIFIED_LEGACY_DOGFOOD_PREVIOUS_ARTIFACT]: previousArtifactCapability,
       } : {}),
@@ -2193,6 +2302,9 @@ export async function validateMacOSSignedReplacementArtifacts({
     }
     if (preMigrationPreviousCapability !== null) {
       VERIFIED_PRE_MIGRATION_CAPABILITIES.delete(preMigrationPreviousCapability);
+    }
+    if (legacyStablePreviousCapability !== null) {
+      VERIFIED_LEGACY_STABLE_CAPABILITIES.delete(legacyStablePreviousCapability);
     }
   }
   await validateArtifact(candidate.artifact, {
@@ -2916,6 +3028,7 @@ export async function validateInstalledMacOSApp(appPath, {
   allowLegacyUnsealedSource = false,
   [VERIFIED_LEGACY_DOGFOOD_PREVIOUS_ARTIFACT]: legacyDogfoodPreviousCapability = null,
   [VERIFIED_PRE_MIGRATION_PREVIOUS_ARTIFACT]: preMigrationPreviousCapability = null,
+  [VERIFIED_LEGACY_STABLE_PREVIOUS_ARTIFACT]: legacyStablePreviousCapability = null,
   channel = "stable",
   expectedBundleIdentifier = null,
   expectedBundleVersion = null,
@@ -2924,10 +3037,12 @@ export async function validateInstalledMacOSApp(appPath, {
 } = {}) {
   validateLegacyDogfoodPreviousCapability(legacyDogfoodPreviousCapability);
   validatePreMigrationPreviousCapability(preMigrationPreviousCapability);
+  validateLegacyStablePreviousCapability(legacyStablePreviousCapability);
   const inspected = await inspectMacOSApp(appPath, {
     allowLegacyUnsealedSource,
     [VERIFIED_LEGACY_DOGFOOD_PREVIOUS_ARTIFACT]: legacyDogfoodPreviousCapability,
     [VERIFIED_PRE_MIGRATION_PREVIOUS_ARTIFACT]: preMigrationPreviousCapability,
+    [VERIFIED_LEGACY_STABLE_PREVIOUS_ARTIFACT]: legacyStablePreviousCapability,
     channel,
     requireExternalDistribution: production,
   });
@@ -3044,6 +3159,7 @@ export async function validateMacOSDMG(path, {
   allowLegacyUnsealedSource = false,
   [VERIFIED_LEGACY_DOGFOOD_PREVIOUS_ARTIFACT]: legacyDogfoodPreviousCapability = null,
   [VERIFIED_PRE_MIGRATION_PREVIOUS_ARTIFACT]: preMigrationPreviousCapability = null,
+  [VERIFIED_LEGACY_STABLE_PREVIOUS_ARTIFACT]: legacyStablePreviousCapability = null,
   channel = "stable",
   distribution = null,
   expectedBundleIdentifier = null,
@@ -3057,10 +3173,14 @@ export async function validateMacOSDMG(path, {
   const preMigrationPrevious = validatePreMigrationPreviousCapability(
     preMigrationPreviousCapability,
   );
+  const legacyStablePrevious = validateLegacyStablePreviousCapability(
+    legacyStablePreviousCapability,
+  );
   const selectedDistribution = distribution ?? (
     production ? DMG_DISTRIBUTIONS.release : DMG_DISTRIBUTIONS.development
   );
   if (typeof allowLegacyUnsealedSource !== "boolean"
+      || (allowLegacyUnsealedSource && !legacyStablePrevious)
       || (allowLegacyUnsealedSource && !production)
       || !Object.values(DMG_DISTRIBUTIONS).includes(selectedDistribution)
       || production !== (selectedDistribution === DMG_DISTRIBUTIONS.release)) {
@@ -3075,6 +3195,16 @@ export async function validateMacOSDMG(path, {
     : PRODUCT_BRAND;
   const selected = resolve(path);
   const metadata = await regularPath(selected);
+  if (legacyStablePrevious
+      && (!production || channel !== STABLE_RELEASE_CHANNEL
+        || metadata.size !== LEGACY_STABLE_PREVIOUS_RELEASE.artifactBytes
+        || await sha256File(selected)
+          !== LEGACY_STABLE_PREVIOUS_RELEASE.artifactSha256)) {
+    fail(
+      "Legacy stable compatibility requires the exact previous DMG bytes",
+      "MACOS_LEGACY_SOURCE_COMPATIBILITY_INVALID",
+    );
+  }
   if (legacyDogfoodPrevious
       && (!production || channel !== INTERNAL_DOGFOOD_RELEASE_CHANNEL
         || metadata.size !== LEGACY_DOGFOOD_PREVIOUS_RELEASE.artifactBytes
@@ -3172,6 +3302,7 @@ export async function validateMacOSDMG(path, {
       allowLegacyUnsealedSource,
       [VERIFIED_LEGACY_DOGFOOD_PREVIOUS_ARTIFACT]: legacyDogfoodPreviousCapability,
       [VERIFIED_PRE_MIGRATION_PREVIOUS_ARTIFACT]: preMigrationPreviousCapability,
+      [VERIFIED_LEGACY_STABLE_PREVIOUS_ARTIFACT]: legacyStablePreviousCapability,
       channel,
       expectedBundleIdentifier,
       expectedBundleVersion,

--- a/scripts/qualify-pr94-attribution.mjs
+++ b/scripts/qualify-pr94-attribution.mjs
@@ -303,7 +303,9 @@ export async function runPr94Qualification(options, { signal = null } = {}) {
     }
     cancelled(signal);
     const receipt = {
-      schema: "pr94-admitted-index-comparison-v1", status: "passed",
+      schema: "pr94-admitted-index-comparison-v2",
+      status: productionResources.after.status === "historical_artifact_refused"
+        ? "passed_with_historical_artifact_refusal" : "passed",
       scope: "fixed_admitted_index_analysis_not_raw_ingestion_or_hosted_activation",
       sources, index: { sha256: indexSha256, bytes: indexStat.size },
       window: { startAt: options.startAt, endAt: options.endAt }, comparison,

--- a/scripts/qualify-pr94-attribution.mjs
+++ b/scripts/qualify-pr94-attribution.mjs
@@ -18,7 +18,9 @@ import {
   disposePr94CalibrationEvidencePrivate,
 } from "./lib/pr94-calibration-evidence.mjs";
 import { runPr94ProductionResourceWorker, PR94_PRODUCTION_ERROR_CODES } from "./lib/pr94-production-resource-worker.mjs";
-import { validatePr94AnalysisResult, validatePr94ComparisonReceipt } from "./lib/pr94-receipt-validation.mjs";
+import {
+  validatePr94AnalysisResult, validatePr94ComparisonEvidence, validatePr94ComparisonReceipt,
+} from "./lib/pr94-receipt-validation.mjs";
 import { PR94_ANALYSIS_ERROR_CODES } from "./lib/pr94-analysis-worker.mjs";
 
 export const PR94_COMPARISON_REVISIONS = Object.freeze({
@@ -275,6 +277,10 @@ export async function runPr94Qualification(options, { signal = null } = {}) {
         || Object.values(evidence).some((value) => value.analysis.populationEvidence.unknownAccountOnlyWithheldEvents !== 0)) {
       fail("pr94_comparison_not_passed");
     }
+    const publicEvidence = Object.fromEntries(Object.entries(evidence).map(([side, value]) => [side, value.analysis]));
+    // Validate the exact semantic projection before starting the six expensive
+    // production probes. Final receipt validation checks this same object again.
+    validatePr94ComparisonEvidence({ comparison, evidence: publicEvidence });
     for (const value of Object.values(evidence)) {
       disposePr94LedgerEvidencePrivate(value.ledger);
       if (value.calibration !== null) disposePr94CalibrationEvidencePrivate(value.calibration);
@@ -310,7 +316,7 @@ export async function runPr94Qualification(options, { signal = null } = {}) {
       sources, index: { sha256: indexSha256, bytes: indexStat.size },
       window: { startAt: options.startAt, endAt: options.endAt }, comparison,
       measurements, productionResources,
-      evidence: Object.fromEntries(Object.entries(evidence).map(([side, value]) => [side, value.analysis])),
+      evidence: publicEvidence,
     };
     validatePr94ComparisonReceipt(receipt);
     await publishPr94Receipt(options.outputDirectory, receipt, { signal });

--- a/scripts/qualify-pr94-attribution.mjs
+++ b/scripts/qualify-pr94-attribution.mjs
@@ -1,0 +1,345 @@
+import { spawn } from "node:child_process";
+import { createHash, randomBytes } from "node:crypto";
+import { createReadStream } from "node:fs";
+import { link, lstat, mkdir, open, readFile, realpath, unlink } from "node:fs/promises";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { isDeepStrictEqual } from "node:util";
+import {
+  digestDetailedAccountingBenchmarkFile, inspectDetailedAccountingBenchmarkIndex,
+  parseMacOsTimeMetrics, runBoundedBenchmarkCommand, snapshotDetailedAccountingDependencies,
+} from "./benchmark-detailed-accounting.mjs";
+import {
+  importPr94LedgerEvidencePrivate, comparePr94LedgerEvidence,
+  disposePr94LedgerEvidencePrivate,
+} from "./lib/pr94-ledger-evidence.mjs";
+import {
+  importPr94CalibrationEvidence, comparePr94CalibrationEvidence,
+  disposePr94CalibrationEvidencePrivate,
+} from "./lib/pr94-calibration-evidence.mjs";
+import { runPr94ProductionResourceWorker, PR94_PRODUCTION_ERROR_CODES } from "./lib/pr94-production-resource-worker.mjs";
+import { validatePr94AnalysisResult, validatePr94ComparisonReceipt } from "./lib/pr94-receipt-validation.mjs";
+import { PR94_ANALYSIS_ERROR_CODES } from "./lib/pr94-analysis-worker.mjs";
+
+export const PR94_COMPARISON_REVISIONS = Object.freeze({
+  before: "a3c850360bc83c0e27bef2171aeb4a302b72f472",
+  after: "20f449ff5c222989029fe343f219f02b497ae1d4",
+});
+const HASH = /^[0-9a-f]{64}$/u;
+const REVISION = /^[0-9a-f]{40}$/u;
+const MAX_RSS = 6_442_450_944;
+const WORKER = fileURLToPath(new URL("./lib/pr94-analysis-worker.mjs", import.meta.url));
+const HARNESS_ROOT = fileURLToPath(new URL("../", import.meta.url)).replace(/\/$/u, "");
+const KEYS = ["beforeRoot", "afterRoot", "finalRoot", "indexFile", "outputDirectory", "startAt", "endAt"];
+function fail(code) { throw Object.assign(new Error(code), { code }); }
+function cancelled(signal) { if (signal?.aborted) fail("pr94_cancelled"); }
+function hash(value) { return createHash("sha256").update(value).digest("hex"); }
+function exact(value, keys) {
+  return value && typeof value === "object" && !Array.isArray(value)
+    && Object.keys(value).sort().join("|") === [...keys].sort().join("|");
+}
+
+export function parsePr94QualificationArguments(argv) {
+  const flags = new Map([
+    ["--before-root", "beforeRoot"], ["--after-root", "afterRoot"], ["--final-root", "finalRoot"],
+    ["--index", "indexFile"], ["--output-dir", "outputDirectory"],
+    ["--start-at", "startAt"], ["--end-at", "endAt"], ["--timeout-seconds", "timeoutSeconds"],
+  ]);
+  const options = { timeoutSeconds: 1800 }; const seen = new Set();
+  for (let i = 0; i < argv.length; i += 1) {
+    const flag = argv[i];
+    if (seen.has(flag)) fail("pr94_arguments_invalid");
+    seen.add(flag);
+    if (flag === "--allow-private-attribution-comparison") continue;
+    const key = flags.get(flag); const value = argv[++i];
+    if (!key || !value || value.startsWith("--")) fail("pr94_arguments_invalid");
+    options[key] = key === "timeoutSeconds" ? Number(value) : value;
+  }
+  if (!seen.has("--allow-private-attribution-comparison")) fail("pr94_approval_required");
+  if (!KEYS.every((key) => typeof options[key] === "string" && options[key].length > 0)
+      || !Number.isSafeInteger(options.timeoutSeconds) || options.timeoutSeconds < 1
+      || options.timeoutSeconds > 3600) fail("pr94_arguments_invalid");
+  for (const key of ["startAt", "endAt"]) {
+    if (!Number.isSafeInteger(Date.parse(options[key]))
+        || new Date(options[key]).toISOString() !== options[key]) fail("pr94_arguments_invalid");
+  }
+  if (options.endAt <= options.startAt) fail("pr94_arguments_invalid");
+  for (const key of KEYS.filter((key) => key.endsWith("Root") || key.endsWith("File") || key.endsWith("Directory"))) {
+    options[key] = resolve(options[key]);
+  }
+  return { ...options, privateOperationApproved: true };
+}
+
+async function privateDirectory(path) {
+  const metadata = await lstat(path);
+  if (!metadata.isDirectory() || metadata.isSymbolicLink() || metadata.uid !== process.getuid()
+      || (metadata.mode & 0o077) !== 0 || await realpath(path) !== path) fail("pr94_path_invalid");
+}
+async function privateFile(path, maximumBytes) {
+  const metadata = await lstat(path);
+  if (!metadata.isFile() || metadata.isSymbolicLink() || metadata.nlink !== 1
+      || metadata.uid !== process.getuid() || (metadata.mode & 0o077) !== 0
+      || metadata.size < 1 || metadata.size > maximumBytes) fail("pr94_path_invalid");
+  return metadata;
+}
+async function sourceIdentity(root, signal) {
+  const command = (args) => runBoundedBenchmarkCommand("/usr/bin/git", ["-C", root, ...args], { signal });
+  if (await realpath(root) !== root) fail("pr94_source_invalid");
+  const revision = (await command(["rev-parse", "HEAD"])).stdout.trim();
+  if (!REVISION.test(revision)
+      || (await command(["status", "--porcelain=v1", "--untracked-files=all"])).stdout !== "") {
+    fail("pr94_source_invalid");
+  }
+  return { revision, dependencies: await snapshotDetailedAccountingDependencies(root, { signal }) };
+}
+
+export async function* readPr94PrivateFrames(path, signal) {
+  const initial = await privateFile(path, 512 * 1024 * 1024);
+  const stream = createReadStream(path, { highWaterMark: 64 * 1024 });
+  const abort = () => stream.destroy();
+  signal?.addEventListener("abort", abort, { once: true });
+  let pending = Buffer.alloc(0);
+  let frames = 0;
+  let bytes = 0;
+  try {
+    cancelled(signal);
+    for await (const chunk of stream) {
+      cancelled(signal);
+      bytes += chunk.length;
+      if (bytes > initial.size) fail("pr94_private_frames_invalid");
+      const combined = Buffer.concat([pending, chunk]);
+      let start = 0;
+      for (let end = combined.indexOf(10, start); end >= 0; end = combined.indexOf(10, start)) {
+        cancelled(signal);
+        if (++frames > 2_000_010 || end - start < 1 || end - start > 1024 * 1024) {
+          fail("pr94_private_frames_invalid");
+        }
+        let frame;
+        try { frame = JSON.parse(combined.subarray(start, end).toString("utf8")); }
+        catch { fail("pr94_private_frames_invalid"); }
+        yield frame;
+        start = end + 1;
+      }
+      pending = Buffer.from(combined.subarray(start));
+      if (pending.length > 1024 * 1024) fail("pr94_private_frames_invalid");
+    }
+    cancelled(signal);
+    if (pending.length !== 0 || bytes !== initial.size) fail("pr94_private_frames_invalid");
+    const final = await privateFile(path, 512 * 1024 * 1024);
+    for (const key of ["dev", "ino", "size", "mtimeMs", "ctimeMs"]) {
+      if (initial[key] !== final[key]) fail("pr94_private_frames_invalid");
+    }
+  } finally { signal?.removeEventListener("abort", abort); stream.destroy(); }
+}
+
+// Exclusive final link is the commit point. The temporary file is fsynced
+// first; a canceled/error path revokes only the exact file created by this run.
+// Existing receipts are never replaced, including races at publication.
+export async function publishPr94Receipt(directory, receipt, {
+  signal = null, closeFile = (file) => file.close(),
+} = {}) {
+  cancelled(signal);
+  await privateDirectory(directory);
+  const temporary = join(directory, "comparison.partial.json");
+  const destination = join(directory, "comparison.json");
+  const body = Buffer.from(JSON.stringify(receipt));
+  if (body.length > 4 * 1024 * 1024) fail("pr94_artifact_invalid");
+  const file = await open(temporary, "wx", 0o600);
+  let identity;
+  let committed = false;
+  let closed = false;
+  try {
+    identity = await file.stat();
+    await file.writeFile(body);
+    await file.sync();
+    cancelled(signal);
+    await link(temporary, destination);
+    committed = true;
+    cancelled(signal);
+    await unlink(temporary);
+    await closeFile(file);
+    closed = true;
+    const folder = await open(directory, "r");
+    try { await folder.sync(); } finally { await folder.close(); }
+    cancelled(signal);
+  } catch (error) {
+    if (committed) {
+      const current = await lstat(destination).catch(() => null);
+      if (identity && current?.dev === identity.dev && current?.ino === identity.ino) await unlink(destination);
+    }
+    if (!closed) await file.close();
+    const current = await lstat(temporary).catch(() => null);
+    if (identity && current?.dev === identity.dev && current?.ino === identity.ino) await unlink(temporary);
+    throw error;
+  }
+}
+
+export function parsePr94AnalysisEnvelope(text) {
+  let value;
+  try { value = JSON.parse(text); } catch { fail("pr94_envelope_invalid"); }
+  if (value?.status === "error") {
+    // Fixed worker codes only; never relay arbitrary subprocess diagnostics.
+    if (!exact(value, ["status", "code"]) || !PR94_ANALYSIS_ERROR_CODES.includes(value.code)) fail("pr94_envelope_invalid");
+    fail(value.code);
+  }
+  if (!exact(value, ["status", "resultBytes", "resultSha256"]) || value.status !== "ok"
+      || !Number.isSafeInteger(value.resultBytes) || value.resultBytes < 1
+      || value.resultBytes > 4 * 1024 * 1024 || !HASH.test(value.resultSha256)) fail("pr94_envelope_invalid");
+  return value;
+}
+
+async function readAnalysis(directory, envelope, signal) {
+  cancelled(signal);
+  const path = join(directory, "analysis.json");
+  const metadata = await privateFile(path, 4 * 1024 * 1024);
+  const bytes = await readFile(path);
+  if (metadata.size !== envelope.resultBytes || bytes.length !== envelope.resultBytes
+      || hash(bytes) !== envelope.resultSha256) fail("pr94_artifact_mismatch");
+  let analysis;
+  try { analysis = JSON.parse(bytes); } catch { fail("pr94_artifact_invalid"); }
+  return validatePr94AnalysisResult(analysis);
+}
+
+// The public receipt is constructed anew: private row fingerprints, report
+// objects, identifiers, filenames, absolute paths and HMAC keys never enter it.
+export async function runPr94Qualification(options, { signal = null } = {}) {
+  if (options?.privateOperationApproved !== true) fail("pr94_approval_required");
+  if (process.version !== "v26.2.0" || process.platform !== "darwin" || process.arch !== "arm64") {
+    fail("pr94_runtime_invalid");
+  }
+  if (options.finalRoot !== await realpath(HARNESS_ROOT)) fail("pr94_source_invalid");
+  cancelled(signal);
+  const roots = { before: options.beforeRoot, after: options.afterRoot, final: options.finalRoot };
+  const sources = {};
+  for (const side of Object.keys(roots)) sources[side] = await sourceIdentity(roots[side], signal);
+  for (const side of ["before", "after"]) {
+    if (sources[side].revision !== PR94_COMPARISON_REVISIONS[side]) fail("pr94_revision_mismatch");
+  }
+  if (sources.before.dependencies.runtimeSha256 !== sources.after.dependencies.runtimeSha256
+      || sources.before.dependencies.lockSha256 !== sources.after.dependencies.lockSha256) {
+    fail("pr94_dependency_mismatch");
+  }
+  const indexStat = await inspectDetailedAccountingBenchmarkIndex(options.indexFile);
+  const indexSha256 = await digestDetailedAccountingBenchmarkFile(options.indexFile, indexStat, { signal });
+  await privateDirectory(dirname(options.outputDirectory));
+  await mkdir(options.outputDirectory, { mode: 0o700 });
+  await privateDirectory(options.outputDirectory);
+  const key = randomBytes(32);
+  const evidence = {}; const measurements = {};
+  let privateEvidenceDisposed = false;
+  try {
+    for (const side of ["before", "after", "final"]) {
+      cancelled(signal);
+      const directory = join(options.outputDirectory, side);
+      await mkdir(directory, { mode: 0o700 });
+      const request = Buffer.from(JSON.stringify({ root: roots[side], indexFile: options.indexFile,
+        outputDirectory: directory, revisionKind: side, startAt: options.startAt, endAt: options.endAt,
+        hmacKey: key.toString("hex") }));
+      let output;
+      try { output = await runBoundedBenchmarkCommand("/usr/bin/time", ["-l", process.execPath,
+        "--max-old-space-size=6144", WORKER], {
+        cwd: directory, env: { LC_ALL: "C", TMPDIR: directory }, signal,
+        timeoutMs: options.timeoutSeconds * 1000,
+        spawnCommand(command, args, settings) {
+          const child = spawn(command, args, settings);
+          child.stdin.end(request);
+          return child;
+        },
+      }); } finally { request.fill(0); }
+      const envelope = parsePr94AnalysisEnvelope(output.stdout);
+      measurements[side] = parseMacOsTimeMetrics(output.stderr);
+      if (measurements[side].peakRssBytes > MAX_RSS) fail("pr94_resource_limit");
+      const analysis = await readAnalysis(directory, envelope, signal);
+      if (analysis.revisionKind !== side) fail("pr94_artifact_invalid");
+      const ledger = await importPr94LedgerEvidencePrivate(
+        readPr94PrivateFrames(join(directory, "ledger.ndjson"), signal), { hmacKey: key, maxRows: 2_000_000 });
+      evidence[side] = { analysis, ledger, calibration: null };
+      // Sealed transport canonicalizes object keys. Property insertion order is
+      // not accounting evidence and must not make an otherwise exact fold fail.
+      if (!isDeepStrictEqual(ledger, analysis.ledger)) fail("pr94_artifact_mismatch");
+      const calibration = await importPr94CalibrationEvidence({ aggregate: analysis.calibration,
+        frames: readPr94PrivateFrames(join(directory, "calibration.ndjson"), signal), hmacKey: key });
+      evidence[side].calibration = calibration;
+    }
+    const comparison = {
+      attributionLedger: comparePr94LedgerEvidence(evidence.before.ledger, evidence.after.ledger),
+      finalLedger: comparePr94LedgerEvidence(evidence.after.ledger, evidence.final.ledger),
+      attributionCalibration: comparePr94CalibrationEvidence(evidence.before.calibration, evidence.after.calibration),
+      finalCalibration: comparePr94CalibrationEvidence(evidence.after.calibration, evidence.final.calibration),
+      readerEvidenceUnchanged: ["inventory", "coverage", "generation"].every((key) =>
+        ["after", "final"].every((side) => isDeepStrictEqual(evidence.before.analysis[key], evidence[side].analysis[key]))),
+    };
+    if (comparison.attributionLedger.status !== "equal" || comparison.finalLedger.status !== "equal"
+        || comparison.attributionCalibration.status !== "pass" || comparison.finalCalibration.status !== "pass"
+        || !comparison.readerEvidenceUnchanged
+        || Object.values(evidence).some((value) => value.analysis.populationEvidence.unknownAccountOnlyWithheldEvents !== 0)) {
+      fail("pr94_comparison_not_passed");
+    }
+    for (const value of Object.values(evidence)) {
+      disposePr94LedgerEvidencePrivate(value.ledger);
+      if (value.calibration !== null) disposePr94CalibrationEvidencePrivate(value.calibration);
+    }
+    privateEvidenceDisposed = true;
+    const productionResources = {};
+    for (const side of ["before", "after", "final"]) {
+      cancelled(signal);
+      productionResources[side] = await runPr94ProductionResourceWorker({
+        privateOperationApproved: true, root: roots[side], expectedRevision: sources[side].revision,
+        indexFile: options.indexFile,
+        expectedIndex: { sha256: indexSha256, bytes: indexStat.size,
+          generationId: evidence[side].analysis.generation.id },
+        outputDirectory: join(options.outputDirectory, `production-${side}`),
+        startAt: options.startAt, endAt: options.endAt, timeoutSeconds: options.timeoutSeconds,
+      }, { signal });
+    }
+    for (const side of Object.keys(roots)) {
+      if (!isDeepStrictEqual(await sourceIdentity(roots[side], signal), sources[side])) {
+        fail("pr94_source_changed");
+      }
+    }
+    if (await digestDetailedAccountingBenchmarkFile(options.indexFile,
+      await inspectDetailedAccountingBenchmarkIndex(options.indexFile), { signal }) !== indexSha256) {
+      fail("pr94_index_changed");
+    }
+    cancelled(signal);
+    const receipt = {
+      schema: "pr94-admitted-index-comparison-v1", status: "passed",
+      scope: "fixed_admitted_index_analysis_not_raw_ingestion_or_hosted_activation",
+      sources, index: { sha256: indexSha256, bytes: indexStat.size },
+      window: { startAt: options.startAt, endAt: options.endAt }, comparison,
+      measurements, productionResources,
+      evidence: Object.fromEntries(Object.entries(evidence).map(([side, value]) => [side, value.analysis])),
+    };
+    validatePr94ComparisonReceipt(receipt);
+    await publishPr94Receipt(options.outputDirectory, receipt, { signal });
+    return receipt;
+  } finally {
+    key.fill(0);
+    for (const value of privateEvidenceDisposed ? [] : Object.values(evidence)) {
+      disposePr94LedgerEvidencePrivate(value.ledger);
+      if (value.calibration !== null) disposePr94CalibrationEvidencePrivate(value.calibration);
+    }
+  }
+}
+
+if (process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  const controller = new AbortController();
+  process.once("SIGTERM", () => controller.abort());
+  process.once("SIGINT", () => controller.abort());
+  try {
+    const receipt = await runPr94Qualification(parsePr94QualificationArguments(process.argv.slice(2)),
+      { signal: controller.signal });
+    process.stdout.write(`${JSON.stringify({ status: receipt.status })}\n`);
+  } catch (error) {
+    const known = new Set(["pr94_approval_required", "pr94_arguments_invalid", "pr94_runtime_invalid",
+      "pr94_path_invalid", "pr94_source_invalid", "pr94_revision_mismatch", "pr94_dependency_mismatch",
+      "pr94_artifact_invalid", "pr94_artifact_mismatch", "pr94_envelope_invalid", "pr94_analysis_refused",
+      "pr94_private_frames_invalid", "pr94_resource_limit", "pr94_comparison_not_passed",
+      "pr94_receipt_analysis_invalid", "pr94_receipt_comparison_invalid",
+      "pr94_source_changed", "pr94_index_changed", "pr94_cancelled", ...PR94_ANALYSIS_ERROR_CODES,
+      ...PR94_PRODUCTION_ERROR_CODES]);
+    process.stdout.write(`${JSON.stringify({ status: "failed", code: known.has(error?.code)
+      ? error.code : "pr94_qualification_failed" })}\n`);
+    process.exitCode = 1;
+  }
+}

--- a/test/macos-app-bundle.test.js
+++ b/test/macos-app-bundle.test.js
@@ -5287,10 +5287,11 @@ test("signed updater replacement contract validates upgrade and rollback artifac
         previousBundleVersion: "0.1.16",
       },
     );
-    assert.doesNotThrow(() => validateMacOSSignedReplacementPair({
+    assert.throws(() => validateMacOSSignedReplacementPair({
       previousManifest: legacyStableManifest,
       candidateManifest: epochCandidateManifest,
-    }));
+    }), { code: "MACOS_LEGACY_SOURCE_COMPATIBILITY_INVALID" },
+    "a legacy version alone remains a continuity input, not exact previous-artifact proof");
     for (const rejectedLegacySource of ["0.1.17", "0.2.0"]) {
       const rejectedManifest = {
         ...legacyStableManifest,
@@ -5666,31 +5667,15 @@ test("signed updater replacement contract validates upgrade and rollback artifac
       JSON.stringify(epochCandidateManifest),
     );
     const legacyValidatedArtifacts = [];
-    await validateMacOSSignedReplacementArtifacts({
+    await assert.rejects(validateMacOSSignedReplacementArtifacts({
       previousReleaseManifestPath: previousManifestPath,
       candidateReleaseManifestPath: candidateManifestPath,
       async validateArtifact(path, options) {
         legacyValidatedArtifacts.push([path, options]);
       },
-    });
-    assert.deepEqual(legacyValidatedArtifacts, [
-      [
-        join(temporaryRoot, legacyStableManifest.artifact.fileName),
-        {
-          allowLegacyUnsealedSource: true,
-          channel: STABLE_RELEASE_CHANNEL,
-          production: true,
-        },
-      ],
-      [
-        join(temporaryRoot, epochCandidateManifest.artifact.fileName),
-        {
-          allowLegacyUnsealedSource: false,
-          channel: STABLE_RELEASE_CHANNEL,
-          production: true,
-        },
-      ],
-    ]);
+    }), { code: "MACOS_LEGACY_SOURCE_COMPATIBILITY_INVALID" });
+    assert.deepEqual(legacyValidatedArtifacts, [],
+      "unbound legacy artifacts cannot reach native validation or obtain compatibility");
     await writeFile(
       previousManifestPath,
       JSON.stringify(previousManifest),
@@ -5942,14 +5927,14 @@ test("legacy dogfood capability rejects Proxy-forged identities before any artif
         { code: "MACOS_LEGACY_SOURCE_COMPATIBILITY_INVALID" },
         `${name} must reject a supplied non-member identity before path resolution`,
       );
-      assert.equal(symbolReads, 2, "both private compatibility reads were exercised");
-      assert.equal(new Set(observedSymbols).size, 2);
+      assert.equal(symbolReads, 3, "all private compatibility reads were exercised");
+      assert.equal(new Set(observedSymbols).size, 3);
       for (const [index, observedSymbol] of observedSymbols.entries()) {
         await assert.rejects(
           validate(null, { ...baseOptions, [observedSymbol]: forged }),
-          { code: index === 0 ? "MACOS_LEGACY_SOURCE_COMPATIBILITY_INVALID"
-            : "MACOS_KEYCHAIN_MIGRATION_COMPATIBILITY_INVALID" },
-          `${name} must reject a forged value replayed with either captured Symbol`,
+          { code: index === 1 ? "MACOS_KEYCHAIN_MIGRATION_COMPATIBILITY_INVALID"
+            : "MACOS_LEGACY_SOURCE_COMPATIBILITY_INVALID" },
+          `${name} must reject a forged value replayed with each captured Symbol`,
         );
       }
     }

--- a/test/macos-app-bundle.test.js
+++ b/test/macos-app-bundle.test.js
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import { execFileSync, spawn, spawnSync } from "node:child_process";
 import { createHash } from "node:crypto";
 import { createServer } from "node:http";
+import { writeFileSync } from "node:fs";
 import {
   appendFile,
   chmod,
@@ -75,8 +76,10 @@ import {
   parseMacOSBuildArguments,
   pinnedPackage,
   pinnedPackageTreeDigest,
+  readMacOSReleaseSourceTimestamp,
   stageMacOSWebModules,
   stageMacOSWorkspaceRuntimePackages,
+  setMacOSBundleFinderMetadata,
   installMacOSExternalBuildOutput,
   validateMacOSPreviewApp,
   validateMacOSPreviewOutputPath,
@@ -338,6 +341,172 @@ test("reviewed product brand owns the native bundle and semantic-open identity",
     "keychainAccount",
   ]) {
     assert.notEqual(PREVIEW_PRODUCT_BRAND[key], PRODUCT_BRAND[key], key);
+  }
+});
+
+test("external release Finder metadata is bound to the source revision", () => {
+  const commit = execFileSync(
+    "/usr/bin/git",
+    ["-C", REPOSITORY_ROOT, "rev-parse", "HEAD"],
+    { encoding: "utf8" },
+  ).trim();
+  const expectedTimestamp = Number(execFileSync(
+    "/usr/bin/git",
+    ["-C", REPOSITORY_ROOT, "show", "-s", "--format=%ct", commit],
+    { encoding: "utf8" },
+  ).trim());
+  const timestamp = readMacOSReleaseSourceTimestamp({ commit });
+  assert.equal(timestamp, expectedTimestamp);
+  assert.notEqual(timestamp, 946_684_800);
+
+  const calls = [];
+  assert.deepEqual(
+    setMacOSBundleFinderMetadata("/private/tmp/TiboTattle.app", {
+      birthTimeSeconds: timestamp,
+      commandRunner: (...arguments_) => calls.push(arguments_),
+    }),
+    {
+      birthTimeSeconds: timestamp,
+      modificationTimeSeconds: timestamp,
+    },
+  );
+  assert.equal(calls.length, 1);
+  assert.equal(calls[0][0], "/usr/bin/SetFile");
+  assert.deepEqual(calls[0][1].slice(0, 1), ["-d"]);
+  assert.equal(calls[0][1][2], "-m");
+  assert.equal(calls[0][1][1], calls[0][1][3]);
+  const expectedDate = new Date(timestamp * 1_000);
+  const pad = (value) => String(value).padStart(2, "0");
+  assert.equal(
+    calls[0][1][1],
+    `${pad(expectedDate.getUTCMonth() + 1)}/${pad(expectedDate.getUTCDate())}/${expectedDate.getUTCFullYear()} `
+      + `${pad(expectedDate.getUTCHours())}:${pad(expectedDate.getUTCMinutes())}:${pad(expectedDate.getUTCSeconds())}`,
+  );
+  assert.equal(calls[0][1][4], "/private/tmp/TiboTattle.app");
+  assert.deepEqual(calls[0][2], {
+    env: {
+      PATH: "/usr/bin:/bin:/usr/sbin:/sbin",
+      TZ: "UTC",
+    },
+  });
+});
+
+test("SetFile normalizes bundle birth and modification dates", {
+  skip: process.platform === "darwin"
+    ? false
+    : "requires macOS SetFile",
+}, async () => {
+  const temporaryRoot = await mkdtemp(
+    join(await realpath(tmpdir()), "usage-monitor-finder-metadata-"),
+  );
+  const app = join(temporaryRoot, "TiboTattle.app");
+  const timestamp = 1_700_000_000;
+  try {
+    await mkdir(app, { recursive: true });
+    setMacOSBundleFinderMetadata(app, {
+      birthTimeSeconds: timestamp,
+    });
+    const metadata = await lstat(app);
+    assert.equal(Math.trunc(metadata.birthtimeMs / 1_000), timestamp);
+    assert.equal(Math.trunc(metadata.mtimeMs / 1_000), timestamp);
+  } finally {
+    await rm(temporaryRoot, { recursive: true, force: true });
+  }
+});
+
+test("release DMG packaging resolves source-bound Finder metadata before hdiutil", {
+  skip: process.platform === "darwin"
+    ? false
+    : "requires macOS release tooling",
+}, async () => {
+  const temporaryRoot = await mkdtemp(
+    join(await realpath(tmpdir()), "usage-monitor-release-finder-metadata-"),
+  );
+  const sourceApp = join(temporaryRoot, "input", "TiboTattle.app");
+  const output = join(temporaryRoot, "output", "TiboTattle-release.dmg");
+  const failedOutput = join(
+    temporaryRoot,
+    "failed-output",
+    "TiboTattle-release.dmg",
+  );
+  const commit = execFileSync(
+    "/usr/bin/git",
+    ["-C", REPOSITORY_ROOT, "rev-parse", "HEAD"],
+    { encoding: "utf8" },
+  ).trim();
+  const expectedTimestamp = readMacOSReleaseSourceTimestamp({ commit });
+  const events = [];
+  const inspectInput = async (appPath, distribution, channel) => {
+    assert.equal(appPath, sourceApp);
+    assert.equal(distribution, "release");
+    assert.equal(channel, STABLE_RELEASE_CHANNEL);
+    return Object.freeze({
+      appPath,
+      shortVersion: RELEASE_VERSION,
+      source: Object.freeze({ commit }),
+    });
+  };
+  const commandRunner = (command, arguments_) => {
+    events.push([command, arguments_[0]]);
+    if (command === "/usr/bin/ditto") {
+      const copied = spawnSync(command, arguments_, {
+        encoding: "utf8",
+      });
+      assert.equal(copied.status, 0, copied.stderr || copied.stdout);
+    } else if (command === "/usr/bin/hdiutil"
+        && arguments_[0] === "create") {
+      writeFileSync(arguments_.at(-1), "synthetic-dmg");
+    }
+    return { stderr: "", stdout: "" };
+  };
+  const finderMetadataSetter = (path, metadata) => {
+    events.push(["/usr/bin/SetFile", path]);
+    setMacOSBundleFinderMetadata(path, metadata);
+  };
+  try {
+    await mkdir(join(sourceApp, "Contents"), { recursive: true });
+    await writeFile(join(sourceApp, "Contents", "marker.txt"), "synthetic");
+    const packaged = await packageMacOSDMG({
+      appPath: sourceApp,
+      output,
+      distribution: "release",
+      channel: STABLE_RELEASE_CHANNEL,
+    }, {
+      commandRunner,
+      finderMetadataSetter,
+      inspectInput,
+    });
+    assert.equal(packaged.output, output);
+    assert.equal(packaged.distribution, "release");
+    assert.equal(packaged.bytes, Buffer.byteLength("synthetic-dmg"));
+    assert.equal(
+      events.findIndex(([command]) => command === "/usr/bin/SetFile")
+        < events.findIndex(([command, action]) =>
+          command === "/usr/bin/hdiutil" && action === "create"),
+      true,
+    );
+    assert.equal(await stat(output).then((metadata) => metadata.isFile()), true);
+
+    await mkdir(dirname(failedOutput), { recursive: true });
+    await assert.rejects(
+      packageMacOSDMG({
+        appPath: sourceApp,
+        output: failedOutput,
+        distribution: "release",
+        channel: STABLE_RELEASE_CHANNEL,
+      }, {
+        commandRunner,
+        finderMetadataSetter() {
+          throw new Error("synthetic SetFile failure");
+        },
+        inspectInput,
+      }),
+      /synthetic SetFile failure/u,
+    );
+    await assert.rejects(lstat(failedOutput), { code: "ENOENT" });
+    assert.equal(expectedTimestamp, readMacOSReleaseSourceTimestamp({ commit }));
+  } finally {
+    await rm(temporaryRoot, { recursive: true, force: true });
   }
 });
 
@@ -4138,6 +4307,57 @@ test("external app output is fresh-only and rejects a TOCTOU target", async () =
       await readFile(join(output, "Contents", "marker.txt"), "utf8"),
       "staged",
     );
+  } finally {
+    await rm(temporaryRoot, { recursive: true, force: true });
+  }
+});
+
+test("external Finder metadata failure happens before output claim", {
+  skip: process.platform === "darwin"
+    ? false
+    : "requires macOS SetFile",
+}, async () => {
+  const temporaryRoot = await mkdtemp(
+    join(await realpath(tmpdir()), "usage-monitor-external-finder-output-"),
+  );
+  const stagedApp = join(temporaryRoot, "staged", "TiboTattle.app");
+  const output = join(temporaryRoot, "output", "TiboTattle.app");
+  const missingStagedApp = join(
+    temporaryRoot,
+    "missing",
+    "TiboTattle.app",
+  );
+  const failedOutput = join(
+    temporaryRoot,
+    "failed-output",
+    "TiboTattle.app",
+  );
+  const finderMetadata = { birthTimeSeconds: 1_700_000_000 };
+  try {
+    await mkdir(join(stagedApp, "Contents"), { recursive: true });
+    await writeFile(join(stagedApp, "Contents", "marker.txt"), "staged");
+    await mkdir(dirname(output), { recursive: true });
+    await installMacOSExternalBuildOutput(stagedApp, output, {
+      finderMetadata,
+    });
+    const outputMetadata = await lstat(output);
+    assert.equal(
+      Math.trunc(outputMetadata.birthtimeMs / 1_000),
+      finderMetadata.birthTimeSeconds,
+    );
+    assert.equal(
+      Math.trunc(outputMetadata.mtimeMs / 1_000),
+      finderMetadata.birthTimeSeconds,
+    );
+
+    await mkdir(dirname(failedOutput), { recursive: true });
+    await assert.rejects(
+      installMacOSExternalBuildOutput(missingStagedApp, failedOutput, {
+        finderMetadata,
+      }),
+      /SetFile|No such file/u,
+    );
+    await assert.rejects(lstat(failedOutput), { code: "ENOENT" });
   } finally {
     await rm(temporaryRoot, { recursive: true, force: true });
   }

--- a/test/macos-keychain-migration-artifact.test.js
+++ b/test/macos-keychain-migration-artifact.test.js
@@ -10,6 +10,7 @@ import {
   createReleaseChannelProvenance,
   getReleaseChannel,
   INTERNAL_DOGFOOD_RELEASE_CHANNEL,
+  STABLE_RELEASE_CHANNEL,
 } from "../config/release-channels.js";
 import {
   MACOS_KEYCHAIN_MIGRATION_HELPER,
@@ -22,7 +23,10 @@ import {
 import {
   createMacOSSignedReplacementContract,
   inspectMacOSApp,
+  validateInstalledMacOSApp,
+  validateMacOSDMG,
   validateMacOSKeychainMigrationSignatureDescriptions,
+  validateMacOSSignedReleaseArtifact,
   validateMacOSSignedReplacementPair,
   verifyMacOSKeychainMigrationSignatures,
 } from "../scripts/macos-release-core.js";
@@ -361,6 +365,352 @@ test("callers cannot forge the previous-only helper compatibility capability", a
   await assert.rejects(inspectMacOSApp("/synthetic/TiboTattle.app", forged), {
     code: "MACOS_KEYCHAIN_MIGRATION_COMPATIBILITY_INVALID",
   });
+});
+
+function legacyStablePreviousManifest() {
+  // Public historical release metadata only; never read the real DMG or user state.
+  const previous = preMigrationPreviousManifest();
+  previous.application.bundleVersion = "0.1.16";
+  previous.application.shortVersion = "0.1.16";
+  previous.artifact = {
+    bytes: 49_341_389,
+    fileName: "TiboTattle-0.1.16-macOS-arm64.dmg",
+    sha256: "5e3e60402ffa3c61d8279f5f759548a8b48084f1ae567eeb1b30156c7f30a9fe",
+  };
+  previous.build = {
+    sourceSha256: "95de0721e5a29ab0988535a55935e516012e9230185bab79d1504b24fc59513a",
+    payloadSha256: "23f41a17bc6f4fede452e53f61972999b7ea144e732cd59807d77aca2ada20e5",
+  };
+  previous.source.commit = "4f30508eff55c122e73025ad06d73b33cadbc508";
+  previous.source.tag = "v0.1.16";
+  previous.updater.publicEdKeySha256 =
+    "ae8a8e00311a4cfc1e7e7f2eedcf7fa53d6bc197997c912a0b8f908e54a28fbf";
+  previous.channel = createReleaseChannelProvenance(STABLE_RELEASE_CHANNEL, {
+    publicEdKeySha256: previous.updater.publicEdKeySha256,
+  });
+  previous.updater.appcastURL = previous.channel.sparkle.appcastURL;
+  return previous;
+}
+
+function stableReplacementCandidate() {
+  const candidate = legacyStablePreviousManifest();
+  candidate.application.bundleVersion = "1024";
+  candidate.application.shortVersion = "0.1.17";
+  candidate.artifact = { bytes: 128, fileName: "candidate.dmg", sha256: "c".repeat(64) };
+  candidate.source.commit = "d".repeat(40);
+  candidate.source.tag = "v0.1.17";
+  return candidate;
+}
+
+test("historical stable compatibility pins every previous receipt field and rejects candidate use", async () => {
+  const previous = legacyStablePreviousManifest();
+  const candidate = stableReplacementCandidate();
+  assert.equal(validateMacOSSignedReplacementPair({
+    previousManifest: previous, candidateManifest: candidate,
+  }).previousBundleVersion, "0.1.16");
+  for (const [section, key, value] of [
+    ["application", "bundleIdentifier", "com.example.other"],
+    ["application", "bundleVersion", "1022"],
+    ["application", "shortVersion", "0.1.15"],
+    ["artifact", "bytes", previous.artifact.bytes - 1],
+    ["artifact", "sha256", "e".repeat(64)],
+    ["artifact", "fileName", "repacked.dmg"],
+    ["source", "commit", "f".repeat(40)],
+    ["source", "repository", "https://github.com/example/other"],
+    ["source", "tag", "v0.1.15"],
+    ["build", "sourceSha256", "a".repeat(64)],
+    ["build", "payloadSha256", "b".repeat(64)],
+    ["updater", "frameworkSha256", "c".repeat(64)],
+    ["updater", "publicEdKeySha256", "d".repeat(64)],
+    ["updater", "appcastURL", "https://updates.example/other.xml"],
+    ["updater", "verifyBeforeExtraction", false],
+    ...Object.keys(previous.assurances).map((key) => ["assurances", key, false]),
+  ]) {
+    const changed = structuredClone(previous);
+    changed[section][key] = value;
+    assert.throws(() => validateMacOSSignedReplacementPair({
+      previousManifest: changed, candidateManifest: candidate,
+    }), (error) => error.code?.startsWith("MACOS_"), `${section}.${key}`);
+  }
+  for (const key of ["source", "build"]) {
+    const changed = structuredClone(previous);
+    delete changed[key];
+    assert.throws(() => validateMacOSSignedReplacementPair({
+      previousManifest: changed, candidateManifest: candidate,
+    }), { code: "MACOS_LEGACY_SOURCE_COMPATIBILITY_INVALID" });
+  }
+  assert.throws(() => validateMacOSSignedReplacementPair({
+    previousManifest: candidate, candidateManifest: previous,
+  }), { code: "MACOS_LEGACY_SOURCE_COMPATIBILITY_INVALID" });
+  const root = await mkdtemp(join(await realpath(tmpdir()), "tibotattle-stable-previous-"));
+  try {
+    const path = join(root, "historical.json");
+    await writeFile(path, JSON.stringify(previous));
+    await assert.rejects(validateMacOSSignedReleaseArtifact({
+      releaseManifestPath: path,
+      validateArtifact() { assert.fail("historical stable must never reach the public installer"); },
+    }), { code: "MACOS_LEGACY_SOURCE_COMPATIBILITY_INVALID" });
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("the public legacy boolean and forged stable capability cannot bypass artifact authorization", async () => {
+  for (const [validate, code] of [
+    [inspectMacOSApp, "MACOS_LEGACY_SOURCE_COMPATIBILITY_INVALID"],
+    [validateInstalledMacOSApp, "MACOS_LEGACY_SOURCE_COMPATIBILITY_INVALID"],
+    [validateMacOSDMG, "MACOS_DMG_DISTRIBUTION_INVALID"],
+  ]) {
+    await assert.rejects(validate(null, {
+      allowLegacyUnsealedSource: true, channel: STABLE_RELEASE_CHANNEL,
+      requireExternalDistribution: true, production: true,
+    }), { code }, "a bare boolean must fail before path resolution");
+    const options = new Proxy({}, {
+      get(target, key) {
+        if (typeof key === "symbol"
+            && key.description === "verified legacy stable previous artifact") return {};
+        return target[key];
+      },
+    });
+    await assert.rejects(validate(null, options), {
+      code: "MACOS_LEGACY_SOURCE_COMPATIBILITY_INVALID",
+    });
+  }
+});
+
+function releaseSourceSection(source, startMarker, endMarker) {
+  const start = source.indexOf(startMarker);
+  const end = source.indexOf(endMarker, start);
+  assert.equal(start >= 0 && end > start, true, startMarker);
+  return source.slice(start, end).replace(/^export /u, "");
+}
+
+test("historical receipt artifact reading rejects changed DMG bytes and size before granting authority", async () => {
+  const source = await readFile(join(REPOSITORY_ROOT, "scripts/macos-release-core.js"), "utf8");
+  const readerSource = releaseSourceSection(source,
+    "async function readReplacementReleaseArtifact(", "\n/**\n * Validate one exact public release artifact");
+  const previous = legacyStablePreviousManifest();
+  for (const [size, digest, accepted] of [
+    [previous.artifact.bytes, previous.artifact.sha256, true],
+    [previous.artifact.bytes - 1, previous.artifact.sha256, false],
+    [previous.artifact.bytes, "0".repeat(64), false],
+  ]) {
+    const readArtifact = runInNewContext(`(${readerSource})`, {
+      resolve, dirname, join,
+      regularPath: async () => ({ size }),
+      readFile: async () => JSON.stringify(previous),
+      sha256File: async () => digest,
+      validateSignedReleaseManifest(manifest) {
+        validateMacOSSignedReplacementPair({
+          previousManifest: manifest, candidateManifest: stableReplacementCandidate(),
+        });
+      },
+      fail(message, code) { throw Object.assign(new Error(message), { code }); },
+    });
+    const reading = readArtifact("/synthetic/previous.json", "Previous release");
+    if (accepted) assert.equal((await reading).manifest.artifact.sha256, previous.artifact.sha256);
+    else await assert.rejects(reading, { code: "MACOS_REPLACEMENT_ARTIFACT_INVALID" });
+  }
+});
+
+test("historical stable DMG validation rechecks exact bytes before native trust commands", async () => {
+  const source = await readFile(join(REPOSITORY_ROOT, "scripts/macos-release-core.js"), "utf8");
+  const dmgSource = releaseSourceSection(source,
+    "export async function validateMacOSDMG(", "\nasync function writeAtomic(");
+  const pin = releaseSourceSection(source,
+    "const LEGACY_STABLE_PREVIOUS_RELEASE =", "// This immutable rc2");
+  const capabilityValidator = releaseSourceSection(source,
+    "function validateLegacyStablePreviousCapability(", "\nfunction resolveOperationalReleaseChannel(");
+  const previous = legacyStablePreviousManifest();
+  const nativeBoundary = new Error("synthetic native trust boundary");
+  for (const [size, digest, channel, accepted] of [
+    [previous.artifact.bytes, previous.artifact.sha256, STABLE_RELEASE_CHANNEL, true],
+    [previous.artifact.bytes - 1, previous.artifact.sha256, STABLE_RELEASE_CHANNEL, false],
+    [previous.artifact.bytes, "0".repeat(64), STABLE_RELEASE_CHANNEL, false],
+    [previous.artifact.bytes, previous.artifact.sha256, INTERNAL_DOGFOOD_RELEASE_CHANNEL, false],
+  ]) {
+    const harness = runInNewContext(`${pin}\n${capabilityValidator}\n${dmgSource}\n`
+      + "const token = Object.freeze({}); VERIFIED_LEGACY_STABLE_CAPABILITIES.add(token);"
+      + "({ validateMacOSDMG, options: { [VERIFIED_LEGACY_STABLE_PREVIOUS_ARTIFACT]: token } })", {
+      resolve, PRODUCT_BRAND, STABLE_RELEASE_CHANNEL,
+      VERIFIED_LEGACY_DOGFOOD_PREVIOUS_ARTIFACT: Symbol("synthetic dogfood"),
+      VERIFIED_PRE_MIGRATION_PREVIOUS_ARTIFACT: Symbol("synthetic pre-migration"),
+      validateLegacyDogfoodPreviousCapability: () => false,
+      validatePreMigrationPreviousCapability: () => false,
+      DMG_DISTRIBUTIONS: { release: "release", preview: "preview", development: "development" },
+      regularPath: async () => ({ size }),
+      sha256File: async () => digest,
+      runMacOSReleaseCommand() { throw nativeBoundary; },
+      fail(message, code) { throw Object.assign(new Error(message), { code }); },
+    });
+    const validation = harness.validateMacOSDMG("/synthetic/previous.dmg", {
+      ...harness.options, channel, production: true,
+    });
+    await assert.rejects(validation, accepted ? (error) => error === nativeBoundary : {
+      code: "MACOS_LEGACY_SOURCE_COMPATIBILITY_INVALID",
+    });
+  }
+});
+
+test("stable previous capabilities expire on success and failure before candidate validation", async () => {
+  const source = await readFile(join(REPOSITORY_ROOT, "scripts/macos-release-core.js"), "utf8");
+  const orchestration = releaseSourceSection(source,
+    "export async function validateMacOSSignedReplacementArtifacts(", "\nfunction releaseEnvironment(");
+  const pin = releaseSourceSection(source,
+    "const LEGACY_STABLE_PREVIOUS_RELEASE =", "// This immutable rc2");
+  const capabilityValidator = releaseSourceSection(source,
+    "function validateLegacyStablePreviousCapability(", "\nfunction resolveOperationalReleaseChannel(");
+  const isExact = releaseSourceSection(source,
+    "function isExactLegacyStablePreviousRelease(", "\nfunction isExactPreMigrationDogfoodPreviousRelease(");
+  const previous = { artifact: "/synthetic/previous.dmg", manifest: legacyStablePreviousManifest() };
+  const candidate = { artifact: "/synthetic/candidate.dmg", manifest: stableReplacementCandidate() };
+  for (const rejectPrevious of [false, true]) {
+    const harness = runInNewContext(`${pin}\n${capabilityValidator}\n${isExact}\n${orchestration}\n`
+      + "({ validateMacOSSignedReplacementArtifacts, validateLegacyStablePreviousCapability })", {
+      STABLE_RELEASE_CHANNEL,
+      BUNDLE_IDENTIFIER: PRODUCT_BRAND.bundleIdentifier,
+      PUBLIC_RELEASE_SOURCE_REPOSITORY: previous.manifest.source.repository,
+      isExactLegacyDogfoodPreviousRelease: () => false,
+      isExactPreMigrationDogfoodPreviousRelease: () => false,
+      validateMacOSSignedReplacementPair,
+      readReplacementReleaseArtifact: async (path) => path === "previous" ? previous : candidate,
+      fail(message, code) { throw Object.assign(new Error(message), { code }); },
+    });
+    let captured = null;
+    const calls = [];
+    const validation = harness.validateMacOSSignedReplacementArtifacts({
+      previousReleaseManifestPath: "previous", candidateReleaseManifestPath: "candidate",
+      async validateArtifact(path, options) {
+        calls.push(path);
+        if (path === previous.artifact) {
+          const keys = Object.getOwnPropertySymbols(options);
+          assert.equal(keys.length, 1);
+          captured = options[keys[0]];
+          assert.equal(harness.validateLegacyStablePreviousCapability(captured), true);
+          assert.equal(options.allowLegacyUnsealedSource, true);
+          if (rejectPrevious) throw new Error("synthetic native rejection");
+        } else {
+          assert.equal(Object.getOwnPropertySymbols(options).length, 0);
+          assert.equal(options.allowLegacyUnsealedSource, false);
+          assert.throws(() => harness.validateLegacyStablePreviousCapability(captured), {
+            code: "MACOS_LEGACY_SOURCE_COMPATIBILITY_INVALID",
+          });
+        }
+      },
+    });
+    if (rejectPrevious) await assert.rejects(validation, /synthetic native rejection/u);
+    else await validation;
+    assert.deepEqual(calls, rejectPrevious ? [previous.artifact] : [previous.artifact, candidate.artifact]);
+    assert.throws(() => harness.validateLegacyStablePreviousCapability(captured), {
+      code: "MACOS_LEGACY_SOURCE_COMPATIBILITY_INVALID",
+    });
+  }
+});
+
+test("historical stable inspection binds the app build digests before accepting legacy payload shape", async () => {
+  const source = await readFile(join(REPOSITORY_ROOT, "scripts/macos-release-core.js"), "utf8");
+  const inspectorSource = releaseSourceSection(source,
+    "export async function inspectMacOSApp(", "\nexport function readMacOSReleaseCredentials(");
+  const pin = releaseSourceSection(source,
+    "const LEGACY_STABLE_PREVIOUS_RELEASE =", "// This immutable rc2");
+  const capabilityValidator = releaseSourceSection(source,
+    "function validateLegacyStablePreviousCapability(", "\nfunction resolveOperationalReleaseChannel(");
+  const previous = legacyStablePreviousManifest();
+  const manifest = {
+    schemaVersion: "usage-monitor-macos-app-build-v0.1",
+    application: previous.application,
+    inputs: { sourceSha256: previous.build.sourceSha256 },
+    payload: { payloadSha256: previous.build.payloadSha256 },
+    release: { updater: previous.updater },
+  };
+  const payloadBoundary = new Error("synthetic payload verification boundary");
+  for (const mutation of [
+    null,
+    (value) => { value.inputs.sourceSha256 = "a".repeat(64); },
+    (value) => { value.payload.payloadSha256 = "b".repeat(64); },
+    (value) => { value.application.bundleVersion = "1024"; },
+    (value) => { value.application.shortVersion = "0.1.17"; },
+    (value) => { value.release.source = { commit: previous.source.commit, tag: previous.source.tag }; },
+    (value) => { value.release.updater.publicEdKeySha256 = "c".repeat(64); },
+    (value) => { value.release.updater.frameworkSha256 = "d".repeat(64); },
+  ]) {
+    const changed = structuredClone(manifest);
+    if (mutation) mutation(changed);
+    const harness = runInNewContext(`${pin}\n${capabilityValidator}\n${inspectorSource}\n`
+      + "const token = Object.freeze({}); VERIFIED_LEGACY_STABLE_CAPABILITIES.add(token);"
+      + "({ inspectMacOSApp, options: { [VERIFIED_LEGACY_STABLE_PREVIOUS_ARTIFACT]: token } })", {
+      resolve, join, basename: (path) => path.split("/").at(-1),
+      STABLE_RELEASE_CHANNEL,
+      APP_NAME: PRODUCT_BRAND.bundleName,
+      BUNDLE_IDENTIFIER: PRODUCT_BRAND.bundleIdentifier,
+      BUILD_MANIFEST_PATH: "Contents/Resources/build-manifest.json",
+      BUILD_MANIFEST_SCHEMA: "usage-monitor-macos-app-build-v0.1",
+      VERIFIED_LEGACY_DOGFOOD_PREVIOUS_ARTIFACT: Symbol("synthetic dogfood"),
+      VERIFIED_PRE_MIGRATION_PREVIOUS_ARTIFACT: Symbol("synthetic pre-migration"),
+      validateLegacyDogfoodPreviousCapability: () => false,
+      validatePreMigrationPreviousCapability: () => false,
+      regularPath: async () => {},
+      readFile: async () => JSON.stringify(changed),
+      verifyMacOSBuildPayload() { throw payloadBoundary; },
+      fail(message, code) { throw Object.assign(new Error(message), { code }); },
+    });
+    await assert.rejects(harness.inspectMacOSApp("/synthetic/TiboTattle.app", {
+      ...harness.options, requireExternalDistribution: true,
+    }), mutation === null ? (error) => error === payloadBoundary : {
+      code: "MACOS_LEGACY_SOURCE_COMPATIBILITY_INVALID",
+    });
+  }
+});
+
+test("stable previous payload compatibility accepts only the exact normalized Keytar tuple", async () => {
+  const source = await readFile(join(REPOSITORY_ROOT, "scripts/macos-release-core.js"), "utf8");
+  const payloadSource = releaseSourceSection(source,
+    "async function verifyMacOSBuildPayload(", "\nfunction parsePlist(");
+  const pinSource = releaseSourceSection(source,
+    "const LEGACY_STABLE_PREVIOUS_RELEASE =", "// This immutable rc2");
+  const nativeInventoryReached = new Error("synthetic native inventory boundary");
+  const token = Object.freeze({});
+  const harness = runInNewContext(`${pinSource}\n${payloadSource}\n`
+    + "({ verifyMacOSBuildPayload, keytar: LEGACY_STABLE_PREVIOUS_RELEASE.keytar })", {
+    validateLegacyDogfoodPreviousCapability: () => false,
+    validatePreMigrationPreviousCapability: () => false,
+    validateLegacyStablePreviousCapability: (value) => value === token,
+    assertMacOSKeychainMigrationManifest,
+    MACOS_KEYCHAIN_MIGRATION_HELPER,
+    BASE_NORMALIZED_MACH_O_PATHS: [MACOS_KEYCHAIN_MIGRATION_HELPER.executable],
+    NORMALIZED_MACH_O_PATHS: new Set([MACOS_KEYCHAIN_MIGRATION_HELPER.executable]),
+    BUILD_MANIFEST_PATH: "Contents/Resources/build-manifest.json",
+    CODE_RESOURCES_PATH: "Contents/_CodeSignature/CodeResources",
+    validateManifestPayloadPath() {},
+    walkMacOSPayload() { throw nativeInventoryReached; },
+    fail(message, code) { throw Object.assign(new Error(message), { code }); },
+  });
+  const manifest = {
+    payload: {
+      files: [{ ...harness.keytar, normalization: "mach_o_without_code_signature" }],
+      links: [], totalBytes: harness.keytar.bytes, payloadSha256: "a".repeat(64),
+    },
+  };
+  await assert.rejects(harness.verifyMacOSBuildPayload("/synthetic", manifest, null, null, token),
+    (error) => error === nativeInventoryReached,
+    "exact historical inventory must continue to unchanged filesystem/byte verification");
+  for (const [key, value] of [
+    ["bytes", harness.keytar.bytes - 1], ["mode", "755"], ["sha256", "b".repeat(64)],
+    ["normalization", "raw"], ["path", "Contents/Resources/other.node"],
+  ]) {
+    const changed = structuredClone(manifest);
+    changed.payload.files[0][key] = value;
+    await assert.rejects(harness.verifyMacOSBuildPayload("/synthetic", changed, null, null, token), {
+      code: "MACOS_PAYLOAD_INTEGRITY_FAILED",
+    }, key);
+  }
+  const missing = structuredClone(manifest);
+  missing.payload.files = [];
+  await assert.rejects(harness.verifyMacOSBuildPayload("/synthetic", missing, null, null, token), {
+    code: "MACOS_PAYLOAD_INTEGRITY_FAILED",
+  });
+  await assert.rejects(harness.verifyMacOSBuildPayload("/synthetic", manifest), ARTIFACT_ERROR,
+    "without historical authority the current migration helper remains mandatory");
 });
 
 test("native helper compilation and inside-out signing exclude keytar and Node runtime exceptions", async () => {

--- a/test/pr94-analysis-worker.test.js
+++ b/test/pr94-analysis-worker.test.js
@@ -109,8 +109,40 @@ test("PR94 raw occurrence counts survive slim projection and deduplicate only fo
   assert.equal(grouped.rawParents[0].snapshotCount, 14);
   assert.equal(grouped.rawParents[0].uniqueSnapshotCount, 13);
   const batched = await derivePr94BatchedTransitions({ modules: { miner }, usage: fixture.usage, grouped, startAt: START, endAt: END });
+  assert.equal(grouped.rawParents[0].derivationEvidence.snapshotCount, 13);
   assert.deepEqual(batched.transitions, (await oracle(fixture)).transitions);
   assert.equal(batched.deduplicatedSnapshotCount, 39);
+});
+
+test("PR94 original derivation summaries are bound to exact parents, groups and emitted counts", async () => {
+  const mutations = [
+    (result) => { delete result.groupSummaries; },
+    (result) => { result.windowGroupCount += 1; },
+    (result) => { result.groupSummaries[0].provider = "different-provider"; },
+    (result) => { result.groupSummaries[0].planType = "plus"; },
+    (result) => { result.groupSummaries[0].limitId = "spark"; },
+    (result) => { result.groupSummaries[0].accountScopeId = "synthetic-different-account"; },
+    (result) => { result.groupSummaries[0].resetsAt += 1; },
+    (result) => { result.groupSummaries[0].windowDurationMins = 300; },
+    (result) => { result.groupSummaries[0].snapshotCount += 1; },
+    (result) => { result.deduplicatedSnapshotCount -= 1; },
+    (result) => { result.groupSummaries[0].transitionCount -= 1; result.groupSummaries[0].monotonicTransitionCount -= 1; },
+    (result) => { result.groupSummaries[0].monotonicTransitionCount = -1; },
+    (result) => { result.groupSummaries[0].planEraKey = "unrelated-era"; },
+    (result) => { result.groupSummaries.push({ ...result.groupSummaries[0] }); result.windowGroupCount += 1; },
+    (result) => { result.transitions.pop(); },
+  ];
+  for (const mutate of mutations) {
+    const fixture = completeFixture();
+    const grouped = buildPr94QuotaGroups(fixture.snapshots, { quota, revisionKind: "final" });
+    const changedMiner = { async deriveCodexTransitionSeriesCooperatively(options) {
+      const result = await miner.deriveCodexTransitionSeriesCooperatively(options);
+      mutate(result);
+      return result;
+    } };
+    await assert.rejects(derivePr94BatchedTransitions({ modules: { miner: changedMiner }, usage: fixture.usage,
+      grouped, startAt: START, endAt: END }), { code: "pr94_derivation_invalid" });
+  }
 });
 
 test("PR94 equal-time contradictory plan evidence cannot choose a population by insertion order", () => {

--- a/test/pr94-analysis-worker.test.js
+++ b/test/pr94-analysis-worker.test.js
@@ -1,0 +1,245 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createHash } from "node:crypto";
+import { spawn } from "node:child_process";
+import { chmod, mkdir, mkdtemp, readFile, realpath, rm, stat } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { buildPr94QuotaGroups, derivePr94BatchedTransitions } from "../scripts/lib/pr94-analysis-worker.mjs";
+import * as quota from "../packages/quota-analysis/index.js";
+import * as miner from "../src/codex-transition-miner.js";
+import * as accounting from "../packages/accounting/index.js";
+import { createLocalUnifiedAccountingSource } from "../src/local-unified-accounting-source.js";
+import { beginUnifiedIndexGeneration, createUnifiedIndexWriter, openLocalUnifiedIndex } from "../src/local-unified-index.js";
+import { createPr94LedgerEvidence, importPr94LedgerEvidencePrivate, comparePr94LedgerEvidence,
+  disposePr94LedgerEvidencePrivate } from "../scripts/lib/pr94-ledger-evidence.mjs";
+import { importPr94CalibrationEvidence, disposePr94CalibrationEvidencePrivate } from "../scripts/lib/pr94-calibration-evidence.mjs";
+import { validatePr94AnalysisResult } from "../scripts/lib/pr94-receipt-validation.mjs";
+
+const START = "2026-08-01T00:00:00.000Z";
+const END = "2026-09-01T00:00:00.000Z";
+const WEEK = 604_800_000;
+const ROOT = fileURLToPath(new URL("..", import.meta.url)).replace(/\/$/u, "");
+const KEY = new Uint8Array(32).fill(29);
+
+function snapshot(at, percent, reset, planType = "pro", duration = 10_080, slot = "primary") {
+  return { timestamp: new Date(at).toISOString(), timestampMs: at,
+    window: { provider: "openai_codex", planType, limitId: "codex", slot, usedPercent: percent,
+      windowDurationMins: duration, resetsAt: reset / 1_000 } };
+}
+
+function usage(at, ordinal, planType = "pro") {
+  return { timestamp: new Date(at).toISOString(), timestampMs: at, model: "gpt-5.6-sol",
+    components: { input_uncached_tokens: 100_000 + ordinal, input_cache_read_tokens: 500,
+      input_cache_write_tokens: 0, output_text_tokens: 20, output_reasoning_tokens: 10, output_combined_tokens: 0 },
+    tierSemantics: { codexSpeedMode: ordinal % 3 === 0 ? "fast" : "standard" },
+    planAttribution: { basis: "same_record", planType, planVariant: null },
+    usageIntervalStartedAt: new Date(at - 1_000).toISOString(), usageIntervalBasis: "previous_source_record" };
+}
+
+function completeFixture() {
+  const snapshots = []; const events = [];
+  for (let reset = 0; reset < 3; reset += 1) {
+    const start = Date.parse(START) + reset * WEEK;
+    for (let boundary = 0; boundary < 13; boundary += 1) {
+      const at = start + boundary * 3_600_000;
+      snapshots.push(snapshot(at, boundary, start + WEEK, "pro", 10_080, boundary < 6 ? "primary" : "secondary"));
+      if (boundary > 0) events.push(usage(at - 30_000, events.length));
+    }
+  }
+  return { snapshots, usage: events };
+}
+
+async function oracle(fixture) {
+  return miner.deriveCodexTransitionSeriesCooperatively({ startAt: START, endAt: END,
+    rawUsageEvents: fixture.usage, rateLimitSnapshots: fixture.snapshots,
+    diagnostics: {}, includeSnapshotIntervals: false, windowDurationMins: 10_080,
+    includeNormalizedInputs: false });
+}
+
+test("PR94 complete multi-reset batches equal actual unbatched miner output without mutating input", async () => {
+  const fixture = completeFixture();
+  const before = structuredClone(fixture);
+  const grouped = buildPr94QuotaGroups(fixture.snapshots, { quota, revisionKind: "final" });
+  let resourceChecks = 0;
+  const batched = await derivePr94BatchedTransitions({ modules: { miner }, usage: fixture.usage, grouped,
+    startAt: START, endAt: END, resourceCheck() { resourceChecks += 1; } });
+  const full = await oracle(fixture);
+  assert.deepEqual(batched.transitions, full.transitions);
+  assert.equal(batched.deduplicatedSnapshotCount, full.deduplicatedSnapshotCount);
+  assert.equal(batched.batchMetrics.batches, 3);
+  assert.equal(batched.batchMetrics.maximumUsageSlice, 12);
+  assert.ok(resourceChecks >= 3);
+  assert.deepEqual(fixture, before);
+});
+
+test("PR94 quota-only short-window plan switch remains global across reset batches", async () => {
+  const start = Date.parse(START);
+  const snapshots = [snapshot(start, 0, start + WEEK), snapshot(start + 3_600_000, 1, start + WEEK),
+    snapshot(start + 2 * 3_600_000, 0, start + 5 * 3_600_000, "plus", 300),
+    snapshot(start + 3 * 3_600_000, 2, start + WEEK), snapshot(start + 4 * 3_600_000, 3, start + WEEK),
+    snapshot(start + WEEK, 0, start + 2 * WEEK), snapshot(start + WEEK + 3_600_000, 1, start + 2 * WEEK)];
+  const events = [usage(start + 30_000, 0), usage(start + 3 * 3_600_000 + 30_000, 1), usage(start + WEEK + 30_000, 2)];
+  const grouped = buildPr94QuotaGroups(snapshots, { quota, revisionKind: "final" });
+  const batched = await derivePr94BatchedTransitions({ modules: { miner }, usage: events, grouped, startAt: START, endAt: END });
+  const full = await oracle({ snapshots, usage: events });
+  assert.deepEqual(batched.transitions, full.transitions);
+  assert.equal(new Set(batched.transitions.map((row) => row.planEraKey)).size, 2);
+  const lostChronology = await oracle({ snapshots: snapshots.filter((row) => row.window.windowDurationMins === 10_080), usage: events });
+  assert.notDeepEqual(batched.transitions, lostChronology.transitions);
+  assert.equal(grouped.rawParents.length, 2);
+});
+
+test("PR94 valid unknown-plan anchors retain original attribution semantics", () => {
+  const start = Date.parse(START);
+  const snapshots = [snapshot(start, 0, start + WEEK, null), snapshot(start + 3_600_000, 1, start + WEEK, null)];
+  const grouped = buildPr94QuotaGroups(snapshots, { quota, revisionKind: "final" });
+  assert.equal(grouped.attribution.status, "ready");
+  assert.equal(grouped.attribution.ignoredObservationCount, 2);
+  assert.equal(grouped.rawParents[0].matchedSnapshotCount, 0);
+  assert.equal(grouped.rawParents[0].unavailableSnapshotCount, 2);
+  assert.equal(grouped.selectedPlanType, "unknown");
+});
+
+test("PR94 raw occurrence counts survive slim projection and deduplicate only for calibration", async () => {
+  const fixture = completeFixture();
+  fixture.snapshots.splice(1, 0, structuredClone(fixture.snapshots[0]));
+  const grouped = buildPr94QuotaGroups(fixture.snapshots, { quota, revisionKind: "final" });
+  assert.equal(grouped.rawParents[0].snapshotCount, 14);
+  assert.equal(grouped.rawParents[0].uniqueSnapshotCount, 13);
+  const batched = await derivePr94BatchedTransitions({ modules: { miner }, usage: fixture.usage, grouped, startAt: START, endAt: END });
+  assert.deepEqual(batched.transitions, (await oracle(fixture)).transitions);
+  assert.equal(batched.deduplicatedSnapshotCount, 39);
+});
+
+test("PR94 equal-time contradictory plan evidence cannot choose a population by insertion order", () => {
+  const start = Date.parse(START);
+  const snapshots = [snapshot(start, 10, start + WEEK, "pro"), snapshot(start, 10, start + WEEK, "plus")];
+  for (const input of [snapshots, [...snapshots].reverse()]) {
+    const grouped = buildPr94QuotaGroups(input, { quota, revisionKind: "final" });
+    assert.equal(grouped.selectedPlanType, "unknown");
+    assert.equal(grouped.attribution.conflicts.length, 1);
+    assert.ok(grouped.rawParents.every((row) => row.conflictedSnapshotCount === 1 && row.matchedSnapshotCount === 0));
+  }
+});
+
+test("PR94 batch resource failures propagate without partial successful evidence", async () => {
+  const fixture = completeFixture();
+  const grouped = buildPr94QuotaGroups(fixture.snapshots, { quota, revisionKind: "final" });
+  const failure = Object.assign(new Error("synthetic_resource_guard"), { code: "synthetic_resource_guard" });
+  await assert.rejects(() => derivePr94BatchedTransitions({ modules: { miner }, usage: fixture.usage, grouped,
+    startAt: START, endAt: END, resourceCheck() { throw failure; } }), (error) => error === failure);
+});
+
+async function createPublishedFixtureIndex(indexFile) {
+  const database = openLocalUnifiedIndex(indexFile, { create: true });
+  const generation = beginUnifiedIndexGeneration(database, { contractVersion: "usage-event-v0.2", receivedAtMs: Date.parse(END),
+    discoveredSourceCount: 1, discoveredSourceBytes: 4_096 });
+  const writer = createUnifiedIndexWriter(database, { contractVersion: "usage-event-v0.2", receivedAtMs: Date.parse(END),
+    generationId: generation.generationId, parserVersionId: generation.parserVersionId, ingestRunId: generation.ingestRunId });
+  const sourceLocal = Buffer.alloc(32, 7); const sessionLocal = Buffer.alloc(32, 8);
+  const accountScopeId = writer.internAccountScope({ status: "unavailable", reason: "missing_account", planType: null, scopeLocal: null });
+  const modelId = writer.internModel("gpt-5.6-sol", "recognized");
+  const tierId = writer.internTier({ apiServiceTier: "unknown", billingSurface: "chatgpt_subscription",
+    codexSpeedMode: "standard", tierSource: "unknown", providerTierRaw: null });
+  const surfaceId = writer.internSurface({ agentScope: "root", surface: "cli_exec", threadSource: "user", lineageDisposition: "standalone" });
+  for (let index = 0; index < 14; index += 1) {
+    const observedAtMs = Date.parse(START) + index * 3_600_000;
+    const sourceOffset = index + 1;
+    const window = { observedAtMs, limitId: "codex", slot: "primary", planType: "pro",
+      usedPercent: index, resetsAtMs: Date.parse(START) + WEEK, durationMins: 10_080 };
+    const quotaObservationId = writer.internQuota(window);
+    writer.writeQuotaOccurrence({ ...window, generationId: generation.generationId, sourceLocal, sourceOffset, sourceOrdinal: 0,
+      surfaceId, canonicalObservationId: quotaObservationId, provider: "openai_codex", slotOrder: 0, admission: "admitted" });
+    const eventKey = Buffer.alloc(32); eventKey.writeUInt32BE(index + 1, 28);
+    writer.writeUsageEvent({ eventKey, observedAtMs, generationId: generation.generationId, sourceLocal, sourceOffset, sourceOrdinal: 0,
+      sessionLocal, accountScopeId, modelId, tierId, surfaceId, quotaObservationId,
+      reasoningEffort: 4, outcome: 5, tierObservedAtMs: null,
+      tokensInUncached: index === 0 ? null : 100_000, tokensInCacheRead: index === 0 ? null : 500,
+      tokensInCacheWrite: index === 0 ? null : 0, tokensInCacheWrite5m: null, tokensInCacheWrite1h: null,
+      tokensOutText: index === 0 ? null : 20, tokensOutReasoning: index === 0 ? null : 10,
+      tokensOutCombined: null, totalInputContext: null, partial: false });
+  }
+  writer.writeSourceCursor({ sourceLocal, sourceOrdinal: 0, sessionLocal, scannedBytes: 4_096, sizeBytes: 4_096,
+    mtimeMs: Date.parse(END), snapshotsPersisted: true, turnContextSeen: true,
+    carryModel: "gpt-5.6-sol", carryEffort: "high", carryTierRaw: null, carryTierObservedAtMs: null, carryTotals: null });
+  writer.writeGenerationSource({ generationId: generation.generationId, sourceLocal, sourceOrdinal: 0, sessionLocal, surfaceId,
+    status: "complete", discoveredSizeBytes: 4_096, scannedBytes: 4_096, mtimeMs: Date.parse(END), diagnosticsComplete: true });
+  writer.writeSourceDiagnostics(sourceLocal, {}, { generationId: generation.generationId });
+  for (const [key, value] of Object.entries({ contract_version: "usage-event-v0.2", status: "complete", generated_at: END, source_count: 1, source_bytes: 4_096 })) writer.writeMeta(key, value);
+  writer.finalizeGeneration({ status: "complete", blockReason: null, discoveredSourceCount: 1, discoveredSourceBytes: 4_096,
+    indexedSourceCount: 1, indexedSourceBytes: 4_096, discoveryComplete: true, diagnosticsComplete: true });
+  await writer.close({ fsyncPath: indexFile });
+}
+
+async function invokeWorker(options) {
+  const workerUrl = new URL("../scripts/lib/pr94-analysis-worker.mjs", import.meta.url).href;
+  // Exercise the exported worker in a clean process without making this source
+  // test a native platform claim. The protected CLI separately pins its runtime.
+  const code = `import { runPr94AnalysisWorker } from ${JSON.stringify(workerUrl)};
+    let input = ''; for await (const chunk of process.stdin) input += chunk;
+    const { key, ...options } = JSON.parse(input);
+    try { process.stdout.write(JSON.stringify(await runPr94AnalysisWorker(options, Buffer.from(key, 'hex')))); }
+    catch(error) { process.stdout.write(JSON.stringify({status:'error',code:typeof error.code==='string'?error.code:'unclassified'})); process.exitCode=1; }`;
+  const child = spawn(process.execPath, ["--input-type=module", "-e", code], { cwd: ROOT, stdio: ["pipe", "pipe", "pipe"] });
+  const timer = setTimeout(() => child.kill("SIGKILL"), 30_000);
+  let stdout = ""; let stderr = "";
+  child.stdout.on("data", (chunk) => { stdout += chunk; });
+  child.stderr.on("data", (chunk) => { stderr += chunk; });
+  child.stdin.end(JSON.stringify({ ...options, key: Buffer.from(KEY).toString("hex") }));
+  const exit = await new Promise((resolve, reject) => { child.once("error", reject); child.once("close", resolve); });
+  clearTimeout(timer);
+  return { exit, stdout, stderr };
+}
+
+test("PR94 worker completes on an actual published synthetic index and binds both private evidence streams", async (t) => {
+  const temporary = await realpath(await mkdtemp(join(tmpdir(), "pr94-worker-synthetic-")));
+  await chmod(temporary, 0o700);
+  t.after(() => rm(temporary, { recursive: true, force: true }));
+  const indexFile = join(temporary, "index.sqlite");
+  const outputDirectory = join(temporary, "out");
+  await mkdir(outputDirectory, { mode: 0o700 });
+  await createPublishedFixtureIndex(indexFile);
+  await chmod(indexFile, 0o400);
+  const before = await readFile(indexFile);
+  const result = await invokeWorker({ root: ROOT, indexFile, outputDirectory, startAt: START, endAt: END, revisionKind: "final" });
+  assert.equal(result.exit, 0, result.stdout + result.stderr);
+  const envelope = JSON.parse(result.stdout);
+  assert.equal(envelope.status, "ok");
+  const body = await readFile(join(outputDirectory, "analysis.json"));
+  assert.equal(envelope.resultBytes, body.length);
+  assert.equal(envelope.resultSha256, createHash("sha256").update(body).digest("hex"));
+  const analysis = JSON.parse(body);
+  assert.deepEqual(validatePr94AnalysisResult(analysis), analysis);
+  assert.equal(analysis.contextBehavior, "legacy_zero");
+  assert.equal(analysis.ledger.usage.events, 13);
+  assert.equal(analysis.ledger.quota.events, 14);
+  assert.equal(analysis.inventory.zeroComponentUsageRows, 1);
+  assert.equal(analysis.calibration.status, "pass");
+  assert.equal(analysis.calibration.counts.rawParents, 1);
+  assert.equal(analysis.calibration.candidates[0].primary.count, 1);
+  assert.equal(analysis.ledger.usage.context.zeroEvents, 13);
+  assert.equal(analysis.ledger.usage.context.missingEvents, 0);
+  assert.deepEqual(await readFile(indexFile), before);
+  for (const name of ["analysis.json", "ledger.ndjson", "calibration.ndjson"]) {
+    assert.equal((await stat(join(outputDirectory, name))).mode & 0o777, 0o600);
+  }
+  const readFrames = async (name) => (await readFile(join(outputDirectory, name), "utf8")).trim().split("\n").map((line) => JSON.parse(line));
+  const importedLedger = await importPr94LedgerEvidencePrivate(await readFrames("ledger.ndjson"), { hmacKey: KEY });
+  t.after(() => disposePr94LedgerEvidencePrivate(importedLedger));
+  assert.deepEqual(importedLedger, analysis.ledger);
+  const expected = createPr94LedgerEvidence({ hmacKey: KEY });
+  await createLocalUnifiedAccountingSource({ indexFile, requireComplete: true, verifyPublishedGeneration: true, contextBehavior: "legacy_zero" })({
+    startAt: START, endAt: END, onUsage(row) { expected.consumeUsage(row, accounting.priceCodexUsageEvent(row)); },
+    onRateLimitSnapshot(row) { expected.consumeQuota(row); },
+  });
+  const expectedEvidence = expected.finish();
+  t.after(() => disposePr94LedgerEvidencePrivate(expectedEvidence));
+  assert.equal(comparePr94LedgerEvidence(expectedEvidence, importedLedger).status, "equal");
+  const importedCalibration = await importPr94CalibrationEvidence({ aggregate: analysis.calibration,
+    frames: await readFrames("calibration.ndjson"), hmacKey: KEY });
+  t.after(() => disposePr94CalibrationEvidencePrivate(importedCalibration));
+  assert.deepEqual(importedCalibration, analysis.calibration);
+  assert.doesNotMatch(result.stdout + body.toString("utf8"), /sourceLocal|sourceOffset|sourceOrdinal|sessionLocal|index\.sqlite|pr94-worker-synthetic|parentKey|fragmentKey/);
+});

--- a/test/pr94-calibration-evidence.test.js
+++ b/test/pr94-calibration-evidence.test.js
@@ -1,6 +1,9 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 import { registerHooks } from "node:module";
+import * as quota from "../packages/quota-analysis/index.js";
+import * as miner from "../src/codex-transition-miner.js";
+import { buildPr94QuotaGroups, derivePr94BatchedTransitions } from "../scripts/lib/pr94-analysis-worker.mjs";
 import {
   buildPr94CalibrationEvidence, comparePr94CalibrationEvidence,
   iteratePr94CalibrationPrivateFrames, importPr94CalibrationEvidence,
@@ -200,6 +203,54 @@ test("PR94 zero-transition parents require demonstrated reasons; ambiguous disap
   assert.equal(unexplained.status, "fail");
   assert.equal(unexplained.counts.unexplainedParents, 1);
   assert.equal(comparePr94CalibrationEvidence(unexplained, unexplained).status, "fail");
+});
+
+test("PR94 original miner proves no within-era percentage change across a Pro Plus Pro switch", async (t) => {
+  const start = Date.parse("2026-08-25T00:00:00.000Z");
+  const snapshot = (hour, percent, planType = "pro", duration = 10_080) => ({
+    timestamp: new Date(start + hour * 3_600_000).toISOString(), timestampMs: start + hour * 3_600_000,
+    window: { provider: "openai_codex", planType, limitId: "codex", slot: "primary",
+      windowDurationMins: duration, resetsAt: RESET, usedPercent: percent },
+  });
+  const snapshots = [snapshot(0, 0), snapshot(1, 0), snapshot(2, 0, "plus", 300), snapshot(3, 1), snapshot(4, 1)];
+  const grouped = buildPr94QuotaGroups(snapshots, { quota, revisionKind: "final" });
+  const unsupported = evidence([], { rawParents: grouped.rawParents });
+  t.after(() => disposePr94CalibrationEvidencePrivate(unsupported));
+  assert.equal(unsupported.status, "fail");
+  assert.equal(candidate(unsupported).outcomes.unexplained_no_transition, 1);
+  const derived = await derivePr94BatchedTransitions({ modules: { miner }, usage: [], grouped,
+    startAt: SCOPE.startAt, endAt: SCOPE.endAt });
+  assert.deepEqual(derived.transitions, []);
+  assert.deepEqual(grouped.rawParents[0].derivationEvidence, {
+    groupCount: 2, snapshotCount: 4, transitionCount: 0, zeroTransitionGroupCount: 2,
+  });
+  const explained = evidence(derived.transitions, { rawParents: grouped.rawParents });
+  t.after(() => disposePr94CalibrationEvidencePrivate(explained));
+  assert.equal(explained.status, "pass");
+  assert.equal(explained.counts.unexplainedParents, 0);
+  assert.ok(explained.candidates.every((item) => item.outcomes.no_within_era_percent_change === 1));
+  const compared = comparePr94CalibrationEvidence(explained, explained);
+  assert.ok(compared.primaryOutcomeMatrix.every((cell) => cell.afterOutcomes[0].outcome === "no_within_era_percent_change"));
+  assert.doesNotMatch(JSON.stringify(explained), /eraKey|2026-|resetsAt|derivationEvidence/);
+});
+
+test("PR94 refuses unsupported, inconsistent or positive derivation summaries for an empty parent", () => {
+  const raw = rawParent(rows()[0]);
+  const valid = { groupCount: 2, snapshotCount: 13, transitionCount: 0, zeroTransitionGroupCount: 2 };
+  const mutations = [
+    { ...valid, extra: 1 }, { ...valid, snapshotCount: 12 }, { ...valid, groupCount: 14 },
+    { ...valid, groupCount: 0 }, { ...valid, zeroTransitionGroupCount: 1 },
+    { ...valid, transitionCount: 1, zeroTransitionGroupCount: 1 },
+    { ...valid, transitionCount: Number.MAX_SAFE_INTEGER },
+  ];
+  for (const derivationEvidence of mutations) {
+    assert.throws(() => evidence([], { rawParents: [{ ...raw, derivationEvidence }] }),
+      isCode("pr94_calibration_snapshot_partition_invalid"));
+  }
+  const single = evidence([], { rawParents: [{ ...raw, derivationEvidence: { ...valid, groupCount: 1, zeroTransitionGroupCount: 1 } }] });
+  assert.equal(single.status, "fail");
+  assert.equal(candidate(single).outcomes.unexplained_no_transition, 1);
+  disposePr94CalibrationEvidencePrivate(single);
 });
 
 test("PR94 rejects incompatible raw snapshot partitions and unknown transition parents", () => {

--- a/test/pr94-calibration-evidence.test.js
+++ b/test/pr94-calibration-evidence.test.js
@@ -1,0 +1,420 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { registerHooks } from "node:module";
+import {
+  buildPr94CalibrationEvidence, comparePr94CalibrationEvidence,
+  iteratePr94CalibrationPrivateFrames, importPr94CalibrationEvidence,
+  disposePr94CalibrationEvidencePrivate,
+} from "../scripts/lib/pr94-calibration-evidence.mjs";
+
+// Synthetic inputs exercise the actual maintained policy, never private history.
+// This export-only test hook does not replace any production function body.
+const sourceUrl = new URL("../src/reporting/weekly-calibration.js?pr94-evidence-test", import.meta.url).href;
+const hook = registerHooks({ load(url, context, nextLoad) {
+  const loaded = nextLoad(url, context);
+  if (url !== sourceUrl) return loaded;
+  return { ...loaded, source: `${loaded.source}\nexport { selectResetGroups, fitReset, uniquePoints, capacityFit, fitRelativeCentral80Width, isEligible, partitionKey, resetParentKey };\n` };
+} });
+let original;
+try { original = await import(sourceUrl); } finally { hook.deregister(); }
+
+const HMAC_KEY = new Uint8Array(32).fill(13);
+const RESET = Date.parse("2026-08-31T00:00:00.000Z") / 1_000;
+const SCOPE = { startAt: "2026-08-01T00:00:00.000Z", endAt: "2026-09-01T00:00:00.000Z" };
+
+async function policyVariant(label, replace) {
+  const url = new URL(`../src/reporting/weekly-calibration.js?pr94-policy-${label}`, import.meta.url).href;
+  const localHook = registerHooks({ load(path, context, nextLoad) {
+    const loaded = nextLoad(path, context);
+    if (path !== url) return loaded;
+    const source = typeof loaded.source === "string" ? loaded.source : Buffer.from(loaded.source).toString("utf8");
+    const changed = replace(source);
+    assert.notEqual(changed, source, "synthetic policy mutation must be exercised");
+    return { ...loaded, source: `${changed}\nexport { selectResetGroups, fitReset, uniquePoints, capacityFit, fitRelativeCentral80Width, isEligible, partitionKey, resetParentKey };\n` };
+  } });
+  try { return await import(url); } finally { localHook.deregister(); }
+}
+
+function rows({ planType = "pro", reset = RESET, era = "era-one", count = 12, offset = 0, slot = "primary", percentStep = 1, costStep = 10 } = {}) {
+  return Array.from({ length: count }, (_, index) => {
+    const time = Date.parse("2026-08-25T00:00:00.000Z") + (index + offset) * 3_600_000;
+    return {
+      accountScopeId: "unattributed", provider: "openai_codex", planType, planVariant: "unknown", planEraKey: era,
+      aggregationEligibility: "primary_conditional", limitId: "codex", slot, windowDurationMins: 10_080, resetsAt: reset,
+      eventTime: new Date(time + 3_600_000).toISOString(), lastPriorObservedAt: new Date(time).toISOString(),
+      firstNextObservedAt: new Date(time + 3_600_000).toISOString(),
+      priorUsedPercent: index * percentStep, nextUsedPercent: (index + 1) * percentStep,
+      lastPriorCumulativeApiPricedUsd: index * costStep, firstNextCumulativeApiPricedUsd: (index + 1) * costStep,
+      lastPriorCumulativeQuotaWeightedLowerUsd: index * costStep,
+      firstNextCumulativeQuotaWeightedLowerUsd: (index + 1) * costStep,
+      lastPriorCumulativeQuotaWeightedUpperUsd: index * costStep * 2,
+      firstNextCumulativeQuotaWeightedUpperUsd: (index + 1) * costStep * 2,
+      marginalUsageEventCount: 1, quality: { localCoverage: { elapsedTimeCoverageFraction: 1 }, pricingWarnings: [], attributionWarnings: [] },
+    };
+  });
+}
+
+function rawParent(first, overrides = {}) {
+  return { accountScopeId: first.accountScopeId, provider: first.provider, planType: first.planType, limitId: first.limitId,
+    windowDurationMins: first.windowDurationMins, resetsAt: first.resetsAt, snapshotCount: 13,
+    uniqueSnapshotCount: 13, distinctPercentCount: 13, matchedSnapshotCount: 13, conflictedSnapshotCount: 0,
+    unavailableSnapshotCount: 0, matchedUniqueSnapshotCount: 13, matchedDistinctPercentCount: 13, ...overrides };
+}
+
+function evidence(transitions = rows(), overrides = {}) {
+  return buildPr94CalibrationEvidence({ internals: original, analyzeWeeklyCalibration: original.analyzeWeeklyCalibration,
+    candidates: original.CANDIDATES, transitions, rawParents: [rawParent(transitions[0] ?? rows()[0])],
+    revisionKind: "final", hmacKey: HMAC_KEY, scope: SCOPE, selectedPlanType: "pro", ...overrides });
+}
+
+function candidate(result, id = "standard_api") { return result.candidates.find((item) => item.candidateId === id); }
+function frames(result) { return [...iteratePr94CalibrationPrivateFrames(result)]; }
+function isCode(code) { return (error) => error.code === code && error.message === code; }
+
+test("PR94 evidence reuses exact original fits and returns no raw identities or timestamps", () => {
+  const transitions = rows().map((row) => ({ ...row, accountScopeId: "private-account-marker", planEraKey: "private-era-marker" }));
+  const result = evidence(transitions);
+  assert.equal(result.status, "pass");
+  assert.equal(result.counts.rawParents, 1);
+  assert.equal(result.counts.parentCandidates, 4);
+  assert.equal(result.counts.knownAccountParents, 1);
+  assert.equal(candidate(result).outcomes.selected_plan_primary, 1);
+  assert.equal(candidate(result).primary.count, 1);
+  assert.ok(candidate(result).primary.median > 0);
+  assert.ok(Object.isFrozen(result.candidates[0].outcomes));
+  assert.doesNotMatch(JSON.stringify(result), /private-account-marker|private-era-marker|2026-|parentKey|fragmentKey|inputDigest/);
+  assert.equal(comparePr94CalibrationEvidence(result, result).identicalFitInputsCompared, 4);
+});
+
+test("PR94 evidence keeps one parent/candidate with primary and losing qualifying fragments", () => {
+  const transitions = [...rows({ era: "a", count: 12 }), ...rows({ era: "b", count: 9, offset: 20 })];
+  const result = evidence(transitions);
+  assert.equal(result.counts.rawParents, 1);
+  for (const item of result.candidates) {
+    assert.equal(item.parentCandidates, 1);
+    assert.equal(item.outcomes.selected_plan_primary, 1);
+    assert.equal(item.outcomes.losing_qualifying_fragment, 1);
+    assert.equal(item.diagnostic.count, 1);
+  }
+  assert.equal(frames(result)[0].fragments.length, 2);
+  const compared = comparePr94CalibrationEvidence(evidence(rows()), result);
+  assert.equal(compared.baselinePrimaryFits, 4);
+  assert.equal(compared.retainedPrimaryFits, 4);
+  assert.equal(compared.lostPrimaryFits, 0);
+  assert.equal(compared.newPrimaryFits, 0);
+  assert.equal(compared.changedOutcomeParentCandidates, 4);
+  assert.equal(compared.requiresCoverageReview, true);
+  assert.ok(compared.primaryOutcomeMatrix.every((cell) => cell.transition === "retained_primary"
+    && cell.afterOutcomes.some((item) => item.outcome === "losing_qualifying_fragment" && item.count === 1)
+    && cell.afterOutcomes.some((item) => item.outcome === "selected_plan_primary" && item.count === 1)));
+});
+
+test("PR94 evidence retains alternate-plan primaries and raw plan populations", () => {
+  const pro = rows();
+  const plus = rows({ planType: "plus", costStep: 20 });
+  const result = evidence([...pro, ...plus], { rawParents: [rawParent(pro[0]), rawParent(plus[0])] });
+  assert.deepEqual(result.plans.map((item) => item.planType), ["plus", "pro"]);
+  assert.equal(candidate(result).outcomes.selected_plan_primary, 1);
+  assert.equal(candidate(result).outcomes.alternate_plan_primary, 1);
+});
+
+test("PR94 comparison uses canonical lexical ordering for mixed plans and outcome signatures", (t) => {
+  const parents = [];
+  const transitions = [];
+  const add = (items) => { parents.push(rawParent(items[0])); transitions.push(...items); };
+  for (const planType of ["plus", "pro", "pro_lite", "unknown"]) add(rows({ planType }));
+  for (const fragments of [1, 10]) {
+    add(Array.from({ length: fragments }, (_, index) => rows({ era: `diagnostic-${index}`, count: 2, offset: index * 3 })
+      .map((row) => ({ ...row, accountScopeId: `synthetic-${fragments}`, aggregationEligibility: "diagnostic_only" }))).flat());
+  }
+  add([...rows({ era: "diagnostic", count: 2 }).map((row) => ({ ...row, aggregationEligibility: "diagnostic_only" })),
+    ...rows({ era: "short", count: 4, offset: 4 })].map((row) => ({ ...row, accountScopeId: "synthetic-mixed" })));
+  const result = evidence(transitions, { rawParents: parents });
+  t.after(() => disposePr94CalibrationEvidencePrivate(result));
+  assert.equal(result.status, "pass");
+  const compared = comparePr94CalibrationEvidence(result, result);
+  assert.equal(compared.status, "pass");
+  const keys = compared.primaryOutcomeMatrix.map((cell) => JSON.stringify([
+    cell.candidateId, cell.planType, cell.accountKnown, cell.transition, cell.afterOutcomes,
+  ]));
+  assert.deepEqual(keys, [...keys].sort());
+  assert.ok(compared.primaryOutcomeMatrix.some((cell) => cell.afterOutcomes.some((item) => item.count === 10)));
+  assert.ok(compared.primaryOutcomeMatrix.some((cell) => cell.afterOutcomes.length > 1));
+  for (const cell of compared.primaryOutcomeMatrix) {
+    const outcomes = cell.afterOutcomes.map((item) => item.outcome);
+    assert.deepEqual(outcomes, [...outcomes].sort());
+  }
+});
+
+test("PR94 evidence preserves unknown and novel plans without publishing arbitrary labels", () => {
+  const a = rows({ planType: "private-plan-a" });
+  const b = rows({ planType: "private-plan-b", costStep: 20 });
+  const result = evidence([...a, ...b], { rawParents: [rawParent(a[0]), rawParent(b[0])] });
+  assert.deepEqual(result.plans.map((item) => item.planType), ["other"]);
+  assert.equal(candidate(result).primary.count, 2);
+  assert.doesNotMatch(JSON.stringify(result), /private-plan/);
+});
+
+test("PR94 evidence names unchanged production rejection gates with null empty distributions", () => {
+  const short = evidence(rows({ count: 4 }));
+  assert.equal(candidate(short).outcomes.insufficient_unique_boundaries, 1);
+  assert.deepEqual(candidate(short).primary, { count: 0, median: null, central80: { lower: null, upper: null } });
+  const narrow = evidence(rows({ percentStep: 0.1 }));
+  assert.equal(candidate(narrow).outcomes.insufficient_percent_span, 1);
+  const flat = evidence(rows({ costStep: 0 }));
+  assert.equal(candidate(flat).outcomes.training_capacity_unavailable, 1);
+});
+
+test("PR94 evidence distinguishes attribution diagnostic-only from other row exclusions", () => {
+  const diagnostic = rows().map((row) => ({ ...row, aggregationEligibility: "diagnostic_only" }));
+  const result = evidence(diagnostic);
+  assert.equal(result.rowReasons.aggregation_diagnostic_only, diagnostic.length);
+  assert.equal(candidate(result).outcomes.aggregation_diagnostic_only, 1);
+  const pricing = rows().map((row) => ({ ...row, quality: { ...row.quality, pricingWarnings: ["unpriced_component"] } }));
+  assert.equal(evidence(pricing).rowReasons.pricing_warning, pricing.length);
+});
+
+test("PR94 evidence reconciles simultaneous slot, near-duplicate and overlap suppression", () => {
+  const primary = rows();
+  const simultaneous = evidence([...primary, ...rows({ slot: "secondary" })]);
+  assert.equal(candidate(simultaneous).outcomes.simultaneous_slot_conflict, 1);
+  const duplicate = rows({ reset: RESET + 1, count: 8 });
+  const dupResult = evidence([...primary, ...duplicate], { rawParents: [rawParent(primary[0]), rawParent(duplicate[0])] });
+  assert.equal(candidate(dupResult).outcomes.near_duplicate_reset_identity_with_less_evidence, 1);
+  const overlap = rows({ reset: RESET + 10, count: 8 });
+  const overlapResult = evidence([...primary, ...overlap], { rawParents: [rawParent(primary[0]), rawParent(overlap[0])] });
+  assert.equal(candidate(overlapResult).outcomes.overlapping_observation_window, 1);
+});
+
+test("PR94 zero-transition parents require demonstrated reasons; ambiguous disappearance fails", () => {
+  const base = rawParent(rows()[0]);
+  const unchanged = evidence([], { rawParents: [{ ...base, distinctPercentCount: 1, matchedDistinctPercentCount: 1 }] });
+  assert.equal(candidate(unchanged).outcomes.no_percent_change, 1);
+  const insufficient = evidence([], { rawParents: [{ ...base, snapshotCount: 1, uniqueSnapshotCount: 1, distinctPercentCount: 1,
+    matchedSnapshotCount: 1, matchedUniqueSnapshotCount: 1, matchedDistinctPercentCount: 1 }] });
+  assert.equal(candidate(insufficient).outcomes.insufficient_snapshots, 1);
+  const withheld = evidence([], { rawParents: [{ ...base, matchedSnapshotCount: 0, unavailableSnapshotCount: 13,
+    matchedUniqueSnapshotCount: 0, matchedDistinctPercentCount: 0 }] });
+  assert.equal(candidate(withheld).outcomes.all_snapshot_attribution_withheld, 1);
+  const unexplained = evidence([], { rawParents: [base] });
+  assert.equal(unexplained.status, "fail");
+  assert.equal(unexplained.counts.unexplainedParents, 1);
+  assert.equal(comparePr94CalibrationEvidence(unexplained, unexplained).status, "fail");
+});
+
+test("PR94 rejects incompatible raw snapshot partitions and unknown transition parents", () => {
+  assert.throws(() => evidence([], { rawParents: [rawParent(rows()[0], { matchedSnapshotCount: 12 })] }), isCode("pr94_calibration_snapshot_partition_invalid"));
+  assert.throws(() => evidence(rows(), { rawParents: [] }), isCode("pr94_calibration_transition_parent_missing"));
+  const raw = rawParent(rows()[0]);
+  assert.throws(() => evidence(rows(), { rawParents: [raw, raw] }), isCode("pr94_calibration_duplicate_parent"));
+});
+
+test("PR94 refuses source-policy drift and reporter disagreement rather than approximating", () => {
+  assert.throws(() => evidence(rows(), { internals: { ...original, fitReset() { return null; } } }), isCode("pr94_calibration_fit_source_unrecognized"));
+  const changed = (dataset, options) => {
+    const report = original.analyzeWeeklyCalibration(dataset, options);
+    if (report.resetValues[0]) report.resetValues[0].apiPriceEquivalentUsd += 1;
+    return report;
+  };
+  assert.throws(() => evidence(rows(), { analyzeWeeklyCalibration: changed }), isCode("pr94_calibration_report_fit_mismatch"));
+});
+
+test("PR94 private transport is sealed, bounded, closed and independently importable", async () => {
+  const originalEvidence = evidence();
+  const imported = await importPr94CalibrationEvidence({ aggregate: JSON.parse(JSON.stringify(originalEvidence)), frames: frames(originalEvidence), hmacKey: HMAC_KEY });
+  assert.deepEqual(imported, originalEvidence);
+  assert.equal(comparePr94CalibrationEvidence(originalEvidence, imported).status, "pass");
+  const changed = frames(originalEvidence);
+  changed[0].fragments[0].capacity += 1;
+  await assert.rejects(() => importPr94CalibrationEvidence({ aggregate: originalEvidence, frames: changed, hmacKey: HMAC_KEY }), isCode("pr94_calibration_seal_invalid"));
+  const foreign = frames(originalEvidence);
+  foreign[0].rawAccount = "should-never-appear";
+  await assert.rejects(() => importPr94CalibrationEvidence({ aggregate: originalEvidence, frames: foreign, hmacKey: HMAC_KEY }), isCode("pr94_calibration_private_frames_invalid"));
+  await assert.rejects(() => importPr94CalibrationEvidence({ aggregate: originalEvidence, frames: frames(originalEvidence), hmacKey: new Uint8Array(32).fill(9) }), isCode("pr94_calibration_seal_invalid"));
+  assert.throws(() => comparePr94CalibrationEvidence(structuredClone(originalEvidence), originalEvidence), isCode("pr94_calibration_evidence_untrusted"));
+});
+
+test("PR94 imports async private streams and rejects truncation, additions and duplicate records", async () => {
+  const result = evidence();
+  async function* stream(items) { for (const item of items) yield item; }
+  const imported = await importPr94CalibrationEvidence({ aggregate: result, frames: stream(frames(result)), hmacKey: HMAC_KEY });
+  assert.equal(comparePr94CalibrationEvidence(result, imported).status, "pass");
+  await assert.rejects(() => importPr94CalibrationEvidence({ aggregate: result, frames: stream(frames(result).slice(0, -1)), hmacKey: HMAC_KEY }),
+    (error) => ["pr94_calibration_parent_candidate_missing", "pr94_calibration_seal_invalid"].includes(error.code));
+  const duplicates = frames(result);
+  duplicates.splice(1, 0, structuredClone(duplicates[0]));
+  await assert.rejects(() => importPr94CalibrationEvidence({ aggregate: result, frames: stream(duplicates), hmacKey: HMAC_KEY }),
+    isCode("pr94_calibration_parent_multiplied"));
+  const trailing = [...frames(result), { kind: "seal", digest: "0".repeat(64) }];
+  await assert.rejects(() => importPr94CalibrationEvidence({ aggregate: result, frames: stream(trailing), hmacKey: HMAC_KEY }),
+    isCode("pr94_calibration_private_frames_invalid"));
+});
+
+test("PR94 fit rejection classifies insufficient training pairs using original helper results", () => {
+  const cost = [0, 0, 0, 1, 1, 1, 1];
+  const transitions = rows({ count: 7 }).map((row, index) => ({ ...row,
+    lastPriorCumulativeApiPricedUsd: cost[index], firstNextCumulativeApiPricedUsd: cost[index],
+  }));
+  assert.equal(candidate(evidence(transitions)).outcomes.insufficient_training_pairs, 1);
+});
+
+test("PR94 selected population and unchanged inputs cannot be silently relabelled", () => {
+  const transitions = rows({ planType: "unknown" });
+  const result = evidence(transitions, { selectedPlanType: "unknown" });
+  assert.equal(result.counts.unknownAccountParents, 1);
+  assert.equal(candidate(result).outcomes.selected_plan_primary, 1);
+  const selectedMissing = evidence(rows(), { selectedPlanType: null });
+  assert.equal(candidate(selectedMissing).outcomes.unselected_plan_primary, 1);
+  const differentPopulation = comparePr94CalibrationEvidence(evidence(rows()), selectedMissing);
+  assert.equal(differentPopulation.status, "fail");
+  assert.equal(differentPopulation.selectedPopulationMatches, false);
+  assert.throws(() => comparePr94CalibrationEvidence(result, evidence(transitions, { hmacKey: new Uint8Array(64).fill(13) })),
+    isCode("pr94_calibration_evidence_untrusted"));
+});
+
+test("PR94 comparison refuses changed raw-parent inventory despite identical fitted transitions", () => {
+  const transitions = rows();
+  const result = evidence(transitions);
+  const changed = evidence(transitions, { rawParents: [rawParent(transitions[0], { snapshotCount: 14, matchedSnapshotCount: 14 })] });
+  const compared = comparePr94CalibrationEvidence(result, changed);
+  assert.equal(compared.changedRawParentInventory, 4);
+  assert.equal(compared.status, "fail");
+});
+
+test("PR94 comparison detects missing raw parent/candidate records without exposing identity", () => {
+  const one = rows();
+  const two = rows({ reset: RESET + 604_800, offset: 168 });
+  const before = evidence([...one, ...two], { rawParents: [rawParent(one[0]), rawParent(two[0])] });
+  const after = evidence(one);
+  const compared = comparePr94CalibrationEvidence(before, after);
+  assert.equal(compared.status, "fail");
+  assert.equal(compared.missingParentCandidates, 4);
+  assert.equal(compared.reconciledParentCandidates, 4);
+  assert.equal(compared.baselinePrimaryFits, 8);
+  assert.equal(compared.retainedPrimaryFits, 4);
+  assert.equal(compared.lostPrimaryFits, 4);
+  assert.equal(compared.unexplainedPrimaryLosses, 4);
+  assert.equal(compared.primaryOutcomeMatrix.filter((cell) => cell.transition === "missing_parent")
+    .reduce((sum, cell) => sum + cell.baselinePrimaryFits, 0), 4);
+  assert.doesNotMatch(JSON.stringify(compared), /[a-f0-9]{64}|2026-|reset/);
+});
+
+test("PR94 comparison accounts for every retained, lost and new primary without a loss tolerance", () => {
+  const full = evidence();
+  const short = evidence(rows({ count: 4 }));
+  const unchanged = comparePr94CalibrationEvidence(full, full);
+  assert.equal(unchanged.schemaVersion, "pr94-calibration-comparison-v2");
+  assert.equal(unchanged.requiresCoverageReview, false);
+  assert.equal(unchanged.retainedPrimaryFits, 4);
+  const lost = comparePr94CalibrationEvidence(full, short);
+  assert.equal(lost.status, "pass"); // Explained numerical reduction, NOT automatic coverage sign-off.
+  assert.equal(lost.requiresCoverageReview, true);
+  assert.equal(lost.baselinePrimaryFits, 4);
+  assert.equal(lost.retainedPrimaryFits, 0);
+  assert.equal(lost.lostPrimaryFits, 4);
+  assert.equal(lost.changedInputPrimaryLosses, 4);
+  assert.equal(lost.unexplainedPrimaryLosses, 0);
+  assert.ok(lost.primaryOutcomeMatrix.every((cell) => cell.transition === "lost_primary"
+    && cell.parentCandidates === 1 && cell.baselinePrimaryFits === 1 && cell.afterPrimaryFits === 0
+    && cell.changedInputPrimaryLosses === 1
+    && JSON.stringify(cell.afterOutcomes) === JSON.stringify([{ outcome: "insufficient_unique_boundaries", count: 1 }])));
+  const gained = comparePr94CalibrationEvidence(short, full);
+  assert.equal(gained.newPrimaryFits, 4);
+  assert.equal(gained.lostPrimaryFits, 0);
+  assert.equal(gained.requiresCoverageReview, true);
+  assert.ok(gained.primaryOutcomeMatrix.every((cell) => cell.transition === "new_primary"));
+  const empty = comparePr94CalibrationEvidence(short, short);
+  assert.ok(empty.primaryOutcomeMatrix.every((cell) => cell.transition === "no_primary"));
+  assert.equal(empty.requiresCoverageReview, false);
+  const repricedInputs = comparePr94CalibrationEvidence(full, evidence(rows({ costStep: 20 })));
+  assert.equal(repricedInputs.status, "pass");
+  assert.equal(repricedInputs.lostPrimaryFits, 0);
+  assert.equal(repricedInputs.newPrimaryFits, 0);
+  assert.equal(repricedInputs.retainedPrimaryInputChanges, 4);
+  assert.equal(repricedInputs.requiresCoverageReview, true);
+});
+
+test("PR94 primary loss matrix preserves attribution withholding and original suppression reasons", () => {
+  const full = evidence();
+  const diagnostic = evidence(rows().map((row) => ({ ...row, aggregationEligibility: "diagnostic_only" })));
+  const withheld = evidence([], { rawParents: [rawParent(rows()[0], { matchedSnapshotCount: 0,
+    matchedUniqueSnapshotCount: 0, matchedDistinctPercentCount: 0, unavailableSnapshotCount: 13 })] });
+  for (const [after, expected] of [[diagnostic, "aggregation_diagnostic_only"], [withheld, "all_snapshot_attribution_withheld"]]) {
+    const compared = comparePr94CalibrationEvidence(full, after);
+    assert.equal(compared.status, "pass");
+    assert.equal(compared.lostPrimaryFits, 4);
+    assert.equal(compared.requiresCoverageReview, true);
+    assert.ok(compared.primaryOutcomeMatrix.every((cell) => cell.afterOutcomes.length === 1
+      && cell.afterOutcomes[0].outcome === expected && cell.afterOutcomes[0].count === 1));
+  }
+  const first = rows();
+  const second = rows({ reset: RESET + 10, count: 8, offset: 30 });
+  const rawParents = [rawParent(first[0]), rawParent(second[0])];
+  const before = evidence([...first, ...second], { rawParents });
+  const after = evidence([...first, ...rows({ reset: RESET + 10, count: 8 })], { rawParents });
+  const compared = comparePr94CalibrationEvidence(before, after);
+  assert.equal(compared.status, "pass");
+  assert.equal(compared.lostPrimaryFits, 4);
+  assert.equal(compared.retainedPrimaryFits, 4);
+  assert.equal(compared.changedInputPrimaryLosses, 0);
+  assert.ok(compared.primaryOutcomeMatrix.filter((cell) => cell.transition === "lost_primary")
+    .every((cell) => cell.afterOutcomes[0].outcome === "overlapping_observation_window"));
+});
+
+test("PR94 comparison fails an identical-point fit rejection instead of silently counting parent presence", async () => {
+  const variant = await policyVariant("reject-capacity", (source) => source.replace(
+    "function capacityFit(points) {", "function capacityFit(points) { return { capacityUsd: null, pairCount: 0 };"));
+  const before = evidence();
+  const after = evidence(rows(), { internals: variant, analyzeWeeklyCalibration: variant.analyzeWeeklyCalibration });
+  assert.equal(after.status, "pass");
+  const compared = comparePr94CalibrationEvidence(before, after);
+  assert.equal(compared.status, "fail");
+  assert.equal(compared.reconciledParentCandidates, 4);
+  assert.equal(compared.rejectedIdenticalInputFits, 4);
+  assert.equal(compared.lostPrimaryFits, 4);
+  assert.equal(compared.unexplainedPrimaryLosses, 4);
+  assert.equal(compared.changedInputPrimaryLosses, 0);
+});
+
+test("PR94 unknown-account independence executes actual original fits and reports its limited scope", async () => {
+  const result = evidence();
+  assert.equal(result.schemaVersion, "pr94-calibration-evidence-v2");
+  assert.deepEqual(result.unknownAccountCheck, { scope: "original_fit_gate_only", fragmentCandidatesChecked: 4,
+    rowsChecked: 48, changedEligibilityRows: 0, changedPointSets: 0, changedFits: 0, unknownOnlyFitExclusions: 0 });
+  const known = evidence(rows().map((row) => ({ ...row, accountScopeId: "synthetic-known" })));
+  assert.equal(known.unknownAccountCheck.rowsChecked, 0);
+  assert.equal(known.unknownAccountCheck.fragmentCandidatesChecked, 0);
+  const variant = await policyVariant("unknown-account-excluded", (source) => source.replace(
+    'const ordered = [...rows].filter(isEligible).sort((left, right) => left.eventTime.localeCompare(right.eventTime));',
+    'const ordered = [...rows].filter(isEligible).filter((row) => row.accountScopeId !== "unattributed").sort((left, right) => left.eventTime.localeCompare(right.eventTime));'));
+  const rejected = evidence(rows(), { internals: variant, analyzeWeeklyCalibration: variant.analyzeWeeklyCalibration });
+  assert.equal(rejected.status, "fail");
+  assert.equal(rejected.unknownAccountCheck.fragmentCandidatesChecked, 4);
+  assert.equal(rejected.unknownAccountCheck.rowsChecked, 48);
+  assert.equal(rejected.unknownAccountCheck.changedPointSets, 4);
+  assert.equal(rejected.unknownAccountCheck.changedFits, 4);
+  assert.equal(rejected.unknownAccountCheck.unknownOnlyFitExclusions, 4);
+  assert.equal(comparePr94CalibrationEvidence(result, rejected).status, "fail");
+  assert.doesNotMatch(JSON.stringify(rejected), /pr94-counterfactual|synthetic-known|[a-f0-9]{64}/u);
+});
+
+test("PR94 rejects hidden private-frame channels and revokes private lifetime explicitly", async () => {
+  const result = evidence();
+  for (const mutate of [
+    (frame) => Object.defineProperty(frame, "hidden", { value: "secret" }),
+    (frame) => Object.defineProperty(frame, "capacity", { get() { throw new Error("must-not-run"); }, enumerable: true }),
+    (frame) => { frame[Symbol("secret")] = "secret"; },
+    (frame) => Object.setPrototypeOf(frame, { hidden: "secret" }),
+  ]) {
+    const privateFrames = frames(result);
+    mutate(privateFrames[0].fragments[0]);
+    await assert.rejects(() => importPr94CalibrationEvidence({ aggregate: result, frames: privateFrames, hmacKey: HMAC_KEY }),
+      isCode("pr94_calibration_private_frames_invalid"));
+  }
+  const iterator = iteratePr94CalibrationPrivateFrames(result);
+  assert.equal(iterator.next().done, false);
+  disposePr94CalibrationEvidencePrivate(result);
+  assert.equal(result.status, "pass");
+  assert.throws(() => iterator.next(), isCode("pr94_calibration_evidence_untrusted"));
+  assert.throws(() => comparePr94CalibrationEvidence(result, result), isCode("pr94_calibration_evidence_untrusted"));
+});

--- a/test/pr94-ledger-evidence.test.js
+++ b/test/pr94-ledger-evidence.test.js
@@ -1,0 +1,467 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { addUsdStrings, priceCodexUsageEvent } from "@app-usagemonitor/accounting";
+import {
+  PR94_LEDGER_COMPONENTS,
+  comparePr94LedgerEvidence,
+  createPr94LedgerEvidence,
+  disposePr94LedgerEvidencePrivate,
+  importPr94LedgerEvidencePrivate,
+  iteratePr94LedgerEvidencePrivate,
+  validatePr94LedgerEvidenceAggregate,
+} from "../scripts/lib/pr94-ledger-evidence.mjs";
+
+// Only synthetic, content-free data. These tests never open a corpus, database,
+// application, Keychain, or private transport file.
+const KEY = Buffer.alloc(32, 71);
+const TIME = "2026-08-01T00:00:00.000Z";
+const SURFACE = { surface: "cli_exec", threadSource: "user", agentScope: "root", lineageDisposition: "standalone" };
+const clone = (value) => structuredClone(value);
+function usage(offset = 1, overrides = {}) {
+  return { timestamp: TIME, timestampMs: Date.parse(TIME), model: "gpt-5.6-sol",
+    sourceLocal: Buffer.alloc(32, 3), sourceRolloutOrdinal: 0, sourceOrdinal: 0,
+    sourceRecordOrdinal: offset, sourceOffset: offset, sequence: offset,
+    components: { input_uncached_tokens: 20_000, input_cache_read_tokens: 0,
+      input_cache_write_tokens: 0, output_text_tokens: 0, output_reasoning_tokens: 0, output_combined_tokens: 0 },
+    totalInputContextTokens: 100,
+    tierSemantics: { billingSurface: "chatgpt_subscription", codexSpeedMode: "standard",
+      apiServiceTier: "unknown", tierSource: "rollout_thread_settings", tierObservedAt: null },
+    surfaceClassification: { ...SURFACE }, ...overrides };
+}
+function quota(offset = 5, overrides = {}) {
+  return { timestamp: TIME, timestampMs: Date.parse(TIME), sourceLocal: Buffer.alloc(32, 3),
+    sourceRolloutOrdinal: 0, sourceOrdinal: 0, sourceRecordOrdinal: offset, sourceOffset: offset,
+    sequence: offset, slotOrder: 0, surfaceClassification: { ...SURFACE },
+    window: { provider: "openai_codex", planType: "unknown", limitId: "codex", slot: "primary",
+      usedPercent: 12.5, windowDurationMins: 300, resetsAt: Date.parse(TIME) / 1_000 + 300 * 60 }, ...overrides };
+}
+function accumulate(usages = [], quotas = [], configuration = {}) {
+  const ledger = createPr94LedgerEvidence({ hmacKey: KEY, ...configuration });
+  usages.forEach((row) => ledger.consumeUsage(row, priceCodexUsageEvent(row)));
+  quotas.forEach((row) => ledger.consumeQuota(row));
+  return ledger.finish();
+}
+function frames(value) { return [...iteratePr94LedgerEvidencePrivate(value)].map(clone); }
+function rejectedUsage(mutateRaw, mutatePrice = () => {}) {
+  const ledger = createPr94LedgerEvidence({ hmacKey: KEY });
+  const row = usage();
+  const price = priceCodexUsageEvent(row);
+  mutateRaw(row); mutatePrice(price);
+  assert.throws(() => ledger.consumeUsage(row, price), { code: "pr94_ledger_row_rejected" });
+  assert.throws(() => ledger.finish(), { code: "pr94_ledger_state" });
+}
+
+test("empty evidence is explicit, closed, deeply frozen, and compares only with authentic evidence", () => {
+  const before = accumulate();
+  assert.equal(validatePr94LedgerEvidenceAggregate(before), before);
+  assert.equal(before.usage.events, 0);
+  assert.equal(before.quota.events, 0);
+  assert.equal(before.usage.totalUsd, "0");
+  assert.deepEqual(Object.keys(before.usage.components), PR94_LEDGER_COMPONENTS);
+  assert.ok(Object.isFrozen(before.usage.components.input_uncached_tokens));
+  assert.throws(() => { before.usage.events = 1; }, TypeError);
+  assert.equal(comparePr94LedgerEvidence(before, accumulate()).status, "equal");
+  assert.throws(() => comparePr94LedgerEvidence(before, clone(before)), { code: "pr94_ledger_private_evidence_required" });
+  assert.throws(() => [...iteratePr94LedgerEvidencePrivate(clone(before))], { code: "pr94_ledger_private_evidence_required" });
+});
+
+test("streaming usage conserves six components, exact decimal event costs and component subtotal", () => {
+  const first = usage(1);
+  const second = usage(2);
+  second.components.input_uncached_tokens = 40_000;
+  const evidence = accumulate([first, second], [quota()]);
+  assert.equal(priceCodexUsageEvent(first).totalUsd, "0.1");
+  assert.equal(priceCodexUsageEvent(second).totalUsd, "0.2");
+  assert.equal(evidence.usage.totalUsd, "0.3");
+  assert.equal(evidence.usage.components.input_uncached_tokens.quantity, "60000");
+  assert.equal(evidence.usage.components.input_uncached_tokens.costUsd, "0.3");
+  assert.equal(evidence.usage.components.output_combined_tokens.zeroEvents, 2);
+  assert.equal(evidence.usage.warnings.informational.unknown_zero_component, 2);
+  assert.equal(evidence.quota.usedPercentTotal, "12.5");
+  assert.equal(evidence.quota.windowDurationMinsTotal, "300");
+  assert.equal(comparePr94LedgerEvidence(evidence, accumulate([second, first], [quota()])).status, "equal");
+});
+
+test("totals beyond safe integer precision are exact strings, not unsafe numeric counters", () => {
+  const first = usage(1, { components: { output_combined_tokens: Number.MAX_SAFE_INTEGER } });
+  const second = usage(2, { components: { output_combined_tokens: Number.MAX_SAFE_INTEGER } });
+  const evidence = accumulate([first, second]);
+  assert.equal(evidence.usage.components.output_combined_tokens.quantity, "18014398509481982");
+  assert.equal(evidence.usage.components.output_combined_tokens.unpricedQuantity, "18014398509481982");
+  assert.equal(evidence.usage.totalUsd, "0");
+  assert.equal(evidence.usage.coverage.unpriced, 2);
+});
+
+test("missing, unavailable and observed zero components/context never collapse", () => {
+  const missing = usage();
+  delete missing.components.input_cache_read_tokens;
+  delete missing.totalInputContextTokens;
+  const unavailable = usage();
+  unavailable.components.input_cache_read_tokens = null;
+  unavailable.totalInputContextTokens = null;
+  const zero = usage();
+  zero.totalInputContextTokens = 0;
+  const missingEvidence = accumulate([missing]);
+  const unavailableEvidence = accumulate([unavailable]);
+  const zeroEvidence = accumulate([zero]);
+  assert.equal(missingEvidence.usage.components.input_cache_read_tokens.missingEvents, 1);
+  assert.equal(unavailableEvidence.usage.components.input_cache_read_tokens.unavailableEvents, 1);
+  assert.equal(unavailableEvidence.usage.components.input_cache_read_tokens.unavailablePricingEvents, 1);
+  assert.equal(zeroEvidence.usage.components.input_cache_read_tokens.zeroEvents, 1);
+  assert.equal(missingEvidence.usage.context.missingEvents, 1);
+  assert.equal(unavailableEvidence.usage.context.unavailableEvents, 1);
+  assert.equal(zeroEvidence.usage.context.zeroEvents, 1);
+  assert.equal(comparePr94LedgerEvidence(missingEvidence, zeroEvidence).status, "different");
+  assert.equal(comparePr94LedgerEvidence(unavailableEvidence, zeroEvidence).status, "different");
+});
+
+test("component availability preserves the raw value privately without pricing unavailable quantity", () => {
+  const row = usage(1, { componentAvailability: { input_uncached_tokens: false, output_combined_tokens: false } });
+  const evidence = accumulate([row]);
+  assert.equal(evidence.usage.components.input_uncached_tokens.unavailableEvents, 1);
+  assert.equal(evidence.usage.components.input_uncached_tokens.quantity, "0");
+  assert.equal(evidence.usage.components.output_combined_tokens.unavailableEvents, 1);
+  assert.equal(evidence.usage.components.output_combined_tokens.unavailablePricingEvents, 0);
+  const changed = clone(row);
+  changed.components.input_uncached_tokens = 1;
+  const comparison = comparePr94LedgerEvidence(evidence, accumulate([changed]));
+  assert.equal(comparison.aggregateEqual, true);
+  assert.equal(comparison.rows.usage.changed, 1);
+  const absent = usage(1, { componentAvailability: { input_cache_read_tokens: false } });
+  delete absent.components.input_cache_read_tokens;
+  const explicitNull = clone(absent);
+  explicitNull.components.input_cache_read_tokens = null;
+  const presenceComparison = comparePr94LedgerEvidence(accumulate([absent]), accumulate([explicitNull]));
+  assert.equal(presenceComparison.aggregateEqual, true);
+  assert.equal(presenceComparison.rows.usage.changed, 1);
+});
+
+test("equal aggregate totals do not prove conservation when event quantities or costs are reassigned", () => {
+  const small = usage(1);
+  const large = usage(2);
+  large.components.input_uncached_tokens = 40_000;
+  const reversedSmall = usage(1);
+  reversedSmall.components.input_uncached_tokens = 40_000;
+  const comparison = comparePr94LedgerEvidence(accumulate([small, large]), accumulate([reversedSmall, usage(2)]));
+  assert.equal(comparison.aggregateEqual, true);
+  assert.equal(comparison.status, "different");
+  assert.deepEqual(comparison.rows.usage, { before: 2, after: 2, unchanged: 0, changed: 2, missing: 0, added: 0 });
+});
+
+test("source identity includes rollout ordinal, record ordinal and quota slot order", () => {
+  const before = accumulate([usage()], [quota()]);
+  const usageChanged = usage(2);
+  const quotaChanged = quota(5, { slotOrder: 1 });
+  let comparison = comparePr94LedgerEvidence(before, accumulate([usageChanged], [quotaChanged]));
+  assert.equal(comparison.aggregateEqual, true);
+  assert.equal(comparison.rows.usage.missing, 1);
+  assert.equal(comparison.rows.usage.added, 1);
+  assert.equal(comparison.rows.quota.missing, 1);
+  comparison = comparePr94LedgerEvidence(before, accumulate([usage(1, { sourceRolloutOrdinal: 1, sourceOrdinal: 1 })], [quota()]));
+  assert.equal(comparison.rows.usage.missing, 1);
+  assert.equal(comparison.rows.usage.added, 1);
+  assert.equal(accumulate([], [quota(), quota(5, { slotOrder: 1 })]).quota.events, 2);
+});
+
+test("same semantic quota windows in distinct raw occurrences remain distinct conserved rows", () => {
+  const before = accumulate([], [quota(1), quota(2)]);
+  const after = accumulate([], [quota(1)]);
+  const comparison = comparePr94LedgerEvidence(before, after);
+  assert.equal(before.quota.events, 2);
+  assert.equal(comparison.rows.quota.missing, 1);
+  const changed = quota(1);
+  changed.window.resetsAt += 1;
+  const resetComparison = comparePr94LedgerEvidence(accumulate([], [quota(1)]), accumulate([], [changed]));
+  assert.equal(resetComparison.aggregateEqual, true);
+  assert.equal(resetComparison.rows.quota.changed, 1);
+});
+
+test("only documented PR94 attribution fields and callback sequence are excluded from row fingerprints", () => {
+  const row = usage(1, { sequence: 999, planAttribution: { basis: "same_record", planType: "pro", planVariant: null },
+    usageIntervalStartedAt: "2026-07-31T23:59:00.000Z", usageIntervalBasis: "previous_source_record" });
+  assert.equal(comparePr94LedgerEvidence(accumulate([usage()]), accumulate([row])).status, "equal");
+  for (const mutate of [
+    (value) => { value.tierSemantics.codexSpeedMode = "fast"; },
+    (value) => { value.surfaceClassification.agentScope = "subagent"; },
+    (value) => { value.timestamp = "2026-08-01T00:00:01.000Z"; value.timestampMs += 1000; },
+    (value) => { value.totalInputContextTokens += 1; },
+    (value) => { value.componentAvailability = { input_uncached_tokens: true }; },
+  ]) {
+    const changed = usage(); mutate(changed);
+    assert.equal(comparePr94LedgerEvidence(accumulate([usage()]), accumulate([changed])).rows.usage.changed, 1);
+  }
+});
+
+test("unknown models and warning diagnostics cannot become dynamic public output", () => {
+  const row = usage(1, { model: "synthetic-unknown-model" });
+  const price = priceCodexUsageEvent(row);
+  for (const warning of [...price.warnings.coverage, ...price.warnings.informational]) {
+    warning.message = "SYNTHETIC_PRIVATE_DIAGNOSTIC";
+    warning.metadata = { source: "SYNTHETIC_PRIVATE_DIAGNOSTIC" };
+  }
+  const ledger = createPr94LedgerEvidence({ hmacKey: KEY });
+  ledger.consumeUsage(row, price);
+  const evidence = ledger.finish();
+  assert.equal(evidence.usage.coverage.unpriced, 1);
+  assert.equal(evidence.usage.warnings.coverage.unknown_model, 1);
+  const output = JSON.stringify(evidence);
+  assert.ok(!output.includes(row.model));
+  assert.ok(!output.includes("SYNTHETIC_PRIVATE_DIAGNOSTIC"));
+  assert.ok(!output.includes("identity"));
+  assert.ok(!output.includes("fingerprint"));
+  assert.ok(!output.includes("sourceLocal"));
+  assert.ok(!output.includes(KEY.toString("hex")));
+});
+
+test("unknown model substitutions remain detectable despite identical unpriced totals", () => {
+  const comparison = comparePr94LedgerEvidence(
+    accumulate([usage(1, { model: "synthetic-unknown-one" })]),
+    accumulate([usage(1, { model: "synthetic-unknown-two" })]),
+  );
+  assert.equal(comparison.aggregateEqual, true);
+  assert.equal(comparison.rows.usage.changed, 1);
+});
+
+test("duplicate usage/quota occurrence poisons the accumulator instead of overwriting", () => {
+  for (const kind of ["usage", "quota"]) {
+    const ledger = createPr94LedgerEvidence({ hmacKey: KEY });
+    const consume = () => kind === "usage"
+      ? ledger.consumeUsage(usage(), priceCodexUsageEvent(usage())) : ledger.consumeQuota(quota());
+    consume();
+    assert.throws(consume, { code: "pr94_ledger_row_rejected" });
+    assert.throws(() => ledger.finish(), { code: "pr94_ledger_state" });
+    assert.throws(consume, { code: "pr94_ledger_state" });
+  }
+});
+
+test("bounded row budget covers both streams, finalization is single-use and copies caller key", () => {
+  const key = Buffer.from(KEY);
+  const ledger = createPr94LedgerEvidence({ hmacKey: key, maxRows: 1 });
+  key.fill(0);
+  ledger.consumeQuota(quota());
+  const evidence = ledger.finish();
+  assert.equal(comparePr94LedgerEvidence(evidence, accumulate([], [quota()])).status, "equal");
+  assert.throws(() => ledger.finish(), { code: "pr94_ledger_state" });
+  assert.throws(() => ledger.consumeQuota(quota(2)), { code: "pr94_ledger_state" });
+  const bounded = createPr94LedgerEvidence({ hmacKey: KEY, maxRows: 1 });
+  bounded.consumeQuota(quota());
+  assert.throws(() => bounded.consumeUsage(usage(), priceCodexUsageEvent(usage())), { code: "pr94_ledger_row_rejected" });
+  assert.throws(() => bounded.finish(), { code: "pr94_ledger_state" });
+});
+
+test("private disposal releases comparison/transport authority but preserves the immutable public aggregate", () => {
+  const evidence = accumulate([usage()]);
+  const inFlight = iteratePr94LedgerEvidencePrivate(evidence);
+  assert.equal(inFlight.next().value.type, "header");
+  disposePr94LedgerEvidencePrivate(evidence);
+  assert.equal(validatePr94LedgerEvidenceAggregate(evidence), evidence);
+  assert.equal(evidence.usage.totalUsd, "0.1");
+  assert.throws(() => [...iteratePr94LedgerEvidencePrivate(evidence)], { code: "pr94_ledger_private_evidence_required" });
+  assert.throws(() => comparePr94LedgerEvidence(evidence, accumulate([usage()])), { code: "pr94_ledger_private_evidence_required" });
+  assert.throws(() => disposePr94LedgerEvidencePrivate(evidence), { code: "pr94_ledger_private_evidence_required" });
+  assert.throws(() => inFlight.next(), { code: "pr94_ledger_private_evidence_required" });
+});
+
+test("unknown/raw diagnostic keys and unsafe/nonfinite/negative counts are rejected without leaking values", () => {
+  for (const mutate of [
+    (row) => { row.secret = "SYNTHETIC_PRIVATE"; },
+    (row) => { row.components.other_tokens = 1; },
+    (row) => { row.tierSemantics.extra = 1; },
+    (row) => { row.surfaceClassification.extra = 1; },
+    (row) => { row.componentAvailability = { other_tokens: true }; },
+    (row) => { row.componentAvailability = { input_uncached_tokens: "false" }; },
+    (row) => { row.sourceOffset += 1; },
+    (row) => { row.sourceOrdinal += 1; },
+    (row) => { row.sourceLocal = Buffer.alloc(31); },
+    (row) => { row.timestampMs += 1; },
+    (row) => { delete row.timestamp; },
+    (row) => { row.components.input_uncached_tokens = undefined; },
+    (row) => { row.planAttribution = { basis: "same_record", planType: "pro", planVariant: null, extra: 1 }; },
+  ]) rejectedUsage(mutate);
+  for (const invalid of [-1, -0, NaN, Infinity, 0.5, Number.MAX_SAFE_INTEGER + 1, "100", null]) {
+    rejectedUsage((row) => { row.sourceRecordOrdinal = invalid; });
+    if (invalid !== null) rejectedUsage((row) => { row.components.input_uncached_tokens = invalid; });
+  }
+});
+
+test("component quantities, coverage, monetary subtotals and card provenance must reconcile per event", () => {
+  for (const mutate of [
+    (price) => { price.totalUsd = "0.2"; },
+    (price) => { price.totalUsd = "0.10"; },
+    (price) => { price.totalUsd = 0.1; },
+    (price) => { price.components[0].quantity = "20001"; },
+    (price) => { price.components[0].costUsd = null; },
+    (price) => { price.components[0].unitPriceUsd = "-1"; },
+    (price) => { price.components[0].name = "other_tokens"; },
+    (price) => { price.components.push(clone(price.components[0])); },
+    (price) => { price.components = []; },
+    (price) => { price.coverageStatus = "unpriced"; },
+    (price) => { price.coverageCounts.pricedComponents = 0; },
+    (price) => { price.coverageCounts.extra = 0; },
+    (price) => { price.model = "synthetic-unknown"; },
+    (price) => { price.selectedPriceCardIds = []; },
+    (price) => { price.selectedPriceCardId = null; },
+    (price) => { price.priceCardBreakdown[0].costUsd = "0.2"; },
+    (price) => { price.priceCardBreakdown.push(clone(price.priceCardBreakdown[0])); },
+    (price) => { price.warnings.informational[0].code = "SYNTHETIC_PRIVATE_UNKNOWN_WARNING"; },
+    (price) => { price.extra = "SYNTHETIC_PRIVATE"; },
+  ]) rejectedUsage(() => {}, mutate);
+});
+
+test("unpriced and unavailable components cannot substitute missing price with monetary zero", () => {
+  for (const mode of ["unpriced", "unavailable"]) {
+    const row = mode === "unpriced" ? usage(1, { model: "synthetic-unknown" })
+      : usage(1, { componentAvailability: { input_uncached_tokens: false } });
+    const price = priceCodexUsageEvent(row);
+    const component = price.components.find((item) => item.name === "input_uncached_tokens");
+    assert.equal(component.pricingStatus, mode);
+    component.costUsd = "0";
+    const ledger = createPr94LedgerEvidence({ hmacKey: KEY });
+    assert.throws(() => ledger.consumeUsage(row, price), { code: "pr94_ledger_row_rejected" });
+  }
+});
+
+test("quota validation rejects invalid windows, unknown keys and missing observations", () => {
+  for (const mutate of [
+    (row) => { row.window.usedPercent = null; },
+    (row) => { row.window.usedPercent = NaN; },
+    (row) => { row.window.usedPercent = Infinity; },
+    (row) => { row.window.usedPercent = -1; },
+    (row) => { row.window.usedPercent = 101; },
+    (row) => { row.window.windowDurationMins = 0; },
+    (row) => { row.window.windowDurationMins = Number.MAX_SAFE_INTEGER + 1; },
+    (row) => { row.window.resetsAt = 0; },
+    (row) => { row.window.slot = "tertiary"; },
+    (row) => { row.window.extra = "SYNTHETIC_PRIVATE"; },
+    (row) => { row.sourceOffset += 1; },
+    (row) => { delete row.slotOrder; },
+  ]) {
+    const ledger = createPr94LedgerEvidence({ hmacKey: KEY });
+    const row = quota(); mutate(row);
+    assert.throws(() => ledger.consumeQuota(row), { code: "pr94_ledger_row_rejected" });
+    assert.throws(() => ledger.finish(), { code: "pr94_ledger_state" });
+  }
+  assert.equal(accumulate([], [quota(1, { window: { ...quota().window, usedPercent: 0 } })]).quota.usedPercentTotal, "0");
+});
+
+test("closed public validator rejects extras, missing counters, unsafe counts and false subtotal consistency", () => {
+  const good = accumulate([usage()], [quota()]);
+  for (const mutate of [
+    (value) => { value.privateRows = []; },
+    (value) => { value.usage.extra = 1; },
+    (value) => { delete value.usage.events; },
+    (value) => { value.usage.events = Infinity; },
+    (value) => { value.usage.events = Number.MAX_SAFE_INTEGER + 1; },
+    (value) => { value.usage.events = -1; },
+    (value) => { value.usage.coverage.fully_priced = 0; },
+    (value) => { value.usage.components.input_uncached_tokens.quantity = "0"; },
+    (value) => { value.usage.components.input_uncached_tokens.pricedQuantity = "99999999999999999999999"; },
+    (value) => { value.usage.components.output_combined_tokens.missingEvents = 1; },
+    (value) => { value.usage.components.output_combined_tokens.unavailablePricingEvents = 1; },
+    (value) => { value.usage.totalUsd = "0"; },
+    (value) => { value.usage.warnings.coverage.unknown_new_warning = 0; },
+    (value) => { delete value.usage.warnings.coverage.unknown_model; },
+    (value) => { value.usage.warnings.coverage.unknown_model = NaN; },
+    (value) => { value.usage.warnings.coverage.unknown_model = 129; },
+    (value) => { value.quota.slots.primary = 0; },
+    (value) => { value.quota.usedPercentTotal = null; },
+    (value) => { value.quota.usedPercentTotal = "100.0000000000000000001"; },
+    (value) => { value.quota.windowDurationMinsTotal = "9007199254740992"; },
+  ]) {
+    const changed = clone(good); mutate(changed);
+    assert.throws(() => validatePr94LedgerEvidenceAggregate(changed), { code: "pr94_ledger_invalid" });
+  }
+});
+
+test("closed validators reject accessors, symbol channels and prototype-bearing records", () => {
+  const evidence = clone(accumulate());
+  Object.defineProperty(evidence, "extra", { get() { throw new Error("SYNTHETIC_PRIVATE"); }, enumerable: true });
+  assert.throws(() => validatePr94LedgerEvidenceAggregate(evidence), { code: "pr94_ledger_invalid" });
+  const symbol = clone(accumulate()); symbol[Symbol("private")] = 1;
+  assert.throws(() => validatePr94LedgerEvidenceAggregate(symbol), { code: "pr94_ledger_invalid" });
+  const prototype = Object.assign(Object.create({ private: true }), accumulate());
+  assert.throws(() => validatePr94LedgerEvidenceAggregate(prototype), { code: "pr94_ledger_invalid" });
+});
+
+test("private streaming transport round-trips without materializing raw rows or exposing the HMAC key", async () => {
+  const original = accumulate([usage()], [quota()]);
+  const output = frames(original);
+  assert.deepEqual(output.map((frame) => frame.type), ["header", "usage", "quota", "seal"]);
+  assert.deepEqual(Object.keys(output[1]).sort(), ["fingerprint", "identity", "type"]);
+  assert.match(output[1].identity, /^[a-f0-9]{64}$/);
+  assert.match(output[1].fingerprint, /^[a-f0-9]{64}$/);
+  const serialized = JSON.stringify(output);
+  for (const forbidden of [KEY.toString("hex"), Buffer.alloc(32, 3).toString("hex"), "sourceLocal", "sourceOffset", TIME, "gpt-5.6-sol"]) {
+    assert.ok(!serialized.includes(forbidden));
+  }
+  async function* stream() { for (const frame of output) yield JSON.parse(JSON.stringify(frame)); }
+  const restored = await importPr94LedgerEvidencePrivate(stream(), { hmacKey: KEY });
+  assert.equal(comparePr94LedgerEvidence(original, restored).status, "equal");
+  assert.deepEqual(restored, original);
+  assert.deepEqual(frames(restored), frames(original));
+});
+
+test("private transport rejects tampered frames, aggregate spoofing, truncation and appended data", async () => {
+  const original = accumulate([usage()], [quota()]);
+  for (const mutate of [
+    (rows) => { rows[0].aggregate.usage.totalUsd = "0"; },
+    (rows) => { rows[0].keyCheck = "0".repeat(64); },
+    (rows) => { rows[0].extra = true; },
+    (rows) => { rows[1].identity = "1".repeat(64); },
+    (rows) => { rows[1].fingerprint = "2".repeat(64); },
+    (rows) => { rows[1].fingerprint = "bad"; },
+    (rows) => { rows[1].type = "other"; },
+    (rows) => { rows[1].raw = "SYNTHETIC_PRIVATE"; },
+    (rows) => { rows.splice(1, 0, clone(rows[1])); },
+    (rows) => { rows.splice(1, 1); },
+    (rows) => { rows.pop(); },
+    (rows) => { rows.push(clone(rows.at(-1))); },
+    (rows) => { rows.at(-1).hmac = "f".repeat(64); },
+    (rows) => { rows[0].aggregate = clone(accumulate([], [quota()])); },
+  ]) {
+    const output = frames(original); mutate(output);
+    await assert.rejects(importPr94LedgerEvidencePrivate(output, { hmacKey: KEY }), { code: "pr94_ledger_private_evidence_rejected" });
+  }
+  await assert.rejects(importPr94LedgerEvidencePrivate([], { hmacKey: KEY }), { code: "pr94_ledger_private_evidence_rejected" });
+});
+
+test("private import validates key consistency and row budget; public booleans cannot authorize comparison", async () => {
+  const original = accumulate([usage()], [quota()]);
+  await assert.rejects(importPr94LedgerEvidencePrivate(frames(original), { hmacKey: Buffer.alloc(32, 9) }), { code: "pr94_ledger_private_evidence_rejected" });
+  await assert.rejects(importPr94LedgerEvidencePrivate(frames(original), { hmacKey: KEY, maxRows: 1 }), { code: "pr94_ledger_private_evidence_rejected" });
+  assert.throws(() => comparePr94LedgerEvidence(original, accumulate([usage()], [quota()], { hmacKey: Buffer.alloc(32, 9) })), { code: "pr94_ledger_key_mismatch" });
+  const forged = { ...clone(original), authentic: true };
+  assert.throws(() => comparePr94LedgerEvidence(original, forged), { code: "pr94_ledger_private_evidence_required" });
+  for (const config of [{}, { hmacKey: "secret" }, { hmacKey: Buffer.alloc(31) },
+    { hmacKey: KEY, maxRows: 0 }, { hmacKey: KEY, maxRows: null },
+    { hmacKey: KEY, maxRows: Number.MAX_SAFE_INTEGER },
+    { hmacKey: KEY, extra: true }]) assert.throws(() => createPr94LedgerEvidence(config), { code: "pr94_ledger_invalid" });
+});
+
+test("per-event private proof detects priced card provenance even when public aggregates are unchanged", () => {
+  const before = accumulate([usage()]);
+  const row = usage();
+  const price = priceCodexUsageEvent(row);
+  price.components[0].priceCardId = "synthetic:other-card";
+  price.selectedPriceCardId = "synthetic:other-card";
+  price.selectedPriceCardIds = ["synthetic:other-card"];
+  price.priceCardBreakdown[0].priceCardId = "synthetic:other-card";
+  const ledger = createPr94LedgerEvidence({ hmacKey: KEY });
+  ledger.consumeUsage(row, price);
+  const comparison = comparePr94LedgerEvidence(before, ledger.finish());
+  assert.equal(comparison.aggregateEqual, true);
+  assert.equal(comparison.rows.usage.changed, 1);
+});
+
+test("deterministic mixed-component stream conserves exact sums under reversed callback order", () => {
+  const rows = Array.from({ length: 40 }, (_, index) => usage(index + 1, {
+    components: Object.fromEntries(PR94_LEDGER_COMPONENTS.map((name, component) => [name, (index * 19 + component * 7) % 53])),
+  }));
+  const evidence = accumulate(rows);
+  assert.equal(evidence.usage.totalUsd, addUsdStrings(...rows.map((row) => priceCodexUsageEvent(row).totalUsd)));
+  for (const name of PR94_LEDGER_COMPONENTS) {
+    assert.equal(evidence.usage.components[name].quantity,
+      rows.reduce((sum, row) => sum + BigInt(row.components[name]), 0n).toString());
+  }
+  assert.equal(comparePr94LedgerEvidence(evidence, accumulate([...rows].reverse())).status, "equal");
+});

--- a/test/pr94-population-evidence.test.js
+++ b/test/pr94-population-evidence.test.js
@@ -1,0 +1,331 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { addUsdStrings, priceCodexUsageEvent } from "@app-usagemonitor/accounting";
+import * as quota from "@app-usagemonitor/quota-analysis";
+import {
+  PR94_LEDGER_COMPONENTS,
+  createPr94LedgerEvidence,
+  disposePr94LedgerEvidencePrivate,
+} from "../scripts/lib/pr94-ledger-evidence.mjs";
+import {
+  buildPr94PopulationEvidence,
+  validatePr94PopulationEvidence,
+} from "../scripts/lib/pr94-population-evidence.mjs";
+
+// Synthetic, content-free events only. Pricing, conservation and classification
+// use their real public APIs; no corpus, database, app or child process runs.
+const TIME = Date.parse("2026-08-01T00:00:00.000Z");
+const CONTEXT = quota.planAttributionContextKey("openai_codex", "codex");
+const ERROR = { code: "pr94_population_invalid", message: "pr94_population_invalid" };
+const clone = (value) => structuredClone(value);
+const at = (offset) => TIME + offset;
+const observation = (offset, planType = "pro", overrides = {}) => ({
+  contextKey: CONTEXT, observedAtMs: at(offset), planType, planVariant: "unknown", ...overrides,
+});
+function usage(ordinal, offset = 150, overrides = {}) {
+  return {
+    timestamp: new Date(at(offset)).toISOString(), timestampMs: at(offset), model: "gpt-5.6-sol",
+    sourceLocal: Buffer.alloc(32, 17), sourceRolloutOrdinal: 0, sourceRecordOrdinal: ordinal,
+    components: { input_uncached_tokens: ordinal * 20_000, input_cache_read_tokens: ordinal * 2_000,
+      input_cache_write_tokens: ordinal * 3_000, output_text_tokens: ordinal * 4_000,
+      output_reasoning_tokens: ordinal * 5_000, output_combined_tokens: ordinal * 6_000 },
+    totalInputContextTokens: 100,
+    tierSemantics: { billingSurface: "chatgpt_subscription", codexSpeedMode: "standard",
+      apiServiceTier: "unknown", tierSource: "rollout_thread_settings", tierObservedAt: null },
+    surfaceClassification: { surface: "cli_exec", threadSource: "user", agentScope: "root", lineageDisposition: "standalone" },
+    ...overrides,
+  };
+}
+function input(rows = [], observations = [observation(100), observation(200)], revisionKind = "after") {
+  const accumulator = createPr94LedgerEvidence({ hmacKey: Buffer.alloc(32, 81) });
+  const costs = rows.map((row) => {
+    const priced = priceCodexUsageEvent(row);
+    accumulator.consumeUsage(row, priced);
+    return priced.totalUsd;
+  });
+  const ledger = accumulator.finish();
+  disposePr94LedgerEvidencePrivate(ledger);
+  return { usage: rows, costs, ledger, quota, attribution: quota.buildPlanAttributionIndex(observations), revisionKind };
+}
+function ledgerTotals(ledger) {
+  return { events: ledger.usage.events, totalUsd: ledger.usage.totalUsd,
+    components: Object.fromEntries(PR94_LEDGER_COMPONENTS.map((name) => [name,
+      Object.fromEntries(["quantity", "observedEvents", "missingEvents", "unavailableEvents"]
+        .map((key) => [key, ledger.usage.components[name][key]]))])) };
+}
+function build(options) {
+  const result = buildPr94PopulationEvidence(options);
+  assert.equal(validatePr94PopulationEvidence(result), result);
+  assert.deepEqual(result.totals, ledgerTotals(options.ledger));
+  return result;
+}
+function costFor(options, ordinals) {
+  return ordinals.reduce((sum, ordinal) => addUsdStrings(sum, options.costs[ordinal - 1]), "0");
+}
+
+test("empty before, after and final populations are closed explicit zero-event evidence", () => {
+  for (const revisionKind of ["before", "after", "final"]) {
+    const evidence = build(input([], [], revisionKind));
+    assert.equal(evidence.schema, "pr94-population-evidence-v1");
+    assert.equal(evidence.context, CONTEXT);
+    assert.equal(evidence.revisionKind, revisionKind);
+    assert.deepEqual(evidence.populations, []);
+    assert.equal(evidence.unknownAccountOnlyWithheldEvents, 0);
+    assert.deepEqual(Object.keys(evidence.totals.components), PR94_LEDGER_COMPONENTS);
+  }
+});
+
+test("Pro to Plus to Pro is a disjoint exact six-component and cost partition including gaps", () => {
+  const options = input([50, 150, 250, 350, 450, 550, 650].map((time, index) => usage(index + 1, time)),
+    [observation(100), observation(200), observation(300, "plus"), observation(400, "plus"),
+      observation(500), observation(600)]);
+  const evidence = build(options);
+  assert.equal(evidence.totals.events, 7);
+  assert.equal(evidence.totals.components.input_uncached_tokens.quantity, "560000");
+  assert.equal(evidence.totals.components.output_combined_tokens.quantity, "168000");
+  assert.equal(evidence.unknownAccountOnlyWithheldEvents, 0);
+  const pro = evidence.populations.find((row) => row.planType === "pro");
+  const plus = evidence.populations.find((row) => row.planType === "plus");
+  const gap = evidence.populations.find((row) => row.reason === "plan_transition_interval");
+  const outside = evidence.populations.find((row) => row.reason === "outside_observed_history");
+  assert.equal(evidence.populations.length, 4);
+  for (const [row, ordinals] of [[pro, [2, 6, 7]], [plus, [4]], [gap, [3, 5]], [outside, [1]]]) {
+    assert.equal(row.totals.events, ordinals.length);
+    assert.equal(row.totals.totalUsd, costFor(options, ordinals));
+    assert.ok(Number(row.totals.totalUsd) > 0);
+    for (const name of PR94_LEDGER_COMPONENTS) {
+      assert.equal(row.totals.components[name].quantity,
+        ordinals.reduce((sum, ordinal) => addUsdStrings(sum, String(options.usage[ordinal - 1].components[name])), "0"));
+      assert.equal(row.totals.components[name].observedEvents, ordinals.length);
+    }
+  }
+  for (const row of [pro, plus]) {
+    assert.equal(row.disposition, "legacy_conditional");
+    assert.equal(row.reason, "account_unresolved");
+    assert.equal(row.accountKnown, false);
+  }
+  for (const row of [gap, outside]) {
+    assert.equal(row.planType, "unknown");
+    assert.equal(row.disposition, "unresolved");
+  }
+});
+
+test("recorded basis remains separate and a conflicted source retains all quantities and cost", () => {
+  const options = input([
+    usage(1),
+    usage(2, 150, { planAttribution: { basis: "unavailable", planType: null, planVariant: null } }),
+    usage(3, 150, { planAttribution: { basis: "same_record", planType: "pro", planVariant: "unknown" } }),
+    usage(4, 150, { planAttribution: { basis: "conflicted", planType: "pro", planVariant: "unknown" } }),
+  ]);
+  const evidence = build(options);
+  assert.deepEqual(evidence.populations.map((row) => row.basis).sort(), ["conflicted", "not_recorded", "same_record", "unavailable"]);
+  const conflict = evidence.populations.find((row) => row.basis === "conflicted");
+  assert.equal(conflict.disposition, "unresolved");
+  assert.equal(conflict.reason, "source_record_conflicted");
+  assert.equal(conflict.totals.totalUsd, options.costs[3]);
+  assert.equal(conflict.totals.components.output_combined_tokens.quantity, "24000");
+  assert.equal(evidence.unknownAccountOnlyWithheldEvents, 0);
+});
+
+test("unknown account is conditional, not withheld, using the public classifier's bounded account policy", () => {
+  for (const scope of [undefined, null, "", "unknown", "unattributed", "unavailable", 42, "x".repeat(513)]) {
+    const options = input([usage(1)]);
+    // The current unified reader supplies no account IDs. This decoration is
+    // only a synthetic classifier boundary test, not positive real coverage.
+    options.usage = options.usage.map((row) => ({ ...row, accountScopeId: scope }));
+    const evidence = build(options);
+    assert.equal(evidence.populations[0].accountKnown, false);
+    assert.equal(evidence.populations[0].disposition, "legacy_conditional");
+    assert.equal(evidence.populations[0].reason, "account_unresolved");
+    assert.equal(evidence.unknownAccountOnlyWithheldEvents, 0);
+  }
+  const scope = "x".repeat(512);
+  const options = input([usage(1)], [observation(100, "pro", { accountScopeId: scope }),
+    observation(200, "pro", { accountScopeId: scope })]);
+  options.usage = options.usage.map((row) => ({ ...row, accountScopeId: scope }));
+  const evidence = build(options);
+  assert.equal(evidence.populations[0].accountKnown, true);
+  assert.equal(evidence.populations[0].disposition, "legacy_conditional");
+  assert.equal(evidence.populations[0].reason, "plan_unresolved");
+});
+
+test("unknown-plan history remains conditional and no-plan evidence remains an explicit nonzero gap", () => {
+  for (const [observations, disposition, reason] of [
+    [[observation(100, "unknown"), observation(200, "unavailable")], "legacy_conditional", "account_unresolved"],
+    [[], "unresolved", "no_plan_evidence"],
+  ]) {
+    const options = input([usage(1)], observations);
+    const evidence = build(options);
+    assert.equal(evidence.populations[0].planType, "unknown");
+    assert.equal(evidence.populations[0].disposition, disposition);
+    assert.equal(evidence.populations[0].reason, reason);
+    assert.equal(evidence.populations[0].totals.totalUsd, options.costs[0]);
+    assert.equal(evidence.populations[0].totals.components.input_uncached_tokens.quantity, "20000");
+    assert.equal(evidence.unknownAccountOnlyWithheldEvents, 0);
+  }
+});
+
+test("interval-spanning deltas and same-record plan conflicts remain unresolved without losing the ledger", () => {
+  const options = input([
+    usage(1, 350, { usageIntervalStartedAt: new Date(at(150)).toISOString(), usageIntervalBasis: "previous_source_record" }),
+    usage(2, 350, { planAttribution: { basis: "same_record", planType: "pro", planVariant: "unknown" } }),
+    usage(3, 150, { usageIntervalStartedAt: new Date(at(200)).toISOString(), usageIntervalBasis: "previous_source_record" }),
+  ], [observation(100), observation(200), observation(300, "plus"), observation(400, "plus")]);
+  const evidence = build(options);
+  assert.deepEqual(evidence.populations.map((row) => row.reason).sort(),
+    ["plan_transition_interval", "usage_interval_unresolved", "usage_plan_conflict"]);
+  assert.ok(evidence.populations.every((row) => row.disposition === "unresolved" && Number(row.totals.totalUsd) > 0));
+});
+
+test("tied contradictory quota evidence is unresolved, not input-order-selected", () => {
+  const observations = [observation(100), observation(150, "plus"), observation(150), observation(200)];
+  const evidence = build(input([usage(1)], observations));
+  assert.equal(evidence.populations[0].disposition, "unresolved");
+  assert.equal(evidence.populations[0].reason, "conflicting_quota_evidence");
+  assert.deepEqual(build(input([usage(1)], observations.toReversed())), evidence);
+});
+
+test("baseline is explicitly unseparated and never invents a classifier result", () => {
+  const options = input([usage(1), usage(2)], [], "before");
+  options.quota = { classifyUsageAttribution() { assert.fail("baseline called after-only attribution"); } };
+  const evidence = build(options);
+  assert.equal(evidence.populations.length, 1);
+  assert.equal(evidence.populations[0].planType, "unknown");
+  assert.equal(evidence.populations[0].disposition, "legacy_unseparated");
+  assert.equal(evidence.populations[0].reason, "legacy_unseparated");
+});
+
+test("missing, unavailable and observed zero stay distinct even when all three have quantity zero", () => {
+  const missing = usage(1); delete missing.components.input_cache_read_tokens;
+  const unavailable = usage(2); unavailable.components.input_cache_read_tokens = null;
+  const flagged = usage(3, 150, { componentAvailability: { input_cache_read_tokens: false } });
+  const zero = usage(4); zero.components.input_cache_read_tokens = 0;
+  const absentFlagged = usage(5, 150, { componentAvailability: { input_cache_read_tokens: false } });
+  delete absentFlagged.components.input_cache_read_tokens;
+  const evidence = build(input([missing, unavailable, flagged, zero, absentFlagged]));
+  assert.deepEqual(evidence.totals.components.input_cache_read_tokens,
+    { quantity: "0", observedEvents: 1, missingEvents: 1, unavailableEvents: 3 });
+  assert.equal(evidence.totals.components.output_combined_tokens.quantity, "90000");
+});
+
+test("unpriced quantities stay nonzero and unknown private labels map to a finite public other label", () => {
+  const label = "synthetic-private-plan";
+  const options = input([usage(1, 150, { model: "synthetic-private-model",
+    planAttribution: { basis: "same_record", planType: label, planVariant: "unknown" } })],
+  [observation(100, label), observation(200, label)]);
+  const evidence = build(options);
+  assert.equal(options.ledger.usage.coverage.unpriced, 1);
+  assert.equal(evidence.totals.totalUsd, "0");
+  assert.equal(evidence.totals.components.input_uncached_tokens.quantity, "20000");
+  assert.equal(evidence.populations[0].planType, "other");
+  const serialized = JSON.stringify(evidence);
+  for (const excluded of [label, "synthetic-private-model", "sourceLocal", "sourceRecordOrdinal", "accountScopeId",
+    "timestamp", "2026-08-01", "eraKey", "planVariant", "hmac", "digest"]) assert.ok(!serialized.includes(excluded));
+});
+
+test("aggregate token strings stay exact beyond numeric safe-integer range", () => {
+  const options = input([1, 2].map((ordinal) => usage(ordinal, 150,
+    { components: { output_combined_tokens: Number.MAX_SAFE_INTEGER } })));
+  const evidence = build(options);
+  assert.equal(evidence.totals.components.output_combined_tokens.quantity, "18014398509481982");
+  assert.equal(evidence.totals.components.output_combined_tokens.observedEvents, 2);
+  assert.equal(evidence.totals.components.output_text_tokens.missingEvents, 2);
+  assert.equal(evidence.totals.totalUsd, "0");
+});
+
+test("admission cardinality, priced total and every ledger component/state must reconcile", () => {
+  for (const mutate of [
+    (options) => { options.costs.pop(); },
+    (options) => { options.costs.push("0"); },
+    (options) => { options.costs[0] = "0"; },
+    (options) => { options.costs[0] = "NaN"; },
+    (options) => { options.costs[0] = "-1"; },
+    (options) => { options.costs[0] = 0; },
+    (options) => { options.ledger.usage.events = 2; },
+    (options) => { options.ledger.usage.components.output_combined_tokens.quantity = "1"; },
+    (options) => { options.ledger.usage.components.output_combined_tokens.missingEvents = 1; },
+    (options) => { options.usage[0].planAttribution = { basis: "unchecked-label" }; },
+    (options) => { options.revisionKind = "unchecked-revision"; },
+  ]) {
+    const options = input([usage(1)]); options.ledger = clone(options.ledger); mutate(options);
+    assert.throws(() => buildPr94PopulationEvidence(options), ERROR);
+  }
+});
+
+test("validator rejects unknown fields, malformed metadata, counts, decimals and population mismatches", () => {
+  const good = build(input([usage(1)]));
+  for (const mutate of [
+    (value) => { value.raw = "synthetic-private"; },
+    (value) => { value.schema = "other"; },
+    (value) => { value.context = "other"; },
+    (value) => { value.revisionKind = "other"; },
+    (value) => { value.populations[0].planType = "synthetic-private"; },
+    (value) => { value.populations[0].basis = "synthetic-private"; },
+    (value) => { value.populations[0].disposition = "synthetic-private"; },
+    (value) => { value.populations[0].reason = "synthetic-private"; },
+    (value) => { value.populations[0].accountKnown = "false"; },
+    (value) => { value.populations[0].accountScopeId = "synthetic-private"; },
+    (value) => { value.totals.totalUsd = "1e3"; },
+    (value) => { value.totals.totalUsd = "1.00"; },
+    (value) => { value.totals.totalUsd = "-1"; },
+    (value) => { value.totals.totalUsd = "NaN"; },
+    (value) => { value.totals.totalUsd = "1".repeat(101); },
+    (value) => { value.totals.events = Number.MAX_SAFE_INTEGER + 1; },
+    (value) => { value.totals.events = NaN; },
+    (value) => { value.totals.events = Infinity; },
+    (value) => { value.totals.events = -0; },
+    (value) => { value.totals.components.output_combined_tokens.extra = 0; },
+    (value) => { delete value.totals.components.output_combined_tokens; },
+    (value) => { value.totals.components.output_combined_tokens.missingEvents = 1; },
+    (value) => { value.populations[0].totals.components.output_combined_tokens.quantity = "0"; },
+    (value) => { value.unknownAccountOnlyWithheldEvents = 1; },
+    (value) => { value.populations.push(clone(value.populations[0])); },
+    (value) => { value.populations = Array(2001).fill(value.populations[0]); },
+    (value) => { value.populations = []; },
+    (value) => { value.totals[Symbol("private")] = 1; },
+    (value) => { Object.setPrototypeOf(value, { private: true }); },
+    (value) => { Object.defineProperty(value.totals, "events", { enumerable: true, get() { assert.fail("getter invoked"); } }); },
+  ]) {
+    const changed = clone(good); mutate(changed);
+    assert.throws(() => validatePr94PopulationEvidence(changed), ERROR);
+  }
+});
+
+test("validator rejects impossible fractional or over-safe per-event token quantities even in balanced totals", () => {
+  const good = build(input([usage(1)]));
+  for (const quantity of ["0.5", "9007199254740992", "9".repeat(100)]) {
+    const changed = clone(good);
+    changed.totals.components.output_combined_tokens.quantity = quantity;
+    changed.populations[0].totals.components.output_combined_tokens.quantity = quantity;
+    assert.throws(() => validatePr94PopulationEvidence(changed), ERROR);
+  }
+  const changed = clone(good);
+  for (const totals of [changed.totals, changed.populations[0].totals]) {
+    Object.assign(totals.components.output_combined_tokens, { observedEvents: 0, missingEvents: 1 });
+  }
+  assert.throws(() => validatePr94PopulationEvidence(changed), ERROR);
+});
+
+test("population ordering is deterministic and source/input objects are not mutated", () => {
+  const observations = [observation(100), observation(200), observation(300, "plus"), observation(400, "plus")];
+  const options = input([usage(1, 150), usage(2, 250), usage(3, 350)], observations);
+  const priorUsage = options.usage.map((row) => ({ ...clone(row), sourceLocal: Buffer.from(row.sourceLocal) }));
+  const priorCosts = clone(options.costs);
+  const evidence = build(options);
+  assert.deepEqual(options.usage, priorUsage);
+  assert.deepEqual(options.costs, priorCosts);
+  const reversed = { ...options, usage: options.usage.toReversed(), costs: options.costs.toReversed(),
+    attribution: quota.buildPlanAttributionIndex(observations.toReversed()) };
+  assert.deepEqual(build(reversed), evidence);
+});
+
+test("resource refusal stops before classification and an incomplete attribution index cannot look successful", () => {
+  const options = input([usage(1)]);
+  const marker = Object.assign(new Error("synthetic resource limit"), { code: "synthetic_limit" });
+  let called = 0;
+  assert.throws(() => buildPr94PopulationEvidence({ ...options, resourceCheck() { called += 1; throw marker; } }),
+    (error) => error === marker);
+  assert.equal(called, 1);
+  assert.throws(() => buildPr94PopulationEvidence({ ...options,
+    attribution: quota.buildPlanAttributionIndex([observation(100), observation(200)], { maxObservations: 1 }) }), ERROR);
+});

--- a/test/pr94-production-resource-worker.test.js
+++ b/test/pr94-production-resource-worker.test.js
@@ -8,6 +8,7 @@ import { REPLAY_SAFE_ACCOUNTING_MEMORY_POLICY } from "../src/replay-safe-account
 import * as readerModule from "../src/local-unified-accounting-source.js";
 import { openLocalUnifiedIndex } from "../src/local-unified-index.js";
 import {
+  assertPr94ProductionCacheContext,
   PR94_PRODUCTION_ERROR_CODES,
   buildPr94ProductionResourceRequest,
   collectPr94AttributionQueryPlans,
@@ -15,6 +16,7 @@ import {
   runPr94ProductionResourceWorker,
   validatePr94AttributionQueryPlans,
   validatePr94ProductionResourceEvidence,
+  validatePr94ProductionResourceOutcome,
 } from "../scripts/lib/pr94-production-resource-worker.mjs";
 
 // All orchestration adapters below are synthetic. No revision child, real
@@ -158,10 +160,31 @@ test("projection rejects wrong clock/generation/source and out-of-budget input c
   ]) { const value = cache(); mutate(value); assert.throws(() => projectPr94ProductionCache(value, CONTEXT)); }
 });
 
+test("historical refusal context guard binds clock and generation without projecting an invalid cache", () => {
+  const full = cache();
+  const invalid = { generatedAt: full.generatedAt, coveredAt: full.coveredAt,
+    sourceDescriptor: full.sourceDescriptor };
+  assert.equal(assertPr94ProductionCacheContext(invalid, CONTEXT), undefined);
+  assert.throws(() => projectPr94ProductionCache(invalid, CONTEXT));
+  for (const mutate of [
+    (value) => { value.generatedAt = START; },
+    (value) => { value.coveredAt.startAt = END; },
+    (value) => { value.coveredAt.endAt = START; },
+    (value) => { value.sourceDescriptor.generation = "45"; },
+    (value) => { value.sourceDescriptor.generationFingerprint = `generation-v2-${"c".repeat(64)}`; },
+    (value) => { delete value.sourceDescriptor; },
+  ]) {
+    const value = clone(invalid); mutate(value);
+    assert.throws(() => assertPr94ProductionCacheContext(value, CONTEXT),
+      { code: "pr94_production_cache_context_mismatch" });
+  }
+});
+
 test("orchestration times only two unmodified production child processes, with exact identical requests", async () => {
   await fixture(async ({ options, adapters, calls, probes, identities, directory }) => {
     const receipt = await runPr94ProductionResourceWorker(options, adapters);
     assert.equal(validatePr94ProductionResourceEvidence(receipt), receipt);
+    assert.equal(receipt.schema, "pr94-production-resource-v2");
     assert.equal(receipt.scope, "isolated_child_repeatability");
     assert.equal(receipt.exactRepeatOutput, true);
     assert.equal(calls.length, 2);
@@ -201,6 +224,88 @@ test("baseline compact-v2 child artifacts remain valid in their own lane", async
     assert.equal(receipt.runs[0].cache.weeklyInput.encoding, "accounting_compact_v2");
     assert.deepEqual(receipt.queryPlans, queryPlans(BEFORE_REVISION));
   }, { encoding: "accounting_compact_v2", revision: BEFORE_REVISION });
+});
+
+test("exact historical after may report two deterministic strict cache-invalid assertions without a projection", async () => {
+  await fixture(async ({ options, adapters, calls, probes, artifact }) => {
+    const original = adapters.probe;
+    adapters.probe = async (request) => request.stage === "artifact"
+      ? (probes.push(request), { status: "refused", code: "cache_invalid" })
+      : original(request);
+    const receipt = await runPr94ProductionResourceWorker(options, adapters);
+    assert.equal(validatePr94ProductionResourceOutcome(receipt), receipt);
+    assert.throws(() => validatePr94ProductionResourceEvidence(receipt));
+    assert.equal(receipt.status, "historical_artifact_refused");
+    assert.equal(receipt.schema, "pr94-production-resource-v2");
+    assert.equal(receipt.revision, AFTER_REVISION);
+    assert.equal(calls.length, 2);
+    assert.equal(probes.filter(({ stage }) => stage === "artifact").length, 2);
+    assert.deepEqual(probes.filter(({ stage }) => stage === "artifact").map(({ context }) => context.revision),
+      [AFTER_REVISION, AFTER_REVISION]);
+    assert.deepEqual(receipt.runs.map((run) => run.cacheAssertion), [
+      { status: "refused", code: "cache_invalid" },
+      { status: "refused", code: "cache_invalid" },
+    ]);
+    assert.ok(receipt.runs.every((run) => !Object.hasOwn(run, "cache")));
+    assert.deepEqual(receipt.runs[0].artifact, receipt.runs[1].artifact);
+    assert.deepEqual(receipt.runs[0].envelope, receipt.runs[1].envelope);
+    assert.equal(receipt.runs[0].artifact.sha256, hash(artifact));
+    for (const mutate of [
+      (value) => { value.status = "passed"; },
+      (value) => { value.revision = REVISION; },
+      (value) => { value.runs[0].cacheAssertion.code = "other"; },
+      (value) => { value.runs[0].cache = { projected: true }; },
+      (value) => { value.runs[1].envelope.resultSha256 = SHA; },
+      (value) => { value.raw = "SYNTHETIC_PRIVATE"; },
+    ]) {
+      const changed = clone(receipt); mutate(changed);
+      assert.throws(() => validatePr94ProductionResourceOutcome(changed));
+    }
+  }, { revision: AFTER_REVISION });
+});
+
+test("historical refusal is rejected for other revisions, other codes, mixed runs and nondeterministic artifacts", async () => {
+  for (const scenario of ["before_revision", "other_revision", "wrong_code", "mixed", "changed_artifact"]) {
+    await fixture(async ({ options, adapters, calls }) => {
+      const originalProbe = adapters.probe;
+      let artifactProbes = 0;
+      adapters.probe = async (request) => {
+        if (request.stage !== "artifact") return originalProbe(request);
+        artifactProbes += 1;
+        if (scenario === "wrong_code") return { status: "refused", code: "accounting_cache_invalid" };
+        if (scenario === "mixed" && artifactProbes === 2) return originalProbe(request);
+        return { status: "refused", code: "cache_invalid" };
+      };
+      if (scenario === "changed_artifact") {
+        const originalCommand = adapters.command;
+        adapters.command = async (...args) => {
+          const output = await originalCommand(...args);
+          if (calls.length === 2) {
+            const changed = `${await readFile(args[1].at(-1), "utf8")} `;
+            await writeFile(args[1].at(-1), changed, { mode: 0o600 });
+            output.stdout = JSON.stringify({ status: "ok", resultBytes: Buffer.byteLength(changed), resultSha256: hash(changed) });
+          }
+          return output;
+        };
+      }
+      await assert.rejects(runPr94ProductionResourceWorker(options, adapters));
+      assert.equal(calls.length, ["before_revision", "other_revision", "wrong_code"].includes(scenario) ? 1 : 2);
+    }, { revision: scenario === "before_revision" ? BEFORE_REVISION
+      : scenario === "other_revision" ? REVISION : AFTER_REVISION });
+  }
+});
+
+test("ordinary strict evidence remains valid for before, after and final revisions", async () => {
+  for (const revision of [BEFORE_REVISION, AFTER_REVISION, REVISION]) {
+    await fixture(async ({ options, adapters }) => {
+      const receipt = await runPr94ProductionResourceWorker(options, adapters);
+      assert.equal(Object.hasOwn(receipt, "status"), false);
+      assert.equal(validatePr94ProductionResourceEvidence(receipt), receipt);
+      assert.equal(validatePr94ProductionResourceOutcome(receipt), receipt);
+      assert.ok(receipt.runs.every((run) => Object.hasOwn(run, "cache")
+        && !Object.hasOwn(run, "cacheAssertion")));
+    }, { revision });
+  }
 });
 
 test("approval, pinned revision, runtime and expected copied-index identity fail before child execution", async () => {

--- a/test/pr94-production-resource-worker.test.js
+++ b/test/pr94-production-resource-worker.test.js
@@ -1,0 +1,336 @@
+import assert from "node:assert/strict";
+import { createHash } from "node:crypto";
+import { chmod, link, mkdir, mkdtemp, readFile, realpath, rm, symlink, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import test from "node:test";
+import { REPLAY_SAFE_ACCOUNTING_MEMORY_POLICY } from "../src/replay-safe-accounting-cache.js";
+import {
+  PR94_PRODUCTION_ERROR_CODES,
+  buildPr94ProductionResourceRequest,
+  projectPr94ProductionCache,
+  runPr94ProductionResourceWorker,
+  validatePr94ProductionResourceEvidence,
+} from "../scripts/lib/pr94-production-resource-worker.mjs";
+
+// All orchestration adapters below are synthetic. No revision child, real
+// database, corpus, native app, credentials or external process is executed.
+const START = "2025-08-01T00:00:00.000Z";
+const END = "2026-08-01T00:00:00.000Z";
+const REVISION = "a".repeat(40);
+const SHA = "b".repeat(64);
+const hash = (value) => createHash("sha256").update(value).digest("hex");
+const clone = (value) => structuredClone(value);
+const POLICY = Object.freeze({ maximumRssBytes: 6_442_450_944, rssDeltaBudgetBytes: 5_637_144_576,
+  rebuildChildOldSpaceMib: 6144, archiveMaximumRssBytes: 3_221_225_472, archiveRssDeltaBudgetBytes: 805_306_368 });
+const GENERATION = Object.freeze({ id: 44, fingerprint: `generation-v2-${SHA}`, status: "partial",
+  blockReason: "tool_provenance_incomplete", toolProvenanceComplete: false, discoveryComplete: true,
+  diagnosticsComplete: true, usageProvenanceComplete: true, sourceOrderComplete: true, quotaProvenanceComplete: true,
+  indexedSourceCount: 3, indexedSourceBytes: 1000, skippedSourceCount: 0, skippedSourceBytes: 0,
+  skippedThreadCount: 0, usageEvents: 2, quotaOccurrences: 1, toolFacts: 0 });
+const METADATA = Object.freeze({ policy: POLICY, generation: GENERATION, requestVersion: "replay-safe-accounting-rebuild-request-v1" });
+const SOURCE = Object.freeze({ revision: REVISION,
+  dependencies: { sourceSha256: SHA, runtimeSha256: SHA, lockSha256: SHA, identitySha256: SHA } });
+const CONTEXT = Object.freeze({ startAt: START, endAt: END, generationId: 44, generationFingerprint: GENERATION.fingerprint });
+const RUNTIME = Object.freeze({ version: "v26.2.0", platform: "darwin", arch: "arm64" });
+
+function cache(encoding = "accounting_compact_v3") {
+  return { schemaVersion: encoding === "accounting_compact_v2" ? "local-replay-safe-accounting-v0.13" : "local-replay-safe-accounting-v0.15",
+    generatedAt: END, coveredAt: { startAt: START, endAt: END },
+    sourceDescriptor: { mode: "unified", contextBehavior: "legacy_zero", generation: "44",
+      generationFingerprint: GENERATION.fingerprint, coverageStatus: "complete", generationMatched: true,
+      capabilities: { readsRawSources: false } },
+    weeklyCalibrationInput: { status: "complete", encoding, source: "unified_index",
+      coveredAt: { startAt: START, endAt: END }, retainedUsageEvents: 2, retainedWeeklySnapshots: 1,
+      estimatedRetainedBytes: encoding === "accounting_compact_v2" ? 704 : 896,
+      limits: { usageEvents: 1_000_000, weeklySnapshots: 1_000_000, combinedInputs: 2_000_000, retainedBytes: 335_544_320 } },
+    periods: [{ private: "SYNTHETIC_PRIVATE" }], timeline: [], sparkUsageTimeline: [], quotaTimeline: [], sparkQuotaTimeline: [],
+    extraDiagnostic: "SYNTHETIC_PRIVATE" };
+}
+
+async function fixture(action, { encoding = "accounting_compact_v3" } = {}) {
+  const directory = await realpath(await mkdtemp(join(tmpdir(), "pr94-production-resource-test-")));
+  try {
+    const inputDirectory = join(directory, "input");
+    await mkdir(inputDirectory, { mode: 0o700 });
+    const indexFile = join(inputDirectory, "synthetic.sqlite");
+    const input = "synthetic offline index bytes, not SQLite";
+    await writeFile(indexFile, input, { mode: 0o400 });
+    const options = { privateOperationApproved: true, root: join(directory, "synthetic-source"), expectedRevision: REVISION,
+      indexFile, expectedIndex: { sha256: hash(input), bytes: Buffer.byteLength(input), generationId: 44 },
+      outputDirectory: join(directory, "output"), startAt: START, endAt: END, timeoutSeconds: 30 };
+    const calls = []; const probes = []; const identities = [];
+    const artifact = JSON.stringify(cache(encoding));
+    const adapters = {
+      runtime: RUNTIME,
+      inspectSource: async (root) => { identities.push(root); return clone(SOURCE); },
+      probe: async (request) => {
+        probes.push(request);
+        return request.stage === "metadata" ? clone(METADATA)
+          : projectPr94ProductionCache(JSON.parse(await readFile(request.path, "utf8")), request.context);
+      },
+      command: async (command, args, configuration) => {
+        calls.push({ command, args, configuration });
+        await writeFile(args.at(-1), artifact, { mode: 0o600, flag: "wx" });
+        return { stdout: JSON.stringify({ status: "ok", resultBytes: Buffer.byteLength(artifact), resultSha256: hash(artifact) }),
+          stderr: "SYNTHETIC_PRIVATE\n 1.25 real 1.01 user 0.04 sys\n 123456789 maximum resident set size\n" };
+      },
+    };
+    await action({ directory, indexFile, options, adapters, calls, probes, identities, artifact });
+  } finally { await rm(directory, { recursive: true, force: true }); }
+}
+
+test("production request pins exact child options and rejects unsupported windows without widening", () => {
+  const input = { startAt: START, endAt: END, indexFile: "/synthetic/index.sqlite", codexHome: "/synthetic/empty", ...METADATA };
+  assert.deepEqual(buildPr94ProductionResourceRequest(input), {
+    version: "replay-safe-accounting-rebuild-request-v1", nowMs: Date.parse(END), windowDays: 365,
+    codexHome: "/synthetic/empty", sourceMode: "unified", contextBehavior: "legacy_zero",
+    expectedGeneration: GENERATION, unifiedIndexFile: "/synthetic/index.sqlite", declaredSpeedBaselines: [],
+    transitionResourceLimits: null, maximumRssBytes: POLICY.maximumRssBytes,
+  });
+  for (const change of [{ startAt: "2026-07-01T00:00:00.000Z" }, { startAt: "2025-08-01T00:00:00.001Z" },
+    { endAt: START }, { startAt: "2025-08-01" }, { indexFile: "relative.sqlite" },
+    { requestVersion: "other" }, { policy: { ...POLICY, maximumRssBytes: POLICY.maximumRssBytes + 1 } },
+    { generation: { ...GENERATION, usageProvenanceComplete: false } }]) {
+    assert.throws(() => buildPr94ProductionResourceRequest({ ...input, ...change }));
+  }
+});
+
+test("production request preserves the reviewed first-parent and current native heap/RSS policy", () => {
+  // First-parent a3c8503 and current source both declare 6 GiB absolute,
+  // 5.25 GiB delta and ceil(absolute/MiB) child old space. This is the shipped
+  // relationship, not a tighter comparator-specific allocation policy.
+  assert.equal(REPLAY_SAFE_ACCOUNTING_MEMORY_POLICY.maximumRssBytes, POLICY.maximumRssBytes);
+  assert.equal(REPLAY_SAFE_ACCOUNTING_MEMORY_POLICY.rebuildChildOldSpaceMib, 6144);
+  for (const policy of [POLICY, REPLAY_SAFE_ACCOUNTING_MEMORY_POLICY]) {
+    const request = buildPr94ProductionResourceRequest({ startAt: START, endAt: END,
+      indexFile: "/synthetic/index.sqlite", codexHome: "/synthetic/empty", ...METADATA, policy });
+    assert.equal(request.maximumRssBytes, policy.maximumRssBytes);
+    assert.equal(policy.rebuildChildOldSpaceMib * 1024 * 1024, request.maximumRssBytes);
+    assert.equal(request.transitionResourceLimits, null);
+  }
+});
+
+test("projection preserves both production compact encodings and reports no raw row material", () => {
+  for (const encoding of ["accounting_compact_v2", "accounting_compact_v3"]) {
+    const projected = projectPr94ProductionCache(cache(encoding), CONTEXT);
+    assert.equal(projected.weeklyInput.encoding, encoding);
+    assert.equal(projected.weeklyInput.estimatedRetainedBytes, encoding === "accounting_compact_v2" ? 704 : 896);
+    assert.equal(projected.rows.periods, 1);
+    assert.equal(projected.source.readsRawSources, false);
+    assert.ok(!JSON.stringify(projected).includes("SYNTHETIC_PRIVATE"));
+    assert.ok(!JSON.stringify(projected).includes("generationFingerprint"));
+  }
+});
+
+test("projection rejects wrong clock/generation/source and out-of-budget input counts", () => {
+  for (const mutate of [
+    (value) => { value.generatedAt = START; },
+    (value) => { value.coveredAt.startAt = "2025-07-31T00:00:00.000Z"; },
+    (value) => { value.sourceDescriptor.generation = "45"; },
+    (value) => { value.sourceDescriptor.generationFingerprint = `generation-v2-${"c".repeat(64)}`; },
+    (value) => { value.sourceDescriptor.generationMatched = false; },
+    (value) => { value.sourceDescriptor.capabilities.readsRawSources = true; },
+    (value) => { value.sourceDescriptor.coverageStatus = "partial"; },
+    (value) => { value.weeklyCalibrationInput.retainedUsageEvents = 1_000_001; },
+    (value) => { value.weeklyCalibrationInput.retainedWeeklySnapshots = -1; },
+    (value) => { value.weeklyCalibrationInput.estimatedRetainedBytes = 335_544_321; },
+    (value) => { value.weeklyCalibrationInput.limits.combinedInputs = 2; },
+    (value) => { value.weeklyCalibrationInput.limits.retainedBytes = NaN; },
+    (value) => { value.weeklyCalibrationInput.encoding = "unknown"; },
+    (value) => { value.timeline = null; },
+    (value) => { value.schemaVersion = "SYNTHETIC_PRIVATE"; },
+  ]) { const value = cache(); mutate(value); assert.throws(() => projectPr94ProductionCache(value, CONTEXT)); }
+});
+
+test("orchestration times only two unmodified production child processes, with exact identical requests", async () => {
+  await fixture(async ({ options, adapters, calls, probes, identities, directory }) => {
+    const receipt = await runPr94ProductionResourceWorker(options, adapters);
+    assert.equal(validatePr94ProductionResourceEvidence(receipt), receipt);
+    assert.equal(receipt.scope, "isolated_child_repeatability");
+    assert.equal(receipt.exactRepeatOutput, true);
+    assert.equal(calls.length, 2);
+    assert.equal(probes.length, 4);
+    assert.equal(identities.length, 2);
+    const requests = [];
+    for (const { command, args, configuration } of calls) {
+      assert.equal(command, "/usr/bin/time");
+      assert.deepEqual(args.slice(0, 4), ["-l", process.execPath, "--max-old-space-size=6144",
+        join(options.root, "src/replay-safe-accounting-rebuild-child.js")]);
+      assert.equal(configuration.timeoutMs, 30_000);
+      assert.deepEqual(Object.keys(configuration.env).sort(), ["LC_ALL", "TMPDIR"]);
+      assert.equal(configuration.env.LC_ALL, "C");
+      requests.push(JSON.parse(await readFile(args.at(-2), "utf8")));
+    }
+    assert.deepEqual(requests[0], requests[1]);
+    assert.deepEqual(receipt.runs.map((run) => run.kind), ["primary", "fresh_process_repeat"]);
+    assert.deepEqual(receipt.runs[0].metrics, { wallMs: 1250, userCpuMs: 1010, systemCpuMs: 40, peakRssBytes: 123456789 });
+    assert.equal(receipt.runs[0].cache.weeklyInput.retainedUsageEvents, 2);
+    assert.equal(receipt.generation.publicationStatus, "partial");
+    assert.equal(receipt.generation.toolProvenanceComplete, false);
+    const output = JSON.stringify(receipt);
+    for (const privateText of [directory, "SYNTHETIC_PRIVATE", "sourceLocal", "request.json", "result.json"]) {
+      assert.ok(!output.includes(privateText));
+    }
+    assert.deepEqual(receipt.notMeasured, ["app_no_change_cache_hit", "app_relaunch", "end_to_end_refresh", "cancellation", "evidence_observer_overhead"]);
+  });
+});
+
+test("baseline compact-v2 child artifacts remain valid in their own lane", async () => {
+  await fixture(async ({ options, adapters }) => {
+    const receipt = await runPr94ProductionResourceWorker(options, adapters);
+    assert.equal(receipt.runs[0].cache.schemaVersion, "local-replay-safe-accounting-v0.13");
+    assert.equal(receipt.runs[0].cache.weeklyInput.encoding, "accounting_compact_v2");
+  }, { encoding: "accounting_compact_v2" });
+});
+
+test("approval, pinned revision, runtime and expected copied-index identity fail before child execution", async () => {
+  for (const mutate of [
+    (options) => { options.privateOperationApproved = false; },
+    (options) => { options.expectedRevision = "d".repeat(40); },
+    (options) => { options.expectedIndex.sha256 = "c".repeat(64); },
+    (options) => { options.expectedIndex.bytes += 1; },
+    (options) => { options.expectedIndex.generationId += 1; },
+    (options) => { options.extra = true; },
+    (options) => { options.timeoutSeconds = Infinity; },
+  ]) await fixture(async ({ options, adapters, calls }) => {
+    mutate(options);
+    await assert.rejects(runPr94ProductionResourceWorker(options, adapters));
+    assert.equal(calls.length, 0);
+  });
+  await fixture(async ({ options, adapters, calls }) => {
+    await assert.rejects(runPr94ProductionResourceWorker(options, { ...adapters, runtime: { ...RUNTIME, platform: "linux" } }),
+      { code: "pr94_production_runtime_invalid" });
+    assert.equal(calls.length, 0);
+  });
+});
+
+test("immutable owner-only copied index and no-clobber output requirements remain enforced", async () => {
+  for (const setup of [
+    async ({ indexFile }) => chmod(indexFile, 0o600),
+    async ({ indexFile }) => chmod(indexFile, 0o444),
+    async ({ indexFile }) => writeFile(`${indexFile}-wal`, "synthetic", { mode: 0o600 }),
+    async ({ indexFile, directory }) => link(indexFile, join(directory, "hard-link")),
+    async ({ indexFile, directory, options }) => { const path = join(directory, "symbolic"); await symlink(indexFile, path); options.indexFile = path; },
+    async ({ options }) => mkdir(options.outputDirectory, { mode: 0o700 }),
+    async ({ options }) => chmod(dirname(options.outputDirectory), 0o755),
+  ]) await fixture(async (context) => {
+    await setup(context);
+    await assert.rejects(runPr94ProductionResourceWorker(context.options, context.adapters));
+    assert.equal(context.calls.length, 0);
+  });
+});
+
+test("typed child refusal, invalid envelope, peak RSS and artifact mismatch are not success", async () => {
+  for (const mutate of [
+    (output) => { output.stdout = JSON.stringify({ status: "error", code: "synthetic_budget_miss" }); },
+    (output) => { output.stdout = JSON.stringify({ status: "ok", resultBytes: 2, resultSha256: SHA, extra: true }); },
+    (output) => { output.stderr = "missing metrics"; },
+    (output) => { output.stderr = ` 1 real 1 user 0 sys\n ${POLICY.maximumRssBytes + 1} maximum resident set size\n`; },
+    (output) => { const envelope = JSON.parse(output.stdout); envelope.resultSha256 = SHA; output.stdout = JSON.stringify(envelope); },
+  ]) await fixture(async ({ options, adapters, calls }) => {
+    const original = adapters.command;
+    adapters.command = async (...args) => { const output = await original(...args); mutate(output); return output; };
+    await assert.rejects(runPr94ProductionResourceWorker(options, adapters));
+    assert.equal(calls.length, 1);
+  });
+});
+
+test("fresh-process repeat must match exact bytes within the lane", async () => {
+  await fixture(async ({ options, adapters, calls }) => {
+    const original = adapters.command;
+    adapters.command = async (...args) => {
+      const output = await original(...args);
+      if (calls.length === 2) {
+        const payload = JSON.stringify({ ...cache(), harmlessSyntheticDifference: true });
+        await writeFile(args[1].at(-1), payload, { mode: 0o600 });
+        output.stdout = JSON.stringify({ status: "ok", resultBytes: Buffer.byteLength(payload), resultSha256: hash(payload) });
+      }
+      return output;
+    };
+    await assert.rejects(runPr94ProductionResourceWorker(options, adapters), { code: "pr94_production_repeat_mismatch" });
+  });
+});
+
+test("post-run source, dependency, generation and copied-index drift cannot yield a receipt", async () => {
+  for (const change of ["source", "dependency", "generation", "index"]) await fixture(async ({ options, adapters }) => {
+    if (change === "source" || change === "dependency") {
+      let calls = 0;
+      adapters.inspectSource = async () => {
+        const value = clone(SOURCE);
+        if (++calls === 2) {
+          if (change === "source") value.revision = "e".repeat(40);
+          else value.dependencies.runtimeSha256 = "e".repeat(64);
+        }
+        return value;
+      };
+    } else if (change === "generation") {
+      const original = adapters.probe; let metadataCalls = 0;
+      adapters.probe = async (request) => {
+        const value = await original(request);
+        if (request.stage === "metadata" && ++metadataCalls === 2) value.generation.id += 1;
+        return value;
+      };
+    } else {
+      const original = adapters.command;
+      adapters.command = async (...args) => {
+        const output = await original(...args);
+        await chmod(options.indexFile, 0o600);
+        await writeFile(options.indexFile, "synthetic changed index");
+        await chmod(options.indexFile, 0o400);
+        return output;
+      };
+    }
+    await assert.rejects(runPr94ProductionResourceWorker(options, adapters));
+  });
+});
+
+test("cancelled work and private exceptions are bounded failures, not cancellation qualification", async () => {
+  assert.ok(Object.isFrozen(PR94_PRODUCTION_ERROR_CODES));
+  assert.equal(new Set(PR94_PRODUCTION_ERROR_CODES).size, PR94_PRODUCTION_ERROR_CODES.length);
+  assert.ok(PR94_PRODUCTION_ERROR_CODES.every((code) => /^pr94_production_[a-z_]+$/u.test(code)));
+  assert.ok(PR94_PRODUCTION_ERROR_CODES.includes("pr94_production_index_changed"));
+  assert.ok(PR94_PRODUCTION_ERROR_CODES.includes("pr94_production_refused"));
+  assert.throws(() => PR94_PRODUCTION_ERROR_CODES.push("pr94_production_private"), TypeError);
+  await fixture(async ({ options, adapters, calls }) => {
+    const controller = new AbortController(); controller.abort();
+    await assert.rejects(runPr94ProductionResourceWorker(options, { ...adapters, signal: controller.signal }),
+      { code: "pr94_production_cancelled", message: "pr94_production_cancelled" });
+    assert.equal(calls.length, 0);
+  });
+  await fixture(async ({ options, adapters }) => {
+    adapters.inspectSource = async () => { throw new Error("SYNTHETIC_PRIVATE_PATH_OR_DIAGNOSTIC"); };
+    await assert.rejects(runPr94ProductionResourceWorker(options, adapters),
+      { code: "pr94_production_refused", message: "pr94_production_refused" });
+  });
+  for (const code of ["command_timeout", "command_output_limit", "command_termination_unconfirmed", "dependency_changed"]) {
+    assert.ok(PR94_PRODUCTION_ERROR_CODES.includes(`pr94_production_${code}`));
+    await fixture(async ({ options, adapters }) => {
+      adapters.inspectSource = async () => { throw Object.assign(new Error("SYNTHETIC_PRIVATE"), { code }); };
+      await assert.rejects(runPr94ProductionResourceWorker(options, adapters),
+        { code: `pr94_production_${code}`, message: `pr94_production_${code}` });
+    });
+  }
+});
+
+test("closed resource receipt rejects unknown keys, fabricated scope, unsafe values and repeat mismatches", async () => {
+  await fixture(async ({ options, adapters }) => {
+    const good = await runPr94ProductionResourceWorker(options, adapters);
+    for (const mutate of [
+      (value) => { value.raw = "SYNTHETIC_PRIVATE"; },
+      (value) => { value.scope = "end_to_end_refresh"; },
+      (value) => { value.runs[0].metrics.sampledRss = true; },
+      (value) => { value.runs[0].metrics.peakRssBytes = 0; },
+      (value) => { value.runs[0].metrics.wallMs = NaN; },
+      (value) => { value.runs[0].artifact.bytes = 16 * 1024 * 1024 + 1; },
+      (value) => { value.runs[0].cache.weeklyInput.limits.extra = 1; },
+      (value) => { value.runs[0].cache.weeklyInput.retainedUsageEvents = Number.MAX_SAFE_INTEGER + 1; },
+      (value) => { value.runs[1].artifact.sha256 = SHA; },
+      (value) => { value.runs.pop(); },
+      (value) => { value.exactRepeatOutput = false; },
+      (value) => { value.indexUnchanged = false; },
+      (value) => { value.notMeasured = []; },
+      (value) => { value.generation.toolProvenanceComplete = "true"; },
+    ]) { const changed = clone(good); mutate(changed); assert.throws(() => validatePr94ProductionResourceEvidence(changed)); }
+  });
+});

--- a/test/pr94-production-resource-worker.test.js
+++ b/test/pr94-production-resource-worker.test.js
@@ -5,19 +5,27 @@ import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import test from "node:test";
 import { REPLAY_SAFE_ACCOUNTING_MEMORY_POLICY } from "../src/replay-safe-accounting-cache.js";
+import * as readerModule from "../src/local-unified-accounting-source.js";
+import { openLocalUnifiedIndex } from "../src/local-unified-index.js";
 import {
   PR94_PRODUCTION_ERROR_CODES,
   buildPr94ProductionResourceRequest,
+  collectPr94AttributionQueryPlans,
   projectPr94ProductionCache,
   runPr94ProductionResourceWorker,
+  validatePr94AttributionQueryPlans,
   validatePr94ProductionResourceEvidence,
 } from "../scripts/lib/pr94-production-resource-worker.mjs";
 
 // All orchestration adapters below are synthetic. No revision child, real
-// database, corpus, native app, credentials or external process is executed.
+// private database, corpus, native app, credentials or external process is used.
+// The query-plan integration test creates its own empty synthetic SQLite index.
 const START = "2025-08-01T00:00:00.000Z";
 const END = "2026-08-01T00:00:00.000Z";
 const REVISION = "a".repeat(40);
+const BEFORE_REVISION = "a3c850360bc83c0e27bef2171aeb4a302b72f472";
+const AFTER_REVISION = "20f449ff5c222989029fe343f219f02b497ae1d4";
+const QUERY_ROLES = ["membership", "same_record_plans", "source_predecessor", "session_predecessor"];
 const SHA = "b".repeat(64);
 const hash = (value) => createHash("sha256").update(value).digest("hex");
 const clone = (value) => structuredClone(value);
@@ -28,7 +36,14 @@ const GENERATION = Object.freeze({ id: 44, fingerprint: `generation-v2-${SHA}`, 
   diagnosticsComplete: true, usageProvenanceComplete: true, sourceOrderComplete: true, quotaProvenanceComplete: true,
   indexedSourceCount: 3, indexedSourceBytes: 1000, skippedSourceCount: 0, skippedSourceBytes: 0,
   skippedThreadCount: 0, usageEvents: 2, quotaOccurrences: 1, toolFacts: 0 });
-const METADATA = Object.freeze({ policy: POLICY, generation: GENERATION, requestVersion: "replay-safe-accounting-rebuild-request-v1" });
+function queryPlans(revision = REVISION) {
+  return { schema: "pr94-attribution-query-plans-v1", scope: "attribution_point_queries_explain_only", binding: "synthetic",
+    status: revision === BEFORE_REVISION ? "feature_absent" : "observed",
+    statements: revision === BEFORE_REVISION ? null : Object.fromEntries(QUERY_ROLES.map((role) => [role,
+      { steps: 1, search: 1, scan: 0, tempSort: 0, other: 0 }])) };
+}
+const METADATA = Object.freeze({ policy: POLICY, generation: GENERATION,
+  requestVersion: "replay-safe-accounting-rebuild-request-v1", queryPlans: queryPlans() });
 const SOURCE = Object.freeze({ revision: REVISION,
   dependencies: { sourceSha256: SHA, runtimeSha256: SHA, lockSha256: SHA, identitySha256: SHA } });
 const CONTEXT = Object.freeze({ startAt: START, endAt: END, generationId: 44, generationFingerprint: GENERATION.fingerprint });
@@ -48,7 +63,7 @@ function cache(encoding = "accounting_compact_v3") {
     extraDiagnostic: "SYNTHETIC_PRIVATE" };
 }
 
-async function fixture(action, { encoding = "accounting_compact_v3" } = {}) {
+async function fixture(action, { encoding = "accounting_compact_v3", revision = REVISION } = {}) {
   const directory = await realpath(await mkdtemp(join(tmpdir(), "pr94-production-resource-test-")));
   try {
     const inputDirectory = join(directory, "input");
@@ -56,17 +71,17 @@ async function fixture(action, { encoding = "accounting_compact_v3" } = {}) {
     const indexFile = join(inputDirectory, "synthetic.sqlite");
     const input = "synthetic offline index bytes, not SQLite";
     await writeFile(indexFile, input, { mode: 0o400 });
-    const options = { privateOperationApproved: true, root: join(directory, "synthetic-source"), expectedRevision: REVISION,
+    const options = { privateOperationApproved: true, root: join(directory, "synthetic-source"), expectedRevision: revision,
       indexFile, expectedIndex: { sha256: hash(input), bytes: Buffer.byteLength(input), generationId: 44 },
       outputDirectory: join(directory, "output"), startAt: START, endAt: END, timeoutSeconds: 30 };
     const calls = []; const probes = []; const identities = [];
     const artifact = JSON.stringify(cache(encoding));
     const adapters = {
       runtime: RUNTIME,
-      inspectSource: async (root) => { identities.push(root); return clone(SOURCE); },
+      inspectSource: async (root) => { identities.push(root); return { ...clone(SOURCE), revision }; },
       probe: async (request) => {
         probes.push(request);
-        return request.stage === "metadata" ? clone(METADATA)
+        return request.stage === "metadata" ? { ...clone(METADATA), queryPlans: queryPlans(revision) }
           : projectPr94ProductionCache(JSON.parse(await readFile(request.path, "utf8")), request.context);
       },
       command: async (command, args, configuration) => {
@@ -151,6 +166,9 @@ test("orchestration times only two unmodified production child processes, with e
     assert.equal(receipt.exactRepeatOutput, true);
     assert.equal(calls.length, 2);
     assert.equal(probes.length, 4);
+    assert.deepEqual(probes.filter(({ stage }) => stage === "metadata").map(({ context }) => context),
+      [{ revision: REVISION, observedAtMs: Date.parse(END) }, { revision: REVISION, observedAtMs: Date.parse(END) }]);
+    assert.deepEqual(receipt.queryPlans, queryPlans());
     assert.equal(identities.length, 2);
     const requests = [];
     for (const { command, args, configuration } of calls) {
@@ -181,7 +199,8 @@ test("baseline compact-v2 child artifacts remain valid in their own lane", async
     const receipt = await runPr94ProductionResourceWorker(options, adapters);
     assert.equal(receipt.runs[0].cache.schemaVersion, "local-replay-safe-accounting-v0.13");
     assert.equal(receipt.runs[0].cache.weeklyInput.encoding, "accounting_compact_v2");
-  }, { encoding: "accounting_compact_v2" });
+    assert.deepEqual(receipt.queryPlans, queryPlans(BEFORE_REVISION));
+  }, { encoding: "accounting_compact_v2", revision: BEFORE_REVISION });
 });
 
 test("approval, pinned revision, runtime and expected copied-index identity fail before child execution", async () => {
@@ -331,6 +350,169 @@ test("closed resource receipt rejects unknown keys, fabricated scope, unsafe val
       (value) => { value.indexUnchanged = false; },
       (value) => { value.notMeasured = []; },
       (value) => { value.generation.toolProvenanceComplete = "true"; },
+      (value) => { delete value.queryPlans; },
+      (value) => { value.queryPlans = queryPlans(BEFORE_REVISION); },
+      (value) => { value.queryPlans.statements.membership.sql = "SYNTHETIC_PRIVATE"; },
     ]) { const changed = clone(good); mutate(changed); assert.throws(() => validatePr94ProductionResourceEvidence(changed)); }
+  });
+});
+
+function explainFixture(details = ["SEARCH synthetic USING INDEX synthetic (key=?)"]) {
+  const calls = [];
+  return {
+    calls,
+    options: { readerModule, generationId: 44, observedAtMs: Date.parse(END), revision: REVISION,
+      database: { prepare(sql) {
+        assert.match(sql, /^EXPLAIN QUERY PLAN\s+SELECT\b/u, "no data SELECT is executed");
+        return { *iterate(...parameters) {
+          calls.push({ sql, parameters });
+          for (const [index, detail] of details.entries()) yield { id: index + 1, parent: 0, notused: 0, detail };
+        } };
+      } },
+    },
+  };
+}
+
+test("EXPLAIN adapter drives exactly four original public-reader queries using synthetic bindings", () => {
+  const fixture = explainFixture(["SEARCH SYNTHETIC_PRIVATE_SEARCH", "SCAN SYNTHETIC_PRIVATE_SCAN",
+    "USE TEMP B-TREE FOR ORDER BY SYNTHETIC_PRIVATE_SORT", "SYNTHETIC_PRIVATE_FUTURE_OPERATION"]);
+  const evidence = collectPr94AttributionQueryPlans(fixture.options);
+  assert.equal(validatePr94AttributionQueryPlans(evidence, REVISION), evidence);
+  assert.equal(fixture.calls.length, 4);
+  assert.deepEqual(fixture.calls.map(({ parameters }) => parameters.length), [2, 5, 3, 5]);
+  assert.deepEqual(Object.keys(evidence.statements), QUERY_ROLES);
+  for (const counts of Object.values(evidence.statements)) {
+    assert.deepEqual(counts, { steps: 4, search: 1, scan: 1, tempSort: 1, other: 1 });
+  }
+  assert.ok(fixture.calls.every(({ parameters }) => parameters[0] === 44));
+  assert.equal(fixture.calls[1].parameters.at(-1), Date.parse(END));
+  assert.equal(fixture.calls[3].parameters.at(-1), Date.parse(END));
+  const serialized = JSON.stringify(evidence);
+  for (const excluded of ["SYNTHETIC_PRIVATE", "SELECT", "EXPLAIN", "source_local", "source_ordinal",
+    "source_offset", "session_local", "parameters", "detail", "index", String(Date.parse(END))]) {
+    assert.ok(!serialized.includes(excluded));
+  }
+});
+
+test("actual SQLite plans compile from the unchanged reader against an immutable synthetic schema-11 index", async () => {
+  const directory = await realpath(await mkdtemp(join(tmpdir(), "pr94-explain-only-test-")));
+  const indexFile = join(directory, "synthetic.sqlite");
+  let database;
+  try {
+    openLocalUnifiedIndex(indexFile, { create: true }).close();
+    await chmod(indexFile, 0o400);
+    const before = await readFile(indexFile);
+    database = openLocalUnifiedIndex(indexFile, { readOnly: true });
+    let explained = 0;
+    const evidence = collectPr94AttributionQueryPlans({ readerModule, generationId: 44,
+      observedAtMs: Date.parse(END), revision: REVISION, database: { prepare(sql) {
+        assert.match(sql, /^EXPLAIN QUERY PLAN\s+SELECT\b/u);
+        explained += 1;
+        return database.prepare(sql);
+      } } });
+    assert.equal(explained, 4);
+    assert.equal(evidence.status, "observed");
+    assert.deepEqual(Object.keys(evidence.statements), QUERY_ROLES);
+    assert.ok(Object.values(evidence.statements).every((counts) => counts.steps > 0));
+    database.close(); database = null;
+    assert.deepEqual(await readFile(indexFile), before);
+  } finally {
+    database?.close();
+    await rm(directory, { recursive: true, force: true });
+  }
+});
+
+test("feature absence is null evidence only at the exact first parent, never after/final zero counters", () => {
+  const fixture = explainFixture();
+  const evidence = collectPr94AttributionQueryPlans({ ...fixture.options, revision: BEFORE_REVISION, readerModule: {} });
+  assert.deepEqual(evidence, queryPlans(BEFORE_REVISION));
+  assert.equal(fixture.calls.length, 0);
+  assert.equal(validatePr94AttributionQueryPlans(evidence, BEFORE_REVISION), evidence);
+  for (const revision of [AFTER_REVISION, REVISION]) {
+    assert.throws(() => collectPr94AttributionQueryPlans({ ...fixture.options, revision, readerModule: {} }),
+      { code: "pr94_production_query_plan_invalid" });
+    assert.throws(() => validatePr94AttributionQueryPlans(evidence, revision));
+  }
+  assert.throws(() => collectPr94AttributionQueryPlans({ ...fixture.options, revision: BEFORE_REVISION }),
+    { code: "pr94_production_query_plan_invalid" });
+  assert.throws(() => validatePr94AttributionQueryPlans(queryPlans(), BEFORE_REVISION));
+});
+
+test("query-plan shape drift, data-query attempts and private SQLite exceptions refuse with a fixed code", () => {
+  for (const mutate of [
+    (options) => { options.revision = "unknown"; },
+    (options) => { options.generationId = 0; },
+    (options) => { options.observedAtMs = NaN; },
+    (options) => { options.database.prepare = () => { throw new Error("SYNTHETIC_PRIVATE_SQL_OR_PATH"); }; },
+    (options) => { options.database.prepare = () => ({ *iterate() { yield { detail: "SEARCH private" }; } }); },
+    (options) => { options.database.prepare = () => ({ *iterate() {} }); },
+    (options) => { options.readerModule = { createLocalUnifiedUsageAttributionReader({ database }) {
+      database.prepare("DELETE FROM synthetic");
+    } }; },
+    (options) => { options.readerModule = { createLocalUnifiedUsageAttributionReader({ database }) {
+      for (let index = 0; index < 5; index += 1) database.prepare("SELECT 1");
+    } }; },
+    (options) => { options.readerModule = { createLocalUnifiedUsageAttributionReader({ database }) {
+      const statement = database.prepare("SELECT 1");
+      return { read() { statement.all(44, Buffer.alloc(32)); } };
+    } }; },
+    (options) => { options.readerModule = { createLocalUnifiedUsageAttributionReader({ database }) {
+      const statement = database.prepare("SELECT 1");
+      return { read() { statement.get(44); } };
+    } }; },
+    (options) => { options.readerModule = { createLocalUnifiedUsageAttributionReader() { return { read() {} }; } }; },
+    (options) => { options.readerModule = { createLocalUnifiedUsageAttributionReader(args) {
+      const original = readerModule.createLocalUnifiedUsageAttributionReader(args);
+      return { read(row) { original.read(row); original.read(row); } };
+    } }; },
+  ]) {
+    const fixture = explainFixture(); mutate(fixture.options);
+    assert.throws(() => collectPr94AttributionQueryPlans(fixture.options),
+      { code: "pr94_production_query_plan_invalid", message: "pr94_production_query_plan_invalid" });
+  }
+});
+
+test("query-plan validator rejects unknown keys, unsafe counts, missing statements and false absence", () => {
+  for (const mutate of [
+    (value) => { value.raw = "SYNTHETIC_PRIVATE"; },
+    (value) => { value.scope = "all_accounting_queries"; },
+    (value) => { value.binding = "real_rows"; },
+    (value) => { value.status = "feature_absent"; },
+    (value) => { value.statements = null; },
+    (value) => { delete value.statements.source_predecessor; },
+    (value) => { value.statements.full_scan = clone(value.statements.membership); },
+    (value) => { value.statements.membership.detail = "SYNTHETIC_PRIVATE"; },
+    (value) => { value.statements.membership.steps = 0; },
+    (value) => { value.statements.membership.scan = NaN; },
+    (value) => { value.statements.membership.scan = Infinity; },
+    (value) => { value.statements.membership.scan = -0; },
+    (value) => { value.statements.membership.scan = Number.MAX_SAFE_INTEGER + 1; },
+    (value) => { value.statements.membership.steps = 2; },
+    (value) => { Object.defineProperty(value.statements.membership, "search", { enumerable: true,
+      get() { assert.fail("getter invoked"); } }); },
+  ]) {
+    const value = queryPlans(); mutate(value);
+    assert.throws(() => validatePr94AttributionQueryPlans(value, REVISION));
+  }
+});
+
+test("query plans are required before timed work and must match the untimed post-run observation", async () => {
+  for (const phase of ["initial", "final"]) await fixture(async ({ options, adapters, calls }) => {
+    const original = adapters.probe; let metadataCalls = 0;
+    adapters.probe = async (request) => {
+      const value = await original(request);
+      if (request.stage === "metadata") {
+        metadataCalls += 1;
+        if (phase === "initial") delete value.queryPlans;
+        else if (metadataCalls === 2) {
+          value.queryPlans.statements.membership.search = 0;
+          value.queryPlans.statements.membership.scan = 1;
+        }
+      }
+      return value;
+    };
+    await assert.rejects(runPr94ProductionResourceWorker(options, adapters),
+      { code: phase === "initial" ? "pr94_production_invalid" : "pr94_production_query_plan_changed" });
+    assert.equal(calls.length, phase === "initial" ? 0 : 2);
   });
 });

--- a/test/pr94-qualification-runner.test.js
+++ b/test/pr94-qualification-runner.test.js
@@ -1,0 +1,130 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { chmod, lstat, mkdtemp, readFile, realpath, rm, symlink, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import {
+  parsePr94QualificationArguments, publishPr94Receipt, readPr94PrivateFrames,
+  runPr94Qualification,
+  parsePr94AnalysisEnvelope,
+} from "../scripts/qualify-pr94-attribution.mjs";
+
+const arguments_ = ["--allow-private-attribution-comparison", "--before-root", "/synthetic/before",
+  "--after-root", "/synthetic/after", "--final-root", "/synthetic/final", "--index", "/synthetic/index.sqlite",
+  "--output-dir", "/synthetic/output", "--start-at", "2025-09-02T00:00:00.000Z",
+  "--end-at", "2026-09-02T00:00:00.000Z"];
+const code = (expected) => (error) => error.code === expected && error.message === expected;
+async function fixture(run) {
+  const directory = await mkdtemp(join(await realpath(tmpdir()), "pr94-runner-synthetic-"));
+  try { await chmod(directory, 0o700); await run(directory); }
+  finally { await rm(directory, { recursive: true, force: true }); }
+}
+
+test("PR94 runner requires explicit private operation and exact bounded options", () => {
+  const parsed = parsePr94QualificationArguments(arguments_);
+  assert.equal(parsed.privateOperationApproved, true);
+  assert.equal(parsed.timeoutSeconds, 1800);
+  assert.equal(parsed.startAt, "2025-09-02T00:00:00.000Z");
+  assert.throws(() => parsePr94QualificationArguments(arguments_.slice(1)), code("pr94_approval_required"));
+  for (const extra of [["--new-option", "x"], ["--before-root", "/duplicate"],
+    ["--timeout-seconds", "0"], ["--timeout-seconds", "3601"], ["--timeout-seconds", "1.2"],
+    ["--timeout-seconds", "NaN"], ["--timeout-seconds"]]) {
+    assert.throws(() => parsePr94QualificationArguments([...arguments_, ...extra]), code("pr94_arguments_invalid"));
+  }
+  const badDate = arguments_.map((value) => value === "2025-09-02T00:00:00.000Z" ? "2025-09-02" : value);
+  assert.throws(() => parsePr94QualificationArguments(badDate), code("pr94_arguments_invalid"));
+  assert.throws(() => parsePr94QualificationArguments(arguments_.map((value) =>
+    value === "2025-09-02T00:00:00.000Z" ? "2027-09-02T00:00:00.000Z" : value)), code("pr94_arguments_invalid"));
+});
+
+test("PR94 programmatic entry refuses before source or private data access without approval", async () => {
+  await assert.rejects(runPr94Qualification({}), code("pr94_approval_required"));
+});
+
+test("analysis envelopes propagate only closed fixed diagnostic codes", () => {
+  const success = { status: "ok", resultBytes: 256, resultSha256: "a".repeat(64) };
+  assert.deepEqual(parsePr94AnalysisEnvelope(JSON.stringify(success)), success);
+  assert.throws(() => parsePr94AnalysisEnvelope(JSON.stringify({ status: "error", code: "pr94_calibration_report_fit_mismatch" })),
+    code("pr94_calibration_report_fit_mismatch"));
+  for (const value of [{ status: "error", code: "private-secret-marker" },
+    { status: "error", code: "pr94_analysis_failed", details: "private-secret-marker" },
+    { ...success, raw: "private-secret-marker" }, { ...success, resultBytes: Number.MAX_SAFE_INTEGER }]) {
+    assert.throws(() => parsePr94AnalysisEnvelope(JSON.stringify(value)), code("pr94_envelope_invalid"));
+  }
+});
+
+test("private frame reader is streaming, exact-ended and owner-only", async () => fixture(async (directory) => {
+  const path = join(directory, "frames.ndjson");
+  const rows = [{ kind: "synthetic", value: 1 }, { kind: "seal", digest: "a".repeat(64) }];
+  await writeFile(path, rows.map((row) => JSON.stringify(row)).join("\n") + "\n", { mode: 0o600 });
+  assert.deepEqual(await Array.fromAsync(readPr94PrivateFrames(path)), rows);
+  await chmod(path, 0o644);
+  await assert.rejects(Array.fromAsync(readPr94PrivateFrames(path)), code("pr94_path_invalid"));
+  await chmod(path, 0o600);
+  const alias = join(directory, "alias.ndjson");
+  await symlink(path, alias);
+  await assert.rejects(Array.fromAsync(readPr94PrivateFrames(alias)), code("pr94_path_invalid"));
+}));
+
+test("private frame reader rejects truncated, malformed, empty and over-limit lines", async () => fixture(async (directory) => {
+  const path = join(directory, "frames.ndjson");
+  for (const body of ['{"kind":"synthetic"}', "bad-json\n", "\n", JSON.stringify({ value: "x".repeat(1024 * 1024) }) + "\n"]) {
+    await writeFile(path, body, { mode: 0o600 });
+    await assert.rejects(Array.fromAsync(readPr94PrivateFrames(path)), code("pr94_private_frames_invalid"));
+  }
+}));
+
+test("private frame reader responds to cancellation before and during consumption", async () => fixture(async (directory) => {
+  const path = join(directory, "frames.ndjson");
+  await writeFile(path, '{"kind":"first"}\n{"kind":"last"}\n', { mode: 0o600 });
+  const pre = new AbortController(); pre.abort();
+  await assert.rejects(Array.fromAsync(readPr94PrivateFrames(path, pre.signal)), code("pr94_cancelled"));
+  const controller = new AbortController();
+  const iterator = readPr94PrivateFrames(path, controller.signal);
+  assert.deepEqual((await iterator.next()).value, { kind: "first" });
+  controller.abort();
+  await assert.rejects(iterator.next(), code("pr94_cancelled"));
+}));
+
+test("receipt publication is private, no-clobber and leaves no partial file", async () => fixture(async (directory) => {
+  const receipt = { status: "synthetic", count: 1 };
+  await publishPr94Receipt(directory, receipt);
+  const path = join(directory, "comparison.json");
+  assert.deepEqual(JSON.parse(await readFile(path, "utf8")), receipt);
+  const metadata = await lstat(path);
+  assert.equal(metadata.mode & 0o777, 0o600);
+  assert.equal(metadata.nlink, 1);
+  await assert.rejects(lstat(join(directory, "comparison.partial.json")), { code: "ENOENT" });
+  await assert.rejects(publishPr94Receipt(directory, { status: "replacement" }), { code: "EEXIST" });
+  assert.deepEqual(JSON.parse(await readFile(path, "utf8")), receipt);
+  await assert.rejects(lstat(join(directory, "comparison.partial.json")), { code: "ENOENT" });
+}));
+
+test("canceled receipt cannot be published and unrelated partial output is preserved", async () => fixture(async (directory) => {
+  const controller = new AbortController(); controller.abort();
+  await assert.rejects(publishPr94Receipt(directory, { status: "synthetic" }, { signal: controller.signal }), code("pr94_cancelled"));
+  await assert.rejects(lstat(join(directory, "comparison.json")), { code: "ENOENT" });
+  const partial = join(directory, "comparison.partial.json");
+  await writeFile(partial, "preserve", { mode: 0o600 });
+  await assert.rejects(publishPr94Receipt(directory, {}), { code: "EEXIST" });
+  assert.equal(await readFile(partial, "utf8"), "preserve");
+}));
+
+test("late cancellation or close failure revokes the exact just-published receipt", async () => {
+  for (const mode of ["cancel", "close-error"]) await fixture(async (directory) => {
+    const controller = new AbortController();
+    await assert.rejects(publishPr94Receipt(directory, { status: "synthetic" }, {
+      signal: controller.signal,
+      async closeFile(file) {
+        // The commit link exists: cancellation here exercised the former gap
+        // after its final check but during asynchronous file cleanup.
+        assert.equal((await lstat(join(directory, "comparison.json"))).isFile(), true);
+        await file.close();
+        if (mode === "cancel") controller.abort();
+        else throw Object.assign(new Error("synthetic close failure"), { code: "SYNTHETIC_CLOSE" });
+      },
+    }), mode === "cancel" ? code("pr94_cancelled") : { code: "SYNTHETIC_CLOSE" });
+    await assert.rejects(lstat(join(directory, "comparison.json")), { code: "ENOENT" });
+    await assert.rejects(lstat(join(directory, "comparison.partial.json")), { code: "ENOENT" });
+  });
+});

--- a/test/pr94-qualification-runner.test.js
+++ b/test/pr94-qualification-runner.test.js
@@ -41,6 +41,19 @@ test("PR94 programmatic entry refuses before source or private data access witho
   await assert.rejects(runPr94Qualification({}), code("pr94_approval_required"));
 });
 
+test("runner validates the shared semantic projection before production resource probes", async () => {
+  const source = await readFile(new URL("../scripts/qualify-pr94-attribution.mjs", import.meta.url), "utf8");
+  const comparison = source.indexOf("const comparison = {");
+  const validation = source.indexOf("validatePr94ComparisonEvidence({ comparison, evidence: publicEvidence });");
+  const disposal = source.indexOf("for (const value of Object.values(evidence)) {", comparison);
+  const production = source.indexOf("const productionResources = {};");
+  const finalValidation = source.indexOf("validatePr94ComparisonReceipt(receipt);");
+  assert.ok(comparison > 0 && validation > comparison);
+  assert.ok(disposal > validation && production > disposal);
+  assert.ok(finalValidation > production);
+  assert.match(source.slice(production, finalValidation), /evidence: publicEvidence,/u);
+});
+
 test("analysis envelopes propagate only closed fixed diagnostic codes", () => {
   const success = { status: "ok", resultBytes: 256, resultSha256: "a".repeat(64) };
   assert.deepEqual(parsePr94AnalysisEnvelope(JSON.stringify(success)), success);

--- a/test/pr94-receipt-validation.test.js
+++ b/test/pr94-receipt-validation.test.js
@@ -147,7 +147,7 @@ function queryPlans(revision) {
 }
 function resource(side, receipt, evidence) {
   const generationEvidence = evidence[side].generation;
-  return { schema: "pr94-production-resource-v1", scope: "isolated_child_repeatability", revision: receipt.sources[side].revision,
+  return { schema: "pr94-production-resource-v2", scope: "isolated_child_repeatability", revision: receipt.sources[side].revision,
     dependencies: receipt.sources[side].dependencies,
     clock: { startAt: INSTANT_START, endAt: INSTANT_END, nowMs: Date.parse(INSTANT_END), windowDays: 365 },
     index: receipt.index, generation: { id: generationEvidence.id, publicationStatus: generationEvidence.publicationStatus,
@@ -171,7 +171,7 @@ function resource(side, receipt, evidence) {
 }
 function receipt() {
   const evidence = { before: analysis("before"), after: analysis("after"), final: analysis("final") };
-  const value = { schema: "pr94-admitted-index-comparison-v1", status: "passed",
+  const value = { schema: "pr94-admitted-index-comparison-v2", status: "passed",
     scope: "fixed_admitted_index_analysis_not_raw_ingestion_or_hosted_activation",
     sources: { before: source(BEFORE_REVISION), after: source(AFTER_REVISION), final: source("c") }, index: { sha256: HASH("6"), bytes: 1 },
     window: { startAt: INSTANT_START, endAt: INSTANT_END },
@@ -352,6 +352,40 @@ test("only the PR94 isolation pair requires identical locks; final dependencies 
   mixedPair.sources.after.dependencies.lockSha256 = HASH("7");
   mixedPair.productionResources.after.dependencies.lockSha256 = HASH("7");
   assert.throws(() => validatePr94ComparisonReceipt(mixedPair), { code: "pr94_receipt_comparison_invalid" });
+});
+
+test("historical artifact refusal requires an explicit v2 result and never substitutes for final validation", () => {
+  const value = receipt();
+  value.status = "passed_with_historical_artifact_refusal";
+  const historical = value.productionResources.after;
+  historical.status = "historical_artifact_refused";
+  historical.runs = historical.runs.map(({ cache, ...run }) => ({
+    ...run, cacheAssertion: { status: "refused", code: "cache_invalid" },
+  }));
+  assert.equal(validatePr94ComparisonReceipt(value), value);
+
+  for (const mutate of [
+    (changed) => { changed.status = "passed"; },
+    (changed) => { changed.schema = "pr94-admitted-index-comparison-v1"; },
+    (changed) => { changed.productionResources.after.schema = "pr94-production-resource-v1"; },
+    (changed) => { changed.productionResources.after.runs[1].cacheAssertion.code = "other_failure"; },
+    (changed) => { changed.productionResources.after.runs[1].artifact.sha256 = HASH("7"); },
+    (changed) => { changed.productionResources.after.index = { ...changed.productionResources.after.index, sha256: HASH("7") }; },
+    (changed) => { changed.productionResources.after.dependencies = {
+      ...changed.productionResources.after.dependencies, identitySha256: HASH("7"),
+    }; },
+    (changed) => { changed.productionResources.final = clone(changed.productionResources.after); },
+    (changed) => { changed.productionResources.before = clone(changed.productionResources.after); },
+    (changed) => { changed.comparison.attributionLedger.status = "different"; },
+    (changed) => { changed.comparison.attributionCalibration.status = "fail"; },
+    (changed) => { changed.productionResources.final.runs[0].cache.source.accountingCoverage = "partial"; },
+  ]) {
+    const changed = clone(value); mutate(changed);
+    assert.throws(() => validatePr94ComparisonReceipt(changed), { code: "pr94_receipt_comparison_invalid" });
+  }
+  const falseRefusal = receipt();
+  falseRefusal.status = "passed_with_historical_artifact_refusal";
+  assert.throws(() => validatePr94ComparisonReceipt(falseRefusal), { code: "pr94_receipt_comparison_invalid" });
 });
 
 test("closed validators reject accessor, symbol, prototype and raw content channels", () => {

--- a/test/pr94-receipt-validation.test.js
+++ b/test/pr94-receipt-validation.test.js
@@ -3,7 +3,7 @@ import assert from "node:assert/strict";
 import { registerHooks } from "node:module";
 import { createPr94LedgerEvidence } from "../scripts/lib/pr94-ledger-evidence.mjs";
 import { buildPr94CalibrationEvidence, comparePr94CalibrationEvidence } from "../scripts/lib/pr94-calibration-evidence.mjs";
-import { validatePr94AnalysisResult, validatePr94ComparisonReceipt } from "../scripts/lib/pr94-receipt-validation.mjs";
+import { validatePr94AnalysisResult, validatePr94ComparisonEvidence, validatePr94ComparisonReceipt } from "../scripts/lib/pr94-receipt-validation.mjs";
 
 const HASH = (character) => character.repeat(64);
 const REVISION = (character) => character.repeat(40);
@@ -43,13 +43,14 @@ const CALIBRATION_HMAC_KEY = new Uint8Array(32).fill(13);
 const CALIBRATION_RESET = Date.parse("2026-08-31T00:00:00.000Z") / 1_000;
 const CALIBRATION_SCOPE = { startAt: "2026-08-01T00:00:00.000Z", endAt: "2026-09-01T00:00:00.000Z" };
 
-function calibrationRows({ planType = "pro", count = 12, offset = 0, costStep = 10 } = {}) {
+function calibrationRows({ planType = "pro", count = 12, offset = 0, costStep = 10,
+  reset = CALIBRATION_RESET, era = "era-one", eligibility = "primary_conditional" } = {}) {
   return Array.from({ length: count }, (_, index) => {
     const time = Date.parse("2026-08-25T00:00:00.000Z") + (index + offset) * 3_600_000;
     return {
-      accountScopeId: "unattributed", provider: "openai_codex", planType, planVariant: "unknown", planEraKey: "era-one",
-      aggregationEligibility: "primary_conditional", limitId: "codex", slot: "primary", windowDurationMins: 10_080,
-      resetsAt: CALIBRATION_RESET, eventTime: new Date(time + 3_600_000).toISOString(),
+      accountScopeId: "unattributed", provider: "openai_codex", planType, planVariant: "unknown", planEraKey: era,
+      aggregationEligibility: eligibility, limitId: "codex", slot: "primary", windowDurationMins: 10_080,
+      resetsAt: reset, eventTime: new Date(time + 3_600_000).toISOString(),
       lastPriorObservedAt: new Date(time).toISOString(), firstNextObservedAt: new Date(time + 3_600_000).toISOString(),
       priorUsedPercent: index, nextUsedPercent: index + 1,
       lastPriorCumulativeApiPricedUsd: index * costStep, firstNextCumulativeApiPricedUsd: (index + 1) * costStep,
@@ -72,12 +73,22 @@ function calibrationRawParent(first) {
 }
 
 function populatedCalibration(revisionKind, options = {}) {
-  const transitions = calibrationRows(options);
+  const parents = Array.from({ length: options.parentCount ?? 1 }, (_, index) => {
+    const parentOptions = { ...options, reset: CALIBRATION_RESET - index * 604_800,
+      offset: (options.offset ?? 0) - index * 168 };
+    return [
+      ...calibrationRows(parentOptions),
+      ...(options.withDiagnostic ? calibrationRows({ ...parentOptions, era: "era-two", count: 9,
+        offset: parentOptions.offset + 20 }) : []),
+    ];
+  });
+  const transitions = parents.flat();
   return buildPr94CalibrationEvidence({ internals: calibrationOriginal,
     analyzeWeeklyCalibration: calibrationOriginal.analyzeWeeklyCalibration,
     candidates: calibrationOriginal.CANDIDATES, transitions,
-    rawParents: [calibrationRawParent(transitions[0])], revisionKind,
-    hmacKey: CALIBRATION_HMAC_KEY, scope: CALIBRATION_SCOPE, selectedPlanType: options.planType ?? "pro" });
+    rawParents: parents.map((rows) => calibrationRawParent(rows[0])), revisionKind,
+    hmacKey: CALIBRATION_HMAC_KEY, scope: CALIBRATION_SCOPE,
+    selectedPlanType: Object.hasOwn(options, "selectedPlanType") ? options.selectedPlanType : options.planType ?? "pro" });
 }
 
 function noWithinEraCalibration(revisionKind) {
@@ -182,6 +193,17 @@ function receipt() {
   for (const side of ["before", "after", "final"]) value.productionResources[side] = resource(side, value, evidence);
   return value;
 }
+function populatedReceipt(options = {}, afterOptions = options) {
+  const result = receipt();
+  result.evidence.before.calibration = populatedCalibration("before", options);
+  result.evidence.after.calibration = populatedCalibration("after", afterOptions);
+  result.evidence.final.calibration = populatedCalibration("final", afterOptions);
+  result.comparison.attributionCalibration = comparePr94CalibrationEvidence(
+    result.evidence.before.calibration, result.evidence.after.calibration);
+  result.comparison.finalCalibration = comparePr94CalibrationEvidence(
+    result.evidence.after.calibration, result.evidence.final.calibration);
+  return result;
+}
 function ledgerComparison() {
   const row = { before: 0, after: 0, unchanged: 0, changed: 0, missing: 0, added: 0 };
   return { schemaVersion: "pr94-ledger-comparison-v1", status: "equal", aggregateEqual: true,
@@ -198,6 +220,16 @@ function calibrationComparison() {
 }
 function rejects(value, expectedCode = "pr94_receipt_analysis_invalid") {
   assert.throws(() => validatePr94AnalysisResult(value), { code: expectedCode });
+}
+function acceptsComparison(value) {
+  const pair = { comparison: value.comparison, evidence: value.evidence };
+  assert.equal(validatePr94ComparisonEvidence(pair), pair);
+  assert.equal(validatePr94ComparisonReceipt(value), value);
+}
+function rejectsComparison(value) {
+  const pair = { comparison: value.comparison, evidence: value.evidence };
+  assert.throws(() => validatePr94ComparisonEvidence(pair), { code: "pr94_receipt_comparison_invalid" });
+  assert.throws(() => validatePr94ComparisonReceipt(value), { code: "pr94_receipt_comparison_invalid" });
 }
 
 test("PR94 receipt validators accept content-free synthetic analysis and comparison projections", () => {
@@ -239,6 +271,139 @@ test("comparison validator accepts actual populated calibration v2 matrices in c
   const reversed = clone(result);
   reversed.comparison.attributionCalibration.primaryOutcomeMatrix.reverse();
   assert.throws(() => validatePr94ComparisonReceipt(reversed), { code: "pr94_receipt_comparison_invalid" });
+});
+
+for (const [selectedPlanType, primaryOutcome] of [
+  ["pro", "selected_plan_primary"], ["plus", "alternate_plan_primary"], [null, "unselected_plan_primary"],
+]) {
+  test(`comparison validator reconciles merged producer cells for ${primaryOutcome}`, () => {
+    const result = populatedReceipt({ parentCount: 3, selectedPlanType });
+    for (const comparison of [result.comparison.attributionCalibration, result.comparison.finalCalibration]) {
+      assert.equal(comparison.status, "pass");
+      assert.equal(comparison.reconciledParentCandidates, 12);
+      assert.equal(comparison.retainedPrimaryFits, 12);
+      assert.equal(comparison.primaryOutcomeMatrix.length, 4);
+      for (const cell of comparison.primaryOutcomeMatrix) {
+        assert.equal(cell.parentCandidates, 3);
+        assert.equal(cell.afterPrimaryFits, 3);
+        assert.deepEqual(cell.afterOutcomes, [{ outcome: primaryOutcome, count: 1 }]);
+      }
+    }
+    acceptsComparison(result);
+    for (const side of ["attributionCalibration", "finalCalibration"]) {
+      for (const mutate of [
+        (cell) => { cell.afterOutcomes[0].count = 2; },
+        (cell) => { cell.afterOutcomes[0].count = 3; },
+        (cell) => { cell.parentCandidates = 2; },
+        (cell) => { cell.afterOutcomes = [{ outcome: "aggregation_diagnostic_only", count: 3 }]; },
+      ]) {
+        const changed = clone(result);
+        mutate(changed.comparison[side].primaryOutcomeMatrix[0]);
+        rejectsComparison(changed);
+      }
+    }
+  });
+}
+
+test("merged primary cells count only primary outcomes, not losing diagnostic fragments", () => {
+  const result = populatedReceipt({ parentCount: 3, withDiagnostic: true });
+  for (const comparison of [result.comparison.attributionCalibration, result.comparison.finalCalibration]) {
+    assert.equal(comparison.primaryOutcomeMatrix.length, 4);
+    for (const cell of comparison.primaryOutcomeMatrix) {
+      assert.equal(cell.parentCandidates, 3);
+      assert.equal(cell.afterPrimaryFits, 3);
+      assert.deepEqual(cell.afterOutcomes, [
+        { outcome: "losing_qualifying_fragment", count: 1 }, { outcome: "selected_plan_primary", count: 1 },
+      ]);
+    }
+  }
+  acceptsComparison(result);
+  for (const side of ["attributionCalibration", "finalCalibration"]) {
+    const diagnosticsAsPrimary = clone(result);
+    diagnosticsAsPrimary.comparison[side].primaryOutcomeMatrix[0].afterOutcomes = [
+      { outcome: "losing_qualifying_fragment", count: 3 },
+    ];
+    rejectsComparison(diagnosticsAsPrimary);
+    const multiplied = clone(result);
+    multiplied.comparison[side].primaryOutcomeMatrix[0].afterOutcomes[1].count = 2;
+    rejectsComparison(multiplied);
+  }
+});
+
+test("merged no-primary cells retain diagnostic outcomes without inventing primary fits", () => {
+  const result = populatedReceipt({ parentCount: 3, eligibility: "diagnostic_only" });
+  for (const comparison of [result.comparison.attributionCalibration, result.comparison.finalCalibration]) {
+    assert.equal(comparison.primaryOutcomeMatrix.length, 4);
+    for (const cell of comparison.primaryOutcomeMatrix) {
+      assert.equal(cell.transition, "no_primary");
+      assert.equal(cell.parentCandidates, 3);
+      assert.equal(cell.afterPrimaryFits, 0);
+      assert.deepEqual(cell.afterOutcomes, [{ outcome: "aggregation_diagnostic_only", count: 1 }]);
+    }
+  }
+  acceptsComparison(result);
+  for (const side of ["attributionCalibration", "finalCalibration"]) {
+    const invented = clone(result);
+    invented.comparison[side].primaryOutcomeMatrix[0].afterOutcomes = [{ outcome: "selected_plan_primary", count: 1 }];
+    rejectsComparison(invented);
+  }
+});
+
+test("merged missing-parent cells remain a failed comparison even when no primaries were lost", () => {
+  const result = populatedReceipt({ parentCount: 3, eligibility: "diagnostic_only" },
+    { parentCount: 1, eligibility: "diagnostic_only" });
+  const comparison = result.comparison.attributionCalibration;
+  assert.equal(comparison.status, "fail");
+  assert.equal(comparison.missingParentCandidates, 8);
+  assert.equal(comparison.lostPrimaryFits, 0);
+  const missing = comparison.primaryOutcomeMatrix.filter((cell) => cell.transition === "missing_parent");
+  assert.equal(missing.length, 4);
+  for (const cell of missing) {
+    assert.equal(cell.parentCandidates, 2);
+    assert.equal(cell.afterPrimaryFits, 0);
+    assert.deepEqual(cell.afterOutcomes, [{ outcome: "missing_parent", count: 1 }]);
+  }
+  rejectsComparison(result);
+  const falsePass = clone(result);
+  falsePass.comparison.attributionCalibration.status = "pass";
+  rejectsComparison(falsePass);
+});
+
+test("early semantic validation accepts exactly the comparison/evidence pair and shares receipt refusals", () => {
+  const result = populatedReceipt({ parentCount: 2 });
+  acceptsComparison(result);
+  for (const mutate of [
+    (value) => { value.comparison.readerEvidenceUnchanged = false; },
+    (value) => { value.comparison.finalLedger.rows.usage.before = 1; },
+    (value) => { value.comparison.attributionCalibration.retainedPrimaryFits += 1; },
+    (value) => { value.evidence.after.revisionKind = "before"; },
+    (value) => { value.evidence.final.coverage.accountingStatus = "partial"; },
+    (value) => { value.evidence.after.calibration.status = "fail"; },
+  ]) {
+    const changed = clone(result); mutate(changed); rejectsComparison(changed);
+  }
+  const pair = { comparison: result.comparison, evidence: result.evidence };
+  for (const invalid of [
+    { comparison: pair.comparison }, { evidence: pair.evidence }, { ...pair, sources: result.sources },
+    { ...pair, productionResources: result.productionResources }, { ...pair, extra: "synthetic" },
+    Object.assign(Object.create({ extra: "synthetic" }), pair), { ...pair, [Symbol("extra")]: "synthetic" },
+    null, [],
+  ]) {
+    assert.throws(() => validatePr94ComparisonEvidence(invalid), { code: "pr94_receipt_comparison_invalid" });
+  }
+  let accessCount = 0;
+  const accessor = { comparison: pair.comparison };
+  Object.defineProperty(accessor, "evidence", { enumerable: true, get() { accessCount += 1; return pair.evidence; } });
+  assert.throws(() => validatePr94ComparisonEvidence(accessor), { code: "pr94_receipt_comparison_invalid" });
+  assert.equal(accessCount, 0);
+
+  // This early gate is semantic only. Final validation still requires the
+  // independently bound source, window, measurement, and production evidence.
+  const invalidResources = clone(result);
+  invalidResources.productionResources.final.runs[0].artifact.sha256 = HASH("7");
+  const semanticPair = { comparison: invalidResources.comparison, evidence: invalidResources.evidence };
+  assert.equal(validatePr94ComparisonEvidence(semanticPair), semanticPair);
+  assert.throws(() => validatePr94ComparisonReceipt(invalidResources), { code: "pr94_receipt_comparison_invalid" });
 });
 
 test("receipt validator accepts the original miner's within-era no-change outcome", () => {

--- a/test/pr94-receipt-validation.test.js
+++ b/test/pr94-receipt-validation.test.js
@@ -321,7 +321,9 @@ test("comparison validator binds evidence revisions, unchanged reader evidence a
       value.comparison.attributionLedger.rows.usage.after = 1;
       value.comparison.attributionLedger.rows.usage.unchanged = 1; },
     (value) => { value.evidence.after.generation.usageEvents = 1; },
-    (value) => { value.sources.final.dependencies.runtimeSha256 = HASH("3"); },
+    (value) => { value.sources.final.dependencies = {
+      ...value.sources.final.dependencies, runtimeSha256: HASH("3"),
+    }; },
     (value) => { value.evidence.final.populationEvidence.unknownAccountOnlyWithheldEvents = 1; },
     (value) => { value.productionResources.final.runs[0].metrics.peakRssBytes = 6_442_450_945; },
     (value) => { value.productionResources.before.queryPlans.status = "observed";
@@ -341,11 +343,12 @@ test("comparison validator binds evidence revisions, unchanged reader evidence a
 test("only the PR94 isolation pair requires identical locks; final dependencies remain independently bound", () => {
   const value = receipt();
   value.sources.final.dependencies.lockSha256 = HASH("7");
+  value.sources.final.dependencies.runtimeSha256 = HASH("8");
   // The fixture intentionally shares the source/probe dependency object.
   assert.equal(validatePr94ComparisonReceipt(value), value);
   const drift = clone(value);
   drift.productionResources.final.dependencies = {
-    ...drift.productionResources.final.dependencies, lockSha256: HASH("8"),
+    ...drift.productionResources.final.dependencies, runtimeSha256: HASH("9"),
   };
   assert.throws(() => validatePr94ComparisonReceipt(drift), { code: "pr94_receipt_comparison_invalid" });
   const mixedPair = clone(value);

--- a/test/pr94-receipt-validation.test.js
+++ b/test/pr94-receipt-validation.test.js
@@ -274,6 +274,22 @@ test("comparison validator binds evidence revisions, unchanged reader evidence a
   }
 });
 
+test("only the PR94 isolation pair requires identical locks; final dependencies remain independently bound", () => {
+  const value = receipt();
+  value.sources.final.dependencies.lockSha256 = HASH("7");
+  // The fixture intentionally shares the source/probe dependency object.
+  assert.equal(validatePr94ComparisonReceipt(value), value);
+  const drift = clone(value);
+  drift.productionResources.final.dependencies = {
+    ...drift.productionResources.final.dependencies, lockSha256: HASH("8"),
+  };
+  assert.throws(() => validatePr94ComparisonReceipt(drift), { code: "pr94_receipt_comparison_invalid" });
+  const mixedPair = clone(value);
+  mixedPair.sources.after.dependencies.lockSha256 = HASH("7");
+  mixedPair.productionResources.after.dependencies.lockSha256 = HASH("7");
+  assert.throws(() => validatePr94ComparisonReceipt(mixedPair), { code: "pr94_receipt_comparison_invalid" });
+});
+
 test("closed validators reject accessor, symbol, prototype and raw content channels", () => {
   const value = analysis("before");
   Object.defineProperty(value, "private", { enumerable: true, get() { throw new Error("synthetic"); } });

--- a/test/pr94-receipt-validation.test.js
+++ b/test/pr94-receipt-validation.test.js
@@ -1,0 +1,285 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { registerHooks } from "node:module";
+import { createPr94LedgerEvidence } from "../scripts/lib/pr94-ledger-evidence.mjs";
+import { buildPr94CalibrationEvidence, comparePr94CalibrationEvidence } from "../scripts/lib/pr94-calibration-evidence.mjs";
+import { validatePr94AnalysisResult, validatePr94ComparisonReceipt } from "../scripts/lib/pr94-receipt-validation.mjs";
+
+const HASH = (character) => character.repeat(64);
+const REVISION = (character) => character.repeat(40);
+const INSTANT_START = "2025-09-01T00:00:00.000Z";
+const INSTANT_END = "2026-09-01T00:00:00.000Z";
+const clone = (value) => structuredClone(value);
+
+function emptyLedger() {
+  return createPr94LedgerEvidence({ hmacKey: Buffer.alloc(32, 19) }).finish();
+}
+
+const OUTCOMES = [
+  "selected_plan_primary", "alternate_plan_primary", "unselected_plan_primary", "losing_qualifying_fragment",
+  "simultaneous_slot_conflict", "near_duplicate_reset_identity_with_less_evidence", "overlapping_observation_window",
+  "aggregation_diagnostic_only", "insufficient_unique_boundaries", "insufficient_percent_span",
+  "training_capacity_unavailable", "insufficient_training_pairs", "full_capacity_unavailable",
+  "relative_width_unavailable", "relative_width_exceeded", "insufficient_snapshots", "no_percent_change",
+  "all_snapshot_attribution_withheld", "unexplained_no_transition",
+];
+const CANDIDATES = ["standard_api", "speed_lower", "speed_midpoint", "speed_upper"];
+const ROW_REASONS = ["eligible", "aggregation_diagnostic_only", "non_increasing_percent", "no_usage",
+  "partial_elapsed_coverage", "pricing_warning", "attribution_warning"];
+
+const calibrationSourceUrl = new URL("../src/reporting/weekly-calibration.js?pr94-receipt-validation", import.meta.url).href;
+const calibrationHook = registerHooks({ load(url, context, nextLoad) {
+  const loaded = nextLoad(url, context);
+  if (url !== calibrationSourceUrl) return loaded;
+  return { ...loaded, source: `${loaded.source}\nexport { selectResetGroups, fitReset, uniquePoints, capacityFit, fitRelativeCentral80Width, isEligible, partitionKey, resetParentKey };\n` };
+} });
+let calibrationOriginal;
+try { calibrationOriginal = await import(calibrationSourceUrl); } finally { calibrationHook.deregister(); }
+
+const CALIBRATION_HMAC_KEY = new Uint8Array(32).fill(13);
+const CALIBRATION_RESET = Date.parse("2026-08-31T00:00:00.000Z") / 1_000;
+const CALIBRATION_SCOPE = { startAt: "2026-08-01T00:00:00.000Z", endAt: "2026-09-01T00:00:00.000Z" };
+
+function calibrationRows({ planType = "pro", count = 12, offset = 0, costStep = 10 } = {}) {
+  return Array.from({ length: count }, (_, index) => {
+    const time = Date.parse("2026-08-25T00:00:00.000Z") + (index + offset) * 3_600_000;
+    return {
+      accountScopeId: "unattributed", provider: "openai_codex", planType, planVariant: "unknown", planEraKey: "era-one",
+      aggregationEligibility: "primary_conditional", limitId: "codex", slot: "primary", windowDurationMins: 10_080,
+      resetsAt: CALIBRATION_RESET, eventTime: new Date(time + 3_600_000).toISOString(),
+      lastPriorObservedAt: new Date(time).toISOString(), firstNextObservedAt: new Date(time + 3_600_000).toISOString(),
+      priorUsedPercent: index, nextUsedPercent: index + 1,
+      lastPriorCumulativeApiPricedUsd: index * costStep, firstNextCumulativeApiPricedUsd: (index + 1) * costStep,
+      lastPriorCumulativeQuotaWeightedLowerUsd: index * costStep,
+      firstNextCumulativeQuotaWeightedLowerUsd: (index + 1) * costStep,
+      lastPriorCumulativeQuotaWeightedUpperUsd: index * costStep * 2,
+      firstNextCumulativeQuotaWeightedUpperUsd: (index + 1) * costStep * 2,
+      marginalUsageEventCount: 1,
+      quality: { localCoverage: { elapsedTimeCoverageFraction: 1 }, pricingWarnings: [], attributionWarnings: [] },
+    };
+  });
+}
+
+function calibrationRawParent(first) {
+  return { accountScopeId: first.accountScopeId, provider: first.provider, planType: first.planType,
+    limitId: first.limitId, windowDurationMins: first.windowDurationMins, resetsAt: first.resetsAt,
+    snapshotCount: 13, uniqueSnapshotCount: 13, distinctPercentCount: 13, matchedSnapshotCount: 13,
+    conflictedSnapshotCount: 0, unavailableSnapshotCount: 0, matchedUniqueSnapshotCount: 13,
+    matchedDistinctPercentCount: 13 };
+}
+
+function populatedCalibration(revisionKind, options = {}) {
+  const transitions = calibrationRows(options);
+  return buildPr94CalibrationEvidence({ internals: calibrationOriginal,
+    analyzeWeeklyCalibration: calibrationOriginal.analyzeWeeklyCalibration,
+    candidates: calibrationOriginal.CANDIDATES, transitions,
+    rawParents: [calibrationRawParent(transitions[0])], revisionKind,
+    hmacKey: CALIBRATION_HMAC_KEY, scope: CALIBRATION_SCOPE, selectedPlanType: options.planType ?? "pro" });
+}
+
+function distribution() { return { count: 0, median: null, central80: { lower: null, upper: null } }; }
+function calibrationCandidate(candidateId, parentCandidates = 0) {
+  return { candidateId, parentCandidates,
+    outcomes: Object.fromEntries(OUTCOMES.map((outcome) => [outcome, 0])),
+    primary: distribution(), diagnostic: distribution(), spans: distribution(), boundaries: distribution() };
+}
+function calibration(revisionKind) {
+  return { schemaVersion: "pr94-calibration-evidence-v2", revisionKind, selectedPlanType: "unknown", status: "pass",
+    counts: { rawParents: 0, parentCandidates: 0, transitionRows: 0, parentsWithTransitions: 0,
+      knownAccountParents: 0, unknownAccountParents: 0, unexplainedParents: 0 },
+    rowReasons: Object.fromEntries(ROW_REASONS.map((reason) => [reason, 0])),
+    unknownAccountCheck: { scope: "original_fit_gate_only", fragmentCandidatesChecked: 0, rowsChecked: 0,
+      changedEligibilityRows: 0, changedPointSets: 0, changedFits: 0, unknownOnlyFitExclusions: 0 },
+    candidates: CANDIDATES.map((candidateId) => calibrationCandidate(candidateId)), plans: [] };
+}
+function generation() {
+  return { id: 1, fingerprintSha256: HASH("a"), publicationStatus: "complete", publicationBlockReason: null,
+    toolProvenanceComplete: true, indexedSourceCount: 0, indexedSourceBytes: 0, skippedSourceCount: 0,
+    skippedSourceBytes: 0, skippedThreadCount: 0, usageEvents: 0, quotaOccurrences: 0, toolFacts: 0 };
+}
+function population(revisionKind) {
+  return { schema: "pr94-population-evidence-v1", context: "openai_codex|codex", revisionKind,
+    totals: { events: 0, totalUsd: "0", components: Object.fromEntries([
+      "input_uncached_tokens", "input_cache_read_tokens", "input_cache_write_tokens",
+      "output_text_tokens", "output_reasoning_tokens", "output_combined_tokens",
+    ].map((name) => [name, { quantity: "0", observedEvents: 0, missingEvents: 0, unavailableEvents: 0 }])) },
+    populations: [], unknownAccountOnlyWithheldEvents: 0 };
+}
+function analysis(revisionKind) {
+  return { schema: "pr94-analysis-worker-v1", revisionKind, contextBehavior: "legacy_zero", generation: generation(),
+    attributionIndex: revisionKind === "before" ? null : { observationCount: 0, ignoredObservationCount: 0, eras: 0, conflicts: 0, contexts: 0 },
+    instrumentation: { sourceSha256: HASH("b"), instrumentationSha256: HASH("c"), transformation: "append_exports_only" },
+    inventory: { indexedUsageRows: 0, zeroComponentUsageRows: 0,
+      quota: { admitted: 0, held: 0, suppressed: 0 }, generationUsageRows: 0, generationQuotaRows: 0 },
+    coverage: { accountingStatus: "complete", diagnosticsSha256: HASH("d"), compatibilitySha256: HASH("e") },
+    ledger: emptyLedger(), calibration: calibration(revisionKind), populationEvidence: population(revisionKind),
+    batchMetrics: { batches: 0, maximumUsageSlice: 0, maximumQuotaSlice: 0 }, deduplicatedWeeklySnapshots: 0,
+    phaseMs: { readAndLedger: 0, attributionAndDerivation: 0, calibrationAndReconciliation: 0 },
+    privateArtifactBytes: { ledger: 1, calibration: 1 } };
+}
+function source(revisionCharacter) {
+  const revisionValue = revisionCharacter.length === 1 ? REVISION(revisionCharacter) : revisionCharacter;
+  return { revision: revisionValue, dependencies: { sourceSha256: HASH("f"), runtimeSha256: HASH("0"),
+    lockSha256: HASH("1"), identitySha256: HASH("2") } };
+}
+function resource(side, receipt, evidence) {
+  const generationEvidence = evidence[side].generation;
+  return { schema: "pr94-production-resource-v1", scope: "isolated_child_repeatability", revision: receipt.sources[side].revision,
+    dependencies: receipt.sources[side].dependencies,
+    clock: { startAt: INSTANT_START, endAt: INSTANT_END, nowMs: Date.parse(INSTANT_END), windowDays: 365 },
+    index: receipt.index, generation: { id: generationEvidence.id, publicationStatus: generationEvidence.publicationStatus,
+      toolProvenanceComplete: generationEvidence.toolProvenanceComplete, usageEvents: generationEvidence.usageEvents,
+      quotaOccurrences: generationEvidence.quotaOccurrences },
+    policy: { maximumRssBytes: 6_442_450_944, rssDeltaBudgetBytes: 1, rebuildChildOldSpaceMib: 6144,
+      archiveMaximumRssBytes: 1, archiveRssDeltaBudgetBytes: 1 },
+    limits: { envelopeBytes: 64 * 1024, transportBytes: 64 * 1024 * 1024, durableCacheBytes: 16 * 1024 * 1024 },
+    runs: ["primary", "fresh_process_repeat"].map((kind) => ({ kind,
+      metrics: { wallMs: 0, userCpuMs: 0, systemCpuMs: 0, peakRssBytes: 1 },
+      envelope: { status: "ok", resultBytes: 2, resultSha256: HASH("4") }, artifact: { sha256: HASH("4"), bytes: 2 },
+      cache: { schemaVersion: "local-replay-safe-accounting-v0.15",
+        source: { mode: "unified", contextBehavior: "legacy_zero", accountingCoverage: "complete", generationMatched: true, readsRawSources: false },
+        weeklyInput: { status: "complete", encoding: "accounting_compact_v3", source: "unified_index",
+          retainedUsageEvents: 0, retainedWeeklySnapshots: 0, estimatedRetainedBytes: 0,
+          limits: { usageEvents: 1, weeklySnapshots: 1, combinedInputs: 1, retainedBytes: 1 } },
+        rows: { periods: 0, timeline: 0, sparkUsageTimeline: 0, quotaTimeline: 0, sparkQuotaTimeline: 0 } } })),
+    exactRepeatOutput: true, indexUnchanged: true, sourceUnchanged: true, dependenciesUnchanged: true,
+    notMeasured: ["app_no_change_cache_hit", "app_relaunch", "end_to_end_refresh", "cancellation", "evidence_observer_overhead"] };
+}
+function receipt() {
+  const evidence = { before: analysis("before"), after: analysis("after"), final: analysis("final") };
+  const value = { schema: "pr94-admitted-index-comparison-v1", status: "passed",
+    scope: "fixed_admitted_index_analysis_not_raw_ingestion_or_hosted_activation",
+    sources: { before: source("a3c850360bc83c0e27bef2171aeb4a302b72f472"), after: source("20f449ff5c222989029fe343f219f02b497ae1d4"), final: source("c") }, index: { sha256: HASH("6"), bytes: 1 },
+    window: { startAt: INSTANT_START, endAt: INSTANT_END },
+    comparison: { attributionLedger: ledgerComparison(), finalLedger: ledgerComparison(),
+      attributionCalibration: calibrationComparison(), finalCalibration: calibrationComparison(), readerEvidenceUnchanged: true },
+    measurements: Object.fromEntries(["before", "after", "final"].map((side) => [side,
+      { wallMs: 0, userCpuMs: 0, systemCpuMs: 0, peakRssBytes: 1 }])), productionResources: {}, evidence };
+  for (const side of ["before", "after", "final"]) value.productionResources[side] = resource(side, value, evidence);
+  return value;
+}
+function ledgerComparison() {
+  const row = { before: 0, after: 0, unchanged: 0, changed: 0, missing: 0, added: 0 };
+  return { schemaVersion: "pr94-ledger-comparison-v1", status: "equal", aggregateEqual: true,
+    rows: { usage: { ...row }, quota: { ...row } } };
+}
+function calibrationComparison() {
+  return { schemaVersion: "pr94-calibration-comparison-v2", status: "pass", beforeParentCandidates: 0,
+    afterParentCandidates: 0, missingParentCandidates: 0, addedParentCandidates: 0, reconciledParentCandidates: 0,
+    identicalFitInputsCompared: 0, changedIdenticalInputFits: 0, unexplainedParents: 0, changedRawParentInventory: 0,
+    selectedPopulationMatches: true, duplicatePrimaryVotes: 0, baselinePrimaryFits: 0, retainedPrimaryFits: 0,
+    lostPrimaryFits: 0, newPrimaryFits: 0, changedInputPrimaryLosses: 0, rejectedIdenticalInputFits: 0,
+    unexplainedPrimaryLosses: 0, retainedPrimaryInputChanges: 0, changedOutcomeParentCandidates: 0,
+    requiresCoverageReview: false, primaryOutcomeMatrix: [] };
+}
+function rejects(value, expectedCode = "pr94_receipt_analysis_invalid") {
+  assert.throws(() => validatePr94AnalysisResult(value), { code: expectedCode });
+}
+
+test("PR94 receipt validators accept content-free synthetic analysis and comparison projections", () => {
+  const result = receipt();
+  assert.equal(validatePr94AnalysisResult(result.evidence.before), result.evidence.before);
+  assert.equal(validatePr94ComparisonReceipt(result), result);
+});
+
+test("comparison validator accepts actual populated calibration v2 matrices in canonical order", () => {
+  const beforeCalibration = populatedCalibration("before");
+  const afterCalibration = populatedCalibration("after");
+  const finalCalibration = populatedCalibration("final");
+  const result = receipt();
+  result.evidence.before.calibration = beforeCalibration;
+  result.evidence.after.calibration = afterCalibration;
+  result.evidence.final.calibration = finalCalibration;
+  result.comparison.attributionCalibration = comparePr94CalibrationEvidence(beforeCalibration, afterCalibration);
+  result.comparison.finalCalibration = comparePr94CalibrationEvidence(afterCalibration, finalCalibration);
+  assert.equal(validatePr94ComparisonReceipt(result), result);
+  for (const comparison of [result.comparison.attributionCalibration, result.comparison.finalCalibration]) {
+    const keys = comparison.primaryOutcomeMatrix.map((cell) => JSON.stringify([
+      cell.candidateId, cell.planType, cell.accountKnown, cell.transition, cell.afterOutcomes]));
+    assert.deepEqual(keys, [...keys].sort());
+  }
+  const wrongParentCounts = clone(result);
+  wrongParentCounts.comparison.attributionCalibration.beforeParentCandidates = 8;
+  wrongParentCounts.comparison.attributionCalibration.afterParentCandidates = 8;
+  wrongParentCounts.comparison.attributionCalibration.reconciledParentCandidates = 8;
+  wrongParentCounts.comparison.attributionCalibration.primaryOutcomeMatrix.forEach((cell) => { cell.parentCandidates = 2; });
+  assert.throws(() => validatePr94ComparisonReceipt(wrongParentCounts), { code: "pr94_receipt_comparison_invalid" });
+  const wrongPrimaryCounts = clone(result);
+  wrongPrimaryCounts.comparison.attributionCalibration.baselinePrimaryFits = 8;
+  wrongPrimaryCounts.comparison.attributionCalibration.retainedPrimaryFits = 8;
+  wrongPrimaryCounts.comparison.attributionCalibration.primaryOutcomeMatrix.forEach((cell) => {
+    cell.baselinePrimaryFits = 2; cell.afterPrimaryFits = 2; cell.retainedPrimaryFits = 2;
+    cell.afterOutcomes[0].count = 2;
+  });
+  assert.throws(() => validatePr94ComparisonReceipt(wrongPrimaryCounts), { code: "pr94_receipt_comparison_invalid" });
+  const reversed = clone(result);
+  reversed.comparison.attributionCalibration.primaryOutcomeMatrix.reverse();
+  assert.throws(() => validatePr94ComparisonReceipt(reversed), { code: "pr94_receipt_comparison_invalid" });
+});
+
+test("analysis validator is closed and rejects raw/private channels, hashes, counts and timings", () => {
+  for (const mutate of [
+    (value) => { value.privatePath = "/private/synthetic"; },
+    (value) => { value.generation.extra = "synthetic-private"; },
+    (value) => { value.instrumentation.sourceSha256 = "not-a-hash"; },
+    (value) => { value.inventory.indexedUsageRows = -1; },
+    (value) => { value.phaseMs.readAndLedger = Infinity; },
+    (value) => { value.privateArtifactBytes.calibration = 0; },
+    (value) => { value.attributionIndex = { observationCount: 0, ignoredObservationCount: 1, eras: 0, conflicts: 0, contexts: 0 }; },
+    (value) => { value.calibration.rowReasons.extra = 0; },
+    (value) => { value.calibration.unknownAccountCheck.changedFits = 1; },
+    (value) => { value.calibration.unknownAccountCheck.extra = 0; },
+  ]) {
+    const value = clone(analysis("before")); mutate(value); rejects(value);
+  }
+  const unknownPlan = analysis("after");
+  unknownPlan.attributionIndex.ignoredObservationCount = 2;
+  unknownPlan.attributionIndex.observationCount = 2;
+  assert.equal(validatePr94AnalysisResult(unknownPlan), unknownPlan);
+});
+
+test("analysis validator delegates closed ledger and calibration aggregate validation", () => {
+  const ledger = clone(analysis("before"));
+  ledger.ledger.usage.events = 1;
+  rejects(ledger);
+  const calibrationValue = analysis("before");
+  calibrationValue.calibration.candidates[0].outcomes.private_outcome = 1;
+  rejects(calibrationValue);
+  const statusMismatch = analysis("before");
+  statusMismatch.calibration.counts.unexplainedParents = 1;
+  statusMismatch.calibration.status = "fail";
+  rejects(statusMismatch);
+});
+
+test("comparison validator binds evidence revisions, unchanged reader evidence and production resources", () => {
+  const good = receipt();
+  assert.equal(validatePr94ComparisonReceipt(good), good);
+  for (const mutate of [
+    (value) => { value.harness = { revision: REVISION("d") }; },
+    (value) => { value.sources.before.revision = "short"; },
+    (value) => { value.index.bytes = 0; },
+    (value) => { value.window.endAt = "2026-09-01T00:00:00.001Z"; },
+    (value) => { value.comparison.readerEvidenceUnchanged = false; },
+    (value) => { value.comparison.attributionLedger.rows.usage.before = 1;
+      value.comparison.attributionLedger.rows.usage.after = 1;
+      value.comparison.attributionLedger.rows.usage.unchanged = 1; },
+    (value) => { value.evidence.after.generation.usageEvents = 1; },
+    (value) => { value.sources.final.dependencies.runtimeSha256 = HASH("3"); },
+    (value) => { value.evidence.final.populationEvidence.unknownAccountOnlyWithheldEvents = 1; },
+    (value) => { value.productionResources.final.runs[0].metrics.peakRssBytes = 6_442_450_945; },
+    (value) => { value.measurements.before.wallMs = -1; },
+  ]) {
+    const value = clone(good); mutate(value);
+    assert.throws(() => validatePr94ComparisonReceipt(value), { code: "pr94_receipt_comparison_invalid" });
+  }
+});
+
+test("closed validators reject accessor, symbol, prototype and raw content channels", () => {
+  const value = analysis("before");
+  Object.defineProperty(value, "private", { enumerable: true, get() { throw new Error("synthetic"); } });
+  rejects(value);
+  const symbol = analysis("before"); symbol[Symbol("private")] = "synthetic"; rejects(symbol);
+  const prototype = Object.assign(Object.create({ private: "synthetic" }), analysis("before")); rejects(prototype);
+  const receiptValue = receipt(); receiptValue.evidence.before.calibration.selectedPlanType = "private-plan";
+  assert.throws(() => validatePr94ComparisonReceipt(receiptValue), { code: "pr94_receipt_comparison_invalid" });
+});

--- a/test/pr94-receipt-validation.test.js
+++ b/test/pr94-receipt-validation.test.js
@@ -9,6 +9,8 @@ const HASH = (character) => character.repeat(64);
 const REVISION = (character) => character.repeat(40);
 const INSTANT_START = "2025-09-01T00:00:00.000Z";
 const INSTANT_END = "2026-09-01T00:00:00.000Z";
+const BEFORE_REVISION = "a3c850360bc83c0e27bef2171aeb4a302b72f472";
+const AFTER_REVISION = "20f449ff5c222989029fe343f219f02b497ae1d4";
 const clone = (value) => structuredClone(value);
 
 function emptyLedger() {
@@ -21,6 +23,7 @@ const OUTCOMES = [
   "aggregation_diagnostic_only", "insufficient_unique_boundaries", "insufficient_percent_span",
   "training_capacity_unavailable", "insufficient_training_pairs", "full_capacity_unavailable",
   "relative_width_unavailable", "relative_width_exceeded", "insufficient_snapshots", "no_percent_change",
+  "no_within_era_percent_change",
   "all_snapshot_attribution_withheld", "unexplained_no_transition",
 ];
 const CANDIDATES = ["standard_api", "speed_lower", "speed_midpoint", "speed_upper"];
@@ -77,6 +80,16 @@ function populatedCalibration(revisionKind, options = {}) {
     hmacKey: CALIBRATION_HMAC_KEY, scope: CALIBRATION_SCOPE, selectedPlanType: options.planType ?? "pro" });
 }
 
+function noWithinEraCalibration(revisionKind) {
+  const first = calibrationRows()[0];
+  return buildPr94CalibrationEvidence({ internals: calibrationOriginal,
+    analyzeWeeklyCalibration: calibrationOriginal.analyzeWeeklyCalibration,
+    candidates: calibrationOriginal.CANDIDATES, transitions: [], rawParents: [{ ...calibrationRawParent(first),
+      matchedDistinctPercentCount: 2,
+      derivationEvidence: { groupCount: 2, snapshotCount: 13, transitionCount: 0, zeroTransitionGroupCount: 2 } }],
+    revisionKind, hmacKey: CALIBRATION_HMAC_KEY, scope: CALIBRATION_SCOPE, selectedPlanType: "pro" });
+}
+
 function distribution() { return { count: 0, median: null, central80: { lower: null, upper: null } }; }
 function calibrationCandidate(candidateId, parentCandidates = 0) {
   return { candidateId, parentCandidates,
@@ -122,6 +135,16 @@ function source(revisionCharacter) {
   return { revision: revisionValue, dependencies: { sourceSha256: HASH("f"), runtimeSha256: HASH("0"),
     lockSha256: HASH("1"), identitySha256: HASH("2") } };
 }
+function queryPlans(revision) {
+  if (revision === BEFORE_REVISION) {
+    return { schema: "pr94-attribution-query-plans-v1", scope: "attribution_point_queries_explain_only",
+      binding: "synthetic", status: "feature_absent", statements: null };
+  }
+  const statements = Object.fromEntries(["membership", "same_record_plans", "source_predecessor", "session_predecessor"]
+    .map((role) => [role, { steps: 1, search: 1, scan: 0, tempSort: 0, other: 0 }]));
+  return { schema: "pr94-attribution-query-plans-v1", scope: "attribution_point_queries_explain_only",
+    binding: "synthetic", status: "observed", statements };
+}
 function resource(side, receipt, evidence) {
   const generationEvidence = evidence[side].generation;
   return { schema: "pr94-production-resource-v1", scope: "isolated_child_repeatability", revision: receipt.sources[side].revision,
@@ -142,6 +165,7 @@ function resource(side, receipt, evidence) {
           retainedUsageEvents: 0, retainedWeeklySnapshots: 0, estimatedRetainedBytes: 0,
           limits: { usageEvents: 1, weeklySnapshots: 1, combinedInputs: 1, retainedBytes: 1 } },
         rows: { periods: 0, timeline: 0, sparkUsageTimeline: 0, quotaTimeline: 0, sparkQuotaTimeline: 0 } } })),
+    queryPlans: queryPlans(receipt.sources[side].revision),
     exactRepeatOutput: true, indexUnchanged: true, sourceUnchanged: true, dependenciesUnchanged: true,
     notMeasured: ["app_no_change_cache_hit", "app_relaunch", "end_to_end_refresh", "cancellation", "evidence_observer_overhead"] };
 }
@@ -149,7 +173,7 @@ function receipt() {
   const evidence = { before: analysis("before"), after: analysis("after"), final: analysis("final") };
   const value = { schema: "pr94-admitted-index-comparison-v1", status: "passed",
     scope: "fixed_admitted_index_analysis_not_raw_ingestion_or_hosted_activation",
-    sources: { before: source("a3c850360bc83c0e27bef2171aeb4a302b72f472"), after: source("20f449ff5c222989029fe343f219f02b497ae1d4"), final: source("c") }, index: { sha256: HASH("6"), bytes: 1 },
+    sources: { before: source(BEFORE_REVISION), after: source(AFTER_REVISION), final: source("c") }, index: { sha256: HASH("6"), bytes: 1 },
     window: { startAt: INSTANT_START, endAt: INSTANT_END },
     comparison: { attributionLedger: ledgerComparison(), finalLedger: ledgerComparison(),
       attributionCalibration: calibrationComparison(), finalCalibration: calibrationComparison(), readerEvidenceUnchanged: true },
@@ -217,6 +241,32 @@ test("comparison validator accepts actual populated calibration v2 matrices in c
   assert.throws(() => validatePr94ComparisonReceipt(reversed), { code: "pr94_receipt_comparison_invalid" });
 });
 
+test("receipt validator accepts the original miner's within-era no-change outcome", () => {
+  const beforeCalibration = noWithinEraCalibration("before");
+  const afterCalibration = noWithinEraCalibration("after");
+  const finalCalibration = noWithinEraCalibration("final");
+  for (const value of [beforeCalibration, afterCalibration, finalCalibration]) {
+    assert.equal(value.candidates[0].outcomes.no_within_era_percent_change, 1);
+  }
+  const result = receipt();
+  result.evidence.before.calibration = beforeCalibration;
+  result.evidence.after.calibration = afterCalibration;
+  result.evidence.final.calibration = finalCalibration;
+  result.comparison.attributionCalibration = comparePr94CalibrationEvidence(beforeCalibration, afterCalibration);
+  result.comparison.finalCalibration = comparePr94CalibrationEvidence(afterCalibration, finalCalibration);
+  assert.equal(validatePr94ComparisonReceipt(result), result);
+  assert.ok(result.comparison.attributionCalibration.primaryOutcomeMatrix.every((cell) =>
+    cell.afterOutcomes.length === 1
+      && cell.afterOutcomes[0].outcome === "no_within_era_percent_change"));
+
+  const unknownOutcome = clone(result);
+  unknownOutcome.evidence.after.calibration.candidates[0].outcomes.no_within_era_percent_change_extra = 1;
+  assert.throws(() => validatePr94ComparisonReceipt(unknownOutcome), { code: "pr94_receipt_comparison_invalid" });
+  const misplacedOutcome = clone(result);
+  misplacedOutcome.evidence.after.calibration.rowReasons.no_within_era_percent_change = 1;
+  assert.throws(() => validatePr94ComparisonReceipt(misplacedOutcome), { code: "pr94_receipt_comparison_invalid" });
+});
+
 test("analysis validator is closed and rejects raw/private channels, hashes, counts and timings", () => {
   for (const mutate of [
     (value) => { value.privatePath = "/private/synthetic"; },
@@ -254,6 +304,13 @@ test("analysis validator delegates closed ledger and calibration aggregate valid
 test("comparison validator binds evidence revisions, unchanged reader evidence and production resources", () => {
   const good = receipt();
   assert.equal(validatePr94ComparisonReceipt(good), good);
+  assert.equal(good.productionResources.before.queryPlans.status, "feature_absent");
+  assert.equal(good.productionResources.before.queryPlans.statements, null);
+  for (const side of ["after", "final"]) {
+    assert.equal(good.productionResources[side].queryPlans.status, "observed");
+    assert.deepEqual(Object.keys(good.productionResources[side].queryPlans.statements), [
+      "membership", "same_record_plans", "source_predecessor", "session_predecessor"]);
+  }
   for (const mutate of [
     (value) => { value.harness = { revision: REVISION("d") }; },
     (value) => { value.sources.before.revision = "short"; },
@@ -267,6 +324,13 @@ test("comparison validator binds evidence revisions, unchanged reader evidence a
     (value) => { value.sources.final.dependencies.runtimeSha256 = HASH("3"); },
     (value) => { value.evidence.final.populationEvidence.unknownAccountOnlyWithheldEvents = 1; },
     (value) => { value.productionResources.final.runs[0].metrics.peakRssBytes = 6_442_450_945; },
+    (value) => { value.productionResources.before.queryPlans.status = "observed";
+      value.productionResources.before.queryPlans.statements = queryPlans(AFTER_REVISION).statements; },
+    (value) => { value.productionResources.after.queryPlans.status = "feature_absent";
+      value.productionResources.after.queryPlans.statements = null; },
+    (value) => { value.productionResources.after.queryPlans.statements.membership.steps = 2; },
+    (value) => { value.productionResources.after.queryPlans.statements.membership.rawSql = "SELECT synthetic"; },
+    (value) => { value.productionResources.final.queryPlans.statements.session_predecessor.search = -1; },
     (value) => { value.measurements.before.wallMs = -1; },
   ]) {
     const value = clone(good); mutate(value);

--- a/test/pr94-revision-loader.test.js
+++ b/test/pr94-revision-loader.test.js
@@ -1,0 +1,108 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createHash } from "node:crypto";
+import { readFile } from "node:fs/promises";
+import { registerHooks } from "node:module";
+import { fileURLToPath } from "node:url";
+import { spawn } from "node:child_process";
+import { instrumentPr94CalibrationSource } from "../scripts/lib/pr94-revision-loader.mjs";
+
+const reportUrl = new URL("../src/reporting/weekly-calibration.js", import.meta.url);
+const root = fileURLToPath(new URL("..", import.meta.url)).replace(/\/$/u, "");
+const source = await readFile(reportUrl, "utf8");
+const hash = (value) => createHash("sha256").update(value).digest("hex");
+
+function syntheticRows() {
+  const reset = Date.parse("2026-08-15T00:00:00.000Z") / 1_000;
+  return Array.from({ length: 12 }, (_, index) => {
+    const at = Date.parse("2026-08-10T00:00:00.000Z") + index * 3_600_000;
+    return { provider: "openai_codex", planType: "pro", limitId: "codex", slot: "primary",
+      accountScopeId: "unattributed", planEraKey: "synthetic-era", planVariant: "unknown",
+      windowDurationMins: 10_080, resetsAt: reset, aggregationEligibility: "primary_conditional",
+      eventTime: new Date(at + 3_600_000).toISOString(), lastPriorObservedAt: new Date(at).toISOString(),
+      firstNextObservedAt: new Date(at + 3_600_000).toISOString(), priorUsedPercent: index, nextUsedPercent: index + 1,
+      lastPriorCumulativeApiPricedUsd: index * 10, firstNextCumulativeApiPricedUsd: (index + 1) * 10,
+      lastPriorCumulativeQuotaWeightedLowerUsd: index * 10, firstNextCumulativeQuotaWeightedLowerUsd: (index + 1) * 10,
+      lastPriorCumulativeQuotaWeightedUpperUsd: index * 20, firstNextCumulativeQuotaWeightedUpperUsd: (index + 1) * 20,
+      marginalUsageEventCount: 1, quality: { localCoverage: { elapsedTimeCoverageFraction: 1 }, pricingWarnings: [], attributionWarnings: [] } };
+  });
+}
+
+test("PR94 export instrumentation preserves every original source byte and binds only its suffix separately", () => {
+  const result = instrumentPr94CalibrationSource(source);
+  assert.equal(result.source.slice(0, source.length), source);
+  assert.equal(result.sourceSha256, hash(source));
+  const suffix = result.source.slice(source.length);
+  assert.equal(result.instrumentationSha256, hash(suffix));
+  assert.match(suffix, /^\nexport const __pr94CalibrationInternals = Object\.freeze\(\{/u);
+  assert.match(suffix, /export \{ CANDIDATES as WEEKLY_CALIBRATION_CANDIDATES \};\n$/u);
+  assert.doesNotMatch(suffix, /function\s|import\s|globalThis|process|eval\(/u);
+  assert.ok(Object.isFrozen(result));
+});
+
+test("PR94 authenticated extra exports do not change actual public reports for any main candidate", async () => {
+  const plainUrl = new URL(reportUrl);
+  plainUrl.search = "pr94-loader-plain";
+  const instrumentedUrl = new URL(reportUrl);
+  instrumentedUrl.search = "pr94-loader-instrumented";
+  const plain = await import(plainUrl.href);
+  const transformed = instrumentPr94CalibrationSource(source);
+  let loadCount = 0;
+  const hook = registerHooks({ load(url, context, nextLoad) {
+    const loaded = nextLoad(url, context);
+    if (url !== instrumentedUrl.href) return loaded;
+    loadCount += 1;
+    assert.equal(typeof loaded.source === "string" ? loaded.source : Buffer.from(loaded.source).toString("utf8"), source);
+    return { ...loaded, source: transformed.source };
+  } });
+  let instrumented;
+  try { instrumented = await import(instrumentedUrl.href); } finally { hook.deregister(); }
+  assert.equal(loadCount, 1);
+  assert.equal(instrumented.CANDIDATES, instrumented.WEEKLY_CALIBRATION_CANDIDATES);
+  assert.ok(Object.isFrozen(instrumented.__pr94CalibrationInternals));
+  const dataset = { transitions: syntheticRows(), scope: { startAt: "2026-08-01T00:00:00.000Z", endAt: "2026-09-01T00:00:00.000Z" } };
+  const before = structuredClone(dataset);
+  for (const candidate of plain.CANDIDATES) {
+    const options = { planType: "pro", forcedCandidateId: candidate.id };
+    assert.deepEqual(instrumented.analyzeWeeklyCalibration(dataset, options), plain.analyzeWeeklyCalibration(dataset, options));
+  }
+  assert.deepEqual(dataset, before);
+  const body = source.slice(source.indexOf("function fitReset("), source.indexOf("\nfunction observedTimestamp")).trimEnd();
+  assert.equal(Function.prototype.toString.call(instrumented.__pr94CalibrationInternals.fitReset), body);
+});
+
+test("PR94 instrumentation refuses missing, duplicate, oversized or already instrumented declarations", () => {
+  for (const invalid of [
+    null,
+    "x".repeat(512 * 1024 + 1),
+    source.replace("function fitReset(", "function renamedFit("),
+    `${source}\nfunction fitReset() {}\n`,
+    `${source}\nconst CANDIDATES = [];\n`,
+    `${source}\nconst __pr94CalibrationInternals = {};\n`,
+  ]) assert.throws(() => instrumentPr94CalibrationSource(invalid), /^Error: pr94_instrumentation_invalid$/u);
+});
+
+test("PR94 actual revision loader exposes original modules in a fresh process and rejects cached reuse", async () => {
+  const loaderUrl = new URL("../scripts/lib/pr94-revision-loader.mjs", import.meta.url).href;
+  const code = `import { loadPr94Revision } from ${JSON.stringify(loaderUrl)};
+    const root = ${JSON.stringify(root)};
+    const loaded = await loadPr94Revision(root);
+    let rejectedReuse = false;
+    try { await loadPr94Revision(root); } catch(error) { rejectedReuse = error.message === 'pr94_instrumentation_invalid'; }
+    process.stdout.write(JSON.stringify({ transformation: loaded.instrumentation.transformation,
+      sourceSha256: loaded.instrumentation.sourceSha256,
+      helper: typeof loaded.reporting.__pr94CalibrationInternals.fitReset,
+      miner: typeof loaded.miner.deriveCodexTransitionSeriesCooperatively,
+      reader: typeof loaded.reader.createLocalUnifiedAccountingSource,
+      rejectedReuse }));`;
+  const child = spawn(process.execPath, ["--input-type=module", "-e", code], { cwd: root, stdio: ["ignore", "pipe", "pipe"] });
+  const timeout = setTimeout(() => child.kill("SIGKILL"), 15_000);
+  let stdout = ""; let stderr = "";
+  child.stdout.on("data", (chunk) => { stdout += chunk; });
+  child.stderr.on("data", (chunk) => { stderr += chunk; });
+  const exit = await new Promise((resolve, reject) => { child.once("error", reject); child.once("close", resolve); });
+  clearTimeout(timeout);
+  assert.equal(exit, 0, stderr);
+  assert.deepEqual(JSON.parse(stdout), { transformation: "append_exports_only", sourceSha256: hash(source),
+    helper: "function", miner: "function", reader: "function", rejectedReuse: true });
+});

--- a/test/release-notes.test.js
+++ b/test/release-notes.test.js
@@ -134,6 +134,26 @@ async function populateLegacyTagFixture(rootDirectory) {
   ]);
 }
 
+function assertReleaseLifecycleInventory(result, packageVersionIsTagged) {
+  assert.equal(
+    result.stableTagVersions.includes(result.packageVersion),
+    packageVersionIsTagged,
+  );
+  assert.equal(
+    result.changelogVersions.includes(result.packageVersion),
+    packageVersionIsTagged,
+  );
+  assert.equal(
+    result.noteVersions.length,
+    result.changelogVersions.length + (packageVersionIsTagged ? 0 : 1),
+  );
+
+  const expectedVersions = new Set(result.stableTagVersions);
+  assert.deepEqual(new Set(result.changelogVersions), expectedVersions);
+  expectedVersions.add(result.packageVersion);
+  assert.deepEqual(new Set(result.noteVersions), expectedVersions);
+}
+
 test("the current repository covers every stable tag and package version", async () => {
   const result = await checkReleaseNotes({ rootDirectory: REPOSITORY_ROOT });
   assert.equal(result.ok, true, formatReleaseNotesReport(result));
@@ -154,9 +174,10 @@ test("the current repository covers every stable tag and package version", async
     true,
   );
   assert.equal(result.noteVersions.length >= 17, true);
-  assert.equal(result.noteVersions.length, result.changelogVersions.length + 1);
-  assert.equal(result.noteVersions.includes(result.packageVersion), true);
-  assert.equal(result.changelogVersions.includes(result.packageVersion), false);
+  assertReleaseLifecycleInventory(
+    result,
+    result.stableTagVersions.includes(result.packageVersion),
+  );
 });
 
 test("only the exact protected v0.1.10 anomaly is pinned", () => {
@@ -291,7 +312,44 @@ test("release preparation covers the package version before its tag exists", asy
     assert.equal(result.ok, true, formatReleaseNotesReport(result));
     assert.deepEqual(result.stableTagVersions, ["1.1.0"]);
     assert.deepEqual(result.changelogVersions, ["1.1.0"]);
-    assert.equal(result.noteVersions.includes("1.2.0"), true);
+    assertReleaseLifecycleInventory(result, false);
+  });
+});
+
+test("release preparation covers the package version after its tag exists", async () => {
+  await withReleaseFixture(async (rootDirectory) => {
+    await populateCompleteFixture(rootDirectory);
+    const changelogPath = join(rootDirectory, "CHANGELOG.md");
+    const changelog = await readFile(changelogPath, "utf8");
+    await writeFile(
+      changelogPath,
+      changelog.replace(
+        [
+          "## [Unreleased]",
+          "",
+          "**Candidate notes:** [1.2.0](./release-notes/1.2.0.md)",
+          "",
+          "- Candidate work remains unreleased.",
+        ].join("\n"),
+        [
+          "## [Unreleased]",
+          "",
+          "## [1.2.0](./release-notes/1.2.0.md) - 2026-08-23",
+          "",
+          ...provenanceLines("1.2.0", "1.1.0"),
+          "- Finalized release.",
+        ].join("\n"),
+      ),
+      "utf8",
+    );
+    const result = await checkReleaseNotes({
+      rootDirectory,
+      tagVersions: ["v1.1.0", "v1.2.0"],
+    });
+    assert.equal(result.ok, true, formatReleaseNotesReport(result));
+    assert.deepEqual(result.stableTagVersions, ["1.1.0", "1.2.0"]);
+    assert.deepEqual(result.changelogVersions, ["1.2.0", "1.1.0"]);
+    assertReleaseLifecycleInventory(result, true);
   });
 });
 

--- a/test/tool-inventory.test.js
+++ b/test/tool-inventory.test.js
@@ -303,16 +303,40 @@ test("the checked-in inventory classifies every retained tool entry point and np
     true,
     formatToolInventoryReport(result),
   );
-  // 86 records / 88 executable paths: release-documentation, Codex contract,
+  // 94 records / 96 executable paths: release-documentation, Codex contract,
   // documentation governance, repository-layout, macOS bundle-version, and
   // local index-recovery gates are reviewed repository operations invoked by
   // CI, release runbooks, or supported internal product tooling.
   // Keep these exact so any future executable still requires an ownership
   // decision.
-  // Includes the reviewed, protected exact-output accounting child benchmark.
-  assert.equal(result.records, 86);
-  assert.equal(result.candidates.length, 88);
+  // Includes the reviewed exact-output accounting child benchmark and eight
+  // protected PR94 qualification entrypoints/helpers; neither is a product API.
+  assert.equal(result.records, 94);
+  assert.equal(result.candidates.length, 96);
   assert.ok(result.aliases >= 25);
+});
+
+test("the eight PR94 qualifier paths retain explicit ownership without product command aliases", async () => {
+  const inventory = JSON.parse(await readFile(join(REPOSITORY_ROOT, "tools/tool-inventory.json"), "utf8"));
+  const records = inventory.records.filter(({ canonicalPath }) => canonicalPath.includes("pr94"));
+  assert.deepEqual(records.map(({ canonicalPath }) => canonicalPath).sort(), [
+    "scripts/lib/pr94-analysis-worker.mjs",
+    "scripts/lib/pr94-calibration-evidence.mjs",
+    "scripts/lib/pr94-ledger-evidence.mjs",
+    "scripts/lib/pr94-population-evidence.mjs",
+    "scripts/lib/pr94-production-resource-worker.mjs",
+    "scripts/lib/pr94-receipt-validation.mjs",
+    "scripts/lib/pr94-revision-loader.mjs",
+    "scripts/qualify-pr94-attribution.mjs",
+  ]);
+  for (const record of records) {
+    assert.equal(record.classification, "reusable_benchmark");
+    assert.equal(record.owner, "local_analysis");
+    assert.equal(record.stableAlias, null);
+    assert.deepEqual(record.additionalAliases, []);
+    assert.equal(record.provenance, "docs/plans/2026-09-03-public-0.1.17-release.md");
+    assert.ok(record.callers.some((path) => path.startsWith("test/pr94-")));
+  }
 });
 
 test("the inventory names every static ESM caller of a classified tool", async () => {

--- a/tools/tool-inventory.json
+++ b/tools/tool-inventory.json
@@ -11,6 +11,9 @@
       "stableAliasReason": "Protected private-index child comparison requires explicit approval and is not a supported product command.",
       "additionalAliases": [],
       "callers": [
+        "scripts/lib/pr94-analysis-worker.mjs",
+        "scripts/lib/pr94-production-resource-worker.mjs",
+        "scripts/qualify-pr94-attribution.mjs",
         "test/detailed-accounting-benchmark.test.js"
       ],
       "decision": "retain_as_optimization_qualification_gate",
@@ -609,6 +612,130 @@
       "legacyPaths": []
     },
     {
+      "classification": "reusable_benchmark",
+      "owner": "local_analysis",
+      "canonicalPath": "scripts/lib/pr94-analysis-worker.mjs",
+      "stableAlias": null,
+      "stableAliasReason": "Private per-revision analysis is an isolated qualification worker, not a supported product command.",
+      "additionalAliases": [],
+      "callers": [
+        "scripts/qualify-pr94-attribution.mjs",
+        "test/pr94-analysis-worker.test.js"
+      ],
+      "decision": "retain_as_attribution_qualification_support",
+      "provenance": "docs/plans/2026-09-03-public-0.1.17-release.md",
+      "provenanceReason": null,
+      "legacyPaths": []
+    },
+    {
+      "classification": "reusable_benchmark",
+      "owner": "local_analysis",
+      "canonicalPath": "scripts/lib/pr94-calibration-evidence.mjs",
+      "stableAlias": null,
+      "stableAliasReason": "Closed calibration evidence and private comparison support are imported by the protected qualifier, not a product command.",
+      "additionalAliases": [],
+      "callers": [
+        "scripts/lib/pr94-analysis-worker.mjs",
+        "scripts/qualify-pr94-attribution.mjs",
+        "test/pr94-analysis-worker.test.js",
+        "test/pr94-calibration-evidence.test.js",
+        "test/pr94-receipt-validation.test.js"
+      ],
+      "decision": "retain_as_attribution_qualification_support",
+      "provenance": "docs/plans/2026-09-03-public-0.1.17-release.md",
+      "provenanceReason": null,
+      "legacyPaths": []
+    },
+    {
+      "classification": "reusable_benchmark",
+      "owner": "local_analysis",
+      "canonicalPath": "scripts/lib/pr94-ledger-evidence.mjs",
+      "stableAlias": null,
+      "stableAliasReason": "Exact ledger conservation and sealed private row comparison are imported qualification support, not a product command.",
+      "additionalAliases": [],
+      "callers": [
+        "scripts/lib/pr94-analysis-worker.mjs",
+        "scripts/lib/pr94-population-evidence.mjs",
+        "scripts/lib/pr94-receipt-validation.mjs",
+        "scripts/qualify-pr94-attribution.mjs",
+        "test/pr94-analysis-worker.test.js",
+        "test/pr94-ledger-evidence.test.js",
+        "test/pr94-population-evidence.test.js",
+        "test/pr94-receipt-validation.test.js"
+      ],
+      "decision": "retain_as_attribution_qualification_support",
+      "provenance": "docs/plans/2026-09-03-public-0.1.17-release.md",
+      "provenanceReason": null,
+      "legacyPaths": []
+    },
+    {
+      "classification": "reusable_benchmark",
+      "owner": "local_analysis",
+      "canonicalPath": "scripts/lib/pr94-population-evidence.mjs",
+      "stableAlias": null,
+      "stableAliasReason": "Disjoint plan-population conservation is imported qualification support, not a product command.",
+      "additionalAliases": [],
+      "callers": [
+        "scripts/lib/pr94-analysis-worker.mjs",
+        "scripts/lib/pr94-receipt-validation.mjs",
+        "test/pr94-population-evidence.test.js"
+      ],
+      "decision": "retain_as_attribution_qualification_support",
+      "provenance": "docs/plans/2026-09-03-public-0.1.17-release.md",
+      "provenanceReason": null,
+      "legacyPaths": []
+    },
+    {
+      "classification": "reusable_benchmark",
+      "owner": "local_analysis",
+      "canonicalPath": "scripts/lib/pr94-production-resource-worker.mjs",
+      "stableAlias": null,
+      "stableAliasReason": "Protected private-index production-child repeatability requires explicit approval and is not a product command.",
+      "additionalAliases": [],
+      "callers": [
+        "scripts/lib/pr94-receipt-validation.mjs",
+        "scripts/qualify-pr94-attribution.mjs",
+        "test/pr94-production-resource-worker.test.js"
+      ],
+      "decision": "retain_as_attribution_qualification_support",
+      "provenance": "docs/plans/2026-09-03-public-0.1.17-release.md",
+      "provenanceReason": null,
+      "legacyPaths": []
+    },
+    {
+      "classification": "reusable_benchmark",
+      "owner": "local_analysis",
+      "canonicalPath": "scripts/lib/pr94-receipt-validation.mjs",
+      "stableAlias": null,
+      "stableAliasReason": "Closed aggregate and cross-lane receipt validation is imported qualification support, not a product command.",
+      "additionalAliases": [],
+      "callers": [
+        "scripts/qualify-pr94-attribution.mjs",
+        "test/pr94-analysis-worker.test.js",
+        "test/pr94-receipt-validation.test.js"
+      ],
+      "decision": "retain_as_attribution_qualification_support",
+      "provenance": "docs/plans/2026-09-03-public-0.1.17-release.md",
+      "provenanceReason": null,
+      "legacyPaths": []
+    },
+    {
+      "classification": "reusable_benchmark",
+      "owner": "local_analysis",
+      "canonicalPath": "scripts/lib/pr94-revision-loader.mjs",
+      "stableAlias": null,
+      "stableAliasReason": "Pinned revision loading and export-only instrumentation are internal qualification support, not a product command.",
+      "additionalAliases": [],
+      "callers": [
+        "scripts/lib/pr94-analysis-worker.mjs",
+        "test/pr94-revision-loader.test.js"
+      ],
+      "decision": "retain_as_attribution_qualification_support",
+      "provenance": "docs/plans/2026-09-03-public-0.1.17-release.md",
+      "provenanceReason": null,
+      "legacyPaths": []
+    },
+    {
       "classification": "build_release_operation",
       "owner": "local_review_release",
       "canonicalPath": "scripts/local-review-network-audit-preload.cjs",
@@ -797,6 +924,22 @@
       ],
       "decision": "retain_and_relocate_after_inventory",
       "provenance": "docs/runbooks/macos-stable-release-runbook.md",
+      "provenanceReason": null,
+      "legacyPaths": []
+    },
+    {
+      "classification": "reusable_benchmark",
+      "owner": "local_analysis",
+      "canonicalPath": "scripts/qualify-pr94-attribution.mjs",
+      "stableAlias": null,
+      "stableAliasReason": "Protected private-index before/after/final comparison requires explicit approval and is not a supported product command.",
+      "additionalAliases": [],
+      "callers": [
+        "docs/plans/2026-09-03-public-0.1.17-release.md",
+        "test/pr94-qualification-runner.test.js"
+      ],
+      "decision": "retain_as_attribution_qualification_gate",
+      "provenance": "docs/plans/2026-09-03-public-0.1.17-release.md",
       "provenanceReason": null,
       "legacyPaths": []
     },

--- a/tools/tool-inventory.json
+++ b/tools/tool-inventory.json
@@ -620,7 +620,8 @@
       "additionalAliases": [],
       "callers": [
         "scripts/qualify-pr94-attribution.mjs",
-        "test/pr94-analysis-worker.test.js"
+        "test/pr94-analysis-worker.test.js",
+        "test/pr94-calibration-evidence.test.js"
       ],
       "decision": "retain_as_attribution_qualification_support",
       "provenance": "docs/plans/2026-09-03-public-0.1.17-release.md",


### PR DESCRIPTION
## Summary

- Correct Finder bundle creation/modification dates using sealed source time, without changing normalized internal payload timestamps.
- Bind previous-stable replacement compatibility to the exact immutable 0.1.16 artifact; keep current-candidate trust checks strict.
- Complete the local, content-free PR94 three-revision attribution qualification and record the reviewed conservation/resource result.
- Finalize 0.1.17 release notes, provenance, publication instructions and tagged/untagged release-note tests.

## Validation

The PR94 comparison passed with the explicit status `passed_with_historical_artifact_refusal`. All 707,889 positive usage records, 954,391 quota observations and 152 accepted candidate fits are preserved; no unexplained loss or duplicate primary representation remains. Historical intermediate artifacts remain refused. Final production accounting runs were 39.57 and 40.75 seconds with identical, strictly valid output. The final tagged runtime/dependency closure exactly matches the qualified source. Only the reviewed content-free summary is committed; private corpus artifacts remain local.

The broad root command completed 3,725 tests: 3,705 passed, 17 platform skips, three failures. Two test files could not start because an existing locked Worker dependency was absent; after installing the unchanged lockfile, both files passed unchanged (7/7). The third failure was a test assuming the current version is always untagged; the corrected strict lifecycle suite passed 11/11, including tagged and untagged fixtures. The broad command is not relabeled green. Retained R7 freshness and native artifact/source smokes passed within that run; separate updater tests passed 2/2. Codex release contracts, architecture, documentation and preflight passed.

Final tagged source: `aa660b24a66196155ba59267ab832cc4ef6e1c7d`. Stable 0.1.17/build1024 finalizer passed Developer ID hardened-runtime signing, Apple notarization/stapling, Gatekeeper and isolated smoke validation. Exact published 0.1.16-to-final1024 replacement validation passed through the unchanged CLI. Read-only mounted-artifact inspection confirms macOS14.0 minimum and source-bound Finder creation/modification dates of September3,2026. Final DMG:49,871,590bytes, SHA-256 `f4a56f7a90e1fe0f6018b9aa5c99a27ff8b34dabd9416fc76a0491aa7fc75d50`. All source changes after the qualified head are release documentation and the release-notes lifecycle test, not app/runtime changes.

## Release boundary

The owner accepted the native dogfood and authorized publishing 0.1.17 after local qualification. The full physical clean-profile/Login Item matrix is explicitly deferred for this release, not passed. Data conservation, final signatures, updater bytes and unexpected automatic Keychain prompts remain stop conditions. Hosted Worker deployment, migrations, v1.1 activation, contribution operations and the separately held website validator backport/deployment are not included.

Release source is the annotated `v0.1.17` PR-head commit. Merge normally, preserving its ancestry and exact tree; do not squash/rebase or rewrite a remote tag. Publish only the final immutable DMG and the complete five-asset GitHub evidence set, then verify before Sparkle/Homebrew publication.
