### PR TITLE
Retain Trends history and expanded details during refresh

### DIFF
--- a/apps/web/public/app.js
+++ b/apps/web/public/app.js
@@ -5386,6 +5386,55 @@ function renderResidualInspectionTable() {
 // panel has a stable target for its toggle's `aria-controls`.
 let nextDivergenceBreakdownId = 0;
 
+// Display-only state for the detector's bounded set of visible windows. Index
+// revisions refresh details without changing a window's identity; a changed
+// population or contributor mix cannot inherit another window's answer.
+const divergenceDetails = new Map();
+const MAX_DIVERGENCE_DETAILS = 20;
+
+function divergenceDetailScope(data) {
+  const scope = data?.timeline?.planScoped?.planScope;
+  return JSON.stringify([
+    data?.mode,
+    data?.allowancePlanSelection?.planType ?? null,
+    scope?.planType ?? null,
+    scope?.methodVersion ?? null,
+    scope?.basisFamilyId ?? null,
+    scope?.cohortId ?? null,
+  ]);
+}
+
+function divergenceDetailKey(period, scope) {
+  return JSON.stringify([scope, period.startMs, period.endMs, period.contributors]);
+}
+
+function prepareDivergenceDetails(data, periods) {
+  const scope = divergenceDetailScope(data);
+  const generation = data?.accounting?.generation;
+  const planScope = data?.timeline?.planScoped?.planScope;
+  const revision = generation == null && !planScope?.sourceGeneration
+    ? data
+    : JSON.stringify([generation, data?.accounting?.generationFingerprint,
+      planScope?.sourceGeneration, planScope?.sourceGenerationFingerprint]);
+  const retained = new Set();
+  for (const period of periods.slice(0, MAX_DIVERGENCE_DETAILS)) {
+    const key = divergenceDetailKey(period, scope);
+    retained.add(key);
+    let state = divergenceDetails.get(key);
+    if (!state) {
+      state = { key, expanded: false, breakdown: null, loadedRevision: null,
+        pending: false, render: null, load: null };
+      divergenceDetails.set(key, state);
+    }
+    state.revision = revision;
+    state.local = ["local", "real_local_evidence"].includes(data?.mode);
+  }
+  for (const key of divergenceDetails.keys()) {
+    if (!retained.has(key)) divergenceDetails.delete(key);
+  }
+  return scope;
+}
+
 function divergenceRangeContext(data) {
   const accounting = accountingPeriod(data);
   if (!accounting) return null;
@@ -5426,7 +5475,7 @@ function divergenceSpeedLabel(key) {
  * magnitude, and the contributor mix (exact per-period totals plus range-level
  * model/speed context).
  */
-function divergencePeriodItem(period, rangeContext) {
+function divergencePeriodItem(period, rangeContext, state) {
   const item = node(
     "li",
     `divergence-period ${period.direction === "under_costed"
@@ -5503,27 +5552,49 @@ function divergencePeriodItem(period, rangeContext) {
   panel.id = breakdownId;
   panel.hidden = true;
 
-  let loadState = "idle";
+  const renderBreakdown = () => {
+    if (state.breakdown !== null || !state.pending) {
+      renderDivergenceBreakdown(panel, state.breakdown, rangeContext);
+    } else {
+      clear(panel);
+      panel.append(localizedNode(
+        "p",
+        "divergence-breakdown-status",
+        "divergence.breakdown.loading",
+      ));
+    }
+  };
+  state.render = renderBreakdown;
   const loadBreakdown = async () => {
-    if (loadState === "loaded" || loadState === "loading") return;
-    loadState = "loading";
-    clear(panel);
-    panel.append(localizedNode(
-      "p",
-      "divergence-breakdown-status",
-      "divergence.breakdown.loading",
-    ));
+    if (!state.local || state.pending
+        || state.loadedRevision === state.revision) return;
+    const revision = state.revision;
+    state.pending = true;
+    renderBreakdown();
     let breakdown = null;
     try {
       breakdown = await localClient.windowBreakdown(period.startMs, period.endMs);
     } catch {
       breakdown = null;
     }
-    loadState = "loaded";
-    renderDivergenceBreakdown(panel, breakdown, rangeContext);
+    state.pending = false;
+    if (divergenceDetails.get(state.key) !== state) return;
+    if (state.revision !== revision) {
+      if (state.expanded) state.load();
+      return;
+    }
+    if (breakdown?.status === "available") {
+      state.breakdown = breakdown;
+      state.loadedRevision = revision;
+    }
+    // Failed refreshes never erase a successful answer or mark failure as
+    // loaded. Reopening or the next dashboard refresh can try again.
+    state.render();
   };
+  state.load = loadBreakdown;
   toggle.addEventListener("click", () => {
     const open = toggle.getAttribute("aria-expanded") === "true";
+    state.expanded = !open;
     toggle.setAttribute("aria-expanded", open ? "false" : "true");
     setLocalizedText(
       toggle,
@@ -5532,7 +5603,14 @@ function divergencePeriodItem(period, rangeContext) {
     panel.hidden = open;
     if (!open) loadBreakdown();
   });
+  toggle.setAttribute("aria-expanded", String(state.expanded));
+  setLocalizedText(toggle, state.expanded
+    ? "divergence.breakdown.hide" : "divergence.breakdown.show");
+  panel.hidden = !state.expanded;
+  renderBreakdown();
+  if (state.expanded) loadBreakdown();
 
+  state.toggle = toggle;
   item.append(toggle, panel);
   return item;
 }
@@ -5647,11 +5725,14 @@ function renderDivergencePeriods(data, points) {
   const summary = $("#divergence-summary");
   const caveat = $("#divergence-caveat");
   if (!list || !empty || !summary) return;
+  const focusedKey = [...divergenceDetails.values()]
+    .find((state) => state.toggle === document.activeElement)?.key;
   clear(list);
 
   const result = detectDeviationPeriods(points, {
     usageBuckets: data?.timeline?.usage ?? [],
   });
+  const detailScope = prepareDivergenceDetails(data, result.periods);
 
   if (!result.periods.length) {
     list.hidden = true;
@@ -5698,8 +5779,11 @@ function renderDivergencePeriods(data, points) {
   }
 
   const rangeContext = divergenceRangeContext(data);
-  for (const period of result.periods) {
-    list.append(divergencePeriodItem(period, rangeContext));
+  for (const period of result.periods.slice(0, MAX_DIVERGENCE_DETAILS)) {
+    const key = divergenceDetailKey(period, detailScope);
+    const state = divergenceDetails.get(key);
+    list.append(divergencePeriodItem(period, rangeContext, state));
+    if (key === focusedKey) state.toggle.focus({ preventScroll: true });
   }
 }
 

--- a/apps/web/test/divergence-retention.test.mjs
+++ b/apps/web/test/divergence-retention.test.mjs
@@ -1,0 +1,176 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+
+const source = await readFile(new URL("../public/app.js", import.meta.url), "utf8");
+const start = source.indexOf("let nextDivergenceBreakdownId = 0;");
+const end = source.indexOf("// A tick label's resolution", start);
+assert.ok(start >= 0 && end > start);
+
+function deferred() {
+  let resolve;
+  const promise = new Promise((done) => { resolve = done; });
+  return { promise, resolve };
+}
+const settle = () => new Promise((resolve) => setImmediate(resolve));
+const period = (startMs = 100) => ({
+  startMs, endMs: startMs + 100, startAt: "start", endAt: "end",
+  durationMs: 100, direction: "under_costed", absPeakDriftPp: 2,
+  peakDriftPp: 2, signedAucPpHours: 1,
+  contributors: { costUsd: 2, totalTokens: 100, usageEvents: 1,
+    unpricedEventShare: 0, unpricedEvents: 0 },
+});
+const snapshot = (generation = "1", planType = "pro", mode = "local") => ({
+  mode, accounting: { generation }, allowancePlanSelection: { planType },
+  timeline: { usage: [], planScoped: { planScope: {
+    planType, cohortId: "synthetic", methodVersion: "plan-era-v1", basisFamilyId: "basis",
+    sourceGeneration: generation, sourceGenerationFingerprint: `fingerprint-${generation}`,
+  } } },
+});
+const result = (model = "gpt-6-astra") => ({
+  status: "available", costUsd: 2, byModel: [{ model, costUsd: 2 }],
+  bySpeed: {}, fastCostUsd: 0, unpricedShare: 0,
+});
+
+function harness() {
+  const document = { activeElement: null };
+  class Element {
+    constructor(tag, className = "", text = "") {
+      this.tag = tag; this.className = className; this.text = text;
+      this.children = []; this.attributes = new Map(); this.listeners = new Map();
+    }
+    append(...items) { this.children.push(...items); }
+    setAttribute(key, value) { this.attributes.set(key, String(value)); }
+    getAttribute(key) { return this.attributes.get(key); }
+    addEventListener(key, listener) { this.listeners.set(key, listener); }
+    click() { this.listeners.get("click")(); }
+    focus() { document.activeElement = this; }
+    get textContent() { return this.text + this.children.map((child) => child.textContent).join(""); }
+  }
+  const elements = new Map(["list", "empty", "summary", "caveat"]
+    .map((key) => [`#divergence-${key}`, new Element("div")]));
+  const requests = [];
+  const node = (...args) => new Element(...args);
+  const translate = (key, values = {}) => `${key} ${Object.values(values).join(" ")}`;
+  const dependencies = {
+    document, node, rawNode: node,
+    localizedNode: (tag, cls, key, values) => node(tag, cls, translate(key, values)),
+    setLocalizedText: (element, key, values) => { element.text = translate(key, values); },
+    setLocalizedPluralText: () => {},
+    clear: (element) => { element.children = []; element.text = ""; },
+    $: (id) => elements.get(id), t: translate,
+    detectDeviationPeriods: (periods) => ({ periods, totalFound: periods.length }),
+    accountingPeriod: () => null,
+    localClient: { windowBreakdown(from, to) {
+      const request = { from, to, ...deferred() }; requests.push(request); return request.promise;
+    } },
+  };
+  for (const name of ["formatChartTimestamp", "formatSpanLength", "formatPp",
+    "formatSignedPp", "formatSignedPpHours", "formatApiMoney", "compact",
+    "formatPercent", "formatNumber", "formatModelName"]) dependencies[name] = String;
+  const api = Function(...Object.keys(dependencies), `${source.slice(start, end)}
+    return { render: renderDivergencePeriods, state: divergenceDetails };`
+  )(...Object.values(dependencies));
+  return { ...api, requests, document,
+    toggle: () => elements.get("#divergence-list").children[0].children.at(-2),
+    panel: () => elements.get("#divergence-list").children[0].children.at(-1),
+  };
+}
+
+test("expanded details and keyboard focus survive unchanged snapshots without another request", async () => {
+  const h = harness();
+  h.render(snapshot(), [period()]);
+  h.toggle().click(); h.toggle().focus();
+  h.requests[0].resolve(result()); await settle();
+  assert.match(h.panel().textContent, /gpt-6-astra/);
+  h.render(snapshot(), [period()]);
+  assert.equal(h.toggle().getAttribute("aria-expanded"), "true");
+  assert.equal(h.document.activeElement, h.toggle());
+  assert.equal(h.panel().hidden, false);
+  assert.match(h.panel().textContent, /gpt-6-astra/);
+  assert.equal(h.requests.length, 1);
+});
+
+test("new revisions refresh behind retained details and failed refreshes can retry", async () => {
+  const h = harness(); h.render(snapshot(), [period()]); h.toggle().click();
+  h.requests[0].resolve(result()); await settle();
+  h.render(snapshot("2"), [period()]);
+  assert.match(h.panel().textContent, /gpt-6-astra/);
+  h.requests[1].resolve({ status: "unavailable" }); await settle();
+  assert.match(h.panel().textContent, /gpt-6-astra/);
+  h.toggle().click(); h.toggle().click();
+  assert.equal(h.requests.length, 3);
+  h.requests[2].resolve(result("gpt-5.6-sol")); await settle();
+  assert.match(h.panel().textContent, /gpt-5.6-sol/);
+});
+
+test("initial failure retries and a superseded response cannot replace the current revision", async () => {
+  const h = harness(); h.render(snapshot(), [period()]); h.toggle().click();
+  h.requests[0].resolve(null); await settle();
+  assert.match(h.panel().textContent, /unavailablePlain/);
+  h.toggle().click(); h.toggle().click();
+  h.render(snapshot("2"), [period()]);
+  assert.equal(h.requests.length, 2, "one pending request per window");
+  h.requests[1].resolve(result("old")); await settle();
+  assert.equal(h.requests.length, 3);
+  assert.doesNotMatch(h.panel().textContent, /old/);
+  h.requests[2].resolve(result("current")); await settle();
+  assert.match(h.panel().textContent, /current/);
+});
+
+test("different windows, evidence, plan cohorts and demo do not inherit pending or successful details", async () => {
+  for (const change of [
+    { data: snapshot(), periods: [period(200)] },
+    { data: snapshot(), periods: [{ ...period(), contributors: { ...period().contributors, costUsd: 3 } }] },
+    { data: snapshot("1", "plus"), periods: [period()] },
+    { data: { ...snapshot(), timeline: { planScoped: { planScope: { ...snapshot().timeline.planScoped.planScope, cohortId: "another" } } } }, periods: [period()] },
+    { data: snapshot("1", "pro", "demo"), periods: [period()] },
+  ]) {
+    const h = harness(); h.render(snapshot(), [period()]); h.toggle().click();
+    h.render(change.data, change.periods);
+    h.requests[0].resolve(result("old")); await settle();
+    assert.equal(h.toggle().getAttribute("aria-expanded"), "false");
+    assert.doesNotMatch(h.panel().textContent, /old/);
+    if (change.data.mode === "demo") {
+      h.toggle().click(); assert.equal(h.requests.length, 1);
+    }
+  }
+});
+
+test("retention is bounded to displayed windows and discarded when no periods remain", () => {
+  const h = harness();
+  h.render(snapshot(), Array.from({ length: 25 }, (_, i) => period(100 * i)));
+  assert.equal(h.state.size, 20);
+  h.render(snapshot(), [period(999)]);
+  assert.equal(h.state.size, 1);
+  h.render(snapshot(), []);
+  assert.equal(h.state.size, 0);
+});
+
+
+test("installed companion real-local mode loads details and changed accounting fingerprint refreshes", async () => {
+  const h = harness();
+  const data = snapshot("1", "pro", "real_local_evidence");
+  data.accounting.generationFingerprint = "first";
+  h.render(data, [period()]); h.toggle().click();
+  assert.equal(h.requests.length, 1);
+  h.requests[0].resolve(result("original")); await settle();
+  h.render({ ...data, accounting: { ...data.accounting, generationFingerprint: "second" } }, [period()]);
+  assert.equal(h.requests.length, 2);
+  assert.match(h.panel().textContent, /original/);
+  h.requests[1].resolve(result("updated")); await settle();
+  assert.match(h.panel().textContent, /updated/);
+});
+
+test("collapsing a pending superseded revision keeps the reopened window retryable", async () => {
+  const h = harness(); h.render(snapshot(), [period()]); h.toggle().click();
+  h.render(snapshot("2"), [period()]);
+  h.toggle().click();
+  h.requests[0].resolve(result("superseded")); await settle();
+  assert.equal(h.requests.length, 1);
+  h.toggle().click();
+  assert.equal(h.requests.length, 2);
+  assert.doesNotMatch(h.panel().textContent, /superseded/);
+  h.requests[1].resolve(result("current")); await settle();
+  assert.match(h.panel().textContent, /current/);
+});

--- a/docs/plans/2026-09-06-v0.1.19-model-attribution-and-labels.md
+++ b/docs/plans/2026-09-06-v0.1.19-model-attribution-and-labels.md
@@ -193,3 +193,32 @@ indexing and an unavailable lookup, then changed its name while preserving the
 UUID after a successful refresh. This is source/browser validation, not an
 installed 0.1.19 or native handoff result. The earlier model-attribution patches
 were merged separately in [PR #107](https://github.com/adamallcock/tibotattle/pull/107).
+
+## Trends retention follow-up — 2026-09-07
+
+The same refresh review found two related gaps in installed 0.1.18:
+
+- `overview.timeline.planScoped` was missing from the companion's retained
+  projection surfaces. A partial build could preserve usage and allowance
+  capacity while dropping the selected-plan numerator and comparison intervals,
+  causing Trends to reject the comparison.
+- The divergence list recreated every expandable period on each dashboard
+  render. Expansion and successfully loaded model/speed details were discarded;
+  an unavailable lookup was also treated as permanently loaded for that row.
+
+Retain the plan-specific history only with its matching capacity scope, using
+the existing deferred/non-authoritative projection rule. Preserve current
+accounting truth fields and fresh quota observations. Authoritative empty
+results still replace prior history. Retain expanded detail results only for
+unchanged windows and compatible selected-plan context; refresh in the
+background, retry failed lookups, and fence stale responses. This is bounded
+transient UI reuse for the details and the existing snapshot-retention contract
+for the chart data, not a new persistent cache.
+
+Prepared follow-up validation: 507 browser tests, 317 local companion tests,
+20 preflight checks, documentation governance, and architecture checks passed.
+The companion regression also invokes the actual Trends plan selector after
+retention and confirms that the comparison stays available. A synthetic browser
+check using the production detail renderer kept an expanded result visible
+during refresh and failure, then updated the model mix without collapsing it.
+No installed-app replacement or release publication is implied.

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -99,7 +99,10 @@ Trends compares the selected plan's compatible usage and quota history. Earlier
 history on another plan does not disable a usable current-plan fit, and it is
 not borrowed into that fit. Ambiguous intervals and plan transitions remain
 gaps. Unresolved speed uses the labelled Standard scenario, without pretending
-that Standard speed was observed.
+that Standard speed was observed. During refresh, its last compatible plan-specific
+history stays visible with the retained calibration. Expanded model/speed details
+for unchanged periods stay open and keep their last successful result while
+updated details load; temporary lookup failures do not erase that result.
 
 Do not repeatedly relaunch during a detailed pass; that can make progress appear
 to restart even when source data is intact.

--- a/src/local-companion-data.js
+++ b/src/local-companion-data.js
@@ -3770,6 +3770,23 @@ const PROJECTION_SURFACES = Object.freeze([
     path: Object.freeze(["overview", "timeline", "allowanceCapacity"]),
     rows: availableStatusRows,
   },
+  {
+    path: Object.freeze(["overview", "timeline", "planScoped"]),
+    rows: availableStatusRows,
+    // Selected-plan Trends needs the scoped numerator and quota intervals as
+    // well as the fitted capacity. Retain them only with the exact matching
+    // capacity scope, after the capacity's own retention step above.
+    canRetain: (incoming, previous) => {
+      const scope = previous.planScoped?.planScope;
+      const capacity = incoming.allowanceCapacity;
+      return capacity?.status === "available"
+        && scope?.methodVersion === PLAN_SCOPED_ATTRIBUTION_METHOD_VERSION
+        && scope.methodVersion === capacity.planScope?.methodVersion
+        && ["planType", "basisFamilyId", "cohortId", "sourceGeneration",
+          "sourceGenerationFingerprint"].every((key) => scope[key] != null
+            && scope[key] === capacity.planScope?.[key]);
+    },
+  },
 ]);
 
 // Resolve a registered path, or null if any segment is absent. Absence is not
@@ -4021,13 +4038,14 @@ export class LocalCompanionDataStore {
     const retained = this.#snapshot;
     if (retained === null) return next;
     let usageEvidenceRetained = false;
-    for (const { path, rows, preserveIncomingKeys = [], retainSiblingKeys = [] }
+    for (const { path, rows, preserveIncomingKeys = [], retainSiblingKeys = [], canRetain = null }
       of PROJECTION_SURFACES) {
       const key = path[path.length - 1];
       const nextParent = surfaceParent(next, path);
       const retainedParent = surfaceParent(retained, path);
       if (nextParent === null || retainedParent === null) continue;
-      if (rows(nextParent[key]) === 0 && rows(retainedParent[key]) > 0) {
+      if (rows(nextParent[key]) === 0 && rows(retainedParent[key]) > 0
+          && (canRetain === null || canRetain(nextParent, retainedParent))) {
         const incoming = nextParent[key];
         const replacement = structuredClone(retainedParent[key]);
         for (const incomingKey of preserveIncomingKeys) {

--- a/test/local-companion-data.test.js
+++ b/test/local-companion-data.test.js
@@ -3370,5 +3370,90 @@ test("every surface a withheld projection empties is registered for retention", 
     "overview.timeline.sparkUsage",
     "overview.timeline.calibrationUsage",
     "overview.timeline.allowanceCapacity",
+    "overview.timeline.planScoped",
   ]);
+});
+
+
+test("Trends retains plan-scoped history through refresh only with its matching capacity", async (t) => {
+  const scope = {
+    methodVersion: "plan-era-v1", planType: "pro", basisFamilyId: "synthetic-basis",
+    cohortId: "a".repeat(64), sourceGeneration: 35,
+    sourceGenerationFingerprint: "synthetic-generation-35",
+  };
+  const available = {
+    schemaVersion: "local-plan-scoped-accounting-timeline-v1",
+    status: "available", reason: null, encoding: "plan_bucket_v1", planScope: scope,
+    usage: [[Date.parse("2026-09-07T11:45:00.000Z"), 1,
+      1000, 0, 0, 0, 0, 0, 4, 4, 8, 0, 0, 1, 0, 1000]],
+    quota: [[Date.parse("2026-09-07T11:45:00.000Z"),
+      Date.parse("2026-09-08T00:00:00.000Z") / 1000, 30]],
+    comparisonIntervals: [[Date.parse("2026-09-07T11:45:00.000Z"),
+      Date.parse("2026-09-07T12:00:00.000Z")]],
+  };
+  const unavailable = {
+    schemaVersion: available.schemaVersion, status: "unavailable",
+    reason: "plan_scoped_timeline_unavailable", planScope: null,
+    usage: [], quota: [], comparisonIntervals: [],
+  };
+  const snapshot = (matched, planScoped, capacity = { status: "unavailable" }) => ({
+    schemaVersion: LOCAL_COMPANION_SCHEMA_VERSION,
+    mode: "real_local_evidence", generatedAt: "2026-09-07T12:00:00.000Z",
+    overview: {
+      accounting: { sourceMode: "unified", generationMatched: matched },
+      timeline: { usage: [1], planScoped, allowanceCapacity: capacity, quota: ["current quota"] },
+    },
+    gradient: { datasets: {} }, weekly: { datasets: {} }, quality: {}, reports: [],
+  });
+  const initial = snapshot(true, available, { status: "available", planScope: scope });
+  async function reload(next, purpose = "full") {
+    const originals = structuredClone([initial, next]);
+    let call = 0;
+    const store = new LocalCompanionDataStore({ builder: async () => call++ === 0 ? initial : next });
+    await store.reload({ purpose: "full" });
+    await store.reload({ purpose });
+    assert.deepEqual([initial, next], originals, "builder snapshots remain immutable");
+    return store.getOverview();
+  }
+  for (const purpose of ["full", "quick", "startup"]) {
+    await t.test(`${purpose} reuses the scoped history and capacity together`, async () => {
+      const result = await reload(snapshot(false, unavailable), purpose);
+      assert.deepEqual(result.timeline.planScoped, available);
+      assert.deepEqual(result.timeline.allowanceCapacity.planScope, scope);
+      assert.deepEqual(result.timeline.quota, ["current quota"]);
+      assert.equal(result.accounting.generationMatched, false);
+      const { selectAllowancePlanPopulation } = await import("../apps/web/public/data-client.js");
+      const selected = selectAllowancePlanPopulation({ ...result, weekly: {
+        planAttribution: { methodVersion: "plan-era-v1" }, selectedPlanType: "pro",
+        planPopulations: [{ planType: "pro", status: "available" }],
+      } });
+      assert.equal(selected.allowancePlanSelection.comparisonAvailable, true,
+        "the actual Trends selector still accepts the retained comparison");
+      assert.deepEqual(selected.timeline.selectedPlanUsage, available.usage);
+      assert.deepEqual(selected.timeline.comparisonIntervals, available.comparisonIntervals);
+    });
+  }
+  for (const key of Object.keys(scope)) {
+    await t.test(`changed capacity ${key} cannot borrow previous scoped history`, async () => {
+      const changed = { ...scope, [key]: key === "sourceGeneration" ? 36 : "different" };
+      const result = await reload(snapshot(false, unavailable, { status: "available", planScope: changed }));
+      assert.deepEqual(result.timeline.planScoped, unavailable);
+      assert.deepEqual(result.timeline.allowanceCapacity.planScope, changed);
+    });
+  }
+  await t.test("authoritative empty and fresh scoped history replace retained data", async () => {
+    assert.deepEqual((await reload(snapshot(true, unavailable))).timeline.planScoped, unavailable);
+    const fresh = { ...available, usage: [[6, 7]], comparisonIntervals: [[6, 8]] };
+    assert.deepEqual((await reload(snapshot(false, fresh))).timeline.planScoped, fresh);
+  });
+  await t.test("cold start, absent capacity scope and omitted surface do not manufacture history", async () => {
+    const incoming = snapshot(false, unavailable);
+    const cold = new LocalCompanionDataStore({ builder: async () => incoming });
+    await cold.reload({ purpose: "quick" });
+    assert.deepEqual(cold.getOverview().timeline.planScoped, unavailable);
+    const noScope = await reload(snapshot(false, unavailable, { status: "available" }));
+    assert.deepEqual(noScope.timeline.planScoped, unavailable);
+    delete incoming.overview.timeline.planScoped;
+    assert.equal(Object.hasOwn((await reload(incoming)).timeline, "planScoped"), false);
+  });
 });


### PR DESCRIPTION
Trends could lose its comparison during a partial refresh because plan-specific history was missing from the companion’s retained projection surfaces, even when the existing history and capacity survived. Retain the plan-specific history only with its exact matching capacity scope. Fresh quota and accounting status stay current, and authoritative empty results still replace old data.

Expanded divergence details also reset on every dashboard render. Preserve expansion, focus, and successful model/speed results for unchanged windows and plan context, refresh behind those results, and allow failed lookups to retry. Bound the transient state to 20 displayed periods and fence superseded responses.

Validation: 507 browser tests, 317 local companion tests, 20 preflight checks, documentation governance, and architecture checks passed. The regression exercises the actual Trends selector after retention; a synthetic browser check verified expansion and results survive refresh/failure and update in place. Installed-app and release qualification remain separate.
