### PR TITLE
fix: restore fork model attribution and Astra labels for 0.1.19

### DIFF
--- a/apps/local/server.js
+++ b/apps/local/server.js
@@ -250,23 +250,24 @@ function openImmutableLocalUnifiedIndex(indexFile) {
   });
 }
 
-const COLD_REFRESH_V14_PREDECESSOR_PARSERS = Object.freeze([
+const COLD_REFRESH_V15_PREDECESSOR_PARSERS = Object.freeze([
   "unified-rollout-typed-v10",
   "unified-rollout-typed-v11",
   "unified-rollout-typed-v12",
   "unified-rollout-typed-v13",
+  "unified-rollout-typed-v14",
 ]);
 
 function publishedParserUpgradeNeedsColdRefresh(database, compatibility, schemaVersion) {
   // This is a deadline decision, not permission to read or publish facts. The
-  // worker still validates the complete index. Only reviewed v10 through v13
-  // predecessors can receive the v14 rescan window. Their physical schema and
+  // worker still validates the complete index. Only reviewed v10 through v14
+  // predecessors can receive the v15 rescan window. Their physical schema and
   // immutable source identity remain compatible; v12 nullable counters and
   // v13 ordinal-bearing compaction headers and v14 paginated setting boundaries
-  // require reparsing present sources.
+  // and v15 historical parent-model fallback require reparsing present sources.
   // Keep the target pinned too: a future parser needs an explicit review and
   // must not silently inherit this longer deadline for every mismatch.
-  if (LOCAL_UNIFIED_INDEX_PARSER_VERSION !== "unified-rollout-typed-v14"
+  if (LOCAL_UNIFIED_INDEX_PARSER_VERSION !== "unified-rollout-typed-v15"
       || schemaVersion !== LOCAL_UNIFIED_INDEX_SCHEMA_VERSION
       || !compatibility.metadataPresent
       || compatibility.formatUserVersion !== LOCAL_UNIFIED_INDEX_USER_VERSION
@@ -308,7 +309,7 @@ function publishedParserUpgradeNeedsColdRefresh(database, compatibility, schemaV
           AND g.tool_provenance_complete = 0)
       )
   `).get(generationId);
-  return COLD_REFRESH_V14_PREDECESSOR_PARSERS.includes(generation?.parser_version)
+  return COLD_REFRESH_V15_PREDECESSOR_PARSERS.includes(generation?.parser_version)
     && generation.parser_contract_version === TELEMETRY_SCHEMA_VERSION
     && generation.contract_version === TELEMETRY_SCHEMA_VERSION
     && Number.isSafeInteger(generation.completed_at_ms)

--- a/apps/local/server.test.mjs
+++ b/apps/local/server.test.mjs
@@ -351,11 +351,11 @@ test("refresh timeout classifier grants the cold window only to missing or prove
   }
 });
 
-test("published v10 v11 v12 v13 upgrades to v14 receive a cold deadline without extending current or uncertain state", async () => {
+test("published v10 v11 v12 v13 v14 upgrades to v15 receive a cold deadline without extending current or uncertain state", async () => {
   const root = await mkdtemp(join(tmpdir(), "local-timeout-parser-upgrade-"));
   // Deliberately pin the target: another parser release must review its
   // predecessor set, not silently keep passing a generic mismatch test.
-  assert.equal(LOCAL_UNIFIED_INDEX_PARSER_VERSION, "unified-rollout-typed-v14");
+  assert.equal(LOCAL_UNIFIED_INDEX_PARSER_VERSION, "unified-rollout-typed-v15");
   const fixtures = [
     { name: "complete", cold: true },
     { name: "quarantine-partial", cold: true, generation: {
@@ -367,7 +367,7 @@ test("published v10 v11 v12 v13 upgrades to v14 receive a cold deadline without 
     // Every fixture retains an older parser/generation row. Only publication
     // provenance may select the deadline, so this stays an ordinary refresh.
     { name: "current-with-old-history", parserVersion: LOCAL_UNIFIED_INDEX_PARSER_VERSION },
-    { name: "future", parserVersion: "unified-rollout-typed-v15" },
+    { name: "future", parserVersion: "unified-rollout-typed-v16" },
     { name: "unknown", parserVersion: "unknown-parser" },
     { name: "empty", parserVersion: "" },
     { name: "malformed-version", parserVersion: "unified-rollout-typed-v011" },
@@ -375,8 +375,9 @@ test("published v10 v11 v12 v13 upgrades to v14 receive a cold deadline without 
     { name: "partial-parser", parserVersion: "unified-rollout-typed-v10-partial" },
     { name: "v11-partial-parser", parserVersion: "unified-rollout-typed-v11-partial" },
     { name: "v12-partial-parser", parserVersion: "unified-rollout-typed-v12-partial" },
+    { name: "v14-partial-parser", parserVersion: "unified-rollout-typed-v14-partial" },
     { name: "v13-partial-parser", parserVersion: "unified-rollout-typed-v13-partial" },
-    { name: "current-partial-parser", parserVersion: "unified-rollout-typed-v14-partial" },
+    { name: "current-partial-parser", parserVersion: "unified-rollout-typed-v15-partial" },
     { name: "unreviewed-predecessor", parserVersion: "unified-rollout-typed-v9" },
     { name: "missing-publication", metadata: { current_generation_id: undefined } },
     { name: "unknown-publication", metadata: { current_generation_id: "99" } },
@@ -407,7 +408,7 @@ test("published v10 v11 v12 v13 upgrades to v14 receive a cold deadline without 
       .map((key) => ({ name: `incomplete-${key}`, generation: { [key]: 0 } })),
   ];
   try {
-    for (const predecessor of [10, 11, 12, 13]) {
+    for (const predecessor of [10, 11, 12, 13, 14]) {
       for (const fixture of fixtures) {
         const name = `v${predecessor}-${fixture.name}`;
         const indexFile = join(root, `${name}.sqlite`);

--- a/apps/web/public/app.js
+++ b/apps/web/public/app.js
@@ -5393,9 +5393,11 @@ function divergenceRangeContext(data) {
     ?? models[0]
     ?? null;
   const modelLabel = topModel === null ? null
-    : topModel.model === "unknown" || topModel.pricingStatus === "unrecognized"
-      ? t("accounting.model.unrecognized")
-      : formatModelName(topModel.model) || topModel.model;
+    : topModel.model === "unknown"
+      ? t("accounting.model.identityUnavailable")
+      : topModel.pricingStatus === "unrecognized"
+        ? t("accounting.model.unrecognized")
+        : formatModelName(topModel.model) || topModel.model;
   const bySpeed = accounting.bySpeed ?? {};
   const rankedSpeed = ["fast", "standard", "unknown"]
     .map((key) => [key, finite(bySpeed?.[key]?.events, 0)])
@@ -5539,7 +5541,7 @@ function divergencePeriodItem(period, rangeContext) {
 // exists to supply; an unavailable breakdown falls back to the range-level
 // context rather than pretending this window had none.
 function divergenceModelLabel(model) {
-  if (model === "unknown") return t("accounting.model.unrecognized");
+  if (model === "unknown") return t("accounting.model.identityUnavailable");
   return formatModelName(model) || model;
 }
 
@@ -10276,7 +10278,9 @@ function modelApiEquivalentCell(row) {
     // guessed one would be worse than none. Printing "$0.00" here read as a
     // priced zero, which is a different and untrue claim.
     setLocalizedText(cell, "accounting.model.notPricedUnknown");
-    cell.title = t("accounting.model.notPricedUnknownTitle");
+    cell.title = t(row.model === "unknown"
+      ? "accounting.model.identityUnavailableTitle"
+      : "accounting.model.notPricedUnknownTitle");
     return cell;
   }
   const amount = finite(row?.apiPriceEquivalentUsd);
@@ -10378,7 +10382,9 @@ function modelComponentRow(model, key, labelKey, totals) {
         : model.pricingStatus === "known_unpriced"
           ? "accounting.model.noPublishedPriceTitle"
           : model.pricingStatus === "unrecognized"
-            ? "accounting.model.notPricedUnknownTitle"
+            ? model.model === "unknown"
+              ? "accounting.model.identityUnavailableTitle"
+              : "accounting.model.notPricedUnknownTitle"
             : "accounting.model.componentCostWithheldTitle",
     );
     costShareCell = localizedNode(
@@ -10450,9 +10456,13 @@ function renderAccountingModels(accounting, { unavailable = false } = {}) {
   for (const model of page.rows) {
     const row = node("tr");
     const identity = node("td", "model-identity");
-    // "Unrecognized model" now means exactly one thing: an identifier this
-    // build has never reviewed, so it is withheld rather than printed.
-    if (model.model === "unknown" || model.pricingStatus === "unrecognized") {
+    // The unknown aggregate combines missing attribution and unreviewed
+    // identifiers. Its label must not claim either cause as established.
+    if (model.model === "unknown") {
+      const label = localizedNode("span", "", "accounting.model.identityUnavailable");
+      label.title = t("accounting.model.identityUnavailableTitle");
+      identity.append(label);
+    } else if (model.pricingStatus === "unrecognized") {
       identity.append(localizedNode("span", "", "accounting.model.unrecognized"));
     } else {
       // The wire identifier is what the provider reported and what any
@@ -10510,7 +10520,11 @@ function renderAccountingModels(accounting, { unavailable = false } = {}) {
             row.getAttribute("aria-expanded") === "true"
               ? "accounting.model.collapse"
               : "accounting.model.expand",
-            { model: formatModelName(model.model) },
+            { model: model.model === "unknown"
+              ? t("accounting.model.identityUnavailable")
+              : model.pricingStatus === "unrecognized"
+                ? t("accounting.model.unrecognized")
+                : formatModelName(model.model) },
           ),
         );
       };

--- a/apps/web/public/localization.js
+++ b/apps/web/public/localization.js
@@ -546,6 +546,8 @@ export const WEB_MESSAGES = Object.freeze({
   "accounting.sideChat.estimateRange": ["{point} ({lower}–{upper})", "{point}（{lower}–{upper}）", "{point} ({lower}–{upper})"],
   "accounting.model.noneInPeriod": ["No model usage in this period.", "此期间没有模型使用记录。", "No hay uso de modelos en este período."],
   "accounting.model.unavailable": ["Model usage accounting is unavailable; no zero usage is inferred.", "模型使用情况核算不可用；不会推断为零使用量。", "La contabilidad de uso por modelo no está disponible; no se infiere un uso cero."],
+  "accounting.model.identityUnavailable": ["Model unavailable", "模型不可用", "Modelo no disponible"],
+  "accounting.model.identityUnavailableTitle": ["The model was not recorded or was not recognized. No price is applied to this usage; it is not a zero.", "模型未记录或无法识别。此使用量不会应用价格；这不是零。", "El modelo no se registró o no se reconoció. No se aplica ningún precio a este uso; no es un cero."],
   "accounting.model.unrecognized": ["Unrecognized model", "无法识别的模型", "Modelo no reconocido"],
   "accounting.model.separateAllowanceChip": ["Separate allowance", "独立额度", "Cuota independiente"],
   // Deliberately a marker, not a figure. Spark is metered against its own

--- a/apps/web/public/ui-format.js
+++ b/apps/web/public/ui-format.js
@@ -365,6 +365,7 @@ export function formatAge(value) {
  * vendor does not use.
  */
 const MODEL_NAME_FRAGMENTS = Object.freeze({
+  astra: "Astra",
   auto: "Auto",
   claude: "Claude",
   codex: "Codex",

--- a/apps/web/test/model-display.test.mjs
+++ b/apps/web/test/model-display.test.mjs
@@ -1,0 +1,108 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+import { formatModelName, finite } from "../public/ui-format.js";
+import { translate, SUPPORTED_LOCALES } from "../public/localization.js";
+
+test("model names format Astra while preserving reviewed names and unknown identifiers", () => {
+  for (const [id, label] of [
+    ["gpt-6-astra", "GPT-6 Astra"],
+    ["gpt-5.6-sol", "GPT-5.6 Sol"],
+    ["gpt-5.6-terra", "GPT-5.6 Terra"],
+    ["gpt-5.6-luna", "GPT-5.6 Luna"],
+    ["gpt-5.3-codex-spark", "GPT-5.3 Codex Spark"],
+    ["codex-auto-review", "Codex Auto Review"],
+  ]) {
+    assert.equal(formatModelName(id), label, id);
+    assert.equal(formatModelName(` ${id.toUpperCase()} `), label, id);
+  }
+  assert.equal(formatModelName("gpt-5.6-sol-wm"), "GPT-5.6 Sol WM");
+  assert.equal(formatModelName("gpt-5.2-preview"), "GPT-5.2 Preview");
+  assert.equal(formatModelName("gpt-6-unreviewed"), "gpt-6-unreviewed");
+  assert.equal(formatModelName(null), "");
+});
+
+function element(tag, className = "", text = "") {
+  return {
+    tag, className, textContent: text, children: [], dataset: {}, attributes: {}, listeners: {},
+    classList: { add() {} },
+    append(...children) { this.children.push(...children); },
+    prepend(child) { this.children.unshift(child); },
+    setAttribute(key, value) { this.attributes[key] = value; },
+    getAttribute(key) { return this.attributes[key]; },
+    addEventListener(type, handler) { this.listeners[type] = handler; },
+  };
+}
+const contents = (node) => node.textContent + node.children.map(contents).join("");
+
+async function modelTable(locale) {
+  const source = await readFile(new URL("../public/app.js", import.meta.url), "utf8");
+  const body = element("tbody");
+  const t = (key, values) => translate(key, values, locale);
+  const environment = {
+    $: (selector) => selector === "#accounting-models" ? body : null,
+    clear: (node) => { node.children = []; },
+    node: element,
+    rawNode: element,
+    localizedNode: (tag, className, key, values) => element(tag, className, t(key, values)),
+    setRawText: (node, text) => { node.textContent = text; },
+    setLocalizedText: (node, key) => { node.textContent = t(key); },
+    t, finite, formatModelName,
+    formatSharePercent: (part, whole) => whole > 0 ? `${(part / whole * 100).toFixed(1)}%` : null,
+    formatCount: String,
+    formatApiMoney: (value) => `$${value.toFixed(2)}`,
+    formatPercent: (value) => `${value.toFixed(1)}%`,
+    accountingModelsTablePagination: {},
+    accountingExpandedModels: new Set(),
+    paginateCacheImpactRows: (rows) => ({ rows }),
+    cacheImpactTableSignature: () => "models",
+    renderCacheImpactPagination() {},
+    document: { createElementNS: (_namespace, tag) => element(tag) },
+  };
+  const start = source.indexOf("function modelUsageRows(accounting) {");
+  const end = source.indexOf("function fastModeCoverageSentence(", start);
+  assert.ok(start >= 0 && end > start);
+  const render = Function(...Object.keys(environment),
+    `${source.slice(start, end)}; return renderAccountingModels;`)(...Object.values(environment));
+  return { render, body, t };
+}
+
+test("model table preserves unavailable, unreviewed, separate-allowance and priced states in each locale", async () => {
+  for (const locale of SUPPORTED_LOCALES) {
+    const { render, body, t } = await modelTable(locale);
+    const rows = [
+      { model: "gpt-6-astra", pricingStatus: "priced", apiPriceEquivalentUsd: 5 },
+      { model: "unknown", pricingStatus: "unrecognized", apiPriceEquivalentUsd: 0 },
+      { model: "unreviewed", pricingStatus: "unrecognized", apiPriceEquivalentUsd: 0 },
+      { model: "gpt-5.3-codex-spark", pricingStatus: "known_unpriced", allowanceTrack: "spark", apiPriceEquivalentUsd: 0 },
+      { model: "codex-auto-review", pricingStatus: "known_unpriced", apiPriceEquivalentUsd: 0 },
+      { model: "gpt-5.5", pricingStatus: "priced", apiPriceEquivalentUsd: 0 },
+    ].map((row) => ({ events: 1, totalTokens: 10, components: { input_cache_read_tokens: 10 }, ...row }));
+    render({ modelUsage: rows, totalTokens: 50, apiPriceEquivalentUsd: 5 });
+    const modelRows = body.children.filter((row) => !row.dataset.componentOf);
+    const byName = (name) => modelRows.find((row) => contents(row.children[0]).replace("*", "") === name);
+    const astra = byName("GPT-6 Astra");
+    assert.equal(astra.children[0].children[1].title, "gpt-6-astra");
+    assert.equal(contents(astra.children[4]), "$5.00");
+    const unavailable = byName(t("accounting.model.identityUnavailable"));
+    assert.ok(unavailable, locale);
+    assert.equal(unavailable.children[0].children[1].title, t("accounting.model.identityUnavailableTitle"));
+    assert.equal(unavailable.children[4].title, t("accounting.model.identityUnavailableTitle"));
+    assert.equal(contents(unavailable.children[4]), t("accounting.model.notPricedUnknown"));
+    assert.equal(contents(unavailable.children[5]), t("accounting.model.shareWithheld"));
+    assert.equal(unavailable.attributes["aria-label"], t("accounting.model.expand", { model: t("accounting.model.identityUnavailable") }));
+    let prevented = false;
+    unavailable.listeners.keydown({ key: "Enter", preventDefault() { prevented = true; } });
+    assert.ok(prevented);
+    assert.equal(unavailable.attributes["aria-expanded"], "true");
+    assert.equal(unavailable.attributes["aria-label"], t("accounting.model.collapse", { model: t("accounting.model.identityUnavailable") }));
+    assert.equal(contents(byName(t("accounting.model.unrecognized")).children[4]), t("accounting.model.notPricedUnknown"));
+    assert.equal(contents(byName("GPT-5.3 Codex Spark").children[4]), t("accounting.model.separateAllowance"));
+    assert.equal(contents(byName("Codex Auto Review").children[4]), t("accounting.model.noPublishedPrice"));
+    assert.equal(contents(byName("GPT-5.5").children[4]), "$0.00");
+    render({ modelUsage: [] }, { unavailable: true });
+    assert.equal(contents(body), t("accounting.model.unavailable"));
+    render({ modelUsage: [] });
+    assert.equal(contents(body), t("accounting.model.noneInPeriod"));
+  }
+});

--- a/docs/README.md
+++ b/docs/README.md
@@ -15,6 +15,7 @@ an informal archive.
 
 | Area | Authority | Boundary |
 |---|---|---|
+| 0.1.19 patches | [Model attribution and labels](./plans/2026-09-06-v0.1.19-model-attribution-and-labels.md) | Prepared model-inheritance and display patches; private history conservation verified, release pending |
 | Status | [Current product and release status](./current-status.md) | Commit- and date-stamped source, live-service, published-release, updater, and support snapshot; reverify before relying on it later |
 | User help | [User guide](./user-guide.md) | Installation, first run, uncertainty, refresh/recovery, optional contribution, data, updates, and support |
 | Architecture | [System architecture](./reference/system-architecture.md) | Current components, trust boundaries, stores, identities, and data flow |

--- a/docs/plans/2026-09-06-v0.1.19-model-attribution-and-labels.md
+++ b/docs/plans/2026-09-06-v0.1.19-model-attribution-and-labels.md
@@ -1,0 +1,176 @@
+---
+title: v0.1.19 model attribution and display labels
+date: 2026-09-06
+type: plan
+status: patches-prepared
+---
+
+# v0.1.19 model attribution and display labels
+
+## Requested scope
+
+Queue the 0.1.18 “Unrecognized model” report and GPT-6 Astra display-name
+formatting for 0.1.19. The owner reports the unknown row in Last 7 days,
+Last 30 days, and All indexed time. This is a local release backlog entry;
+source patches are prepared and validation is recorded below. Release verification remains pending.
+
+## Verified diagnosis
+
+Read-only inspection of the installed 0.1.18 bundle and its live local index
+on 2026-09-06 established:
+
+- The screenshot's unknown usage-change count and all four token components
+  reconcile exactly to indexed `model_id = unknown` records. This is not
+  evidence of one additional model missing from the reviewed catalog.
+- Every physical source containing these unknown records is a paginated fork
+  with parent metadata but no `history_base`. All affected records carry the
+  installed v14 parser stamp, so this is not simply an older-parser cache.
+- Inspected source examples place unknown usage before the first
+  `turn_context` model declaration. Later declarations include GPT-5.6 Luna,
+  Terra, Sol, and Codex Auto Review; these later identities do not establish
+  which model produced the preceding copied history.
+- The installed v14 parser explicitly prevents paginated sources without an
+  exact history base from inheriting a logical parent's later model state.
+  Exact attribution requires evidence at the original usage boundary;
+  inferred attribution is a separate product policy, clarified below.
+- Recent unknown rows have no nonzero token components, while the nonzero
+  unknown token population ends on 2026-08-29 UTC. The reported Last 7 days
+  presentation still needs a rendered check; missing components must not be
+  described as proven zero usage.
+- `gpt-6-astra` already has a reviewed identity and the label `GPT-6 Astra`
+  in the installed model catalog. The UI formatter's
+  `MODEL_NAME_FRAGMENTS` omits `astra`, causing the raw identifier fallback.
+
+These findings are from the installed bundle, not this older local checkout.
+No app data was changed or reindexed. Private source paths, session identities,
+and raw conversation content are deliberately absent from this document.
+
+## Owner clarification: preserve the parent-model fallback
+
+The owner recalled the intended policy on 2026-09-06: assume a fork uses its
+parent's model unless a UI model selection or other explicit child-model
+declaration changes it. The initial queue entry overstated the need to leave
+all missing exact-history attribution unknown.
+
+Source verification confirms that commit `014380c75c33573b7fc4596b9c34b86a7d02783e`
+(2026-09-04), included in installed 0.1.18, removed the logical-parent fallback
+for paginated sources while retaining it for legacy inline forks. Previously,
+an unavailable exact-history model could fall back to the logical parent's
+carried model. The new `selectRolloutUsageSeed` deliberately returns unknown
+for a paginated source without a history base. Its tests protect against a
+parent's later model/tier changes rewriting earlier child usage.
+
+For 0.1.19, restore useful parent-model inheritance as an explicit assumption.
+Resolve the parent's model at the fork boundary for new child work, and at the
+original usage boundary for copied history where recoverable. Explicit child
+model selections override the inherited default from that point onward.
+Preserve inferred-versus-direct attribution internally; a missing exact
+`history_base` alone must not force an otherwise resolvable model to unknown.
+Do not reintroduce future-state leakage, inherit cumulative counters by this
+model-only rule, or treat model inheritance as proof of replay duplication.
+Recovery coverage against the real corpus remains to be measured.
+
+## Queued work and acceptance criteria
+
+1. Restore the parent-model fallback described above, with explicit child
+   selections taking precedence and a stable attribution basis. Quantify the
+   recovered model mix and residual unknown usage on a private index copy.
+2. Distinguish remaining unavailable attribution from unreviewed identifiers;
+   use clear copy such as “Model not recorded” only for unresolved cases.
+   Verify whether copied parent usage is already represented before admitting
+   it as additional usage. Neither the child's later model nor the parent's
+   later final model should rewrite earlier usage. Retain an explicit gap when
+   no applicable parent state can be established.
+3. Render `gpt-6-astra` as **GPT-6 Astra** everywhere the shared formatter is
+   used, keeping the wire identifier available on hover. Cover the reviewed
+   catalog labels to prevent another catalog/formatter mismatch.
+4. Exercise Last 7 days, Last 30 days, and All indexed time, including unknown
+   rows with missing components. Confirm period boundaries, row visibility,
+   totals, component counts, and pricing-coverage explanations.
+5. Use synthetic paginated-fork fixtures with and without an exact history
+   base, differing parent/child models, and copied-history replay. Validate
+   attribution/replay changes on a private copy of the real index before any
+   migration. Inspect the rendered model table in the candidate 0.1.19 app.
+
+## Implementation entry points
+
+- `apps/web/public/ui-format.js`: `formatModelName`, `MODEL_NAME_FRAGMENTS`.
+- `apps/web/public/app.js`: `renderAccountingModels` and model summary labels.
+- `apps/web/public/localization.js`: unknown-model labels and explanations.
+- `packages/telemetry-contract/src/model-catalog.js`: reviewed identity labels.
+- `src/local-unified-index-extract.js`: model carry and usage extraction.
+- `src/local-unified-index-ingest.js`: paginated lineage and replay admission.
+- `src/local-unified-index-history.js` in the integration source:
+  `selectRolloutUsageSeed` and exact-history resolution.
+- `src/local-unified-index.js`: parser provenance and indexed model identity.
+
+Implement against the current integration source: the inspected local `main`
+is divergent from `origin/main`. Preserve its existing work.
+
+
+## Patch preparation — 2026-09-07
+
+Prepared on `codex/0.1.19-model-attribution` from integration commit `7f515af9`.
+The original divergent checkout and live installed app/index were preserved.
+
+- Added a timestamp-bounded parent-model resolver to serial rebuild, worker
+  rebuild, and incremental refresh. Explicit applied UI model selections now
+  update model state; sparse records preserve it. The fallback changes model
+  attribution only, with per-event inherited provenance in parser v15 variants.
+- Reviewed the v14-to-v15 parser upgrade: same physical schema and immutable
+  source keys, present sources reparse, rotated source facts retain provenance,
+  and the foreground companion grants the existing bounded cold-refresh window.
+- The shared display formatter now includes the reviewed Astra name, with a
+  regression test. Directly importing the dashboard's complete catalog was
+  rejected by the public-site build boundary, so the formatter stays independent.
+  The collapsed `unknown` identity uses “Model unavailable” and explains that
+  its name was not recorded or not recognized. It cannot truthfully be split
+  into those causes without a separate accounting-contract change.
+- Replay suppression and token derivation were not changed. The real-history
+  audit compared the new extractor against the existing indexed events; it
+  does not claim a new independent audit of historical replay accounting.
+
+### Validation
+
+A read-only source snapshot and a private SQLite backup were checked with the
+patched production extractor and resolver. All 89,833 indexed records across
+807 affected sources matched at exact offsets, with unchanged timestamps and
+all nine nullable token columns. None of the 27,376 already-recognized records
+changed model. Every positive-input usage change in the reported unknown bucket
+was recovered. The two recovery routes were inherited parent models and
+explicit applied UI model selections. No model-catalog addition was needed.
+
+The same pinned snapshot was checked for all indexed time, the last 30 days,
+and the last seven days. The seven-day unknown population contained quota-only
+observations, with no positive-input usage. Missing token values remain missing.
+Exact private model totals are retained outside the repository.
+
+| Validation | Result |
+|---|---|
+| Core/index/compatibility/cache and parent resolver | 206 passed on final backend source |
+| Local companion | 305 passed |
+| Browser | 496 passed on final formatter patch |
+| Public site and preview | 29 passed on final formatter patch |
+| Architecture | Passed |
+| Documentation and preflight | Passed |
+| Full root suite | 3,888 tests: 3,856 passed, 11 failed, 21 skipped on initial combined patch |
+
+The full-suite failures were investigated rather than suppressed. Two test-file
+load failures were caused by missing locked Worker dependencies; after installing
+them, all seven affected tests passed. Six public-site tests exposed the catalog
+import regression, fixed by keeping the formatter independent. Two R7 tests
+correctly reject receipts bound to the previous workload-source hash: fresh
+release qualification remains required. The static tool-inventory failure was
+reproduced unchanged on integration base `7f515af9` (missing caller inventory for
+`apps/worker/scripts/generate-admin-ui-assets.mjs`). These three broader checks
+remain open; the full suite is not claimed green.
+
+Automatic approval review rejected serving real private usage aggregates for
+browser preview as unnecessary sensitive-data exposure. Visual verification used
+synthetic data instead: the English all-time expanded Astra table was visually
+inspected, and Spanish seven-day and Chinese thirty-day labels were checked in
+the browser accessibility tree. The temporary preview server was stopped. The separate private history audit uses no HTTP server.
+
+No live index migration, installation, publication, push, or release was made.
+Synthetic browser rendering and test builds do not qualify the installed
+0.1.19 app, release feed, or public deployment.

--- a/docs/reference/unified-index-schema.md
+++ b/docs/reference/unified-index-schema.md
@@ -3,7 +3,6 @@ title: Unified Local Index Schema
 date: 2026-08-27
 type: reference
 status: maintained
-last_verified_commit: 52399658
 ---
 
 # Unified local index schema
@@ -28,7 +27,7 @@ one another:
 | Stable filename | `local-unified-index-v1.sqlite` | Machine path continuity across app releases. |
 | Schema-family metadata | `local-unified-index-v2` | Logical family stored in `meta.schema_version`. |
 | SQLite `PRAGMA user_version` | `11` | Physical table/index/migration generation. |
-| Parser version | `unified-rollout-typed-v14` | Meaning and provenance of facts extracted from rollout sources, including ordinal-bearing compaction headers and settings pinned to paginated history boundaries. |
+| Parser version | `unified-rollout-typed-v15` | Meaning and provenance of facts extracted from rollout sources, including ordinal-bearing compaction headers and settings pinned to paginated history boundaries. |
 | Source identity version | `codex-immutable-rollout-v1` | Rules for physical rollout identity/generation. |
 
 The application id is a separate SQLite format guard. A file with the wrong
@@ -75,8 +74,9 @@ alongside both legacy header orders. It validates the bounded unsigned ordinal
 without decoding replacement history. The version change reparses present
 sources so earlier missed compaction boundaries can be recovered safely.
 
-Parser v14 isolates paginated settings from logical-parent state. An independent
-reset starts with unknown model, effort and tier; an anchored continuation uses
+Parser v14 introduced isolation of paginated settings from logical-parent state.
+Before the v15 model-only fallback below, an independent reset started with
+unknown model, effort and tier; an anchored continuation uses
 only its exact physical history boundary, including unknown values at that
 boundary. A parent's later final settings cannot fill those gaps. Resume keeps
 the segment's own cursor observations; inherited tier provenance may be
@@ -89,6 +89,28 @@ sources remain accounting evidence but cannot overwrite that head's settings;
 ambiguous heads do not supply inherited state. Legacy noncanonical singleton
 sources remain unambiguous. This interpretation change reparses present sources without
 changing physical schema 11 or relabeling rotated-source facts.
+
+Parser v15 adds the owner-approved model-only assumption for paginated forks
+without an exact history base. It looks up reviewed parent declarations at or
+before each usage timestamp, capped at the child's creation time. Copied history
+can therefore use the parent's original model switches; a later parent switch
+cannot rewrite new child work. Explicit child `turn_context.model` or applied
+UI `thread_settings.model` overrides the inherited default. Sparse declarations
+keep the default; custom/unreviewed selections block a previously reviewed model.
+An exact history base, including an unknown model, retains its prior semantics.
+Tier, effort, cumulative counters and replay admission are unchanged.
+
+The per-event parser stamps `unified-rollout-typed-v15-parent-model` and
+`unified-rollout-typed-v15-parent-model-partial` record the inherited assumption;
+other records retain the base and `-partial` v15 stamps. These suffixes
+identify the new fallback; they do not reclassify legacy inline inheritance.
+These are local provenance variants, not new physical schemas or telemetry
+fields. Cursor/generation stamps remain the base v15 so warm refresh does not
+mistake an assumed-model row for an obsolete parser. Model lookup retains at
+most 128 timelines of 4,096 transitions and traverses at most 128 ancestors.
+Missing/ambiguous parents, invalid metadata, clock regression and exceeded
+bounds leave the model unavailable. The resolver caches only reviewed identities
+and timestamps during one physically guarded discovery pass.
 
 Parser v12 additionally preserves omitted or null usage counters as SQL NULL,
 including the cumulative cursor carried across refreshes. Explicit zero remains
@@ -120,7 +142,7 @@ effort. No effective-effort carry is inferred across compaction, fork or resume.
 Actual application/eligible-mode and installed-client evidence remains a
 qualification gate, separate from catalogue recognition.
 
-The foreground companion treats verified published v10/v11/v12/v13-to-v14 parser
+The foreground companion treats verified published v10/v11/v12/v13/v14-to-v15 parser
 upgrades as cold work even when the physical schema is already 11. The target
 and predecessor set are deliberately closed; current, unknown, malformed and
 future parser evidence cannot obtain a longer deadline. That run receives the

--- a/docs/runbooks/unified-index-recovery.md
+++ b/docs/runbooks/unified-index-recovery.md
@@ -3,7 +3,6 @@ title: Unified Index Preservation and Recovery
 date: 2026-08-27
 type: runbook
 status: maintained
-last_verified_commit: 52399658
 ---
 
 # Unified index preservation and recovery
@@ -80,11 +79,11 @@ Compare the copy with the current constants in `src/local-unified-index.js`:
 
 - schema family `local-unified-index-v2`;
 - `user_version` 11;
-- parser `unified-rollout-typed-v14`; and
+- parser `unified-rollout-typed-v15`; and
 - source identity `codex-immutable-rollout-v1`.
 
 A physical schema-11 index can still need older-parser sources reparsed under
-v14. Still-present sources are rescanned; facts whose sources have rotated away
+v15. Still-present sources are rescanned; facts whose sources have rotated away
 retain their original parser provenance. Parser v12 preserves missing counters
 as unknown rather than zero, and v13 recognizes ordinal-bearing compaction
 headers. Parser v14 prevents paginated resets or unknown physical-base settings
@@ -95,13 +94,19 @@ Descendants also stop tier and replay-snapshot inheritance at the selected
 paginated history. A retired physical export remains counted but cannot replace
 the explicitly resolved logical head, regardless of scan order. Ambiguous heads
 do not supply inherited state.
+Parser v15 restores a model-only assumption for a fork without an exact base:
+use the parent's declaration at/before the usage and child-creation boundary,
+then let explicit child selections override it. Per-row `-parent-model` parser
+variants preserve this inferred provenance. It does not inherit tier, effort,
+counters or replay state; the safeguards above still apply to those fields.
+
 These interpretation changes do not change the physical schema or the
 `codex-immutable-rollout-v1` source-identity contract; never relabel retained
 facts to the new parser.
 
 The companion grants the bounded four-hour cold-refresh deadline only to the
-reviewed published v10/v11/v12/v13-to-v14 parser transitions. The target is pinned
-to v14; a future parser must review its predecessor set explicitly. Physical
+reviewed published v10/v11/v12/v13/v14-to-v15 parser transitions. The target is pinned
+to v15; a future parser must review its predecessor set explicitly. Physical
 schema, reader/writer compatibility, source identity, and telemetry contracts
 must match, and the published generation must be complete or one of the
 already supported quarantine/tool-provenance partial states. Only the current

--- a/src/cache-switch-impact.js
+++ b/src/cache-switch-impact.js
@@ -8,6 +8,8 @@ import { codexPrimaryAllowanceBasis } from "./codex-primary-allowance-basis.js";
 import {
   LOCAL_UNIFIED_INDEX_PARSER_VERSION,
   LOCAL_UNIFIED_INDEX_PARTIAL_PARSER_VERSION,
+  LOCAL_UNIFIED_INDEX_PARENT_MODEL_PARSER_VERSION,
+  LOCAL_UNIFIED_INDEX_PARENT_MODEL_PARTIAL_PARSER_VERSION,
   reasoningEffortName,
 } from "./local-unified-index.js";
 import {
@@ -255,7 +257,9 @@ function sameContinuityConfiguration(row) {
 
 function compactionAwareParser(value) {
   return value === LOCAL_UNIFIED_INDEX_PARSER_VERSION
-    || value === LOCAL_UNIFIED_INDEX_PARTIAL_PARSER_VERSION;
+    || value === LOCAL_UNIFIED_INDEX_PARTIAL_PARSER_VERSION
+    || value === LOCAL_UNIFIED_INDEX_PARENT_MODEL_PARSER_VERSION
+    || value === LOCAL_UNIFIED_INDEX_PARENT_MODEL_PARTIAL_PARSER_VERSION;
 }
 
 function componentsFor(row) {

--- a/src/local-cache-drop-thread-links.js
+++ b/src/local-cache-drop-thread-links.js
@@ -7,6 +7,8 @@ import {
   REASONING_EFFORTS,
   LOCAL_UNIFIED_INDEX_PARSER_VERSION,
   LOCAL_UNIFIED_INDEX_PARTIAL_PARSER_VERSION,
+  LOCAL_UNIFIED_INDEX_PARENT_MODEL_PARSER_VERSION,
+  LOCAL_UNIFIED_INDEX_PARENT_MODEL_PARTIAL_PARSER_VERSION,
 } from "./local-unified-index.js";
 import { readCodexLocalThreadMetadata } from "./platform/index.js";
 
@@ -22,6 +24,8 @@ const PERIODS = new Set(["24h", "7d", "30d", "all"]);
 const KINDS = new Set(["switch", "continuity"]);
 const CURRENT_PARSERS = new Set([
   LOCAL_UNIFIED_INDEX_PARSER_VERSION, LOCAL_UNIFIED_INDEX_PARTIAL_PARSER_VERSION,
+  LOCAL_UNIFIED_INDEX_PARENT_MODEL_PARSER_VERSION,
+  LOCAL_UNIFIED_INDEX_PARENT_MODEL_PARTIAL_PARSER_VERSION,
 ]);
 const EFFORTS = new Set(REASONING_EFFORTS.filter((value) => value !== "unknown"));
 const THREAD_ID = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/iu;

--- a/src/local-unified-index-build.js
+++ b/src/local-unified-index-build.js
@@ -18,6 +18,7 @@ import {
 } from "./local-unified-index-extract.js";
 import {
   createHistoryBaseSeedResolver,
+  createParentModelResolver,
   selectRolloutUsageSeed,
 } from "./local-unified-index-history.js";
 import { withStableRolloutSource } from "./rollout-source-snapshot.js";
@@ -714,6 +715,7 @@ export function createEventSink({
         tokensOutCombined: null,
         totalInputContext: null,
         partial: event.partial === true,
+        modelInherited: event.modelInherited === true,
       });
       add(source, "usageEvents");
       if (onCounts !== null && onCounts !== undefined
@@ -1249,6 +1251,7 @@ export async function rebuildLocalUnifiedIndex({
       seedTier: inheritedTierSeed(parentState.finalTier),
     };
   }
+  const parentModels = createParentModelResolver(infos, { maximumLineBytes, signal });
   const historySeeds = createHistoryBaseSeedResolver(infos, {
     maximumLineBytes,
     signal,
@@ -1309,6 +1312,8 @@ export async function rebuildLocalUnifiedIndex({
               deviceSalt,
               sessionLocalKey: state.sessionLocal,
             });
+            const parentModelAt = selectedSeed.seedModel === null
+              ? await parentModels.forSource(info) : null;
             const outcome = await withStableRolloutSource(info, (source) => (
               extractRolloutUsage(source, {
               size: Number(info.size ?? 0),
@@ -1323,6 +1328,7 @@ export async function rebuildLocalUnifiedIndex({
                 state.sessionLocal,
               ),
               ...selectedSeed,
+              parentModelAt,
               maximumLineBytes,
               signal,
               onEvent: (event) => sink.write(state, event),

--- a/src/local-unified-index-extract.js
+++ b/src/local-unified-index-extract.js
@@ -398,6 +398,7 @@ export async function extractRolloutUsage(path, {
   highWaterMark = 1024 * 1024,
   signal = null,
   onEvent,
+  parentModelAt = null,
   onBoundary = null,
   onTool = null,
 } = {}) {
@@ -409,6 +410,9 @@ export async function extractRolloutUsage(path, {
   }
   if (onTool !== null && typeof onTool !== "function") {
     throw new TypeError("onTool must be a function or null");
+  }
+  if (parentModelAt !== null && typeof parentModelAt !== "function") {
+    throw new TypeError("parentModelAt must be a function or null");
   }
   let currentModel = seedModel;
   let currentEffort = seedEffort;
@@ -457,6 +461,11 @@ export async function extractRolloutUsage(path, {
   // continuity lens compares positive-input requests, so only the next one is
   // a meaningful boundary.
   function emitUsage(event, rawUsage) {
+    if (event.model === null && parentModelAt !== null) {
+      event.model = parentModelAt(event.observedAtMs);
+      event.modelInherited = event.model !== null;
+    }
+    if (event.model === null) diagnostics.modelMissing += 1;
     const finish = () => {
       if ((compactionPending === null && !turnContextPending)
           || !positiveInput(rawUsage)) return;
@@ -701,6 +710,9 @@ export async function extractRolloutUsage(path, {
           diagnostics.malformedAccountingRecords += 1;
           return;
         }
+        // An explicit UI selection supersedes the inherited default. A later
+        // turn_context remains authoritative for its own turn.
+        if (typeof settings.model === "string") currentModel = settings.model;
         if (Object.hasOwn(settings, "service_tier")) {
           const raw = settings.service_tier;
           if (raw !== null && typeof raw !== "string") {
@@ -834,7 +846,6 @@ export async function extractRolloutUsage(path, {
       }
       if ((!usage || !(usage.input_tokens > 0 || usage.output_tokens > 0))
           && quota.length === 0) return;
-      if (currentModel === null) diagnostics.modelMissing += 1;
       return emitUsage({
         observedAtMs,
         sourceOffset: lineEndOffset,

--- a/src/local-unified-index-history.js
+++ b/src/local-unified-index-history.js
@@ -1,8 +1,15 @@
 import {
   extractRolloutUsage,
   inheritedTierSeed,
+  resolveLogicalRolloutHeads,
 } from "./local-unified-index-extract.js";
+import { reviewedModelIdentity } from "@app-usagemonitor/telemetry-contract";
+import { forEachRolloutLine, ROLLOUT_LINE_BYTES } from "./rollout-line-reader.js";
 import { withStableRolloutSource } from "./rollout-source-snapshot.js";
+
+const MODEL_CONTEXT_MARKER = Buffer.from('"turn_context"');
+const MODEL_SETTINGS_MARKER = Buffer.from('"thread_settings_applied"');
+const MODEL_META_MARKER = Buffer.from('"session_meta"');
 
 function fixedError(code) {
   const error = new Error(code);
@@ -34,6 +41,154 @@ export function selectRolloutUsageSeed(info, {
       : selected?.seedTier ?? null,
     seedTotals: selected?.seedTotals ?? null,
   };
+}
+
+/**
+ * Model-only fallback for forks without an exact history base. A parent's
+ * final cursor is not historical evidence: use its declarations at or before
+ * the event, capped at the child's creation time. Copied history therefore
+ * follows the original model switches, while later parent switches cannot
+ * change new child work. No counters, tier, effort or replay state is inherited.
+ *
+ * The cache retains only reviewed model IDs and timestamps, with explicit
+ * bounds on both timeline size and ancestry. It is scoped to one discovery
+ * snapshot; every read uses the same physical-source guard as normal ingest.
+ */
+export function createParentModelResolver(infos, {
+  maximumLineBytes = ROLLOUT_LINE_BYTES,
+  signal = null,
+} = {}) {
+  const heads = resolveLogicalRolloutHeads(infos);
+  const byRollout = new Map(infos.filter((info) => info.rolloutId)
+    .map((info) => [info.rolloutId, info]));
+  const cache = new Map();
+  const none = () => null;
+
+  async function timeline(info, end = info.size) {
+    const key = `${info.rolloutKey}\0${end}`;
+    if (cache.has(key)) {
+      const value = cache.get(key);
+      cache.delete(key);
+      cache.set(key, value);
+      return value;
+    }
+    const entries = [];
+    let createdAt = null;
+    let valid = true;
+    let lastDeclarationAt = -Infinity;
+    const read = await withStableRolloutSource(info, (source) => forEachRolloutLine(source, {
+      end: Number(end), maximumLineBytes, signal,
+      onLine(line, offset, partial) {
+        // Reject unrelated content as bytes before decoding the bounded header.
+        if (!line.includes(MODEL_CONTEXT_MARKER) && !line.includes(MODEL_SETTINGS_MARKER)
+            && !line.includes(MODEL_META_MARKER)) return;
+        // Inspect the bounded top-level header, never a marker in content.
+        const header = line.toString("utf8", 0, Math.min(line.length, 200));
+        if (!/^\{\s*"(?:timestamp|type|ordinal)"/.test(header)) return;
+        const type = header.match(/"type"\s*:\s*"(session_meta|turn_context|event_msg)"/u)?.[1];
+        if (!type) return;
+        if (type === "event_msg"
+            && !line.includes(MODEL_SETTINGS_MARKER)) return;
+        if (partial) { valid = false; return; }
+        let record;
+        try { record = JSON.parse(line.toString("utf8")); }
+        catch { valid = false; return; }
+        if (record.type !== type) return;
+        if (type === "session_meta") {
+          const timestamp = Date.parse(record.timestamp);
+          if (Number.isFinite(timestamp)) createdAt = timestamp;
+          return;
+        }
+        const payload = type === "turn_context" ? record.payload
+          : record.payload?.type === "thread_settings_applied"
+            ? record.payload.thread_settings : null;
+        if (!payload || !Object.hasOwn(payload, "model")) return;
+        if (typeof payload.model !== "string") { valid = false; return; }
+        const at = Date.parse(record.timestamp);
+        if (!Number.isFinite(at)) { valid = false; return; }
+        // A regressing clock cannot safely order settings against copied
+        // history. Refuse this timeline instead of dropping a later switch.
+        if (at < lastDeclarationAt) { valid = false; return; }
+        lastDeclarationAt = at;
+        // An explicit unreviewed selection blocks the previous known model.
+        const model = reviewedModelIdentity(payload.model)?.id ?? "unknown";
+        if (entries.at(-1)?.model === model && entries.at(-1).at <= at) return;
+        if (entries.length >= 4096) { valid = false; return; }
+        entries.push({ at, model, offset });
+      },
+    }));
+    if (read.aborted) signal?.throwIfAborted();
+    valid &&= !read.aborted && read.nextOffset === Number(end);
+    entries.sort((a, b) => a.at - b.at || a.offset - b.offset);
+    const value = { entries: valid ? entries : [], createdAt, valid };
+    cache.set(key, value);
+    if (cache.size > 128) cache.delete(cache.keys().next().value);
+    return value;
+  }
+
+  async function forSource(info) {
+    if (info.lineage?.historyMode !== "paginated"
+        || info.lineage.historyBase != null || !info.lineage.parentId) return none;
+    // Only the first complete metadata record is needed for the fork time.
+    // Do not reread the child's entire history merely to seed its first turn.
+    let createdAt = null;
+    await withStableRolloutSource(info, (source) => forEachRolloutLine(source, {
+      end: Math.min(Number(info.size), maximumLineBytes), maximumLineBytes, signal,
+      onLine(line, offset, partial) {
+        if (offset !== line.length + 1 || partial || !line.includes(MODEL_META_MARKER)) return;
+        const header = line.toString("utf8", 0, Math.min(line.length, 200));
+        if (!/"type"\s*:\s*"session_meta"/u.test(header)) return;
+        try {
+          const record = JSON.parse(line.toString("utf8"));
+          if (record.type === "session_meta" && typeof record.timestamp === "string") {
+            const at = Date.parse(record.timestamp);
+            if (Number.isFinite(at)) createdAt = at;
+          }
+        } catch { /* No reliable creation boundary: leave it unknown. */ }
+      },
+    }));
+    signal?.throwIfAborted();
+    if (createdAt === null) return none;
+    const chain = [];
+    const seen = new Set([info.rolloutKey]);
+    let parent = heads.get(info.lineage.parentId);
+    let end = parent?.size;
+    let ceiling = createdAt;
+    while (parent && chain.length < 128) {
+      if (seen.has(parent.rolloutKey)) return none;
+      seen.add(parent.rolloutKey);
+      const state = await timeline(parent, end);
+      if (!state.valid) return none;
+      chain.push({ entries: state.entries, ceiling });
+      const base = parent.lineage?.historyBase;
+      if (base != null) {
+        parent = byRollout.get(base.rolloutId);
+        end = base.endByteOffset;
+      } else {
+        if (state.createdAt === null) break;
+        ceiling = Math.min(ceiling, state.createdAt);
+        parent = heads.get(parent.lineage?.parentId);
+        end = parent?.size;
+      }
+    }
+    if (parent && chain.length === 128) return none;
+    return (observedAtMs) => {
+      if (!Number.isFinite(observedAtMs)) return null;
+      for (const { entries, ceiling: limit } of chain) {
+        const cutoff = Math.min(observedAtMs, limit);
+        let low = 0;
+        let high = entries.length;
+        while (low < high) {
+          const mid = (low + high) >>> 1;
+          if (entries[mid].at <= cutoff) low = mid + 1;
+          else high = mid;
+        }
+        if (low > 0) return entries[low - 1].model;
+      }
+      return null;
+    };
+  }
+  return Object.freeze({ forSource });
 }
 
 /**

--- a/src/local-unified-index-ingest.js
+++ b/src/local-unified-index-ingest.js
@@ -29,6 +29,7 @@ import {
 } from "./local-unified-index-build.js";
 import {
   createHistoryBaseSeedResolver,
+  createParentModelResolver,
   selectRolloutUsageSeed,
 } from "./local-unified-index-history.js";
 import { withStableRolloutSource } from "./rollout-source-snapshot.js";
@@ -1339,6 +1340,7 @@ export async function ingestLocalUnifiedIndexIncrement({
       }
       return chain;
     }
+    const parentModels = createParentModelResolver(infos, { maximumLineBytes, signal });
     const historySeeds = createHistoryBaseSeedResolver(infos, {
       maximumLineBytes,
       signal,
@@ -1569,6 +1571,8 @@ export async function ingestLocalUnifiedIndexIncrement({
               );
             }
           }
+          const parentModelAt = selectedSeed.seedModel === null
+            ? await parentModels.forSource(info) : null;
           const outcome = await withStableRolloutSource(info, (source) => (
             extractRolloutUsage(source, {
             size: Number(info.size ?? 0),
@@ -1584,6 +1588,7 @@ export async function ingestLocalUnifiedIndexIncrement({
               state.sessionLocal,
             ),
             ...selectedSeed,
+            parentModelAt,
             seedCompactionPending: resuming ? carriedCompaction(cursor) : null,
             seedTurnContextPending: resuming
               && carriedTurnContextPending(cursor),

--- a/src/local-unified-index-worker.js
+++ b/src/local-unified-index-worker.js
@@ -10,6 +10,7 @@ import {
 } from "./local-unified-index-extract.js";
 import {
   createHistoryBaseSeedResolver,
+  createParentModelResolver,
   selectRolloutUsageSeed,
 } from "./local-unified-index-history.js";
 import { withStableRolloutSource } from "./rollout-source-snapshot.js";
@@ -139,6 +140,7 @@ async function run() {
     const snapshots = createLineageSnapshots(shaped);
     const logicalHeads = resolveLogicalRolloutHeads(shaped);
     const finalBySessionId = new Map();
+    const parentModels = createParentModelResolver(shaped, { maximumLineBytes });
     const historySeeds = createHistoryBaseSeedResolver(shaped, {
       maximumLineBytes,
     });
@@ -239,8 +241,11 @@ async function run() {
         while (snapshotSeedKeys.length > batchEvents) {
           flush(source.rolloutKey, false, null);
         }
+        const parentModelAt = selectedSeed.seedModel === null
+          ? await parentModels.forSource(source) : null;
         const outcome = await withStableRolloutSource(source, (stableSource) => (
           extractRolloutUsage(stableSource, {
+          parentModelAt,
           size: source.size,
           isFork: source.isInlineFork === true,
           inheritedSnapshots: source.isInlineFork === true

--- a/src/local-unified-index.js
+++ b/src/local-unified-index.js
@@ -122,7 +122,10 @@ export const LEGACY_LOCAL_UNIFIED_INDEX_SCHEMA_VERSION =
 // physical boundary instead of reviving discarded logical-ancestor history.
 // Logical-parent state and ancestry are selected by resolved head, never by
 // dependency/scan order among retained physical generations of one thread.
-export const LOCAL_UNIFIED_INDEX_PARSER_VERSION = "unified-rollout-typed-v14";
+// v15 (2026-09-07): parent model declarations at/before the event and fork
+// boundary recover missing paginated-fork models. Explicit child selections
+// supersede the default. Counters, effort, tier and replay remain independent.
+export const LOCAL_UNIFIED_INDEX_PARSER_VERSION = "unified-rollout-typed-v15";
 export const LOCAL_UNIFIED_INDEX_SOURCE_IDENTITY_VERSION =
   "codex-immutable-rollout-v1";
 
@@ -133,7 +136,14 @@ export const LOCAL_UNIFIED_INDEX_SOURCE_IDENTITY_VERSION =
 // degraded row is recorded. Kept in lockstep with the main constant: salvaged
 // rows run the same delta derivation.
 export const LOCAL_UNIFIED_INDEX_PARTIAL_PARSER_VERSION =
-  "unified-rollout-typed-v14-partial";
+  "unified-rollout-typed-v15-partial";
+
+// Per-row provenance variants retain the inherited-model assumption without
+// changing the physical schema. Ingest cursors keep the base v15 stamp.
+export const LOCAL_UNIFIED_INDEX_PARENT_MODEL_PARSER_VERSION =
+  "unified-rollout-typed-v15-parent-model";
+export const LOCAL_UNIFIED_INDEX_PARENT_MODEL_PARTIAL_PARSER_VERSION =
+  "unified-rollout-typed-v15-parent-model-partial";
 
 export const LOCAL_UNIFIED_INDEX_APPLICATION_ID = 0x554d5549;
 const INDEX_APPLICATION_ID = LOCAL_UNIFIED_INDEX_APPLICATION_ID;
@@ -2440,9 +2450,13 @@ export function createUnifiedIndexWriter(database, {
         event.observedAtMs,
         event.generationId ?? generationId,
         ingestRunId,
-        event.partial
-          ? internParserVersion(LOCAL_UNIFIED_INDEX_PARTIAL_PARSER_VERSION)
-          : defaultParserVersionId,
+        event.modelInherited
+          ? internParserVersion(event.partial
+            ? LOCAL_UNIFIED_INDEX_PARENT_MODEL_PARTIAL_PARSER_VERSION
+            : LOCAL_UNIFIED_INDEX_PARENT_MODEL_PARSER_VERSION)
+          : event.partial
+            ? internParserVersion(LOCAL_UNIFIED_INDEX_PARTIAL_PARSER_VERSION)
+            : defaultParserVersionId,
         event.sourceId ?? null,
         event.sourceOffset ?? null,
         event.sessionLocal,

--- a/test/codex-usage-compatibility.test.js
+++ b/test/codex-usage-compatibility.test.js
@@ -77,7 +77,7 @@ test("missing cache components remain null; explicit zero remains observed acros
     const refreshed = await ingestLocalUnifiedIndexIncrement({ ...options, indexFile: incremental });
     assert.equal(refreshed.sourcesReparsedForParserVersion, 1);
     assert.deepEqual(rows(incremental), expected);
-    assert.equal(LOCAL_UNIFIED_INDEX_PARSER_VERSION, "unified-rollout-typed-v14");
+    assert.equal(LOCAL_UNIFIED_INDEX_PARSER_VERSION, "unified-rollout-typed-v15");
   } finally { await rm(value.root, { recursive: true }); }
 });
 

--- a/test/local-cache-drop-thread-links.test.js
+++ b/test/local-cache-drop-thread-links.test.js
@@ -8,6 +8,8 @@ import {
 } from "../src/local-cache-drop-thread-links.js";
 import {
   LOCAL_UNIFIED_INDEX_PARSER_VERSION,
+  LOCAL_UNIFIED_INDEX_PARENT_MODEL_PARSER_VERSION,
+  LOCAL_UNIFIED_INDEX_PARENT_MODEL_PARTIAL_PARSER_VERSION,
   openLocalUnifiedIndex,
   readUnifiedIndexGenerationDescriptor,
   reasoningEffortOrdinal,
@@ -553,5 +555,18 @@ test("switch rows preserve exact prior Max/Ultra labels rather than adopting con
   for (const row of rows) {
     assert.equal(result.entries.find((entry) => entry.key === cacheDropThreadLookupKey("switch", row))?.thread.id,
       row.previous.reasoningEffort === "max" ? ROOT : THIRD);
+  }
+});
+
+
+test("inherited-model provenance retains exact cache-drop thread links", async (t) => {
+  const f = await fixture(t);
+  for (const version of [LOCAL_UNIFIED_INDEX_PARENT_MODEL_PARSER_VERSION,
+    LOCAL_UNIFIED_INDEX_PARENT_MODEL_PARTIAL_PARSER_VERSION]) {
+    f.database.prepare("UPDATE parser_version SET parser_version = ? WHERE id = 1").run(version);
+    const result = await f.run();
+    assert.equal(result.status, "available");
+    assert.equal(result.entries.length, 2);
+    assert.deepEqual(result.entries.map((entry) => entry.thread.id), [ROOT, WORKER]);
   }
 });

--- a/test/local-parent-model-fallback.test.js
+++ b/test/local-parent-model-fallback.test.js
@@ -1,0 +1,304 @@
+import assert from "node:assert/strict";
+import { appendFile, mkdtemp, rm, stat, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+
+import { extractRolloutUsage } from "../src/local-unified-index-extract.js";
+import {
+  createHistoryBaseSeedResolver,
+  createParentModelResolver,
+  selectRolloutUsageSeed,
+} from "../src/local-unified-index-history.js";
+
+const timestamp = (second) => new Date(Date.UTC(2026, 8, 1, 0, 0, second)).toISOString();
+const at = (second) => Date.parse(timestamp(second));
+const meta = (second, extra = {}) => ({
+  timestamp: timestamp(second), type: "session_meta", payload: {}, ...extra,
+});
+const context = (second, model, extra = {}) => ({
+  timestamp: timestamp(second), type: "turn_context",
+  payload: { ...(model === undefined ? {} : { model }), ...extra },
+});
+const settings = (second, model, extra = {}) => ({
+  timestamp: timestamp(second), type: "event_msg",
+  payload: { type: "thread_settings_applied", thread_settings: { model, ...extra } },
+});
+const usage = (input) => ({
+  input_tokens: input, cached_input_tokens: 0, cache_write_input_tokens: 0,
+  output_tokens: 0, reasoning_output_tokens: 0, total_tokens: input,
+});
+const tokens = (second, input) => ({
+  timestamp: timestamp(second), type: "event_msg",
+  payload: {
+    type: "token_count",
+    info: { total_token_usage: usage(input), last_token_usage: usage(10) },
+  },
+});
+
+async function fixture(t) {
+  const root = await mkdtemp(join(tmpdir(), "parent-model-fallback-"));
+  t.after(() => rm(root, { recursive: true, force: true }));
+  return async (name, records, lineage = {}, overrides = {}) => {
+    const path = join(root, `${name}.jsonl`);
+    const body = records.map((record) => typeof record === "string"
+      ? record : JSON.stringify(record)).join("\n") + "\n";
+    await writeFile(path, body);
+    const info = await stat(path);
+    return {
+      path, ...info, rolloutKey: name, rolloutId: name, resolvedHead: true,
+      lineage: {
+        sessionId: name, parentId: null, historyMode: "paginated", historyBase: null,
+        ...lineage,
+      },
+      ...overrides,
+    };
+  };
+}
+
+async function extract(info, options = {}) {
+  const events = [];
+  const outcome = await extractRolloutUsage(info.path, {
+    size: info.size, ...options, onEvent: (event) => { events.push(event); },
+  });
+  return { events, outcome };
+}
+
+test("parent fallback follows copied history and freezes at the child creation time", async (t) => {
+  const source = await fixture(t);
+  const parent = await source("parent", [
+    meta(0), context(1, "gpt-5.6-luna"), context(5, "gpt-5.6-terra"),
+    settings(20, "gpt-5.6-sol"),
+  ]);
+  const child = await source("child", [meta(10)], { parentId: "parent" });
+  const modelAt = await createParentModelResolver([parent, child]).forSource(child);
+  assert.equal(modelAt(at(0)), null);
+  assert.equal(modelAt(at(2)), "gpt-5.6-luna");
+  assert.equal(modelAt(at(6)), "gpt-5.6-terra");
+  assert.equal(modelAt(at(30)), "gpt-5.6-terra");
+  assert.equal(modelAt(Number.NaN), null);
+});
+
+test("ordinal-first paginated metadata supplies creation time and model changes", async (t) => {
+  const source = await fixture(t);
+  const parent = await source("parent", [
+    { ordinal: 0, ...meta(0) }, { ordinal: 1, ...context(1, "gpt-5.6-luna") },
+  ]);
+  const child = await source("child", [{ ordinal: 0, ...meta(10) }], { parentId: "parent" });
+  const modelAt = await createParentModelResolver([parent, child]).forSource(child);
+  assert.equal(modelAt(at(11)), "gpt-5.6-luna");
+});
+
+test("settings key order and a subtype beyond the header limit preserve explicit model switches", async (t) => {
+  const source = await fixture(t);
+  const parent = await source("parent", [
+    meta(0), context(1, "gpt-5.6-luna"), {
+      timestamp: timestamp(2), type: "event_msg",
+      payload: {
+        thread_settings: { model: "gpt-5.6-sol", padding: "x".repeat(256) },
+        type: "thread_settings_applied",
+      },
+    },
+  ]);
+  const child = await source("child", [meta(10)], { parentId: "parent" });
+  const modelAt = await createParentModelResolver([parent, child]).forSource(child);
+  assert.equal(modelAt(at(11)), "gpt-5.6-sol");
+});
+
+test("out-of-order model timestamps invalidate the timeline instead of losing a repeated declaration", async (t) => {
+  const source = await fixture(t);
+  const parent = await source("parent", [
+    meta(0), context(1, "gpt-5.6-luna"), context(10, "gpt-5.6-luna"),
+    context(5, "gpt-5.6-sol"),
+  ]);
+  const child = await source("child", [meta(20)], { parentId: "parent" });
+  const modelAt = await createParentModelResolver([parent, child]).forSource(child);
+  assert.equal(modelAt(at(6)), null);
+  assert.equal(modelAt(at(11)), null);
+});
+
+test("explicit child selection overrides fallback, sparse settings preserve it, and custom selection blocks it", async (t) => {
+  const source = await fixture(t);
+  const parent = await source("parent", [meta(0), context(1, "gpt-5.6-luna")]);
+  const child = await source("child", [
+    meta(10), tokens(11, 10), context(12, undefined, { effort: "high" }),
+    tokens(13, 20), context(14, "gpt-5.6-terra"), tokens(15, 30),
+    settings(16, "gpt-5.6-sol"), tokens(17, 40),
+    settings(18, "custom-local-model"), tokens(19, 50),
+    context(20, undefined), tokens(21, 60),
+  ], { parentId: "parent" });
+  const parentModelAt = await createParentModelResolver([parent, child]).forSource(child);
+  const { events } = await extract(child, { parentModelAt });
+  assert.deepEqual(events.map((event) => event.model), [
+    "gpt-5.6-luna", "gpt-5.6-luna", "gpt-5.6-terra", "gpt-5.6-sol",
+    "custom-local-model", "custom-local-model",
+  ]);
+  assert.deepEqual(events.map((event) => event.modelInherited === true), [
+    true, true, false, false, false, false,
+  ]);
+});
+
+test("an explicit custom parent selection blocks older reviewed ancestry", async (t) => {
+  const source = await fixture(t);
+  const grandparent = await source("grandparent", [meta(0), context(1, "gpt-5.6-sol")]);
+  const parent = await source("parent", [meta(2), context(3, "custom-local-model")], {
+    parentId: "grandparent",
+  });
+  const child = await source("child", [meta(10)], { parentId: "parent" });
+  const modelAt = await createParentModelResolver([grandparent, parent, child]).forSource(child);
+  assert.equal(modelAt(at(11)), "unknown");
+});
+
+test("a parent without its own model inherits its ancestor only through its creation boundary", async (t) => {
+  const source = await fixture(t);
+  const grandparent = await source("grandparent", [
+    meta(0), context(1, "gpt-5.6-luna"), context(5, "gpt-5.6-sol"),
+  ]);
+  const parent = await source("parent", [meta(2)], { parentId: "grandparent" });
+  const child = await source("child", [meta(10)], { parentId: "parent" });
+  const modelAt = await createParentModelResolver([grandparent, parent, child]).forSource(child);
+  assert.equal(modelAt(at(11)), "gpt-5.6-luna");
+});
+
+test("missing parents, ambiguous selected heads, and ancestry cycles do not inherit", async (t) => {
+  const source = await fixture(t);
+  const child = await source("child", [meta(10)], { parentId: "parent" });
+  const parent = await source("parent", [meta(0), context(1, "gpt-5.6-luna")]);
+  const duplicate = await source("duplicate", [meta(0), context(1, "gpt-5.6-sol")], {
+    sessionId: "parent",
+  });
+  for (const infos of [
+    [child], [parent, duplicate, child],
+    [{ ...parent, lineage: { ...parent.lineage, parentId: "child" } }, child],
+  ]) {
+    const modelAt = await createParentModelResolver(infos).forSource(child);
+    assert.equal(modelAt(at(11)), null);
+  }
+});
+
+test("malformed and oversized relevant parent metadata fail closed", async (t) => {
+  const source = await fixture(t);
+  const child = await source("child", [meta(10)], { parentId: "parent" });
+  for (const [index, record] of [
+    '{"timestamp":"2026-09-01T00:00:02.000Z","type":"turn_context","payload":',
+    context(2, "gpt-5.6-sol", { padding: "x".repeat(1024) }),
+    { ...context(2, "gpt-5.6-sol"), timestamp: "invalid-time" },
+    context(2, 123),
+  ].entries()) {
+    const parent = await source(`parent-${index}`, [meta(0), context(1, "gpt-5.6-luna"), record], {
+      sessionId: "parent",
+    });
+    const modelAt = await createParentModelResolver([parent, child], {
+      maximumLineBytes: 512,
+    }).forSource(child);
+    assert.equal(modelAt(at(11)), null);
+  }
+});
+
+test("absent or malformed child creation metadata does not inherit", async (t) => {
+  const source = await fixture(t);
+  const parent = await source("parent", [meta(0), context(1, "gpt-5.6-luna")]);
+  for (const [index, records] of [
+    [], [{ ...meta(10), timestamp: "invalid-time" }],
+    ['{"timestamp":"2026-09-01T00:00:10.000Z","type":"session_meta","payload":'],
+  ].entries()) {
+    const child = await source(`child-${index}`, records, { parentId: "parent" });
+    const modelAt = await createParentModelResolver([parent, child]).forSource(child);
+    assert.equal(modelAt(at(11)), null);
+  }
+});
+
+test("fallback changes only model attribution, preserving tokens, counters, effort and tier", async (t) => {
+  const source = await fixture(t);
+  const parent = await source("parent", [
+    meta(0), context(1, "gpt-5.6-luna", { effort: "high" }),
+    settings(2, "gpt-5.6-luna", { service_tier: "priority" }), tokens(3, 900),
+  ]);
+  const child = await source("child", [meta(10), tokens(11, 10), tokens(12, 25)], { parentId: "parent" });
+  const parentModelAt = await createParentModelResolver([parent, child]).forSource(child);
+  const before = await extract(child);
+  const after = await extract(child, { parentModelAt });
+  assert.deepEqual(after.outcome, {
+    ...before.outcome,
+    diagnostics: { ...before.outcome.diagnostics, modelMissing: 0 },
+  });
+  assert.equal(before.outcome.diagnostics.modelMissing, 2);
+  assert.deepEqual(after.events.map(({ model, modelInherited, ...event }) => event),
+    before.events.map(({ model, modelInherited, ...event }) => event));
+  assert.ok(after.events.every((event) => event.reasoningEffort === null && event.tier === null));
+  assert.equal(after.outcome.finalTotals.total_tokens, 25);
+});
+
+test("resuming at a complete event retains inherited model attribution deterministically", async (t) => {
+  const source = await fixture(t);
+  const parent = await source("parent", [meta(0), context(1, "gpt-5.6-luna")]);
+  const child = await source("child", [
+    meta(10), tokens(11, 10), context(12, undefined), tokens(13, 20),
+    settings(14, "gpt-5.6-sol"), tokens(15, 30), tokens(16, 40),
+  ], { parentId: "parent" });
+  const parentModelAt = await createParentModelResolver([parent, child]).forSource(child);
+  const whole = await extract(child, { parentModelAt });
+  for (const index of [0, 1, 2]) {
+    const prefix = await extract(child, { parentModelAt, size: whole.events[index].sourceOffset });
+    const resumed = await extract(child, {
+      parentModelAt,
+      startOffset: prefix.outcome.read.nextOffset,
+      seedModel: prefix.outcome.finalModel,
+      seedEffort: prefix.outcome.finalEffort,
+      seedTier: prefix.outcome.finalTier,
+      seedTotals: prefix.outcome.finalTotals,
+      seedCompactionPending: prefix.outcome.finalCompactionPending,
+      seedTurnContextPending: prefix.outcome.finalTurnContextPending,
+      seedTurnContextSeen: prefix.outcome.finalTurnContextSeen,
+    });
+    assert.deepEqual([...prefix.events, ...resumed.events], whole.events);
+    assert.equal(resumed.outcome.finalModel, whole.outcome.finalModel);
+    assert.deepEqual(resumed.outcome.finalTotals, whole.outcome.finalTotals);
+  }
+});
+
+test("exact history bases retain their existing model and counter seed without logical fallback", async (t) => {
+  const source = await fixture(t);
+  const base = await source("base", [meta(0), context(1, "gpt-5.6-terra"), tokens(2, 50)]);
+  const parent = await source("parent", [meta(0), context(1, "gpt-5.6-luna")]);
+  const child = await source("child", [meta(10)], {
+    parentId: "parent",
+    historyBase: { rolloutId: "base", endByteOffset: base.size, endOrdinalExclusive: 3 },
+  });
+  const infos = [base, parent, child];
+  const modelAt = await createParentModelResolver(infos).forSource(child);
+  assert.equal(modelAt(at(11)), null);
+  const historySeed = await createHistoryBaseSeedResolver(infos).resolveSeed(child);
+  const selected = selectRolloutUsageSeed(child, {
+    historySeed, logicalSeed: { seedModel: "gpt-5.6-luna" },
+  });
+  assert.equal(selected.seedModel, "gpt-5.6-terra");
+  assert.equal(selected.seedTotals.total_tokens, 50);
+});
+
+test("parent physical history traversal excludes declarations after its exact byte boundary", async (t) => {
+  const source = await fixture(t);
+  const records = [meta(0), context(1, "gpt-5.6-luna")];
+  const prefixSize = Buffer.byteLength(records.map(JSON.stringify).join("\n") + "\n");
+  const base = await source("base", [...records, context(5, "gpt-5.6-sol")]);
+  const parent = await source("parent", [meta(7)], {
+    historyBase: { rolloutId: "base", endByteOffset: prefixSize, endOrdinalExclusive: 2 },
+  });
+  const child = await source("child", [meta(10)], { parentId: "parent" });
+  const modelAt = await createParentModelResolver([base, parent, child]).forSource(child);
+  assert.equal(modelAt(at(11)), "gpt-5.6-luna");
+});
+
+test("resolver reads only the discovery snapshot and rejects replaced parent contents", async (t) => {
+  const source = await fixture(t);
+  const parent = await source("parent", [meta(0), context(1, "gpt-5.6-luna")]);
+  const child = await source("child", [meta(10)], { parentId: "parent" });
+  await appendFile(parent.path, JSON.stringify(context(5, "gpt-5.6-sol")) + "\n");
+  const modelAt = await createParentModelResolver([parent, child]).forSource(child);
+  assert.equal(modelAt(at(11)), "gpt-5.6-luna");
+  await writeFile(parent.path, "{}\n");
+  await assert.rejects(
+    createParentModelResolver([parent, child]).forSource(child),
+    { code: "codex_rollout_source_changed" },
+  );
+});

--- a/test/local-unified-index.test.js
+++ b/test/local-unified-index.test.js
@@ -1909,6 +1909,10 @@ for (const history of ["reset", "anchored-null"]) {
           tokenCount("2026-07-25T01:00:01.000Z", usage(50, 5), usage(50, 5)),
         ],
       });
+      // A reset now inherits the parent's historical model only. The exact
+      // all-null base still remains unknown; later Astra never rewrites either.
+      const seedRow = { ...UNKNOWN_PAGINATED_SEED_ROW,
+        model: history === "reset" ? "gpt-5.6-sol" : "unknown" };
       const indexFile = join(root, "index.sqlite");
       const ingest = () => ingestLocalUnifiedIndexIncrement({
         codexHome: root,
@@ -1924,7 +1928,15 @@ for (const history of ["reset", "anchored-null"]) {
         if (pipeline !== "incremental") {
           assert.equal(initial.modelSeededFromLineage, 0);
         }
-        assert.deepEqual(paginatedSeedRows(indexFile), [UNKNOWN_PAGINATED_SEED_ROW]);
+        assert.deepEqual(paginatedSeedRows(indexFile), [seedRow]);
+        const provenance = openLocalUnifiedIndex(indexFile, { readOnly: true });
+        try {
+          const stamp = provenance.prepare(`SELECT p.parser_version
+            FROM usage_event u JOIN parser_version p ON p.id = u.parser_version_id
+            WHERE u.observed_at_ms = ?`).get(Date.parse("2026-07-25T01:00:01.000Z"));
+          assert.equal(stamp.parser_version, history === "reset"
+            ? "unified-rollout-typed-v15-parent-model" : LOCAL_UNIFIED_INDEX_PARSER_VERSION);
+        } finally { provenance.close(); }
 
         if (pipeline !== "incremental") return;
 
@@ -1938,8 +1950,8 @@ for (const history of ["reset", "anchored-null"]) {
         assert.equal(resumed.sourcesResumed, 2);
         assert.equal(resumed.insertedUsageEvents, 2);
         const unknownRows = [
-          UNKNOWN_PAGINATED_SEED_ROW,
-          { ...UNKNOWN_PAGINATED_SEED_ROW, input: 30, output: 3 },
+          seedRow,
+          { ...seedRow, input: 30, output: 3 },
         ];
         assert.deepEqual(paginatedSeedRows(indexFile), unknownRows);
 
@@ -1968,7 +1980,7 @@ for (const history of ["reset", "anchored-null"]) {
         const raw = openLocalUnifiedIndex(indexFile, { readOnly: false });
         try {
           raw.prepare(
-            "UPDATE parser_version SET parser_version = 'unified-rollout-typed-v13'",
+            "UPDATE parser_version SET parser_version = replace(parser_version, 'v15', 'v13')",
           ).run();
         } finally {
           raw.close();


### PR DESCRIPTION
## Summary

Restore the model-only parent fallback for paginated forks without an exact history base. Resolve parent declarations at or before the usage and fork boundary, then let explicit child model selections override them. Applied UI model selections now update attribution as well. Preserve inferred-model provenance without changing token counters, replay admission, tier, effort, or the physical index schema.

Prepare parser v15 refresh/reparse handling for 0.1.19. Format `gpt-6-astra` as **GPT-6 Astra**, and label unresolved identity as **Model unavailable** with an explanatory tooltip in all three supported languages.

## Validation

- 206 core/index/compatibility/cache/resolver tests passed.
- 305 local companion tests, 496 browser tests, and 29 public-site/preview tests passed.
- Architecture, documentation, and 20 preflight tests passed.
- Synthetic browser rendering inspected. A local private-copy comparison preserved exact source offsets, timestamps, nullable token components, and already-recognized model assignments while recovering the reported unknown attribution.
- Both exported patches applied cleanly to integration base `7f515af9` and matched the prepared source byte-for-byte.

The complete root suite was run. Remaining failures are the two retained R7 receipt checks invalidated by the changed workload-source hash, and a static tool-inventory failure reproduced on the unchanged integration base. Initial dependency and public-site import failures were resolved and their affected suites rerun successfully. No tests or release guards were weakened.

This merges source for the 0.1.19 queue; it does not qualify or publish a release, install an app, or migrate the live index. Fresh R7 qualification remains a release gate. The durable plan and validation record are in `docs/plans/2026-09-06-v0.1.19-model-attribution-and-labels.md`.
