### PR TITLE
Fix hosted quota sampling memory and restore allowance graph

### DIFF
--- a/apps/worker/src/quota-analysis-v1.ts
+++ b/apps/worker/src/quota-analysis-v1.ts
@@ -543,10 +543,16 @@ function attributeSnapshot(
 // Binds (in order): era markers JSON, winnersJson, participantId, observedAt cutoff, resetsAt
 // cutoff, window minutes, minimum boundaries, minimum span, row limit. Anonymous
 // `?` because the leading json_each winner filter binds one parameter and fixed
-// numbering across the CTE chain buys nothing. `scoped` is MATERIALIZED so its
-// winner-filtered index scan runs once rather than being re-evaluated by both
-// `fitable` and `survivors`.
-const QUOTA_DOWNSAMPLE_SQL = `WITH era_markers AS MATERIALIZED (
+// numbering across the CTE chain buys nothing. Plan-era bounds are disjoint
+// within each provider/limit context, including conflict gaps. Seek each era's
+// range through the deployed 0036 index; no wide raw or marker-stream table is
+// needed. Only rowids and compact partition values cross the window sorter.
+// Materialize endpoints BEFORE reset eligibility: collapse preserves every
+// distinct percentage and extremum, so the same slot-independent gates commute
+// with this slot-partitioned reduction. Hydrate wide rows only after the cap.
+// NOT MATERIALIZED keeps SQLite from retaining the entire compact window output
+// as a second dense table; the owning query-plan test verifies its coroutine.
+export const QUOTA_DOWNSAMPLE_SQL = `WITH era_markers AS MATERIALIZED (
     SELECT json_extract(e.value, '$[0]') AS provider,
       json_extract(e.value, '$[1]') AS limit_id,
       json_extract(e.value, '$[2]') AS plan_type,
@@ -556,24 +562,17 @@ const QUOTA_DOWNSAMPLE_SQL = `WITH era_markers AS MATERIALIZED (
       json_extract(e.value, '$[6]') AS upper_bound,
       json_extract(e.value, '$[7]') AS era_ordinal
     FROM json_each(?) e
-  ), raw_scoped AS MATERIALIZED (
-    SELECT r.occurrence_id AS occurrence_id,
-           r.observed_at AS observed_at,
-           r.provider AS provider,
-           r.plan_type AS plan_type,
-           r.plan_variant AS plan_variant,
-           r.limit_id AS limit_id,
-           r.slot AS slot,
-           r.used_percent AS used_percent,
-           r.window_duration_minutes AS window_duration_minutes,
-           r.resets_at AS resets_at,
-           r.id AS id
-      FROM telemetry_v1_records r
+  ), marked AS NOT MATERIALIZED (
+    SELECT r.id, r.observed_at, r.resets_at, r.used_percent, e.era_ordinal,
+           LAG(r.used_percent) OVER win AS prev_up,
+           LEAD(r.used_percent) OVER win AS next_up
+      FROM era_markers e
+      CROSS JOIN telemetry_v1_records r INDEXED BY telemetry_v1_records_participant_stream_observed
       JOIN participants p ON p.id = r.participant_id AND p.state = 'active'
      WHERE ${WINNER_FILTER_SQL}
        AND r.participant_id = ?
        AND r.stream = 'quota'
-       AND r.observed_at >= ?
+       AND r.observed_at >= MAX(?, e.lower_bound)
        AND r.resets_at >= ?
        AND r.limit_id = 'codex'
        AND r.window_duration_minutes = ?
@@ -582,70 +581,37 @@ const QUOTA_DOWNSAMPLE_SQL = `WITH era_markers AS MATERIALIZED (
        AND r.used_percent IS NOT NULL
        AND r.plan_type IS NOT NULL
        AND r.plan_variant IS NOT NULL
-  ),
-  marker_stream AS (
-    SELECT r.*, 0 AS is_marker, 0 AS era_ordinal FROM raw_scoped r
-    UNION ALL
-    SELECT NULL AS occurrence_id, e.lower_bound AS observed_at, e.provider,
-      e.plan_type, e.plan_variant, e.limit_id, NULL AS slot,
-      NULL AS used_percent, NULL AS window_duration_minutes, NULL AS resets_at,
-      0 AS id, 1 AS is_marker, e.era_ordinal
-      FROM era_markers e
-  ), assigned AS (
-    SELECT *, MAX(era_ordinal) OVER (
-      PARTITION BY provider, limit_id ORDER BY observed_at, is_marker DESC, id
-      ROWS UNBOUNDED PRECEDING
-    ) AS assigned_era FROM marker_stream
-  ), scoped AS MATERIALIZED (
-    SELECT a.*, e.plan_era_key
-    FROM assigned a JOIN era_markers e ON e.era_ordinal = a.assigned_era
-    WHERE a.is_marker = 0 AND a.plan_type = e.plan_type
-      AND a.plan_variant = e.plan_variant AND a.observed_at >= e.lower_bound
-      AND (e.upper_bound IS NULL OR a.observed_at <= e.upper_bound)
-  ), fragment_stats AS (
-    SELECT provider, plan_type, plan_variant, limit_id,
-           window_duration_minutes, resets_at, plan_era_key,
-           COUNT(DISTINCT used_percent) AS boundary_count,
-           MAX(used_percent) - MIN(used_percent) AS displayed_span,
-           MAX(observed_at) AS last_observed_at
-      FROM scoped
-     GROUP BY provider, plan_type, plan_variant, limit_id,
-              window_duration_minutes, resets_at, plan_era_key
-  ), fitable AS (
-    SELECT * FROM fragment_stats WHERE boundary_count >= ? AND displayed_span >= ?
-  ),
-  survivors AS (
-    SELECT s.*
-      FROM scoped s
-      JOIN fitable f
-        ON f.provider = s.provider
-       AND f.plan_type = s.plan_type
-       AND f.plan_variant = s.plan_variant
-       AND f.limit_id = s.limit_id
-       AND f.window_duration_minutes = s.window_duration_minutes
-       AND f.resets_at = s.resets_at
-       AND f.plan_era_key = s.plan_era_key
-  ),
-  marked AS (
-    SELECT survivors.*,
-           LAG(used_percent) OVER win AS prev_up,
-           LEAD(used_percent) OVER win AS next_up
-      FROM survivors
+       AND r.provider = e.provider AND r.limit_id = e.limit_id
+       AND r.plan_type = e.plan_type AND r.plan_variant = e.plan_variant
+       -- Accepted v1 anchors have canonical four-digit-year chunk days. A
+       -- finite open-era bound preserves that domain and makes BOTH ends seekable.
+       AND r.observed_at <= COALESCE(e.upper_bound, '9999-12-31T23:59:59.999Z')
     WINDOW win AS (
-      PARTITION BY provider, plan_type, plan_variant, limit_id,
-                   window_duration_minutes, resets_at, slot, plan_era_key
-      ORDER BY observed_at, id
+      PARTITION BY e.era_ordinal, r.resets_at, r.slot
+      ORDER BY r.observed_at, r.id
     )
+  ), endpoints AS MATERIALIZED (
+    SELECT id, observed_at, resets_at, used_percent, era_ordinal
+      FROM marked
+     WHERE prev_up IS NULL OR next_up IS NULL
+        OR used_percent <> prev_up OR used_percent <> next_up
+  ), fitable AS (
+    SELECT era_ordinal, resets_at FROM endpoints
+     GROUP BY era_ordinal, resets_at
+    HAVING COUNT(DISTINCT used_percent) >= ?
+       AND MAX(used_percent) - MIN(used_percent) >= ?
+  ), selected AS (
+    SELECT s.id, s.observed_at, s.era_ordinal FROM endpoints s
+      JOIN fitable f ON f.era_ordinal = s.era_ordinal AND f.resets_at = s.resets_at
+     ORDER BY s.observed_at, s.id
+     LIMIT ?
   )
-  SELECT occurrence_id, observed_at, provider, plan_type, plan_variant,
-         limit_id, slot, used_percent, window_duration_minutes, resets_at, plan_era_key
-    FROM marked
-   WHERE prev_up IS NULL
-      OR next_up IS NULL
-      OR used_percent <> prev_up
-      OR used_percent <> next_up
-   ORDER BY observed_at, id
-   LIMIT ?`;
+  SELECT r.occurrence_id, r.observed_at, r.provider, r.plan_type, r.plan_variant,
+         r.limit_id, r.slot, r.used_percent, r.window_duration_minutes, r.resets_at,
+         e.plan_era_key
+    FROM selected s JOIN telemetry_v1_records r ON r.id = s.id
+    JOIN era_markers e ON e.era_ordinal = s.era_ordinal
+   ORDER BY s.observed_at, s.id`;
 
 // The already-deployed 0036 index has implicit rowid (= id) as its last key.
 // D1 does not seek that suffix through a row-value (time,id) predicate, but

--- a/apps/worker/src/quota-analysis-v1.ts
+++ b/apps/worker/src/quota-analysis-v1.ts
@@ -81,7 +81,8 @@ export const V1_PLAN_ATTRIBUTION_ADAPTER_VERSION =
  *     trailing horizon snapped to whole reset cycles, pre-filters to the only
  *     track the consumer keeps (limit_id='codex', window=10080), drops reset
  *     groups the shared calibration always refuses (the fitable HAVING), and
- *     collapses each flat used_percent run to its endpoints via LAG/LEAD. A
+ *     collapses each flat used_percent run to its endpoints via indexed
+ *     predecessor/successor seeks. A
  *     boundary is emitted only on a strict used_percent increase and anchors
  *     lowerCost on the LAST row of the preceding run and upperCost on the FIRST
  *     row of the new run, so keeping both run endpoints is byte-identical for
@@ -533,25 +534,50 @@ function attributeSnapshot(
  * window) includes a reset only when its ENTIRE first..last series is within the
  * window, so a cycle straddling the cutoff is excluded wholesale rather than
  * read partially and mis-fit. The fitable HAVING drops reset groups the shared
- * calibration always refuses; the LAG/LEAD collapse keeps every row that differs
+ * calibration always refuses; the neighbor collapse keeps every row that differs
  * from its predecessor OR successor — the first and last row of every flat
  * used_percent run — because a boundary anchors lowerCost on the last row of the
  * preceding run and upperCost on the first row of the new run. The partition
  * INCLUDES slot (an eligible multi-slot reset has time-disjoint slots); the
  * fitable GROUP BY EXCLUDES slot (= the shared resetKey).
  */
-// Binds (in order): era markers JSON, winnersJson, participantId, observedAt cutoff, resetsAt
-// cutoff, window minutes, minimum boundaries, minimum span, row limit. Anonymous
-// `?` because the leading json_each winner filter binds one parameter and fixed
-// numbering across the CTE chain buys nothing. Plan-era bounds are disjoint
-// within each provider/limit context, including conflict gaps. Seek each era's
-// range through the deployed 0036 index; no wide raw or marker-stream table is
-// needed. Only rowids and compact partition values cross the window sorter.
+const QUOTA_WINNER_FILTER_SQL = WINNER_FILTER_SQL.replace("?", "?2");
+
+// The tuple (time,id) predecessor/successor must use two explicit seeks, just
+// like the usage cursor below. Looking within the tied timestamp first preserves
+// rowid order; only an absent neighbor advances to the adjacent time. The other
+// partition fields and the exact winner/era bounds must also match. Every
+// accepted percentage is nonnegative, so -1 denotes an absent neighbor without
+// becoming a retained value or confusing a genuine zero-percent endpoint.
+function quotaNeighborSql(previous: boolean): string {
+  const comparison = previous ? "<" : ">";
+  const direction = previous ? "DESC" : "ASC";
+  const select = (sameTime: boolean) => `(SELECT n.used_percent FROM telemetry_v1_records n
+      INDEXED BY telemetry_v1_records_participant_stream_observed
+    WHERE n.participant_id = r.participant_id AND n.stream = 'quota'
+      AND ${sameTime ? `n.observed_at = r.observed_at AND n.id ${comparison} r.id` : `n.observed_at ${comparison} r.observed_at`}
+      AND n.observed_at >= MAX(?4, e.lower_bound)
+      AND n.observed_at <= COALESCE(e.upper_bound, '9999-12-31T23:59:59.999Z')
+      AND n.provider = r.provider AND n.limit_id = r.limit_id
+      AND n.plan_type = r.plan_type AND n.plan_variant = r.plan_variant
+      AND n.window_duration_minutes = r.window_duration_minutes
+      AND n.resets_at = r.resets_at AND n.slot = r.slot
+      AND n.used_percent IS NOT NULL AND ${QUOTA_WINNER_FILTER_SQL.replaceAll("r.", "n.")}
+    ORDER BY ${sameTime ? "" : `n.observed_at ${direction}, `}n.id ${direction} LIMIT 1)`;
+  return `COALESCE(${select(true)}, ${select(false)}, -1)`;
+}
+
+// Binds (in order): era markers JSON, winnersJson, participantId, observedAt
+// cutoff, resetsAt cutoff, window minutes, minimum boundaries, minimum span,
+// row limit. Numbered parameters reuse the same winner and cutoff bindings in
+// all four neighbor seeks. Plan-era bounds are disjoint within each
+// provider/limit context, including conflict gaps. Seek through deployed 0036;
+// no dense marker-stream table, partition sorter, or window spool is needed.
 // Materialize endpoints BEFORE reset eligibility: collapse preserves every
 // distinct percentage and extremum, so the same slot-independent gates commute
 // with this slot-partitioned reduction. Hydrate wide rows only after the cap.
-// NOT MATERIALIZED keeps SQLite from retaining the entire compact window output
-// as a second dense table; the owning query-plan test verifies its coroutine.
+// NOT MATERIALIZED prevents retaining the dense per-record neighbor results;
+// the owning query-plan test forbids a sort/materialization before endpoints.
 export const QUOTA_DOWNSAMPLE_SQL = `WITH era_markers AS MATERIALIZED (
     SELECT json_extract(e.value, '$[0]') AS provider,
       json_extract(e.value, '$[1]') AS limit_id,
@@ -561,21 +587,21 @@ export const QUOTA_DOWNSAMPLE_SQL = `WITH era_markers AS MATERIALIZED (
       json_extract(e.value, '$[5]') AS lower_bound,
       json_extract(e.value, '$[6]') AS upper_bound,
       json_extract(e.value, '$[7]') AS era_ordinal
-    FROM json_each(?) e
+    FROM json_each(?1) e
   ), marked AS NOT MATERIALIZED (
     SELECT r.id, r.observed_at, r.resets_at, r.used_percent, e.era_ordinal,
-           LAG(r.used_percent) OVER win AS prev_up,
-           LEAD(r.used_percent) OVER win AS next_up
+           ${quotaNeighborSql(true)} AS prev_up,
+           ${quotaNeighborSql(false)} AS next_up
       FROM era_markers e
       CROSS JOIN telemetry_v1_records r INDEXED BY telemetry_v1_records_participant_stream_observed
       JOIN participants p ON p.id = r.participant_id AND p.state = 'active'
-     WHERE ${WINNER_FILTER_SQL}
-       AND r.participant_id = ?
+     WHERE ${QUOTA_WINNER_FILTER_SQL}
+       AND r.participant_id = ?3
        AND r.stream = 'quota'
-       AND r.observed_at >= MAX(?, e.lower_bound)
-       AND r.resets_at >= ?
+       AND r.observed_at >= MAX(?4, e.lower_bound)
+       AND r.resets_at >= ?5
        AND r.limit_id = 'codex'
-       AND r.window_duration_minutes = ?
+       AND r.window_duration_minutes = ?6
        AND r.resets_at IS NOT NULL
        AND r.slot IS NOT NULL
        AND r.used_percent IS NOT NULL
@@ -586,25 +612,20 @@ export const QUOTA_DOWNSAMPLE_SQL = `WITH era_markers AS MATERIALIZED (
        -- Accepted v1 anchors have canonical four-digit-year chunk days. A
        -- finite open-era bound preserves that domain and makes BOTH ends seekable.
        AND r.observed_at <= COALESCE(e.upper_bound, '9999-12-31T23:59:59.999Z')
-    WINDOW win AS (
-      PARTITION BY e.era_ordinal, r.resets_at, r.slot
-      ORDER BY r.observed_at, r.id
-    )
   ), endpoints AS MATERIALIZED (
     SELECT id, observed_at, resets_at, used_percent, era_ordinal
       FROM marked
-     WHERE prev_up IS NULL OR next_up IS NULL
-        OR used_percent <> prev_up OR used_percent <> next_up
+     WHERE used_percent <> prev_up OR used_percent <> next_up
   ), fitable AS (
     SELECT era_ordinal, resets_at FROM endpoints
      GROUP BY era_ordinal, resets_at
-    HAVING COUNT(DISTINCT used_percent) >= ?
-       AND MAX(used_percent) - MIN(used_percent) >= ?
+    HAVING COUNT(DISTINCT used_percent) >= ?7
+       AND MAX(used_percent) - MIN(used_percent) >= ?8
   ), selected AS (
     SELECT s.id, s.observed_at, s.era_ordinal FROM endpoints s
       JOIN fitable f ON f.era_ordinal = s.era_ordinal AND f.resets_at = s.resets_at
      ORDER BY s.observed_at, s.id
-     LIMIT ?
+     LIMIT ?9
   )
   SELECT r.occurrence_id, r.observed_at, r.provider, r.plan_type, r.plan_variant,
          r.limit_id, r.slot, r.used_percent, r.window_duration_minutes, r.resets_at,

--- a/apps/worker/test/community-allowance.spec.ts
+++ b/apps/worker/test/community-allowance.spec.ts
@@ -1669,6 +1669,76 @@ describe("v1 plan attribution before fit and cost reduction", () => {
 });
 
 describe("v1 analyzer scale fix — fit-preserving reduction", () => {
+  it("keeps exact tied endpoints across winning devices, partitions and era gaps", async () => {
+    const participantId = await newV1Participant("quota-neighbors");
+    const devices = ["v1-device-quota-neighbors", "v1-device-quota-neighbors-next"];
+    const loser = "v1-device-quota-neighbors-loser";
+    for (const device of [devices[1]!, loser]) {
+      await seedV1Device(participantId, device, "v1-session-quota-neighbors");
+    }
+    const foreign = await newV1Participant("quota-neighbors-foreign");
+    const baseMs = SCALE_NOW - 3 * DAY_MS;
+    const at = (minutes: number) => new Date(baseMs + minutes * MINUTE_MS).toISOString();
+    const resetsAt = new Date(baseMs + 7 * DAY_MS).toISOString();
+    const markers = [
+      ["openai_codex", "codex", "pro", "unknown", "first", "", at(20), 1],
+      ["openai_codex", "codex", "pro", "unknown", "return", at(1440), null, 2],
+      ["other_provider", "codex", "pro", "unknown", "other", "", null, 3],
+    ];
+    const expected: Array<V1SeedRecord & { plan_era_key: string; insertion: number }> = [];
+    let insertion = 0;
+    for (const [dayIndex, offset] of [0, 1440].entries()) {
+      const day = at(offset).slice(0, 10);
+      const records: V1SeedRecord[] = [];
+      for (const provider of ["openai_codex", "other_provider"]) for (const slot of ["seven_day", "secondary"]) {
+        for (let level = 0; level <= 10; level++) for (let repeat = 0; repeat < 3; repeat++) {
+          const row = { occurrence_id: `neighbor-${offset}-${provider}-${slot}-${level}-${2 - repeat}`,
+            observed_at: at(offset + level), provider, plan_type: "pro", plan_variant: "unknown",
+            limit_id: "codex", slot, used_percent: level * 10, window_duration_minutes: 10_080,
+            resets_at: resetsAt };
+          records.push(row);
+          // Literal fixture oracle: each three-row flat run retains its first
+          // and last INSERTED id, not the opposite lexical occurrence order.
+          if (repeat !== 1) expected.push({ ...row, insertion,
+            plan_era_key: provider === "other_provider" ? "other" : offset === 0 ? "first" : "return" });
+          insertion += 1;
+        }
+      }
+      const exemplar = records[0]!;
+      const noise = records.map((row) => ({ ...row, occurrence_id: `loser-${row.occurrence_id}`, used_percent: 0.5 }));
+      if (offset === 0) records.push(
+        { ...exemplar, occurrence_id: "neighbor-before-cutoff", observed_at: at(-1) },
+        { ...exemplar, occurrence_id: "neighbor-era-gap", observed_at: at(60) },
+        { ...exemplar, occurrence_id: "neighbor-short-window", used_percent: 0.5, window_duration_minutes: 300 },
+        { ...exemplar, occurrence_id: "neighbor-other-variant", used_percent: 0.5, plan_variant: "other" },
+        { ...exemplar, occurrence_id: "neighbor-short-reset", used_percent: 0.5,
+          resets_at: new Date(baseMs + 6 * DAY_MS).toISOString() },
+        ...[0, 1, 2].map((minute) => ({ ...exemplar, occurrence_id: `neighbor-nonfit-${minute}`,
+          observed_at: at(minute), used_percent: 20, resets_at: new Date(baseMs + 8 * DAY_MS).toISOString() })),
+      );
+      await seedChunkedRecords(participantId, devices[dayIndex]!, "quota", day, records);
+      await seedChunkedRecords(participantId, loser, "quota", day, noise, `${day}T19:00:00.000Z`);
+      await seedChunkedRecords(foreign, "v1-device-quota-neighbors-foreign", "quota", day, noise);
+    }
+    const pin = await loadV1SourcePin(db(), { participantId, fromDay: at(0).slice(0, 10) });
+    expect(pin.winners.map((entry) => entry.device_id)).toEqual(devices);
+    const oracle = expected.sort((left, right) => left.observed_at.localeCompare(right.observed_at)
+      || left.insertion - right.insertion).map(({ insertion: _insertion, ...row }) => row);
+    expect(oracle).toHaveLength(176);
+    // Ingest admits finite0..100 (including zero), never the -1 absence sentinel.
+    expect(oracle.filter((row) => row.used_percent === 0)).toHaveLength(16);
+    expect(oracle.filter((row) => row.used_percent === 100)).toHaveLength(16);
+    for (const limit of [1, oracle.length - 1, oracle.length, oracle.length + 1]) {
+      const result = await db().prepare(QUOTA_DOWNSAMPLE_SQL).bind(JSON.stringify(markers), pin.winnersJson,
+        participantId, at(0), resetsAt, 10_080, QUOTA_CALIBRATION_POLICY.minimumBoundaries,
+        QUOTA_CALIBRATION_POLICY.minimumDisplayedSpanPp, limit).all();
+      expect(result.results).toEqual(oracle.slice(0, limit));
+    }
+    expect((await db().prepare(QUOTA_DOWNSAMPLE_SQL).bind(JSON.stringify(markers), pin.winnersJson,
+      participantId, at(0), resetsAt, 10_080, 1000,
+      QUOTA_CALIBRATION_POLICY.minimumDisplayedSpanPp, 1).all()).results).toEqual([]);
+  });
+
   it("reduces dense quota before materializing and preserves exact run endpoints and fits", async () => {
     const participantId = await newV1Participant("quota-working-set");
     const device = "v1-device-quota-working-set";
@@ -1690,7 +1760,7 @@ describe("v1 analyzer scale fix — fit-preserving reduction", () => {
         QUOTA_CALIBRATION_POLICY.minimumBoundaries,
         QUOTA_CALIBRATION_POLICY.minimumDisplayedSpanPp,
         MAX_DOWNSAMPLED_QUOTA_ROWS + 1)
-      .all<{ detail: string }>();
+      .all<{ id: number; parent: number; detail: string }>();
     const materialized = plan.results.map((row) => row.detail)
       .filter((detail) => detail.startsWith("MATERIALIZE "));
     // No wide raw/assigned/survivor table may be retained before the dense
@@ -1701,6 +1771,19 @@ describe("v1 analyzer scale fix — fit-preserving reduction", () => {
     expect(plan.results.some(({ detail }) => detail.includes("telemetry_v1_records_participant_stream_observed")
       && detail.includes("participant_id=? AND stream=? AND observed_at>? AND observed_at<?"))).toBe(true);
     expect(plan.results.some(({ detail }) => detail.includes("SEARCH r USING INTEGER PRIMARY KEY (rowid=?)"))).toBe(true);
+    const endpointNode = plan.results.find(({ detail }) => detail === "MATERIALIZE endpoints");
+    expect(endpointNode).toBeDefined();
+    const endpointDescendants = new Set([endpointNode!.id]);
+    for (const row of plan.results) {
+      if (endpointDescendants.has(row.parent)) endpointDescendants.add(row.id);
+    }
+    expect(plan.results.filter((row) => endpointDescendants.has(row.id))
+      .some(({ detail }) => /TEMP B-TREE/u.test(detail))).toBe(false);
+    const neighborSeeks = plan.results.filter(({ detail }) => detail.includes("SEARCH n USING INDEX telemetry_v1_records_participant_stream_observed"));
+    expect(neighborSeeks).toHaveLength(4);
+    for (const predicate of ["observed_at=? AND rowid<?", "observed_at=? AND rowid>?", "observed_at>? AND observed_at<?"]) {
+      expect(neighborSeeks.some(({ detail }) => detail.includes(predicate)), predicate).toBe(true);
+    }
     const reducedRows = await downsampleQuotaForTest(db(), participantId, SCALE_NOW);
     expect(reducedRows.map((row) => row.occurrence_id)).toEqual(
       Array.from({ length: 17 }, (_, level) => [

--- a/apps/worker/test/community-allowance.spec.ts
+++ b/apps/worker/test/community-allowance.spec.ts
@@ -28,6 +28,7 @@ import {
   downsampleQuotaForTest,
   MAX_DOWNSAMPLED_QUOTA_ROWS,
   MAX_WINDOWED_USAGE_ROWS,
+  QUOTA_DOWNSAMPLE_SQL,
   V1_ANALYSIS_WINDOW_DAYS,
   V1_PLAN_ATTRIBUTION_ADAPTER_VERSION,
   V1_USAGE_PAGE_AT_TIME_SQL,
@@ -1668,6 +1669,50 @@ describe("v1 plan attribution before fit and cost reduction", () => {
 });
 
 describe("v1 analyzer scale fix — fit-preserving reduction", () => {
+  it("reduces dense quota before materializing and preserves exact run endpoints and fits", async () => {
+    const participantId = await newV1Participant("quota-working-set");
+    const device = "v1-device-quota-working-set";
+    const baseMs = SCALE_NOW - 2 * DAY_MS;
+    const resetsAt = new Date(baseMs + 7 * DAY_MS).toISOString();
+    const day = new Date(baseMs).toISOString().slice(0, 10);
+    const dense = buildDenseReset({ tag: "quota-working-set", baseMs, resetsAt,
+      levels: 17, startPp: 5, stepPp: 5, repeats: 300, snapshotStepMs: 1_000,
+      usageOffsetMs: 500, gridExactLevels: [3, 8] });
+    await seedChunkedRecords(participantId, device, "quota", day, dense.quota);
+    await seedChunkedRecords(participantId, device, "usage", day, dense.usage);
+    const pin = await loadV1SourcePin(db(), { participantId, fromDay: day });
+    const markers = JSON.stringify([["openai_codex", "codex", "pro", "unknown", "synthetic-era", "", null, 1]]);
+    const cutoff = new Date(SCALE_NOW - V1_ANALYSIS_WINDOW_DAYS * DAY_MS)
+      .toISOString().slice(0, 10) + "T00:00:00.000Z";
+    const plan = await db().prepare("EXPLAIN QUERY PLAN " + QUOTA_DOWNSAMPLE_SQL)
+      .bind(markers, pin.winnersJson, participantId, cutoff,
+        new Date(Date.parse(cutoff) + 7 * DAY_MS).toISOString(), 10_080,
+        QUOTA_CALIBRATION_POLICY.minimumBoundaries,
+        QUOTA_CALIBRATION_POLICY.minimumDisplayedSpanPp,
+        MAX_DOWNSAMPLED_QUOTA_ROWS + 1)
+      .all<{ detail: string }>();
+    const materialized = plan.results.map((row) => row.detail)
+      .filter((detail) => detail.startsWith("MATERIALIZE "));
+    // No wide raw/assigned/survivor table may be retained before the dense
+    // stream is reduced. The bounded era vector and endpoint table may be.
+    expect(materialized).not.toEqual([]);
+    expect(materialized.every((detail) => ["MATERIALIZE era_markers", "MATERIALIZE endpoints", "MATERIALIZE fitable"]
+      .includes(detail)), materialized.join("\n")).toBe(true);
+    expect(plan.results.some(({ detail }) => detail.includes("telemetry_v1_records_participant_stream_observed")
+      && detail.includes("participant_id=? AND stream=? AND observed_at>? AND observed_at<?"))).toBe(true);
+    expect(plan.results.some(({ detail }) => detail.includes("SEARCH r USING INTEGER PRIMARY KEY (rowid=?)"))).toBe(true);
+    const reducedRows = await downsampleQuotaForTest(db(), participantId, SCALE_NOW);
+    expect(reducedRows.map((row) => row.occurrence_id)).toEqual(
+      Array.from({ length: 17 }, (_, level) => [
+        `q-quota-working-set-${level}-0`, `q-quota-working-set-${level}-299`,
+      ]).flat(),
+    );
+    const reference = await accountScopedQuotaAnalysisV1FullReferenceForTest(db(), participantId) as AnalysisLike;
+    const actual = await accountScopedQuotaAnalysisV1(db(), participantId, { nowMs: SCALE_NOW }) as AnalysisLike;
+    expect(bandResets(actual)).toHaveLength(1);
+    expect(bandResets(actual)).toEqual(bandResets(reference));
+  }, 20_000);
+
   it("preserves occurrence-first same-session intervals when insertion order disagrees", async () => {
     const scenario = await seedPlanEraScenario("tie-order", [
       { plan: "pro", offsetMinutes: 0, sharedSession: true },

--- a/docs/current-status.md
+++ b/docs/current-status.md
@@ -3,250 +3,106 @@ title: Current product and release status
 date: 2026-09-05
 type: status
 status: current
-source_commit: 68d7451be10b5b7ac098591863ad11e76b6523e5
+source_commit: 55c813a1bf7e67c00e47410b760104c0d9fbc0ea
 observation_date: 2026-09-05
 ---
 
 # Current product and release status
 
-This page is the maintained starting point for “what is current?” It separates
-the checked-out source, the public service, published artifacts, and platform
-support because those are independent facts. Re-check the named source before
-using this page for a later release or operational decision.
+This is the maintained starting point for “what is current?” Source, installed
+applications, public downloads, update feeds and hosted service behavior are
+independent observations. Re-check their own source of truth for a later
+operational decision.
 
-Continuation on 2026-09-05: both first-attempt stable `1026` installers from
-`eac8df45` pass final native artifact checks, but remain unpublished pre-repair
-evidence. The reviewed existing-index repair passed the complete Worker gate,
-and all four approved production migrations `0042`–`0045` are now applied.
-After the original `0044` refusal, a read-only probe reproduced D1's
-CASE-expression trigger parser issue. The parentheses-only repair passed
-543 Worker tests, 185 script checks, all three dry bundles and both pinned
-R7 runtime checks. The owner explicitly approved a
-data-preserving repair and source/build requalification. The [execution plan](./plans/2026-09-05-public-0-1-18-release.md#approved-migration-repair-continuation)
-records the active boundary; the frozen pre-repair artifacts are not public.
+## Published release
 
-The earlier 200-record decrease is fully reconciled to normal concurrent
-corrections: 748 exact predecessor/successor pairs contribute a net -374
-records, and four first revisions add 174. No revision links are unmatched;
-one read-only statement matches current journal and record totals exactly.
-The 05:47 UTC post-migration check verifies exact prefix 45, the complete
-schema, unchanged collection controls, zero new consent/domain data and
-unchanged transport floors. The exact record count is 3,208,989; retained
-snapshot counts are separate observations, not payload-level identity proof.
-The 05:53 UTC independent reconciliation exactly explains the full +16,172
-before/after delta and matches both reconstructed historical totals and the
-same-statement current view, with all sixteen checks passing and zero writes.
+[TiboTattle 0.1.18](https://github.com/adamallcock/tibotattle/releases/tag/v0.1.18)
+is public and immutable. Both macOS 14+ installers are stable build `1026`,
+bound to annotated tag `v0.1.18` at exact source
+`55c813a1bf7e67c00e47410b760104c0d9fbc0ea`.
+[PR #104](https://github.com/adamallcock/tibotattle/pull/104) merged that source
+normally; the release tag and public artifacts must not be rewritten.
 
-## Snapshot identity
-
-| Boundary | Verified state |
+| Distribution boundary | Verified on 2026-09-05 |
 |---|---|
-| Documentation/source review | Combined Astra/Intel `0.1.18` remains based on requested `9e1c3333`. Parser v14, copy-only preservation/accounting proof, ten fresh R7 receipts and the 3,859-pass root qualification are retained. Both first-attempt stable `1026` artifacts from `eac8df45` passed native finalization; their local-only annotated tag and bytes are preserved, not published. The approved Worker migration repair requires a new final source freeze and fresh exact-source artifacts. R7 resource decisions remain open |
-| Combined signed RC3 | ARM and Intel `0.1.18` build `1025.2` dogfood DMGs from common clean `7701debf` and a local annotated tag; [exact receipt](./receipts/2026-09-04-macos-combined-rc3-signed-candidates.md). Both signed/notarized/stapled with independent final-byte and RC2-to-RC3 replacement checks; real installed runtime, manual lifecycle and physical Intel remain separate |
-| Combined signed RC2 | ARM and Intel `0.1.18` build `1025.1` dogfood DMGs from common source `4ea16586` and a new local annotated tag; [exact receipt](./receipts/2026-09-04-macos-combined-rc2-signed-candidates.md). Both signed/notarized/stapled with independent exact-byte and same-architecture replacement checks; not installed-upgrade, manual lifecycle or physical Intel proof |
-| Earlier Intel tester artifact | Preserved signed/notarized `0.1.18` build `1025` dogfood DMG from source `18c7065b`; [historical receipt](./receipts/2026-09-03-macos-intel-signed-candidate.md). Predates combined Astra changes; remains immutable rollback/test evidence, not physically Intel-qualified |
-| Installed app | Final signed ARM RC3 `0.1.18` / `1025.2`, source `7701debf`, passes production installed-artifact validation. After owner unlock, a native-menu detailed refresh completed at 2026-09-05 03:58 UTC with replay-safe accounting bound to exact v14 generation 71, complete usage coverage and zero fallback. Stopped-state verification preserves all baseline/rehearsal historical keys, reviewed counter changes, salt and paused contribution settings; SQLite quick checks pass. Normal relaunch is observed; stable `1026` installation remains a separate gate |
-| Public service | Health HTTP 200 at 2026-09-05 05:47 UTC, source `b4c8f103bf697fb530434e6de196f2c187645661`; no Worker deployment has occurred. All approved migrations are applied, with exact primary prefix 45 and complete schema verified. Controls/consent and staged transport lifecycle remain unchanged. The earlier count decrease is reconciled to concurrent corrections. Recovery bookmarks are retained; no v1.1 activation operation has been performed |
-| Public updater | Stable `0.1.16`; read-only feed check recorded 2026-09-03 in the release plan |
-| Published release | Immutable GitHub `v0.1.17`, published 2026-09-03 at 19:47:43 UTC; ARM DMG, appcast, manifest, checksums and verification guide; exact source tag commit `aa660b24a66196155ba59267ab832cc4ef6e1c7d` |
+| GitHub release | All seven public assets independently re-downloaded and matched to the canonical manifest and checksums; immutable release and asset attestations verified |
+| Apple silicon installer | 49,908,061 bytes; SHA-256 `2ea8eca02df7cc5210b6b6ce3d6e44016bffd9d081544a4efc6fa1afeeb0f1ae` |
+| Intel installer | 52,128,441 bytes; SHA-256 `70630ba90e92a1cd8cb904e66e1aebe85b04e9d23a50bef7e4e41aca84c4d2f6` |
+| Native trust | Both final artifacts pass their own Developer ID signing, Apple notarization/stapling, Gatekeeper, source/payload and architecture checks |
+| Update feeds | [Apple silicon](https://updates.tibotattle.com/appcast.xml) and [Intel](https://updates.tibotattle.com/intel/appcast.xml) both publish 0.1.18 / 1026; independent signed-XML and streamed enclosure checksum checks passed at 19:38 UTC |
+| Homebrew | Apple silicon cask updated to 0.1.18 with the exact ARM checksum; [update workflow](https://github.com/adamallcock/homebrew-tap/actions/runs/33973076582) succeeded and the live cask was checked |
+| Website | [Both macOS tabs](https://tibotattle.com/#download) show 0.1.18 and their own correct public installer URL, minimum OS and architecture |
+| Installed ARM application | Final stable 1026 passes installed-artifact validation, ordinary launch, detailed replay-safe accounting refresh and restart, with matching generation and zero fallback |
 
-This is a snapshot, not an automatic monitor. A newer commit, deployment, feed,
-or release makes the corresponding row stale without changing the other rows.
+The manifest honestly leaves optional SBOM, source-to-binary provenance and
+store fields unset. GitHub's immutable release/asset attestations are not
+substitutes for SLSA build provenance. Follow
+[verify-release.md](./verify-release.md) for independent artifact verification.
 
-## Source tree
+## Hosted service and current graph incident
 
-The reviewed source implements a local-first macOS product, a loopback local
-analysis service, the public website and optional hosted contribution service,
-and release tooling. The maintained architecture, interface, privacy, schema,
-and command contracts are indexed in [the documentation index](./README.md).
+All approved forward migrations `0042`–`0045` are applied. Exact migration
+prefix 45, complete schema and the preservation reconciliation were verified
+without deleting telemetry, restoring production, changing consent or
+activating v1.1 transport. Applied migration files must not be rewritten.
 
-The source snapshot and live Worker identity below are separate observations.
-Source merge does not prove public deployment.
+[PR #105](https://github.com/adamallcock/tibotattle/pull/105) repaired the
+authenticated admin module dependency and atomic weekly revision replacement.
+The website deployment is source
+`26f372a7b3cb7dbf6885b8a75a0019d47d04c7ad`, whose tree matches that reviewed
+repair. Public downloads and the optional hosted analyzer have separate gates.
 
-### Source-only amendments through 2026-08-31
+The remaining graph incident is a database memory-limit failure in quota
+endpoint sampling. The website truthfully displays history-updating status
+instead of an incomplete estimate. A bounded-memory query repair is being
+qualified separately from the frozen desktop release. Recovery requires
+successful scheduled rebuilding, a subsequent valid preview cache and a
+rendered live graph; health HTTP 200 alone is not sufficient.
 
-The [approved self-service deletion retirement](./decisions/2026-08-30-self-service-deletion-retirement.md)
-retires `DELETE /api/v1/me` as `404 NOT_FOUND` without D1 access or participant
-mutation. It replaces the app control with confirmed **Disconnect this Mac**,
-preserving hosted/local history, and retains private owner erasure through
-admin maintenance. The source health contract is `participantDeletion: false`
-with `deletionSafeRestoreReplay: true`. No migration or retention change is
-part of that retirement. This amendment does not refresh or supersede the
-independent live-service, installed-artifact, release, or updater observations
-below; deployment and release remain separate gates.
+The existing dated social preview was temporarily retained to prioritize the
+verified 0.1.18 download rollout. Regenerate it from the recovered live estimate;
+do not describe that retained image as a new release preview.
 
-[PR #89](https://github.com/adamallcock/tibotattle/pull/89) adds a hosted
-admin-only per-model allowance series and **By model** view. Its original
-migration 0041 is now the distinct forward migration 0042 under the
-[verified lineage reconciliation](./reviews/2026-09-04-hosted-migration-lineage-reconciliation.md).
-Worker deployment, warming, and real cohort evidence remain separate; desktop
-installation does not activate it.
+The admin per-model view supports the reviewed model catalog, including Astra
+and older model families. Source support does not establish that its live
+preview has recovered. Contribution consent and staged v1.1 activation remain
+unchanged. The source health contract retains `participantDeletion: false`
+and `deletionSafeRestoreReplay: true`; these flags do not prove every route.
 
-[PR #94](https://github.com/adamallcock/tibotattle/pull/94) adds local plan-era
-attribution plus a staged telemetry v1.1 transport and device-continuity repair.
-Local estimates, history, ranges, forecasts, and share cards use one compatible
-selected population; missing or conflicting identity remains unavailable.
-Current migrations 0043-0045 (originally 0042-0044), stronger-format hosted activation, and new explicit
-consent are not supplied by installing the desktop app.
+## Platform support and qualification limits
 
-[PR #95](https://github.com/adamallcock/tibotattle/pull/95) makes compatible
-Keychain migration bounded and non-interactive, with an explained approval
-fallback available only through a deliberate Settings action. Automatic
-security prompts are release-blocking.
+- **Supported:** macOS 14+ Apple silicon and Intel through the published 0.1.18
+  artifacts and their independent update feeds.
+- **Not released or supported:** Windows, Linux or Electron.
+- Homebrew support remains Apple silicon only; the Intel DMG is distributed
+  directly through the website and GitHub release.
 
-[PR #96](https://github.com/adamallcock/tibotattle/pull/96) makes native startup
-use the bounded primary projection and recover from readiness that arrives after
-the initial wait without retaining a stale timeout page. These entries describe
-merged source at the release-preparation base; they are not installed-artifact,
-hosted-deployment, updater, or stable-release evidence.
+The owner explicitly accepted the unavailable disposable-profile/manual Login
+Item matrix and formal physical Intel install/runtime/update/upload evidence
+**for 0.1.18 only**. These observations are waived, not passed. User-reported
+tester success is not a retained hardware-bound qualification receipt.
+See the [release-specific decision](./decisions/2026-09-05-release-0-1-18-manual-qualification-waiver.md)
+and [platform support authority](./reference/platform-support.md).
 
-## Public service
+Data preservation, exact source/artifact binding, native trust, updater
+integrity and unexpected automatic Keychain prompts were not waived.
+Fresh R7 evidence and both pinned-runtime checks were retained; the existing
+open resource decisions are not relabeled as `release_ready`. The supported
+paginated-history reset subset is documented in the
+[qualification review](./reviews/2026-09-04-paginated-export-qualification.md);
+physical-base continuations remain refused.
 
-The earlier 2026-08-31 `/api/health` observation returned HTTP 200 and source
-commit `304f3d736b6f9451d32a616bf3046ea628e828a3`. That deployment predates PR
-#94's device-continuity protocol. It can treat replay of one pairing identifier
-idempotently, but does not establish the fresh-pairing recovery protocol needed
-for an already registered local device.
+Private RC1, RC2 and RC3 candidates, the first pre-repair stable attempt, and
+compatible application/state recovery pairs remain preserved historical
+evidence. They are not the published stable bytes. Do not downgrade upgraded
+state by replacing only its application with an older writer.
 
-The Intel handoff recheck returned health/readiness HTTP 200, open enrollment,
-enabled v1.0 uploads and deployment source
-`b4c8f103bf697fb530434e6de196f2c187645661`. This supersedes the older identity
-observation, but does not independently qualify PR #89/94 migrations, device
-repair or optional v1.1 grants. Those routes and migrations require their own
-evidence. A later read-only inspection found 41 applied primary migrations,
-ending in historical `0041_community_model_composition_cache.sql`, not the
-different composition migration inherited by the candidate. Schema metadata
-confirms the historical column/table and absence of the new composition tables
-and withdrawal trigger. Both deletion-ledger migrations are applied. No
-configured staging database appears in the current account's database-name
-inventory. This is a forward-sequence repair requirement, not permission to
-rewrite the ledger or apply migrations; no live account upload was performed.
-The local reconciliation restores all 41 historical SQL files byte-identically
-to the deployed source and moves only the four unapplied successors to unique
-0042-0045 names, without SQL edits. Alternative applied histories still fail
-the unchanged ordered-prefix deployment gate.
+## Maintaining this snapshot
 
-## Published macOS release and updater
-
-GitHub's release API confirmed immutable stable release `v0.1.17`, published
-2026-09-03 at 19:47:43 UTC. Its exact source tag commit is
-`aa660b24a66196155ba59267ab832cc4ef6e1c7d`; its five assets are the Apple silicon
-DMG, appcast, release manifest, checksums and verification guide.
-
-The earlier public appcast observation advertised `0.1.16`. A fresh read during
-Intel implementation returned HTTP 403, as did the public health endpoint, so
-this document does not claim current feed or service state from that attempt.
-GitHub publication alone does not prove updater or website deployment.
-
-These observations prove public availability of the named release endpoints.
-They do not re-run code signing, notarization, Gatekeeper, clean-install, or
-update-install qualification. Use [verify-release.md](./verify-release.md) for
-artifact verification and the retained release receipts for their exact
-point-in-time evidence only.
-
-## Platform support
-
-- **Supported:** macOS 14 or later on Apple silicon, through the published
-  `v0.1.17` stable artifact described above.
-- **Not supported:** Intel macOS, Windows and Linux. Source, contract, or simulated lanes do
-  not establish an installed, signed, updateable product on those platforms.
-The complete qualification matrix and rules for changing these claims are in
-[platform-support.md](./reference/platform-support.md).
-
-## Release qualification and known boundaries
-
-- The subsequent [publication preparation](./plans/2026-09-04-release-0-1-18-publication-preparation.md)
-  closes two native qualification-tooling gaps: architecture/channel selection
-  and cross-target manual receipt reuse. Current v2 receipts bind inspected
-  source/payload and require explicit human-observed native hardware/OS; they
-  cannot turn synthetic tests into physical qualification. Local checks and
-  [combined RC2 signing/notarization](./receipts/2026-09-04-macos-combined-rc2-signed-candidates.md)
-  pass on their named source. Corrected parser v14 and its upgrade deadline now
-  have fresh [signed RC3 evidence](./receipts/2026-09-04-macos-combined-rc3-signed-candidates.md).
-  Final ARM installation, production installed-artifact checks, detailed
-  accounting and stopped-state preservation now pass; normal relaunch is observed.
-  The owner explicitly authorized publication and separately accepted the
-  [0.1.18-only manual/physical waiver](./decisions/2026-09-05-release-0-1-18-manual-qualification-waiver.md).
-  Those unavailable tests are waived, not passed; the 0.1.17 decision does not
-  carry forward. Follow the [current execution plan](./plans/2026-09-05-public-0-1-18-release.md)
-  for remaining stable-artifact, installed-stable, CI, publication and hosted gates.
-  No publication or update activation is claimed by this snapshot.
-
-- The [Intel implementation plan](./plans/2026-09-03-macos-intel-release.md)
-  records separate thin builds, architecture-specific update/publication
-  contracts and manifest-driven website availability. Native/Rosetta and Worker
-  checks passed on that Intel branch. Its owner-authorized R7 regeneration refreshed all ten receipts;
-  both pinned-runtime freshness checks pass. The final root run has 3,738 passes,
-  zero failures and 17 existing conditional skips. The
-  [Intel dogfood candidate](./receipts/2026-09-03-macos-intel-signed-candidate.md)
-  passes signing/notarization and local artifact checks for source `18c7065b`.
-  The combined Astra/Intel workload invalidates those inherited R7 receipts.
-  The owner-authorized [RC2 proof](./reviews/2026-09-04-release-0-1-18-rc2-build-proof.md)
-  passed optimized builds and isolated smokes on both architectures, but the
-  fresh R7 attempt refused paginated Codex history in resumable export source
-  planning. The [approved reset compatibility fix](./reviews/2026-09-04-paginated-export-qualification.md)
-  now passes focused tests; complete R7 regeneration and both runtime freshness
-  checks pass. Both optimized development artifacts, twelve isolated smokes,
-  the full root suite and all 108 retained macOS tests pass. RC2
-  allocation was `1025.1`, stable remains `1026`, and both signed
-  combined candidates pass exact-artifact and replacement checks in the
-  [RC2 receipt](./receipts/2026-09-04-macos-combined-rc2-signed-candidates.md). Physical Intel,
-  actual consented upload and installed update qualification remain separate
-  gates. No public Intel release, feed or website was published.
-
-- The [public-release plan](./plans/2026-09-03-public-0.1.17-release.md)
-  tracks final build `1024`, exact signed-artifact and prior-stable replacement
-  checks, immutable GitHub publication, Sparkle, and Homebrew independently.
-  Source preparation and a dated changelog are not publication evidence.
-- The accepted RC9 runtime has one manual Refresh for quota and detailed
-  accounting, quick startup/automatic checks, at-most-hourly automatic detailed
-  attempts, selected-plan Trends, retained authoritative snapshots, and the
-  measured accounting optimization. The
-  [performance receipt](./receipts/2026-09-03-optimized-rc9-accounting-comparison.md)
-  measures the accounting child, not end-to-end refresh latency.
-- PR #94's local qualification passed with the historical artifact refusal
-  explicitly recorded; the final candidate passes its strict cache validator. The
-  [local qualification receipt](./receipts/2026-09-03-pr94-account-plan-attribution-qualification.md)
-  binds the exact before, after, and final revisions to one immutable admitted
-  index. Its scope is accounting, attribution, calibration, and isolated-child
-  resources; it does not prove raw ingestion, account-exact identity, hosted
-  activation, or installed native lifecycle behavior.
-- The earlier 2026-08-31 raw-source attempt failed closed at
-  `codex_rollout_content_invalid` / `benchmark_cold_rebuild_incomplete` and
-  produced no comparison receipt. Later admitted-index qualification does not
-  relabel that attempt as passed or establish repair of its raw sources.
-- Retained dual-runtime R7 receipts were fully regenerated on the combined
-  source snapshot above and pass both pinned-runtime freshness checks. The earlier protected
-  [R7 attempt](./reviews/2026-09-04-release-0-1-18-rc2-build-proof.md)
-  completed six runtime profiles, then stopped at
-  `export_source_codex_rollout_checkpoint_history_unsupported`. The current
-  selected corpus genuinely declares paginated history. The approved ordinal-zero,
-  no-physical-base reset subset is implemented; the new complete
-  [R7 run](./reviews/2026-09-04-paginated-export-qualification.md#fresh-r7-evidence)
-  completed all ten validated receipts on frozen source. Actual physical-base
-  continuations remain refused.
-  Do not narrow the corpus or bypass the guard to obtain a receipt. Earlier
-  decisions remain
-  `release_open` with unresolved export resource ceilings; that expected state
-  is not a generic macOS release blocker. Receipt freshness is a separate gate,
-  and neither inherited files nor new synthetic tests establish fresh evidence.
-- Following the owner's 2026-09-03 confidence-based release direction, the full
-  clean-profile/physical Login Item matrix is deferred for 0.1.17, not passed.
-  The release still stops for data loss, invalid signatures or updater bytes,
-  and unexpected Keychain prompts. Isolated-profile and fake-manager smokes
-  do not establish the deferred manual evidence.
-- Hosted migrations/deployment, plan-transport consent activation, and repaired
-  device pairing remain separate. Website validator backport/deployment is
-  separately held; publishing the desktop must not deploy current-main Worker
-  code or mutate hosted data.
-- Remote health and availability can change after this snapshot. Public health
-  is not proof of every admin, identity, contribution, deletion, or updater path.
-
-## How to refresh this page
-
-Update each row from its own source of truth: exact Git commit, read-only public
-health response, public appcast bytes, and the GitHub release API. Record the
-observation date, preserve any disagreement, and never infer deployment or
-platform support from source alone. If the page cannot be refreshed in the same
-change as a material claim, narrow or remove the claim instead of carrying it
-forward.
+Update each boundary from exact source, artifact checks, read-only public
+responses, signed feed bytes and actual rendered behavior. Preserve any
+disagreement instead of inferring publication from a build, service recovery
+from health, or physical qualification from a simulated lane. The
+[documentation index](./README.md) and
+[release execution plan](./plans/2026-09-05-public-0-1-18-release.md) retain the
+implementation and historical qualification context.

--- a/docs/reference/platform-support.md
+++ b/docs/reference/platform-support.md
@@ -9,8 +9,8 @@ status: maintained
 
 This is the authority for public operating-system support claims. It defines
 what must be proven before a platform moves from source work to supported use.
-macOS 14+ on Apple silicon is supported. The 0.1.18 release adds Intel macOS
-14+ support on publication under the narrow, owner-approved
+macOS 14+ on Apple silicon and Intel is supported through the published 0.1.18
+release. Intel support is covered by the narrow, owner-approved
 [manual-qualification waiver](../decisions/2026-09-05-release-0-1-18-manual-qualification-waiver.md).
 This support declaration does not assert that the missing physical/manual
 tests passed. Windows and Linux remain unsupported; Electron is not a released
@@ -20,8 +20,8 @@ desktop surface.
 
 | Platform | Source and contract | Native/physical qualification | Install, trust, update, release | Public status |
 |---|---|---|---|---|
-| macOS 14+ arm64 | Implemented | Native macOS product and retained qualification paths; 0.1.18 disposable-profile/manual matrix explicitly waived, not passed | Existing stable support; 0.1.18 build 1026 must retain its own final native trust, update and publication evidence | **Supported** |
-| macOS 14+ x86_64 | Explicit thin Intel build, native broker, packaging and isolated updater contracts | Cross-compilation and Rosetta checks; formal physical Intel/manual matrix explicitly waived for 0.1.18, not passed | Signed/notarized RC3 verified locally; final stable 1026 trust, architecture-specific update and public-delivery gates remain required | **Supported from v0.1.18 publication under the release-specific waiver** |
+| macOS 14+ arm64 | Implemented | Native macOS product and retained qualification paths; 0.1.18 disposable-profile/manual matrix explicitly waived, not passed | Stable 0.1.18 / 1026 published with exact final native trust, installed refresh/restart, signed update feed and public-delivery checks | **Supported** |
+| macOS 14+ x86_64 | Explicit thin Intel build, native broker, packaging and isolated updater contracts | Cross-compilation and Rosetta checks; formal physical Intel/manual matrix explicitly waived for 0.1.18, not passed | Stable 0.1.18 / 1026 published with its own final native trust, independent signed update feed and public-delivery checks | **Supported under the release-specific waiver** |
 | Windows x64 | Portable core and fail-closed native filesystem/credential adapter exist | Partial qualification evidence; not a standing release gate | No supported signed installer, clean install/upgrade/uninstall receipt, updater, or stable artifact | **Unsupported** |
 | Linux x86_64 | Portable/core and container checks may run | Contract or container results are not physical desktop qualification | No supported signed package/repository, clean install/uninstall receipt, updater boundary, or stable artifact | **Unsupported** |
 


### PR DESCRIPTION
## Summary

- Replace dense quota partition sorting with indexed predecessor/successor seeks through the existing deployed index. Preserve exact plan-era and winning-source scope, run endpoints, nine bindings, eligibility thresholds and row limits.
- Materialize only reduced endpoints and hydrate wide records after the existing cap. No migration, consent, collection-control or attribution-version changes.
- Add exact tied-row/partition/era/cutoff/cap regression coverage and query-plan checks against a dense pre-reduction sort.
- Update maintained status and platform documentation to reflect the immutable 0.1.18 release, both verified macOS download/update lanes and the separately tracked hosted graph incident.

## Validation

- 51 owning Worker tests, TypeScript and whitespace checks pass.
- 20 repository preflight tests, documentation governance and architecture boundaries pass.
- Independent synthetic 1.28-million-row oracle matches all 200 typed endpoint rows. Final source uses approximately 5.26 MiB under an enforced 128 MiB SQLite heap cap. Source and read-only fixture hashes remain unchanged. This is local SQLite evidence, not a production D1 qualification claim.
- Complete frozen-source validation passes: 554 Worker tests across 43 files, 190 script checks, both sets of 27 package guards, generated mirrors, and all three fresh identical dry bundles. All three GitHub checks pass. Source remained clean and unchanged throughout.

## Release boundary

The already published v0.1.18 tag, signed desktop artifacts and feeds remain immutable. Hosted deployment preserves both current 0.1.18 download links. Natural scheduled rebuilds, preview recovery and the rendered public allowance graph will be verified after deployment. No raw telemetry or private operational receipts are included in this change.
