### PR TITLE
Document Intel Homebrew installation and show it on the website

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,17 +6,24 @@ optional hosted contribution service. Contributions are welcome, but the
 project's privacy boundaries and verification gates are non-negotiable, so
 please read this page before opening an issue or pull request.
 
-## Prerequisites
+## Developer prerequisites
+
+Just installing the app? Use the [installation instructions](README.md#install-macos-apple-silicon-or-intel)
+for Apple silicon or Intel Macs. The published app bundles its runtime and does
+not require the development tools below.
 
 - **Node.js ≥ 22.13** for all repository tooling and tests.
 - **macOS on arm64 with exactly Node v26.2.0** for the macOS app-bundle
   build and the retained release gate (`npm run product:macos:test`). The
   build pins that version deliberately and fails on any other runtime
   rather than producing an unverifiable bundle.
+  This is a build-host requirement, not an end-user architecture restriction;
+  the same builder can [explicitly target Intel](apps/macos/README.md#developer-build)
+  with its verified x64 runtime.
 - **pnpm 11** (the repository sets `packageManager: pnpm@11.9.0`).
 - **Xcode command-line tools** for the native macOS app build.
 
-## Install
+## Developer setup
 
 The root workspace uses pnpm; the Worker keeps its own npm lockfile. Install
 both dependency sets:

--- a/README.md
+++ b/README.md
@@ -42,36 +42,50 @@ an exact local review and explicit send step.
 - **A menu bar item** — where the allowance stands without opening the app,
   including a Check for Updates entry in builds that ship the updater.
 
-## Install
+## Install (macOS, Apple silicon or Intel)
 
-For a published macOS release, install the signed, notarized app with Homebrew:
+Requires **macOS 14 or later**, on either Apple silicon or Intel. With
+[Homebrew](https://brew.sh/) installed, one command selects the correct signed,
+notarized app for your Mac:
 
 ```bash
 brew install --cask adamallcock/tap/tibotattle
 ```
 
-Or, when the website exposes a current download, download the DMG from
+The app includes its runtime. You do **not** need Node.js, pnpm, or Xcode to
+install or use the published app.
+
+Alternatively, choose the **macOS Apple silicon** or **macOS Intel** DMG from
 [tibotattle.com](https://tibotattle.com) or the
 [TiboTattle releases page](https://github.com/adamallcock/tibotattle/releases).
+If you are unsure, **Apple menu → About This Mac** shows either an Apple chip or
+an Intel processor. Open the DMG, drag TiboTattle to Applications, and launch it.
 When both refer to the same published version, those channels point to the same
-Developer ID artifact; the app continues to use its signed Sparkle feed for
+architecture-specific Developer ID artifact; the app continues to use its signed Sparkle feed for
 updates. A missing website slot is not a release claim—use the GitHub release
 page for the exact version and digest. A v1 release manifest may explicitly
 leave SBOM or provenance fields `null`; source-to-binary provenance is claimed
 only when a trusted hosted workflow generated/finalized and cryptographically
 verified the exact final bytes for that specific release. This repository is
-the source of truth for the public app and its releases. To build from source
-instead, follow the quick start below.
+the source of truth for the public app and its releases. See the
+[user guide](docs/user-guide.md#install-and-first-launch) for first launch,
+or the developer section below to build from source.
 See [Verify a TiboTattle release](docs/verify-release.md) to check the downloaded
 bytes, Apple signature and notarization, and any non-null release-specific
 GitHub provenance evidence yourself.
 
-## Quick start (macOS, Apple Silicon)
+## Build from source (developers)
 
-Requirements: macOS 14 or later on arm64, Node.js ≥ 22.13 for the repository tooling,
+These requirements are for development, not installation of the released app.
+The native app builder runs on macOS 14 or later on Apple silicon. Repository
+tooling requires Node.js ≥ 22.13,
 [pnpm](https://pnpm.io) 11, and the Xcode command-line tools. The app-bundle
 build itself requires exactly Node v26.2.0 on macOS arm64: it fails on any
 other runtime rather than producing an unverifiable bundle.
+The default target is Apple silicon. To build an Intel target on that same
+builder, follow the explicit target and verified-runtime instructions in
+[the native developer guide](apps/macos/README.md#developer-build). A native
+Intel build host is not currently supported by this builder.
 
 The root workspace uses pnpm; the Worker keeps its own npm lockfile, which is
 needed only for hosted-service checks and the full gates:

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -54,7 +54,10 @@ the diagnostic text is safe.
 
 ## Supported surface
 
-The published product currently supports macOS 14 or later on Apple silicon.
+The published product supports macOS 14 or later on Apple silicon and Intel.
+Both use the same [Homebrew command](README.md#install-macos-apple-silicon-or-intel),
+or their matching direct DMG. See [platform qualification](docs/reference/platform-support.md)
+for the release-specific Intel testing boundary.
 Windows and Linux work in this repository is preparation or experimental
 evidence, not a supported install. Local analysis works without the hosted
 service; a hosted outage should remain visibly unavailable rather than make the

--- a/apps/macos/README.md
+++ b/apps/macos/README.md
@@ -264,7 +264,9 @@ npm run product:macos:validate:development
 open ".release-build/macos/TiboTattle.app"
 ```
 
-An Intel target is available on the same builder; it is not yet publicly qualified:
+An Intel target is available on the same Apple silicon builder. The published
+0.1.18 Intel app is supported under its release-specific manual-qualification
+waiver; the command here creates only a development test build:
 
 ```bash
 node scripts/build-macos-app.js --architecture x64 \
@@ -284,7 +286,9 @@ x64`; native inspection checks all bundled executables against that target.
 Release construction also requires the verified `--node-runtime`. Preview and
 release modes retain their existing signing, source, identity and credential
 gates. Intel uses separate stable/dogfood/Preview feeds; it cannot consume the
-Apple silicon feed. No new Homebrew Intel support is claimed.
+Apple silicon feed. Published installers for both architectures are also
+available through the [same Homebrew cask](../../README.md#install-macos-apple-silicon-or-intel),
+which selects the matching DMG; it does not change the app's update feed.
 
 These source paths do not qualify real Intel hardware, final signed/notarized
 installers or updater installation. See the

--- a/apps/web/public/community.html
+++ b/apps/web/public/community.html
@@ -305,6 +305,34 @@
                     <img class="download-platform-icon" src="./apple.svg" alt="" width="22" height="22">
                     <span data-i18n="installer.macosIntel.download">Download for macOS Intel</span>
                   </a>
+                  <div
+                    class="homebrew-install"
+                    id="intel-homebrew-install"
+                    role="group"
+                    aria-label="Install with Homebrew"
+                    data-i18n-aria-label="aria.installWithHomebrew"
+                    hidden
+                  >
+                    <span class="homebrew-prompt" aria-hidden="true">$</span>
+                    <code id="intel-homebrew-install-command" data-i18n-skip>brew install --cask adamallcock/tap/tibotattle</code>
+                    <button
+                      class="homebrew-copy-button"
+                      id="intel-homebrew-copy-button"
+                      type="button"
+                      aria-label="Copy Homebrew install command"
+                      aria-describedby="intel-homebrew-copy-status"
+                      data-i18n-aria-label="aria.copyHomebrewCommand"
+                    >
+                      <span id="intel-homebrew-copy-label" data-i18n="installer.homebrew.copy">Copy</span>
+                    </button>
+                  </div>
+                  <span
+                    class="sr-only"
+                    id="intel-homebrew-copy-status"
+                    role="status"
+                    aria-live="polite"
+                    aria-atomic="true"
+                  ></span>
                 </div>
                 <div class="installer-details installer-details-compact" id="intel-installer-details" hidden>
                   <span class="installer-summary">

--- a/apps/web/public/community.js
+++ b/apps/web/public/community.js
@@ -282,6 +282,8 @@ export function renderPublicInstallerJourney(documentRef = document) {
       checksumFallback.hidden = true;
     }
     renderInstallerAssurance(documentRef, release, { architecture });
+    const homebrewInstall = select(`#${prefix}homebrew-install`);
+    if (homebrewInstall) homebrewInstall.hidden = release === null;
     return release;
   };
   const release = renderArchitecture("arm64");
@@ -293,8 +295,6 @@ export function renderPublicInstallerJourney(documentRef = document) {
     headerDownloadLabel.dataset.i18n = "installer.headerDownload";
     headerDownloadLabel.textContent = t("installer.headerDownload");
   }
-  const homebrewInstall = select("#homebrew-install");
-  if (homebrewInstall) homebrewInstall.hidden = release === null;
   return release;
 }
 
@@ -324,8 +324,8 @@ export async function copyInstallerChecksum(checksum, clipboard) {
   }
 }
 
-function selectHomebrewInstallCommand() {
-  const command = $("#homebrew-install-command");
+function selectHomebrewInstallCommand(prefix = "") {
+  const command = $(`#${prefix}homebrew-install-command`);
   const selection = window.getSelection?.();
   const range = document.createRange?.();
   if (!command || !selection || !range) return;
@@ -334,10 +334,10 @@ function selectHomebrewInstallCommand() {
   selection.addRange(range);
 }
 
-function renderHomebrewCopyState(state = "idle") {
-  const button = $("#homebrew-copy-button");
-  const label = $("#homebrew-copy-label");
-  const status = $("#homebrew-copy-status");
+function renderHomebrewCopyState(state = "idle", prefix = "") {
+  const button = $(`#${prefix}homebrew-copy-button`);
+  const label = $(`#${prefix}homebrew-copy-label`);
+  const status = $(`#${prefix}homebrew-copy-status`);
   if (!button || !label || !status) return;
   const presentation = {
     copied: ["installer.homebrew.copied", "installer.homebrew.copySuccess"],
@@ -350,17 +350,17 @@ function renderHomebrewCopyState(state = "idle") {
   status.textContent = presentation[1] ? t(presentation[1]) : "";
 }
 
-function wireHomebrewInstallCommand() {
-  const button = $("#homebrew-copy-button");
+function wireHomebrewInstallCommand(prefix = "") {
+  const button = $(`#${prefix}homebrew-copy-button`);
   if (!button || button.dataset.copyBound === "true") return;
   button.dataset.copyBound = "true";
-  renderHomebrewCopyState();
+  renderHomebrewCopyState("idle", prefix);
   button.addEventListener("click", async () => {
     button.disabled = true;
     const copied = await copyHomebrewInstallCommand(navigator.clipboard);
     button.disabled = false;
-    if (!copied) selectHomebrewInstallCommand();
-    renderHomebrewCopyState(copied ? "copied" : "failed");
+    if (!copied) selectHomebrewInstallCommand(prefix);
+    renderHomebrewCopyState(copied ? "copied" : "failed", prefix);
   });
 }
 
@@ -574,6 +574,7 @@ if (typeof document !== "undefined") {
   renderPublicInstallerJourney();
   wirePublicPlatformSelector();
   wireHomebrewInstallCommand();
+  wireHomebrewInstallCommand("intel-");
   wireInstallerChecksumCopy();
   wireInstallerChecksumCopy("intel-");
   wireAllowanceRangeControls();
@@ -585,6 +586,9 @@ if (typeof document !== "undefined") {
     renderPublicInstallerJourney();
     renderHomebrewCopyState(
       $("#homebrew-copy-button")?.dataset.copyState ?? "idle",
+    );
+    renderHomebrewCopyState(
+      $("#intel-homebrew-copy-button")?.dataset.copyState ?? "idle", "intel-",
     );
     renderInstallerChecksumCopyState(
       $("#installer-sha256-copy")?.dataset.copyState ?? "idle",

--- a/apps/web/public/docs.html
+++ b/apps/web/public/docs.html
@@ -246,7 +246,7 @@
           <h2>Platform support</h2>
           <p>
             The published product currently supports macOS 14 or later on Apple
-            silicon. Windows and Linux source, contract, container, or native
+            silicon and Intel. Windows and Linux source, contract, container, or native
             experiments are preparation evidence only; neither platform is a
             supported install until a release lists and qualifies its own final
             artifact.

--- a/apps/web/public/docs.html
+++ b/apps/web/public/docs.html
@@ -127,8 +127,20 @@
         <article class="resource-card" id="start">
           <h2>Start on your Mac</h2>
           <p>
-            Install the current signed release from the public home page,
-            Homebrew, or GitHub Releases. On first launch, read the complete
+            TiboTattle supports macOS 14 or later on Apple silicon and Intel.
+            If you use <a href="https://brew.sh/" target="_blank" rel="noreferrer">Homebrew</a>,
+            the same command installs the signed release for your Mac:
+          </p>
+          <pre><code data-i18n-skip>brew install --cask adamallcock/tap/tibotattle</code></pre>
+          <p>
+            Or choose the matching Apple silicon or Intel download on the
+            <a href="./community.html#download">public home page</a> or
+            <a href="https://github.com/adamallcock/tibotattle/releases/latest" target="_blank" rel="noreferrer">GitHub Releases</a>,
+            open the DMG, and drag TiboTattle to Applications. The app includes
+            its runtime; installing it does not require Node.js, pnpm, or Xcode.
+          </p>
+          <p>
+            On first launch, read the complete
             local-source disclosure, choose whether TiboTattle starts at login,
             and select <strong>Get Started</strong>. The app hosts its private
             dashboard in its own window; this public website never scans local

--- a/apps/web/public/styles.css
+++ b/apps/web/public/styles.css
@@ -4075,6 +4075,15 @@ html.community-chart-modal-open body {
   margin: 0;
   padding-inline-start: 1.2rem;
 }
+.community-site .resource-card pre {
+  padding: 12px;
+  border: 1px solid var(--line);
+  border-radius: var(--radius-sm);
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+  font-size: .75rem;
+  line-height: 1.6;
+}
 .community-site .download-security-card {
   padding: clamp(26px, 4vw, 40px);
 }

--- a/apps/web/test/community-site.test.mjs
+++ b/apps/web/test/community-site.test.mjs
@@ -307,6 +307,8 @@ test("the public site presents only the install call to action and the community
   assert.match(html, /id="installer-unavailable"/u);
   assert.match(html, /id="homebrew-install"[^>]*hidden/u);
   assert.match(html, /id="homebrew-copy-button"/u);
+  assert.match(html, /id="intel-homebrew-install"[^>]*hidden/u);
+  assert.match(html, /id="intel-homebrew-copy-button"/u);
   assert.doesNotMatch(html, /open-installed-app|usage-monitor-semantic-open-target|usagemonitor:\/\//u);
   assert.match(html, /id="community-daily-result"/u);
   assert.match(html, /id="community-daily-state"/u);
@@ -584,6 +586,9 @@ test("platform tabs keep the live macOS release separate from honest unavailable
   assert.match(macosPanel, /id="homebrew-install"/u);
   assert.match(macosPanel, /id="installer-sha256-copy"/u);
   assert.match(macosPanel, /Developer ID signed and Apple notarized\./u);
+  assert.match(intelPanel, /id="intel-homebrew-install"/u);
+  assert.match(intelPanel, /id="intel-homebrew-install-command"[^>]*>brew install --cask adamallcock\/tap\/tibotattle<\/code>/u);
+  assert.match(intelPanel, /id="intel-homebrew-copy-button"[\s\S]*?aria-describedby="intel-homebrew-copy-status"/u);
 
   for (const [platform, panel] of [
     ["macOS Intel", intelPanel.slice(intelPanel.indexOf('id="intel-installer-unavailable"'))],
@@ -1144,6 +1149,9 @@ test("the public guidance pages are useful stubs without app-only controls", asy
   const verifyRelease = await readFile(VERIFY_RELEASE, "utf8");
   const privacy = await readFile(PRIVACY_HTML, "utf8");
   assert.match(docs, /<title>TiboTattle Docs<\/title>/u);
+  assert.match(docs, /macOS 14 or later on Apple silicon and Intel/u);
+  assert.match(docs, /<code data-i18n-skip>brew install --cask adamallcock\/tap\/tibotattle<\/code>/u);
+  assert.match(docs, /installing it does not require Node\.js, pnpm, or Xcode/u);
   assert.match(
     docs,
     /Estimated API-equivalent value of the observed seven-day allowance\./u,
@@ -2189,7 +2197,14 @@ test("Intel download rendering stays independent and refuses partial or ARM meta
   assert.equal(documentRef.byId.get("installer-sha256-copy").dataset.checksum, "a".repeat(64));
   assert.equal(documentRef.byId.get("intel-installer-version").textContent, "Version 1.2.3");
   assert.equal(documentRef.byId.get("intel-installer-compatibility").textContent, "macOS 14 or later · Intel");
-  assert.equal(documentRef.byId.has("intel-homebrew-install"), false);
+  assert.equal(documentRef.byId.get("homebrew-install").hidden, false);
+  assert.equal(documentRef.byId.get("intel-homebrew-install").hidden, false);
+
+  // The existing release contract requires a verified, same-version pair.
+  const missingPrimary = fakeDocument({ ...metadata, "usage-monitor-installer-url": "", ...intel });
+  renderPublicInstallerJourney(missingPrimary);
+  assert.equal(missingPrimary.byId.get("homebrew-install").hidden, true);
+  assert.equal(missingPrimary.byId.get("intel-homebrew-install").hidden, true);
 
   for (const invalid of [
     {},
@@ -2200,6 +2215,8 @@ test("Intel download rendering stays independent and refuses partial or ARM meta
     const unavailable = fakeDocument({ ...metadata, ...invalid });
     renderPublicInstallerJourney(unavailable);
     assert.equal(unavailable.byId.get("installer-link").hidden, false);
+    assert.equal(unavailable.byId.get("homebrew-install").hidden, false);
+    assert.equal(unavailable.byId.get("intel-homebrew-install").hidden, true);
     assert.equal(unavailable.byId.get("intel-installation").hidden, true);
     assert.equal(unavailable.byId.get("intel-installer-link").hidden, true);
     assert.equal(Object.hasOwn(unavailable.byId.get("intel-installer-link"), "href"), false);

--- a/docs/current-status.md
+++ b/docs/current-status.md
@@ -34,6 +34,14 @@ normally; the release tag and public artifacts must not be rewritten.
 | Website | [Both macOS tabs](https://tibotattle.com/#download) show 0.1.18 and their own correct public installer URL, minimum OS and architecture |
 | Installed ARM application | Final stable 1026 passes installed-artifact validation, ordinary launch, detailed replay-safe accounting refresh and restart, with matching generation and zero fallback |
 
+Homebrew update verified on **2026-09-07**: the
+[dual-architecture cask](https://github.com/adamallcock/homebrew-tap/pull/2)
+adds Intel with its independent published checksum. Both native Mac
+[audit/install/uninstall lanes](https://github.com/adamallcock/homebrew-tap/actions/runs/34141158444)
+passed. This supersedes the Apple-silicon-only Homebrew row in the dated
+2026-09-05 release snapshot above; it does not change the desktop artifacts or
+claim completion of the waived manual tests.
+
 The manifest honestly leaves optional SBOM, source-to-binary provenance and
 store fields unset. GitHub's immutable release/asset attestations are not
 substitutes for SLSA build provenance. Follow
@@ -74,8 +82,8 @@ and `deletionSafeRestoreReplay: true`; these flags do not prove every route.
 - **Supported:** macOS 14+ Apple silicon and Intel through the published 0.1.18
   artifacts and their independent update feeds.
 - **Not released or supported:** Windows, Linux or Electron.
-- Homebrew support remains Apple silicon only; the Intel DMG is distributed
-  directly through the website and GitHub release.
+- Homebrew selects Apple silicon or Intel with the same install command; both
+  DMGs also remain available through the website and GitHub release.
 
 The owner explicitly accepted the unavailable disposable-profile/manual Login
 Item matrix and formal physical Intel install/runtime/update/upload evidence

--- a/docs/decisions/2026-08-15-homebrew-distribution-and-macos-support.md
+++ b/docs/decisions/2026-08-15-homebrew-distribution-and-macos-support.md
@@ -9,6 +9,9 @@ status: maintained
 
 ## Decision
 
+Updated on 2026-09-07 for the qualified dual-architecture cask; the original
+Apple-silicon-only decision is retained in Git history.
+
 Publish TiboTattle through the first-party
 [`adamallcock/homebrew-tap`](https://github.com/adamallcock/homebrew-tap) tap.
 The supported one-command install is:
@@ -17,17 +20,17 @@ The supported one-command install is:
 brew install --cask adamallcock/tap/tibotattle
 ```
 
-The cask installs the same signed, notarized arm64 DMG as the website and
-GitHub Release. It declares `auto_updates true`, preserving the existing signed
+The cask selects the same signed, notarized architecture-specific DMG as the
+website and GitHub Release: `arm64` for Apple silicon and `x64` for Intel,
+with independent SHA-256 values. It declares `auto_updates true`, preserving the existing signed
 Sparkle feed as the installed app's update authority. Homebrew is an additional
 install and uninstall route, not a replacement release channel.
 
-The public support floor is macOS 14 (Sonoma) on Apple silicon. The app bundle,
+The public support floor is macOS 14 (Sonoma) on Apple silicon and Intel. The app bundle,
 Swift compiler target, public release-site metadata, release runbook, and cask
-must all carry that same floor. The already-published v0.1.11 binary is more
-permissive at the bundle level; the cask and public support contract still
-require Sonoma, and the next signed release will carry 14.0 in the bundle and
-Sparkle appcast.
+must all carry that same floor. The packaged runtime means end users do not
+need Node.js, pnpm or Xcode. The separate Apple silicon build-host requirement
+does not restrict which published installer they can use.
 
 ## Uninstall and data boundary
 
@@ -53,12 +56,20 @@ credential reset.
 ## Tap automation
 
 The tap owns an hourly and manually dispatchable GitHub Actions workflow. It
-reads the latest non-draft `adamallcock/tibotattle` release, requires the exact
-`TiboTattle-X.Y.Z-macOS-arm64.dmg` asset, downloads and hashes it, validates the
-mounted app's signature and stapled notarization ticket, updates only the cask
-version and SHA-256, and runs Homebrew style, audit, install, and uninstall
-checks before committing. This avoids a long-lived cross-repository write
-credential in the application repository.
+reads the latest immutable, non-draft, non-prerelease `adamallcock/tibotattle`
+release and requires both exact `TiboTattle-X.Y.Z-macOS-arm64.dmg` and
+`TiboTattle-X.Y.Z-macOS-x64.dmg` assets. Independent native Apple silicon and
+Intel jobs verify each HTTPS download's size, SHA-256, architecture, signature
+and stapled notarization ticket, then run Homebrew style, online audit,
+installation and uninstall checks. Both jobs must pass before the main-branch
+publication job may update only the cask version and architecture checksums.
+
+Checks detect architecture or checksum drift even when the version is unchanged
+and reject downgrades. A manual `force_verify` run rechecks a matching release;
+the publication job makes no commit if the cask already matches. Normal pushes
+require the same clean source base used for qualification. This preserves the
+existing automatic publication behavior without a long-lived cross-repository
+write credential in the application repository.
 
 ## Official Homebrew cask gate
 

--- a/docs/reference/platform-support.md
+++ b/docs/reference/platform-support.md
@@ -1,6 +1,6 @@
 ---
 title: Platform support and qualification
-date: 2026-09-05
+date: 2026-09-07
 type: reference
 status: maintained
 ---
@@ -79,8 +79,14 @@ record private artifact qualification, not final stable publication. The waiver
 does not authorize relabeling those candidates as stable, fabricating a v2
 manual receipt, ignoring data-loss or integrity failures, weakening native
 signing/updater checks, or approving unexpected automatic Keychain prompts.
-Future releases must apply their normal gates unless separately decided; no
-new Homebrew Intel support is declared here.
+Future releases must apply their normal gates unless separately decided.
+
+From 2026-09-07, the first-party Homebrew cask selects the matching Apple silicon
+or Intel DMG with independent checksums. Both native hosted Mac lanes passed
+[cask audit, installation, trust checks and uninstall](https://github.com/adamallcock/homebrew-tap/actions/runs/34141158444).
+These distribution checks do not replace the waived 0.1.18 interactive runtime,
+physical Intel, update or upload observations. See the
+[Homebrew distribution contract](../decisions/2026-08-15-homebrew-distribution-and-macos-support.md).
 
 ## Windows
 

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -1,6 +1,6 @@
 ---
 title: User guide
-date: 2026-08-27
+date: 2026-09-07
 type: guide
 status: maintained
 ---
@@ -12,15 +12,27 @@ cost, quota windows, and trends. Local analysis works without an account and
 keeps session content on this Mac. Optional community contribution is a separate,
 content-free, consented feature.
 
-Current support is macOS 14 or later on Apple silicon. Windows and Linux are not
+Current support is macOS 14 or later on Apple silicon and Intel. Windows and Linux are not
 supported; see [platform support](./reference/platform-support.md).
 
 ## Install and first launch
 
-Download the current stable DMG from `https://tibotattle.com` or the latest
-GitHub release. For checksum and artifact checks, follow
-[verify-release.md](./verify-release.md). Move TiboTattle to Applications and
-launch it normally.
+With [Homebrew](https://brew.sh/) installed, use the same command on either Mac
+architecture; the cask selects the matching signed, notarized installer:
+
+```bash
+brew install --cask adamallcock/tap/tibotattle
+```
+
+Alternatively, choose the Apple silicon or Intel download at
+[tibotattle.com](https://tibotattle.com/#download) or the
+[latest GitHub release](https://github.com/adamallcock/tibotattle/releases/latest).
+**Apple menu → About This Mac** shows whether your Mac has an Apple chip or an
+Intel processor. Open the matching DMG and drag TiboTattle to Applications.
+For checksum and artifact checks, follow [verify-release.md](./verify-release.md).
+
+Launch TiboTattle from Applications. The app bundles its runtime; Node.js, pnpm,
+and Xcode are needed only for development, not for installing or using the app.
 
 On first launch, the app explains which local sources it may inspect. Those are
 the selected OpenAI Codex session and archived-session directories, the Codex

--- a/docs/verify-release.md
+++ b/docs/verify-release.md
@@ -1,6 +1,6 @@
 ---
 title: Verify a TiboTattle release
-date: 2026-08-28
+date: 2026-09-07
 type: guide
 status: current
 ---
@@ -24,13 +24,17 @@ software is vulnerability-free or universally “safe.”
 
 ## Current availability boundary
 
-The latest source-backed availability snapshot records public stable release
-`v0.1.16`, published 2026-08-21 for macOS 14 or later on Apple silicon. Its
-GitHub release includes the DMG, appcast, release manifest, checksums, and this
-guide; the public appcast advertised the same `0.1.16` DMG. Recheck the
-[current status](./current-status.md) and release endpoints before relying on
-that snapshot. Endpoint availability is not fresh proof of the downloaded
-artifact's Apple signature or notarization, so perform the checks in Section 3.
+As checked on 2026-09-07, the public stable release is
+[`v0.1.18`](https://github.com/adamallcock/tibotattle/releases/tag/v0.1.18), for
+macOS 14 or later on Apple silicon and Intel. It has separate `macOS-arm64.dmg`
+and `macOS-x64.dmg` artifacts with independent checksums and update feeds.
+Homebrew selects the matching artifact automatically; for a direct download,
+choose the one matching **Apple menu → About This Mac**. Always verify that
+artifact's own entry in `release-manifest.json`, not the other architecture's
+digest. Recheck [current status](./current-status.md) and the release endpoints
+before relying on this dated snapshot. Endpoint availability is not fresh proof
+of the downloaded artifact's Apple signature or notarization, so perform the
+checks in Section 3.
 
 Windows and Linux remain unsupported. Source, plans, contract tests, or
 simulated qualification do not make a build an official supported release.

--- a/test/public-documentation-contract.test.js
+++ b/test/public-documentation-contract.test.js
@@ -13,6 +13,23 @@ function exactStringLiterals(source) {
     .map(([, value]) => value);
 }
 
+test("Mac installation guidance separates both supported cask targets from the pinned build host", async () => {
+  const readme = await text("README.md");
+  const guide = await text("docs/user-guide.md");
+  const webDocs = await text("apps/web/public/docs.html");
+  for (const [name, content] of [["README", readme], ["user guide", guide], ["website docs", webDocs]]) {
+    assert.match(content, /Apple silicon[\s\S]*Intel/u, `${name} includes both Mac targets`);
+    assert.ok(content.includes("brew install --cask adamallcock/tap/tibotattle"), `${name} retains the qualified tap command`);
+    assert.match(content, /macOS 14 or later/u, `${name} preserves the support floor`);
+  }
+  assert.match(readme, /## Build from source \(developers\)/u);
+  assert.match(readme, /exactly Node v26\.2\.0 on macOS arm64/u);
+  assert.match(readme, /A native\s+Intel build host is not currently supported/u);
+  assert.doesNotMatch(readme, /## Quick start \(macOS, Apple Silicon\)/u);
+  assert.match(await text("CONTRIBUTING.md"), /## Developer setup/u);
+  assert.match(await text("SUPPORT.md"), /macOS 14 or later on Apple silicon and Intel/u);
+});
+
 test("maintained Markdown retires self-service promises without implying history loss", async () => {
   const paths = [
     "README.md",


### PR DESCRIPTION
## Summary
- Show the same first-party Homebrew command on both Mac download tabs, with independent copy feedback and existing release-metadata gating.
- Update README, setup/user guide, support and native-build guidance for macOS 14+ on Apple silicon and Intel; separate end-user installation from developer build-host requirements.
- Preserve published desktop artifacts, update feeds, calculator, migrations and consent behavior. Production website deployment uses a separate website-only commit based on the current live source, preserving its newer graph changes.

## Validation
- Both native cask audit/install/uninstall lanes passed: https://github.com/adamallcock/homebrew-tap/actions/runs/34141158444
- Both full updater artifact-verification lanes passed: https://github.com/adamallcock/homebrew-tap/actions/runs/34141557913
- Web UI suite and 36 release-site tests pass on the deployment candidate.
- Documentation governance, links and 20 preflight tests pass.
- Chrome preview: Intel and Apple-silicon tab/copy feedback, Spanish localization and 390px layout checked. Public deployment will be verified independently.