### PR TITLE
Complete the native Sparkle to Electron update path for 0.1.21

### DIFF
--- a/.github/workflows/electron-macos-empty-profile.yml
+++ b/.github/workflows/electron-macos-empty-profile.yml
@@ -1,5 +1,7 @@
 name: Signed Mac empty-profile clean install
 on:
+  push:
+    branches: [codex/electron-sparkle-transition-021]
   workflow_dispatch:
     inputs:
       mode:
@@ -27,8 +29,14 @@ concurrency:
   group: signed-mac-empty-profile-${{ inputs.target }}
   cancel-in-progress: false
 jobs:
+  registration:
+    if: github.event_name == 'push'
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Register without installing an application
+        run: echo "Only an explicit reviewed workflow dispatch executes the hosted clean install."
   clean_arm64:
-    if: inputs.target == 'darwin-arm64'
+    if: github.event_name == 'workflow_dispatch' && inputs.target == 'darwin-arm64'
     runs-on: macos-26
     timeout-minutes: 15
     env:
@@ -80,7 +88,7 @@ jobs:
           if-no-files-found: error
           retention-days: 14
   clean_x64:
-    if: inputs.target == 'darwin-x64'
+    if: github.event_name == 'workflow_dispatch' && inputs.target == 'darwin-x64'
     runs-on: macos-15-intel
     timeout-minutes: 15
     env:

--- a/.github/workflows/electron-macos-empty-profile.yml
+++ b/.github/workflows/electron-macos-empty-profile.yml
@@ -1,0 +1,133 @@
+name: Signed Mac empty-profile clean install
+on:
+  workflow_dispatch:
+    inputs:
+      mode:
+        description: Plan only or launch the pinned signed app on a disposable Mac
+        type: choice
+        options: [plan, execute]
+        default: plan
+        required: true
+      target:
+        description: Pinned signed application architecture
+        type: choice
+        options: [darwin-arm64, darwin-x64]
+        default: darwin-arm64
+        required: true
+      intake:
+        description: Closed JSON with target and exact runnerRevision only; app source and hashes are pinned in the runner
+        type: string
+        required: true
+      confirmation:
+        description: Execute requires RUN_DISPOSABLE_EMPTY_PROFILE
+        type: string
+permissions:
+  contents: read
+concurrency:
+  group: signed-mac-empty-profile-${{ inputs.target }}
+  cancel-in-progress: false
+jobs:
+  clean_arm64:
+    if: inputs.target == 'darwin-arm64'
+    runs-on: macos-26
+    timeout-minutes: 15
+    env:
+      EMPTY_PROFILE_INTAKE: ${{ inputs.intake }}
+      SELECTED_TARGET: ${{ inputs.target }}
+      SELECTED_MODE: ${{ inputs.mode }}
+      SELECTED_CONFIRMATION: ${{ inputs.confirmation }}
+    steps:
+      - name: Check out exact qualification source
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ github.sha }}
+          persist-credentials: false
+      - name: Set up pinned Node
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: 26.2.0
+          architecture: arm64
+          package-manager-cache: false
+      - name: Install locked verification dependencies
+        run: |
+          npm install --global corepack@0.34.0 --force --ignore-scripts
+          corepack enable
+          corepack prepare pnpm@11.9.0 --activate
+          pnpm install --frozen-lockfile --ignore-scripts
+      - name: Verify intake and exercise clean install
+        shell: bash
+        run: |
+          umask 077
+          mkdir -m 700 empty-profile-receipts
+          node --input-type=module - <<'JS'
+          import { validateEmptyProfileIntake } from './scripts/smoke-electron-macos-empty-profile.mjs';
+          const input = validateEmptyProfileIntake(JSON.parse(process.env.EMPTY_PROFILE_INTAKE));
+          if (input.target !== process.env.SELECTED_TARGET || input.runnerRevision !== process.env.GITHUB_SHA) throw new Error('Intake mismatch');
+          if (!['plan', 'execute'].includes(process.env.SELECTED_MODE)) throw new Error('Mode mismatch');
+          if (process.env.SELECTED_CONFIRMATION !== (process.env.SELECTED_MODE === 'execute' ? 'RUN_DISPOSABLE_EMPTY_PROFILE' : '')) throw new Error('Confirmation mismatch');
+          JS
+          args=(--plan)
+          if [[ "$SELECTED_MODE" == execute ]]; then
+            args=(--execute --confirm "$SELECTED_CONFIRMATION")
+          fi
+          node scripts/smoke-electron-macos-empty-profile.mjs "${args[@]}" > empty-profile-receipts/execution.json
+      - name: Retain separate content-free clean-install evidence
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: signed-mac-empty-profile-darwin-arm64-${{ github.run_id }}
+          path: empty-profile-receipts/*.json
+          if-no-files-found: error
+          retention-days: 14
+  clean_x64:
+    if: inputs.target == 'darwin-x64'
+    runs-on: macos-15-intel
+    timeout-minutes: 15
+    env:
+      EMPTY_PROFILE_INTAKE: ${{ inputs.intake }}
+      SELECTED_TARGET: ${{ inputs.target }}
+      SELECTED_MODE: ${{ inputs.mode }}
+      SELECTED_CONFIRMATION: ${{ inputs.confirmation }}
+    steps:
+      - name: Check out exact qualification source
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ github.sha }}
+          persist-credentials: false
+      - name: Set up pinned Node
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: 26.2.0
+          architecture: x64
+          package-manager-cache: false
+      - name: Install locked verification dependencies
+        run: |
+          npm install --global corepack@0.34.0 --force --ignore-scripts
+          corepack enable
+          corepack prepare pnpm@11.9.0 --activate
+          pnpm install --frozen-lockfile --ignore-scripts
+      - name: Verify intake and exercise clean install
+        shell: bash
+        run: |
+          umask 077
+          mkdir -m 700 empty-profile-receipts
+          node --input-type=module - <<'JS'
+          import { validateEmptyProfileIntake } from './scripts/smoke-electron-macos-empty-profile.mjs';
+          const input = validateEmptyProfileIntake(JSON.parse(process.env.EMPTY_PROFILE_INTAKE));
+          if (input.target !== process.env.SELECTED_TARGET || input.runnerRevision !== process.env.GITHUB_SHA) throw new Error('Intake mismatch');
+          if (!['plan', 'execute'].includes(process.env.SELECTED_MODE)) throw new Error('Mode mismatch');
+          if (process.env.SELECTED_CONFIRMATION !== (process.env.SELECTED_MODE === 'execute' ? 'RUN_DISPOSABLE_EMPTY_PROFILE' : '')) throw new Error('Confirmation mismatch');
+          JS
+          args=(--plan)
+          if [[ "$SELECTED_MODE" == execute ]]; then
+            args=(--execute --confirm "$SELECTED_CONFIRMATION")
+          fi
+          node scripts/smoke-electron-macos-empty-profile.mjs "${args[@]}" > empty-profile-receipts/execution.json
+      - name: Retain separate content-free clean-install evidence
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: signed-mac-empty-profile-darwin-x64-${{ github.run_id }}
+          path: empty-profile-receipts/*.json
+          if-no-files-found: error
+          retention-days: 14

--- a/.github/workflows/electron-macos-production-update.yml
+++ b/.github/workflows/electron-macos-production-update.yml
@@ -1,0 +1,175 @@
+name: Signed Electron production update acceptance
+on:
+  push:
+    branches: [codex/electron-sparkle-transition-021]
+  workflow_dispatch:
+    inputs:
+      mode:
+        description: Plan only, or accept the already activated production update
+        type: choice
+        options: [plan, execute]
+        default: plan
+        required: true
+      target:
+        description: Installed predecessor and successor architecture
+        type: choice
+        options: [darwin-arm64, darwin-x64]
+        default: darwin-arm64
+        required: true
+      runner_revision:
+        description: Exact reviewed acceptance runner commit
+        type: string
+        required: true
+      identity_json:
+        description: Exact 021 source/build/DMG/ASAR/ZIP/feed and 020 ASAR identity JSON; directory is supplied by the workflow
+        type: string
+        required: true
+      confirmation:
+        description: Execute requires RUN_DISPOSABLE_PRODUCTION_ELECTRON_UPDATE
+        type: string
+permissions:
+  contents: read
+concurrency:
+  group: electron-production-update-acceptance-${{ inputs.target }}
+  cancel-in-progress: false
+jobs:
+  registration:
+    if: github.event_name == 'push'
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Register without launching an installed update
+        run: echo "Only a reviewed dispatch after feed activation executes acceptance."
+  acceptance_arm64:
+    if: github.event_name == 'workflow_dispatch' && inputs.target == 'darwin-arm64'
+    runs-on: macos-26
+    timeout-minutes: 25
+    env:
+      SELECTED_MODE: ${{ inputs.mode }}
+      SELECTED_TARGET: ${{ inputs.target }}
+      SELECTED_RUNNER: ${{ inputs.runner_revision }}
+      SELECTED_IDENTITY: ${{ inputs.identity_json }}
+      SELECTED_CONFIRMATION: ${{ inputs.confirmation }}
+    steps:
+      - name: Check out exact qualification source
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ github.sha }}
+          persist-credentials: false
+      - name: Set up pinned Node
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: 26.2.0
+          architecture: arm64
+          package-manager-cache: false
+      - name: Install pinned inspection dependencies
+        run: |
+          npm install --global corepack@0.34.0 --force --ignore-scripts
+          corepack enable
+          corepack prepare pnpm@11.9.0 --activate
+          pnpm install --frozen-lockfile --ignore-scripts
+      - name: Validate intake and run only the selected acceptance mode
+        shell: bash
+        run: |
+          node --input-type=module <<'NODE'
+          import { mkdir, realpath, writeFile } from 'node:fs/promises';
+          import { join } from 'node:path';
+          import { spawnSync } from 'node:child_process';
+          import { validateProductionUpdateIntake } from './scripts/smoke-electron-macos-production-update.mjs';
+          const env = process.env;
+          if (!/^[a-f0-9]{40}$/.test(env.SELECTED_RUNNER) || env.SELECTED_RUNNER !== env.GITHUB_SHA
+            || env.SELECTED_TARGET !== 'darwin-arm64' || !['plan', 'execute'].includes(env.SELECTED_MODE)
+            || (env.SELECTED_MODE === 'execute' ? env.SELECTED_CONFIRMATION !== 'RUN_DISPOSABLE_PRODUCTION_ELECTRON_UPDATE'
+              : Boolean(env.SELECTED_CONFIRMATION))) throw new Error('ACCEPTANCE_DISPATCH_REFUSED');
+          if (Buffer.byteLength(env.SELECTED_IDENTITY ?? '') > 8192) throw new Error('ACCEPTANCE_IDENTITY_REFUSED');
+          const identity = JSON.parse(env.SELECTED_IDENTITY);
+          if (Object.hasOwn(identity, 'directory') || identity.target !== env.SELECTED_TARGET) throw new Error('ACCEPTANCE_IDENTITY_REFUSED');
+          const directory = join(await realpath(env.RUNNER_TEMP), 'production-electron-update');
+          validateProductionUpdateIntake({ ...identity, directory });
+          await mkdir(directory, { mode: 0o700 });
+          const intakePath = join(directory, 'intake.json');
+          await writeFile(intakePath, JSON.stringify({ ...identity, directory }), { mode: 0o600, flag: 'wx' });
+          const args = ['scripts/smoke-electron-macos-production-update.mjs', '--' + env.SELECTED_MODE, '--intake', intakePath];
+          if (env.SELECTED_MODE === 'execute') args.push('--confirm', env.SELECTED_CONFIRMATION);
+          const result = spawnSync(process.execPath, args, { timeout: 22 * 60 * 1000, encoding: 'utf8', maxBuffer: 131072 });
+          const evidence = join(env.GITHUB_WORKSPACE, '.release-build', 'production-update-evidence');
+          await mkdir(evidence, { recursive: true });
+          let proof;
+          try { proof = JSON.parse(result.stdout); } catch { proof = { status: 'failed', failureStage: 'runner_execution' }; }
+          await writeFile(join(evidence, 'acceptance.json'), JSON.stringify(proof) + '\n', { mode: 0o600, flag: 'wx' });
+          if (result.status !== 0 || result.error || !['planned', 'passed'].includes(proof.status)) process.exitCode = 1;
+          NODE
+      - name: Preserve content-free acceptance evidence
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: electron-production-update-darwin-arm64-${{ github.run_id }}
+          path: .release-build/production-update-evidence/acceptance.json
+          if-no-files-found: error
+          retention-days: 30
+  acceptance_x64:
+    if: github.event_name == 'workflow_dispatch' && inputs.target == 'darwin-x64'
+    runs-on: macos-26-intel
+    timeout-minutes: 25
+    env:
+      SELECTED_MODE: ${{ inputs.mode }}
+      SELECTED_TARGET: ${{ inputs.target }}
+      SELECTED_RUNNER: ${{ inputs.runner_revision }}
+      SELECTED_IDENTITY: ${{ inputs.identity_json }}
+      SELECTED_CONFIRMATION: ${{ inputs.confirmation }}
+    steps:
+      - name: Check out exact qualification source
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ github.sha }}
+          persist-credentials: false
+      - name: Set up pinned Node
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: 26.2.0
+          architecture: x64
+          package-manager-cache: false
+      - name: Install pinned inspection dependencies
+        run: |
+          npm install --global corepack@0.34.0 --force --ignore-scripts
+          corepack enable
+          corepack prepare pnpm@11.9.0 --activate
+          pnpm install --frozen-lockfile --ignore-scripts
+      - name: Validate intake and run only the selected acceptance mode
+        shell: bash
+        run: |
+          node --input-type=module <<'NODE'
+          import { mkdir, realpath, writeFile } from 'node:fs/promises';
+          import { join } from 'node:path';
+          import { spawnSync } from 'node:child_process';
+          import { validateProductionUpdateIntake } from './scripts/smoke-electron-macos-production-update.mjs';
+          const env = process.env;
+          if (!/^[a-f0-9]{40}$/.test(env.SELECTED_RUNNER) || env.SELECTED_RUNNER !== env.GITHUB_SHA
+            || env.SELECTED_TARGET !== 'darwin-x64' || !['plan', 'execute'].includes(env.SELECTED_MODE)
+            || (env.SELECTED_MODE === 'execute' ? env.SELECTED_CONFIRMATION !== 'RUN_DISPOSABLE_PRODUCTION_ELECTRON_UPDATE'
+              : Boolean(env.SELECTED_CONFIRMATION))) throw new Error('ACCEPTANCE_DISPATCH_REFUSED');
+          if (Buffer.byteLength(env.SELECTED_IDENTITY ?? '') > 8192) throw new Error('ACCEPTANCE_IDENTITY_REFUSED');
+          const identity = JSON.parse(env.SELECTED_IDENTITY);
+          if (Object.hasOwn(identity, 'directory') || identity.target !== env.SELECTED_TARGET) throw new Error('ACCEPTANCE_IDENTITY_REFUSED');
+          const directory = join(await realpath(env.RUNNER_TEMP), 'production-electron-update');
+          validateProductionUpdateIntake({ ...identity, directory });
+          await mkdir(directory, { mode: 0o700 });
+          const intakePath = join(directory, 'intake.json');
+          await writeFile(intakePath, JSON.stringify({ ...identity, directory }), { mode: 0o600, flag: 'wx' });
+          const args = ['scripts/smoke-electron-macos-production-update.mjs', '--' + env.SELECTED_MODE, '--intake', intakePath];
+          if (env.SELECTED_MODE === 'execute') args.push('--confirm', env.SELECTED_CONFIRMATION);
+          const result = spawnSync(process.execPath, args, { timeout: 22 * 60 * 1000, encoding: 'utf8', maxBuffer: 131072 });
+          const evidence = join(env.GITHUB_WORKSPACE, '.release-build', 'production-update-evidence');
+          await mkdir(evidence, { recursive: true });
+          let proof;
+          try { proof = JSON.parse(result.stdout); } catch { proof = { status: 'failed', failureStage: 'runner_execution' }; }
+          await writeFile(join(evidence, 'acceptance.json'), JSON.stringify(proof) + '\n', { mode: 0o600, flag: 'wx' });
+          if (result.status !== 0 || result.error || !['planned', 'passed'].includes(proof.status)) process.exitCode = 1;
+          NODE
+      - name: Preserve content-free acceptance evidence
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: electron-production-update-darwin-x64-${{ github.run_id }}
+          path: .release-build/production-update-evidence/acceptance.json
+          if-no-files-found: error
+          retention-days: 30

--- a/.github/workflows/electron-macos-sparkle-transition.yml
+++ b/.github/workflows/electron-macos-sparkle-transition.yml
@@ -1,0 +1,305 @@
+name: Native Sparkle to Electron installed upgrade
+on:
+  push:
+    branches: [codex/electron-sparkle-transition-021]
+  workflow_dispatch:
+    inputs:
+      mode:
+        description: Verify signed intake or execute on a disposable hosted Mac
+        type: choice
+        options: [plan, execute]
+        default: plan
+        required: true
+      target:
+        description: Native predecessor and Electron target architecture
+        type: choice
+        options: [darwin-arm64, darwin-x64]
+        default: darwin-arm64
+        required: true
+      feed_scope:
+        description: Verify the isolated signed test feed or actual published native feed
+        type: choice
+        options: [isolated_test_feed, production_feed]
+        default: isolated_test_feed
+        required: true
+      runner_revision:
+        description: Exact reviewed qualification commit
+        type: string
+        required: true
+      source_revision:
+        description: Exact signed Electron source commit
+        type: string
+        required: true
+      build_number:
+        description: Exact Electron provenance build number
+        type: string
+        required: true
+      dmg_sha256:
+        description: Exact final signed and notarized Electron DMG
+        type: string
+        required: true
+      asar_sha256:
+        description: Exact signed application ASAR
+        type: string
+        required: true
+      feed_sha256:
+        description: Exact selected appcast signed with the existing native stable key
+        type: string
+        required: true
+      confirmation:
+        description: Execute requires RUN_DISPOSABLE_NATIVE_SPARKLE_TRANSITION
+        type: string
+permissions:
+  contents: read
+concurrency:
+  group: native-sparkle-electron-installed-upgrade-${{ inputs.target }}-${{ inputs.feed_scope }}
+  cancel-in-progress: false
+jobs:
+  registration:
+    if: github.event_name == 'push'
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Register without executing a signed upgrade
+        run: echo "Only an explicit reviewed workflow dispatch executes the hosted upgrade."
+  upgrade_arm64:
+    if: github.event_name == 'workflow_dispatch' && inputs.target == 'darwin-arm64'
+    runs-on: macos-26
+    timeout-minutes: 25
+    env:
+      SELECTED_MODE: ${{ inputs.mode }}
+      SELECTED_TARGET: ${{ inputs.target }}
+      SELECTED_FEED_SCOPE: ${{ inputs.feed_scope }}
+      SELECTED_RUNNER: ${{ inputs.runner_revision }}
+      SELECTED_SOURCE: ${{ inputs.source_revision }}
+      SELECTED_BUILD: ${{ inputs.build_number }}
+      SELECTED_DMG: ${{ inputs.dmg_sha256 }}
+      SELECTED_ASAR: ${{ inputs.asar_sha256 }}
+      SELECTED_FEED: ${{ inputs.feed_sha256 }}
+      SELECTED_CONFIRMATION: ${{ inputs.confirmation }}
+    steps:
+      - name: Check out exact qualification source
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ github.sha }}
+          persist-credentials: false
+      - name: Set up pinned Node
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: 26.2.0
+          architecture: arm64
+          package-manager-cache: false
+      - name: Install locked verification dependencies
+        run: |
+          npm install --global corepack@0.34.0 --force --ignore-scripts
+          corepack enable
+          corepack prepare pnpm@11.9.0 --activate
+          pnpm install --frozen-lockfile --ignore-scripts
+      - name: Verify exact signed test intake and unchanged native predecessor
+        shell: bash
+        run: |
+          umask 077
+          mkdir -m 700 sparkle-transition-receipts
+          python3 - <<'PY'
+          import hashlib,json,os,pathlib,re,subprocess
+          e=os.environ
+          source=e['SELECTED_SOURCE']; runner=e['SELECTED_RUNNER']
+          assert re.fullmatch('[0-9a-f]{40}',source)
+          assert re.fullmatch('[0-9a-f]{40}',runner) and runner==e['GITHUB_SHA']
+          assert re.fullmatch('[1-9][0-9]{0,9}',e['SELECTED_BUILD'])
+          for name in ['SELECTED_DMG','SELECTED_ASAR','SELECTED_FEED']:
+            assert re.fullmatch('[0-9a-f]{64}',e[name])
+          assert e['SELECTED_MODE'] in ['plan','execute']
+          assert e['SELECTED_CONFIRMATION']==('RUN_DISPOSABLE_NATIVE_SPARKLE_TRANSITION' if e['SELECTED_MODE']=='execute' else '')
+          root=pathlib.Path(e['RUNNER_TEMP'])/'native-sparkle-intake'; root.mkdir(mode=0o700)
+          target=e['SELECTED_TARGET']; scope=e['SELECTED_FEED_SCOPE']
+          assert target in ['darwin-arm64','darwin-x64']
+          assert scope in ['isolated_test_feed','production_feed']
+          intel=target=='darwin-x64'
+          architecture='x64' if intel else 'arm64'
+          prefix='intel/' if intel else ''
+          native=('70630ba90e92a1cd8cb904e66e1aebe85b04e9d23a50bef7e4e41aca84c4d2f6' if intel else
+            '2ea8eca02df7cc5210b6b6ce3d6e44016bffd9d081544a4efc6fa1afeeb0f1ae')
+          origin='https://updates.tibotattle.com'
+          if scope=='isolated_test_feed':
+            base=f"{origin}/electron/test/native-sparkle/{source}/1028/{e['SELECTED_DMG']}"
+            feed=base+'/appcast.xml'
+          else:
+            base=f"{origin}/{prefix}releases/1028/{e['SELECTED_DMG']}"
+            feed=f'{origin}/{prefix}appcast.xml'
+          candidate_name='TiboTattle-0.1.21-macOS-x64.dmg' if intel else 'TiboTattle-0.1.21-mac-arm64.dmg'
+          files=[
+            ('native.dmg',f'{origin}/{prefix}releases/1026/{native}/TiboTattle-0.1.18-macOS-{architecture}.dmg',native,1024**3),
+            ('candidate.dmg',base+'/'+candidate_name,e['SELECTED_DMG'],1024**3),
+            ('appcast.xml',feed,e['SELECTED_FEED'],1024**2),
+          ]
+          for name,url,digest,limit in files:
+            path=root/name
+            result=subprocess.run(['/usr/bin/curl','--disable','--fail','--silent','--show-error','--proto','=https',
+              '--max-time','180','--max-filesize',str(limit),'--output',str(path),'--write-out','%{http_code}',url],
+              capture_output=True,text=True,check=True,timeout=190)
+            assert result.stdout=='200' and 0<path.stat().st_size<=limit
+            with path.open('rb') as stream: assert hashlib.file_digest(stream,'sha256').hexdigest()==digest
+          for name in ['native','candidate']:
+            mount=root/(name+'-mount'); mount.mkdir(mode=0o700)
+            subprocess.run(['/usr/bin/hdiutil','attach','-readonly','-nobrowse','-noautoopen','-mountpoint',str(mount),str(root/(name+'.dmg'))],
+              stdout=subprocess.DEVNULL,stderr=subprocess.DEVNULL,check=True,timeout=90)
+            try:
+              app=mount/'TiboTattle.app'
+              assert app.is_dir() and not app.is_symlink()
+              assert [p.name for p in mount.glob('*.app')]==['TiboTattle.app']
+              target=root/name; target.mkdir(mode=0o700)
+              subprocess.run(['/usr/bin/ditto',str(app),str(target/'TiboTattle.app')],check=True,timeout=120)
+            finally:
+              subprocess.run(['/usr/bin/hdiutil','detach',str(mount)],stdout=subprocess.DEVNULL,stderr=subprocess.DEVNULL,check=True,timeout=90)
+          intake={'schemaVersion':'tibotattle-native-sparkle-test-intake-v1','sourceRevision':source,
+            'target':target,'feedScope':scope,'version':'0.1.21','buildNumber':e['SELECTED_BUILD'],'bundleVersion':'1028',
+            'dmgSha256':e['SELECTED_DMG'],'asarSha256':e['SELECTED_ASAR'],'feedSha256':e['SELECTED_FEED'],
+            'nativeDmgSha256':native,'directory':str(root)}
+          (root/'intake.json').write_text(json.dumps(intake)+'\n')
+          pathlib.Path('sparkle-transition-receipts/intake.json').write_text(json.dumps({
+            'runnerRevision':runner,'sourceRevision':source,'target':target,'feedScope':scope,'dmgSha256':e['SELECTED_DMG'],
+            'asarSha256':e['SELECTED_ASAR'],'feedSha256':e['SELECTED_FEED'],'nativeDmgSha256':native,
+            'downloadsVerified':True,'signedBundlesModified':False})+'\n')
+          PY
+      - name: Exercise native Check for Updates and retained state
+        shell: bash
+        run: |
+          umask 077
+          args=(--plan)
+          if [[ "$SELECTED_MODE" == execute ]]; then
+            args=(--execute)
+          fi
+          args+=(--intake "$RUNNER_TEMP/native-sparkle-intake/intake.json")
+          if [[ "$SELECTED_MODE" == execute ]]; then
+            args+=(--confirm "$SELECTED_CONFIRMATION")
+          fi
+          node scripts/smoke-electron-macos-sparkle-transition.mjs "${args[@]}" > sparkle-transition-receipts/execution.json
+      - name: Retain content-free proof only
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: native-sparkle-electron-${{ inputs.target }}-${{ inputs.feed_scope }}-${{ github.run_id }}
+          path: sparkle-transition-receipts/*.json
+          if-no-files-found: error
+          retention-days: 14
+  upgrade_x64:
+    if: github.event_name == 'workflow_dispatch' && inputs.target == 'darwin-x64'
+    runs-on: macos-26-intel
+    timeout-minutes: 25
+    env:
+      SELECTED_MODE: ${{ inputs.mode }}
+      SELECTED_TARGET: ${{ inputs.target }}
+      SELECTED_FEED_SCOPE: ${{ inputs.feed_scope }}
+      SELECTED_RUNNER: ${{ inputs.runner_revision }}
+      SELECTED_SOURCE: ${{ inputs.source_revision }}
+      SELECTED_BUILD: ${{ inputs.build_number }}
+      SELECTED_DMG: ${{ inputs.dmg_sha256 }}
+      SELECTED_ASAR: ${{ inputs.asar_sha256 }}
+      SELECTED_FEED: ${{ inputs.feed_sha256 }}
+      SELECTED_CONFIRMATION: ${{ inputs.confirmation }}
+    steps:
+      - name: Check out exact qualification source
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ github.sha }}
+          persist-credentials: false
+      - name: Set up pinned Node
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: 26.2.0
+          architecture: x64
+          package-manager-cache: false
+      - name: Install locked verification dependencies
+        run: |
+          npm install --global corepack@0.34.0 --force --ignore-scripts
+          corepack enable
+          corepack prepare pnpm@11.9.0 --activate
+          pnpm install --frozen-lockfile --ignore-scripts
+      - name: Verify exact signed test intake and unchanged native predecessor
+        shell: bash
+        run: |
+          umask 077
+          mkdir -m 700 sparkle-transition-receipts
+          python3 - <<'PY'
+          import hashlib,json,os,pathlib,re,subprocess
+          e=os.environ
+          source=e['SELECTED_SOURCE']; runner=e['SELECTED_RUNNER']
+          assert re.fullmatch('[0-9a-f]{40}',source)
+          assert re.fullmatch('[0-9a-f]{40}',runner) and runner==e['GITHUB_SHA']
+          assert re.fullmatch('[1-9][0-9]{0,9}',e['SELECTED_BUILD'])
+          for name in ['SELECTED_DMG','SELECTED_ASAR','SELECTED_FEED']:
+            assert re.fullmatch('[0-9a-f]{64}',e[name])
+          assert e['SELECTED_MODE'] in ['plan','execute']
+          assert e['SELECTED_CONFIRMATION']==('RUN_DISPOSABLE_NATIVE_SPARKLE_TRANSITION' if e['SELECTED_MODE']=='execute' else '')
+          root=pathlib.Path(e['RUNNER_TEMP'])/'native-sparkle-intake'; root.mkdir(mode=0o700)
+          target=e['SELECTED_TARGET']; scope=e['SELECTED_FEED_SCOPE']
+          assert target in ['darwin-arm64','darwin-x64']
+          assert scope in ['isolated_test_feed','production_feed']
+          intel=target=='darwin-x64'
+          architecture='x64' if intel else 'arm64'
+          prefix='intel/' if intel else ''
+          native=('70630ba90e92a1cd8cb904e66e1aebe85b04e9d23a50bef7e4e41aca84c4d2f6' if intel else
+            '2ea8eca02df7cc5210b6b6ce3d6e44016bffd9d081544a4efc6fa1afeeb0f1ae')
+          origin='https://updates.tibotattle.com'
+          if scope=='isolated_test_feed':
+            base=f"{origin}/electron/test/native-sparkle/{source}/1028/{e['SELECTED_DMG']}"
+            feed=base+'/appcast.xml'
+          else:
+            base=f"{origin}/{prefix}releases/1028/{e['SELECTED_DMG']}"
+            feed=f'{origin}/{prefix}appcast.xml'
+          candidate_name='TiboTattle-0.1.21-macOS-x64.dmg' if intel else 'TiboTattle-0.1.21-mac-arm64.dmg'
+          files=[
+            ('native.dmg',f'{origin}/{prefix}releases/1026/{native}/TiboTattle-0.1.18-macOS-{architecture}.dmg',native,1024**3),
+            ('candidate.dmg',base+'/'+candidate_name,e['SELECTED_DMG'],1024**3),
+            ('appcast.xml',feed,e['SELECTED_FEED'],1024**2),
+          ]
+          for name,url,digest,limit in files:
+            path=root/name
+            result=subprocess.run(['/usr/bin/curl','--disable','--fail','--silent','--show-error','--proto','=https',
+              '--max-time','180','--max-filesize',str(limit),'--output',str(path),'--write-out','%{http_code}',url],
+              capture_output=True,text=True,check=True,timeout=190)
+            assert result.stdout=='200' and 0<path.stat().st_size<=limit
+            with path.open('rb') as stream: assert hashlib.file_digest(stream,'sha256').hexdigest()==digest
+          for name in ['native','candidate']:
+            mount=root/(name+'-mount'); mount.mkdir(mode=0o700)
+            subprocess.run(['/usr/bin/hdiutil','attach','-readonly','-nobrowse','-noautoopen','-mountpoint',str(mount),str(root/(name+'.dmg'))],
+              stdout=subprocess.DEVNULL,stderr=subprocess.DEVNULL,check=True,timeout=90)
+            try:
+              app=mount/'TiboTattle.app'
+              assert app.is_dir() and not app.is_symlink()
+              assert [p.name for p in mount.glob('*.app')]==['TiboTattle.app']
+              target=root/name; target.mkdir(mode=0o700)
+              subprocess.run(['/usr/bin/ditto',str(app),str(target/'TiboTattle.app')],check=True,timeout=120)
+            finally:
+              subprocess.run(['/usr/bin/hdiutil','detach',str(mount)],stdout=subprocess.DEVNULL,stderr=subprocess.DEVNULL,check=True,timeout=90)
+          intake={'schemaVersion':'tibotattle-native-sparkle-test-intake-v1','sourceRevision':source,
+            'target':target,'feedScope':scope,'version':'0.1.21','buildNumber':e['SELECTED_BUILD'],'bundleVersion':'1028',
+            'dmgSha256':e['SELECTED_DMG'],'asarSha256':e['SELECTED_ASAR'],'feedSha256':e['SELECTED_FEED'],
+            'nativeDmgSha256':native,'directory':str(root)}
+          (root/'intake.json').write_text(json.dumps(intake)+'\n')
+          pathlib.Path('sparkle-transition-receipts/intake.json').write_text(json.dumps({
+            'runnerRevision':runner,'sourceRevision':source,'target':target,'feedScope':scope,'dmgSha256':e['SELECTED_DMG'],
+            'asarSha256':e['SELECTED_ASAR'],'feedSha256':e['SELECTED_FEED'],'nativeDmgSha256':native,
+            'downloadsVerified':True,'signedBundlesModified':False})+'\n')
+          PY
+      - name: Exercise native Check for Updates and retained state
+        shell: bash
+        run: |
+          umask 077
+          args=(--plan)
+          if [[ "$SELECTED_MODE" == execute ]]; then
+            args=(--execute)
+          fi
+          args+=(--intake "$RUNNER_TEMP/native-sparkle-intake/intake.json")
+          if [[ "$SELECTED_MODE" == execute ]]; then
+            args+=(--confirm "$SELECTED_CONFIRMATION")
+          fi
+          node scripts/smoke-electron-macos-sparkle-transition.mjs "${args[@]}" > sparkle-transition-receipts/execution.json
+      - name: Retain content-free proof only
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: native-sparkle-electron-${{ inputs.target }}-${{ inputs.feed_scope }}-${{ github.run_id }}
+          path: sparkle-transition-receipts/*.json
+          if-no-files-found: error
+          retention-days: 14

--- a/.github/workflows/electron-macos-sparkle-transition.yml
+++ b/.github/workflows/electron-macos-sparkle-transition.yml
@@ -147,8 +147,8 @@ jobs:
               app=mount/'TiboTattle.app'
               assert app.is_dir() and not app.is_symlink()
               assert [p.name for p in mount.glob('*.app')]==['TiboTattle.app']
-              target=root/name; target.mkdir(mode=0o700)
-              subprocess.run(['/usr/bin/ditto',str(app),str(target/'TiboTattle.app')],check=True,timeout=120)
+              extracted=root/name; extracted.mkdir(mode=0o700)
+              subprocess.run(['/usr/bin/ditto',str(app),str(extracted/'TiboTattle.app')],check=True,timeout=120)
             finally:
               subprocess.run(['/usr/bin/hdiutil','detach',str(mount)],stdout=subprocess.DEVNULL,stderr=subprocess.DEVNULL,check=True,timeout=90)
           intake={'schemaVersion':'tibotattle-native-sparkle-test-intake-v1','sourceRevision':source,
@@ -268,8 +268,8 @@ jobs:
               app=mount/'TiboTattle.app'
               assert app.is_dir() and not app.is_symlink()
               assert [p.name for p in mount.glob('*.app')]==['TiboTattle.app']
-              target=root/name; target.mkdir(mode=0o700)
-              subprocess.run(['/usr/bin/ditto',str(app),str(target/'TiboTattle.app')],check=True,timeout=120)
+              extracted=root/name; extracted.mkdir(mode=0o700)
+              subprocess.run(['/usr/bin/ditto',str(app),str(extracted/'TiboTattle.app')],check=True,timeout=120)
             finally:
               subprocess.run(['/usr/bin/hdiutil','detach',str(mount)],stdout=subprocess.DEVNULL,stderr=subprocess.DEVNULL,check=True,timeout=90)
           intake={'schemaVersion':'tibotattle-native-sparkle-test-intake-v1','sourceRevision':source,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,10 +35,23 @@ remains accountable for release wording, validation, signing, and publication.
 
 ## [Unreleased]
 
-The [0.1.20 candidate](./release-notes/0.1.20.md) fixes native Mac upgrades so
-users can replace the app and carry over their retained history and settings
-without preserving the old application bundle. Signed replacement qualification
-and publication remain pending; 0.1.19 is the current published Electron release.
+The [0.1.21 candidate](./release-notes/0.1.21.md) corrects the Mac installers'
+minimum-system metadata to match their supported macOS 14 requirement. Final
+installer verification and publication remain pending.
+
+## [0.1.20](./release-notes/0.1.20.md) - 2026-09-11
+
+**Provenance:** [GitHub release](https://github.com/adamallcock/tibotattle/releases/tag/v0.1.20) ·
+[annotated source tag](https://github.com/adamallcock/tibotattle/tree/v0.1.20) ·
+[exact application source](https://github.com/adamallcock/tibotattle/commit/f518126a05a6d165b9617f6417a87219d7047273) ·
+[changes since v0.1.19](https://github.com/adamallcock/tibotattle/compare/v0.1.19...v0.1.20)
+
+- Replacing the native Mac application automatically imports compatible retained
+  history and settings, without manually preserving the old application bundle.
+- Makes a recoverable backup and preserves identity, sharing choices and selected
+  activity folders; reopening the app does not duplicate the import.
+- Keeps recovery explicit for damaged or incompatible data and preserves unknown
+  startup registration without changing it.
 
 ## [0.1.19](./release-notes/0.1.19.md) - 2026-09-10
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,9 +35,19 @@ remains accountable for release wording, validation, signing, and publication.
 
 ## [Unreleased]
 
-The [0.1.21 candidate](./release-notes/0.1.21.md) corrects the Mac installers'
-minimum-system metadata to match their supported macOS 14 requirement. Final
-installer verification and publication remain pending.
+No further changes recorded.
+
+## [0.1.21](./release-notes/0.1.21.md) - 2026-09-11
+
+**Provenance:** [GitHub release](https://github.com/adamallcock/tibotattle/releases/tag/v0.1.21) ·
+[annotated source tag](https://github.com/adamallcock/tibotattle/tree/v0.1.21) ·
+[changes since v0.1.20](https://github.com/adamallcock/tibotattle/compare/v0.1.20...v0.1.21)
+
+Complete native 0.1.18's update path to Electron, preserving local history,
+settings and contribution choice. Retain the public key needed by the incoming
+native update and declare macOS 14 correctly in both Mac installers. Restore
+compact website download controls with GitHub asset links. See the
+[release notes](./release-notes/0.1.21.md).
 
 ## [0.1.20](./release-notes/0.1.20.md) - 2026-09-11
 

--- a/apps/electron/electron-builder.production.config.cjs
+++ b/apps/electron/electron-builder.production.config.cjs
@@ -317,9 +317,9 @@ const configuration = {
   artifactName: "TiboTattle-${version}-${os}-${arch}.${ext}",
   buildNumber: INPUTS.buildNumber,
   // electron-builder uses this for CFBundleVersion and PE FileVersion. The
-  // closed policy maps the same explicit candidate input to each platform's
-  // accepted numeric representation; ambient CI build-number variables cannot
-  // affect it.
+  // closed policy uses the canonical signed allocation on macOS and encodes
+  // the separate candidate identifier on Windows; ambient CI variables cannot
+  // affect either value.
   buildVersion: targetBuildVersion,
   directories: {
     app: path.join(targetDirectory, "app"),

--- a/apps/electron/electron-builder.production.config.cjs
+++ b/apps/electron/electron-builder.production.config.cjs
@@ -388,6 +388,14 @@ if (INPUTS.targetSpec.platform === "darwin") {
     to: nativeMacOSKeychainAdapterResourcesPath,
   }];
   configuration.mac = {
+    // Preserve the native predecessor's archive-verification identity for its
+    // incoming Sparkle upgrade. No Sparkle framework/feed is installed, and
+    // electron-updater remains the only outgoing updater. Isolated rehearsal
+    // and signed staging packages do not inherit this stable trust metadata.
+    ...(!INPUTS.signedStaging
+      && INPUTS.distributionSelection.channel === distribution.PRODUCTION_ELECTRON_CHANNEL
+      ? { extendInfo: { SUPublicEDKey: distribution.PRODUCTION_ELECTRON_NATIVE_SPARKLE_PUBLIC_ED_KEY } }
+      : {}),
     // Match the supported platform floor in the signed bundle metadata, so
     // macOS and package managers can reject unsupported systems accurately.
     minimumSystemVersion: "14.0",

--- a/apps/electron/electron-builder.production.config.cjs
+++ b/apps/electron/electron-builder.production.config.cjs
@@ -388,6 +388,9 @@ if (INPUTS.targetSpec.platform === "darwin") {
     to: nativeMacOSKeychainAdapterResourcesPath,
   }];
   configuration.mac = {
+    // Match the supported platform floor in the signed bundle metadata, so
+    // macOS and package managers can reject unsupported systems accurately.
+    minimumSystemVersion: "14.0",
     // electron-updater uses the prerelease package version. The guided native
     // handover reads the numeric plist fields, so tie both values to this one
     // reviewed selection rather than letting electron-builder derive one from

--- a/config/electron-production-distribution.cjs
+++ b/config/electron-production-distribution.cjs
@@ -1,5 +1,7 @@
 "use strict";
 
+const { SIGNED_MACOS_BUNDLE_VERSION_PLAN } = require("./macos-bundle-version-plan.cjs");
+
 /**
  * Closed production distribution policy shared by the Electron builder and
  * the main-process updater.  Development packages intentionally do not read
@@ -73,11 +75,9 @@ const PRODUCTION_ELECTRON_NATIVE_TO_ELECTRON_HANDOVER_REHEARSAL_CANDIDATES = Obj
   current: "current",
   next: "next",
 });
-// This is deliberately a supplied candidate input rather than a release
-// allocation in source control. It is limited to ten decimal digits because
-// the macOS handover validator compares CFBundleVersion components as bounded
-// numeric values. A candidate still has to prove it is newer than the actual
-// installed native application before a handover can proceed.
+// Immutable artifact/source-candidate identity, independent of the canonical
+// macOS bundle allocation. Retain the historical ten-digit bound for receipt
+// compatibility; a timestamp must not become a new Apple CFBundleVersion.
 const PRODUCTION_ELECTRON_BUILD_NUMBER_PATTERN = /^[1-9][0-9]{0,9}$/u;
 const PRODUCTION_ELECTRON_RELEASE_VERSION_PATTERN =
   /^(?:0|[1-9][0-9]*)\.(?:0|[1-9][0-9]*)\.(?:0|[1-9][0-9]*)$/u;
@@ -310,7 +310,7 @@ function productionElectronWindowsFileVersion(buildNumber) {
 
 /**
  * Return the target-specific value passed to electron-builder's buildVersion.
- * macOS retains the supplied integer as CFBundleVersion for native handover
+ * macOS uses the reviewed signed release allocation for native Sparkle
  * ordering. Windows receives four valid PE components, and AppImage carries
  * both the release version and exact candidate identifier.
  */
@@ -322,11 +322,35 @@ function productionElectronBuildVersionForTarget({ target, version, buildNumber 
     throw new TypeError("target and release version are required");
   }
   const selectedBuildNumber = assertProductionBuildNumber(buildNumber);
-  if (targetSpec.platform === "darwin") return selectedBuildNumber;
+  if (targetSpec.platform === "darwin") {
+    const allocation = SIGNED_MACOS_BUNDLE_VERSION_PLAN[version]?.stable;
+    if (allocation !== undefined) return allocation;
+    // Retain already-frozen Electron 019/020 receipts and named private
+    // rehearsal fixtures. These historical timestamps are not allocations
+    // for future stable releases or native Sparkle publication.
+    if (["0.1.19", "0.1.20"].includes(version)
+        || parseNativeToElectronHandoverRehearsalVersion(version) !== null) {
+      return selectedBuildNumber;
+    }
+    throw new TypeError("macOS release requires an explicit signed bundle version allocation");
+  }
   if (targetSpec.platform === "win32") {
     return productionElectronWindowsFileVersion(selectedBuildNumber);
   }
   return `${version}.${selectedBuildNumber}`;
+}
+
+/** Validate actual signed/installed plist values without confusing provenance
+ * buildNumber with the platform's bundle allocation. */
+function assertProductionElectronMacOSBundleMetadata({
+  target, version, buildNumber, bundleVersion, bundleShortVersion,
+} = {}) {
+  const expectedShortVersion = productionElectronMacOSBundleShortVersionForTarget({ target, version });
+  const expectedBundleVersion = productionElectronBuildVersionForTarget({ target, version, buildNumber });
+  if (bundleVersion !== expectedBundleVersion || bundleShortVersion !== expectedShortVersion) {
+    throw new TypeError("macOS bundle metadata does not match the reviewed production allocation");
+  }
+  return Object.freeze({ bundleVersion, bundleShortVersion });
 }
 
 /**
@@ -381,6 +405,7 @@ module.exports = Object.freeze({
   accountlessSignedStagingRehearsalForTarget,
   accountlessSignedStagingRehearsalStagingPathSegments,
   productionElectronBuildVersionForTarget,
+  assertProductionElectronMacOSBundleMetadata,
   productionElectronDistributionForTarget,
   productionElectronFeedForTarget,
   productionElectronMacOSBundleShortVersionForTarget,

--- a/config/electron-production-distribution.cjs
+++ b/config/electron-production-distribution.cjs
@@ -17,6 +17,12 @@ const PRODUCTION_ELECTRON_APP_ID = "com.usagemonitor.local";
 const PRODUCTION_ELECTRON_WINDOWS_TOAST_ACTIVATOR_CLSID =
   "FDA705D7-5644-50E8-8CD2-3005D51B98C5";
 const PRODUCTION_ELECTRON_CHANNEL = "stable";
+// Public verification key retained from the signed native stable predecessor.
+// Sparkle checks its preservation while installing an incoming upgrade, even
+// when the archive and Developer ID signatures are valid. This passive plist
+// value does not enable Sparkle or change Electron's outgoing updater.
+const PRODUCTION_ELECTRON_NATIVE_SPARKLE_PUBLIC_ED_KEY =
+  "jhgPwmvWLMr7TGURJUoi6sXias7YP1F+hejZawKVTGw=";
 const PRODUCTION_ELECTRON_CONTRIBUTION_POLICY = "accountless-opt-out-v1";
 const PRODUCTION_ELECTRON_UPDATE_ORIGIN = "https://updates.tibotattle.com";
 // This is a separately packaged, unsigned development-only selection for
@@ -353,6 +359,15 @@ function assertProductionElectronMacOSBundleMetadata({
   return Object.freeze({ bundleVersion, bundleShortVersion });
 }
 
+/** Validate the actual mounted stable Mac app's incoming-upgrade trust key. */
+function assertProductionElectronMacOSIncomingUpgradeMetadata({ target, publicEDKey } = {}) {
+  if (!["darwin-arm64", "darwin-x64"].includes(target)
+      || publicEDKey !== PRODUCTION_ELECTRON_NATIVE_SPARKLE_PUBLIC_ED_KEY) {
+    throw new TypeError("macOS incoming upgrade must retain the native stable public key");
+  }
+  return Object.freeze({ publicEDKey });
+}
+
 /**
  * electron-updater reads the packaged semantic version, while the guided
  * native handover reads the numeric CFBundleShortVersionString. A rehearsal
@@ -373,6 +388,7 @@ function productionElectronMacOSBundleShortVersionForTarget({ target, version } 
 }
 
 module.exports = Object.freeze({
+  PRODUCTION_ELECTRON_NATIVE_SPARKLE_PUBLIC_ED_KEY,
   ACCOUNTLESS_HOSTED_REHEARSAL_APP_ID,
   ACCOUNTLESS_HOSTED_REHEARSAL_CHANNEL,
   ACCOUNTLESS_HOSTED_REHEARSAL_CREDENTIAL_STORAGE,
@@ -406,6 +422,7 @@ module.exports = Object.freeze({
   accountlessSignedStagingRehearsalStagingPathSegments,
   productionElectronBuildVersionForTarget,
   assertProductionElectronMacOSBundleMetadata,
+  assertProductionElectronMacOSIncomingUpgradeMetadata,
   productionElectronDistributionForTarget,
   productionElectronFeedForTarget,
   productionElectronMacOSBundleShortVersionForTarget,

--- a/config/macos-bundle-version-plan.cjs
+++ b/config/macos-bundle-version-plan.cjs
@@ -1,0 +1,32 @@
+"use strict";
+
+// Signed releases keep the production bundle identifier, so their build
+// numbers must advance from the last installed shared-identity dogfood build.
+// Freeze the owner-reviewed allocations per marketing version and channel;
+// adding a future release is an explicit policy change, never an implicit
+// timestamp or environment-controlled counter.
+// The 0.1.17 RC2 used 1023, RC3 used 1023.1, installed startup-recovery RC4
+// used 1023.2, installed integrated RC5 used 1023.3, and installed accounting-
+// deadline RC6 used 1023.4, and the retired-checkpoint RC7 used 1023.5. The
+// fitted-transition correction used RC8 allocation 1023.6. RC9 reserves 1023.7
+// for refresh-policy, selected-plan Trends, and last-good snapshot corrections,
+// preserving allocated stable 1024. Allocation is not built/installed evidence.
+const SIGNED_MACOS_BUNDLE_VERSION_PLAN = Object.freeze({
+  "0.1.17": Object.freeze({
+    "internal-dogfood": "1023.7",
+    stable: "1024",
+  }),
+  // Separate ARM and Intel installers share the same source and build ordering.
+  // Preserve signed Intel RC1 1025 and combined Astra/Intel RC2 1025.1.
+  // RC3 reserves 1025.2 for parser-upgrade deadlines and paginated seed isolation.
+  // Allocation does not establish signing, installation, or publication.
+  "0.1.18": Object.freeze({
+    "internal-dogfood": "1025.2",
+    stable: "1026",
+  }),
+  // First native-Sparkle-to-Electron stable allocation. Timestamp buildNumber
+  // remains independent artifact provenance, never an Apple bundle version.
+  "0.1.21": Object.freeze({ stable: "1028" }),
+});
+
+module.exports = { SIGNED_MACOS_BUNDLE_VERSION_PLAN };

--- a/config/release-evidence.js
+++ b/config/release-evidence.js
@@ -181,7 +181,7 @@ export const RELEASE_EVIDENCE_RUN_URL_PATTERN =
   /^https:\/\/github\.com\/[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+\/actions\/runs\/[1-9][0-9]*(?:\/attempt\/[1-9][0-9]*)?$/u;
 
 export const RELEASE_EVIDENCE_DEFAULT_UPDATER_MECHANISMS = Object.freeze({
-  macos: Object.freeze(["sparkle", "none", "store-managed"]),
+  macos: Object.freeze(["sparkle", "electron-updater", "none", "store-managed"]),
   windows: Object.freeze(["electron-updater", "none", "store-managed"]),
-  linux: Object.freeze(["none", "store-managed"]),
+  linux: Object.freeze(["electron-updater", "none", "store-managed"]),
 });

--- a/docs/decisions/2026-09-11-electron-macos-bundle-version-allocation.md
+++ b/docs/decisions/2026-09-11-electron-macos-bundle-version-allocation.md
@@ -1,0 +1,56 @@
+---
+title: Electron macOS bundle version allocation
+date: 2026-09-11
+type: decision-record
+status: accepted-source-contract
+---
+
+# Electron macOS bundle version allocation
+
+Stable Electron 0.1.21 uses the explicit signed Mac allocation `1028` in
+`config/macos-bundle-version-plan.cjs`. Both Mac architectures share it.
+`CFBundleShortVersionString` remains `0.1.21`; the timestamp `buildNumber`
+continues to identify the exact source candidate and artifact receipts.
+The allocation itself is not signing, installation, or update evidence.
+
+The native 0.1.18 predecessor uses `1026`, so Sparkle can order the new
+bundle above it without relaxing Apple's version grammar or the Worker
+validator. The held timestamp-based 0.1.21 installers must be rebuilt after
+source integration. Previously frozen 0.1.19/0.1.20 artifacts and named private
+rehearsal receipts retain explicit compatibility handling; they are not
+allocations for future stable Mac releases. An unallocated future stable
+release fails packaging.
+
+## Two update entry points
+
+Electron 0.1.20 has a larger timestamp `CFBundleVersion`, but its installed
+updater selects releases by marketing semantic version. The locally pinned
+`electron-updater` 6.8.9 `AppUpdater.isUpdateAvailable` compares `app.version`
+with feed `version`; the regression executes this method for 0.1.20→0.1.21.
+Its `MacUpdater` serves a URL-only loopback response to the default native
+updater mode after choosing the candidate.
+
+[Electron 43.2.0's dependency lock](https://github.com/electron/electron/blob/v43.2.0/DEPS)
+pins Squirrel.Mac commit `0e5d146ba13101a1302d59ea6e6e0b3cace4ae38`.
+[Electron's native adapter](https://github.com/electron/electron/blob/v43.2.0/shell/browser/auto_updater_mac.mm)
+selects its default release-server mode for this call.
+That mode's [download preparation](https://github.com/Squirrel/Squirrel.Mac/blob/0e5d146ba13101a1302d59ea6e6e0b3cace4ae38/Squirrel/SQRLUpdater.m)
+and [installer verification](https://github.com/Squirrel/Squirrel.Mac/blob/0e5d146ba13101a1302d59ea6e6e0b3cace4ae38/Squirrel/SQRLInstaller.m)
+verify the signed replacement without ordering `CFBundleVersion`.
+Electron's applied [optional downgrade guard](https://github.com/electron/electron/blob/v43.2.0/patches/squirrel.mac/feat_add_ability_to_prevent_version_downgrades.patch)
+uses `CFBundleShortVersionString`, not the build number. The other pinned
+Squirrel patches introduce no build-number comparison.
+
+This supports the source-level expectation that Electron 0.1.20→0.1.21
+accepts the corrected allocation. Actual signed replacement remains required,
+as does native 0.1.18→Electron through its real Sparkle Check for Updates flow.
+
+## Verification contract
+
+Signed artifact and installed-app inspectors call
+`assertProductionElectronMacOSBundleMetadata` with actual plist values and
+independently bound target, semantic version, and provenance build number.
+The validator rejects a missing value, stale marketing version, wrong
+allocation, or timestamp substituted for `1028`. Final updater metadata must
+still bind the exact final signed ZIP/DMG bytes; this change does not weaken
+that separate check or publish any artifact.

--- a/docs/plans/2026-09-11-electron-upgrade-release-closure.md
+++ b/docs/plans/2026-09-11-electron-upgrade-release-closure.md
@@ -69,6 +69,27 @@ diagnostic reached Check but lost all accessibility windows afterwards.
 Bounded direct Accessibility and window-count diagnostics now distinguish API
 failure from an empty UI. Neither failed run is a release qualification.
 
+Apple Silicon run 34563532865 subsequently passed the complete actual native
+update, migration, repeated restart, preservation and owned-process cleanup.
+Its source, build, DMG, ASAR and isolated feed are the corrected identities
+above. This fixture does not contain an existing credential and does not prove
+the later production-feed path.
+
+Intel macOS 26 run 34563534703 reported Accessibility `cannot_complete` despite
+permission being present. The isolated macOS 15 comparison, run 34564076590,
+reached Check and Install before the UI reader failed during installation.
+The runner now tolerates a closing window during a read, while refusing to
+repeat a click whose outcome is unknown. Run 34564895606 tests that correction
+against the same signed Intel artifact. No app rebuild or security change is
+part of this test-tool correction.
+
+Fresh-install qualification is separate from the native upgrade fixture. Its
+manual workflow starts the exact signed app without predecessor, Codex home,
+usage records or credentials, checks first-run sharing and Settings controls,
+then verifies default and opt-out persistence across controlled restarts. It
+does not claim native quit, credential persistence or successful uploads.
+Publication remains held for the pending Intel and clean-install receipts.
+
 The publication coordinator now reuses the established release-evidence
 contract from the website verifier and reconciles the exact four-target
 Electron inventory plus incoming native feeds. Its 24 owning tests pass.

--- a/docs/plans/2026-09-11-electron-upgrade-release-closure.md
+++ b/docs/plans/2026-09-11-electron-upgrade-release-closure.md
@@ -24,17 +24,36 @@ installed evidence.
   Electron transition receipt, separate from embedded application updater
   metadata. Native receipt validation, key continuity, artifact validation and
   atomic feed replacement remain in use.
-- Corrected application source is frozen at
+- The first Sparkle candidate used application source
   dd9e99f38b3802746de88b76160fdbb56051edeb, version 0.1.21,
-  provenance build 2026091106, Mac bundle version 1028. Previous signed
-  0.1.21 candidates remain historical evidence; they will not be published.
-- Both final Mac applications and outer disk images are signed, notarized and
-  stapled. The final Windows installer passed its hosted install, processing,
+  provenance build 2026091106, Mac bundle version 1028. It is superseded by the
+  public-key compatibility correction below and will not be published.
+- That candidate's Mac applications and outer disk images are signed, notarized
+  and stapled. Its Windows installer passed the hosted install, processing,
   restart and uninstall journey (run 34559592872). Linux packaging passed
   (run 34559594120); this is not a new installed Linux acceptance run.
 - Both installed Mac update runners are prepared: native 0.1.18 through Sparkle,
   and released Electron 0.1.20 through its unchanged production updater.
   Their contract tests passed; actual installed execution remains below.
+
+## Installed findings and correction
+
+Apple Silicon run 34561060979 reached the actual Check and Install controls,
+then Sparkle rejected the successor. Pinned Sparkle 2.9.3 forbids removing the
+predecessor's public update key; the signed Electron bundle omitted it. Both
+old and new signing identities match and their signatures are valid. The
+correction retains the exact public SUPublicEDKey as passive signed metadata.
+Electron remains the only outgoing updater. No signature checks are relaxed.
+
+Intel run 34561079561 stopped at the About menu; no update was attempted. Its
+runner now opens the app menu once and waits for its item, with bounded
+diagnostics from only the synthetic process. Repeated clicks previously could
+toggle the menu while accessibility information was still arriving.
+
+The corrected source will be recorded by the frozen application tag and fresh
+four-target receipts, using provenance build 2026091107. Both failed receipts
+and the superseded installers remain preserved. Public publication remains
+held until the corrected installed journeys succeed.
 
 ## Remaining sequence
 

--- a/docs/plans/2026-09-11-electron-upgrade-release-closure.md
+++ b/docs/plans/2026-09-11-electron-upgrade-release-closure.md
@@ -50,10 +50,33 @@ runner now opens the app menu once and waits for its item, with bounded
 diagnostics from only the synthetic process. Repeated clicks previously could
 toggle the menu while accessibility information was still arriving.
 
-The corrected source will be recorded by the frozen application tag and fresh
-four-target receipts, using provenance build 2026091107. Both failed receipts
-and the superseded installers remain preserved. Public publication remains
-held until the corrected installed journeys succeed.
+The corrected application source is
+a651ea130dd1460e4443a037c4434f57b911fec4, provenance build 2026091107.
+Both Mac applications and disk images are signed, notarized, stapled and retain
+the verified native public key. Windows run 34561980268 passed signing and
+the installed processing/restart/uninstall journey. Linux packaging run
+34561981708 passed; it does not add a new installed Linux acceptance claim.
+
+The corrected isolated feeds and their exact installers were uploaded with
+all four R2 and public readbacks verified; the shared owner was released.
+Native ARM run 34562927824 passed actual Check, Install, updater relaunch and
+first migration, then stopped because the runner misclassified the signed
+same-executable companion as a second independent app. The runner now selects
+the unique process-tree root, retains descendant ownership checks and still
+refuses independent app roots. Restart and final preservation remain unproven.
+Intel run 34562929758 lost its accessibility menu before Check; the prior
+diagnostic reached Check but lost all accessibility windows afterwards.
+Bounded direct Accessibility and window-count diagnostics now distinguish API
+failure from an empty UI. Neither failed run is a release qualification.
+
+The publication coordinator now reuses the established release-evidence
+contract from the website verifier and reconciles the exact four-target
+Electron inventory plus incoming native feeds. Its 24 owning tests pass.
+The native runner and diagnostic fixes pass 25 tests. These are tooling
+checks; the frozen application artifacts remain unchanged.
+All failed receipts and superseded installers remain preserved. The local
+annotated v0.1.21 tag has not been pushed, and public publication remains held
+until the corrected installed journeys succeed.
 
 ## Remaining sequence
 

--- a/docs/plans/2026-09-11-electron-upgrade-release-closure.md
+++ b/docs/plans/2026-09-11-electron-upgrade-release-closure.md
@@ -28,12 +28,18 @@ installed evidence.
   dd9e99f38b3802746de88b76160fdbb56051edeb, version 0.1.21,
   provenance build 2026091106, Mac bundle version 1028. Previous signed
   0.1.21 candidates remain historical evidence; they will not be published.
+- Both final Mac applications and outer disk images are signed, notarized and
+  stapled. The final Windows installer passed its hosted install, processing,
+  restart and uninstall journey (run 34559592872). Linux packaging passed
+  (run 34559594120); this is not a new installed Linux acceptance run.
+- Both installed Mac update runners are prepared: native 0.1.18 through Sparkle,
+  and released Electron 0.1.20 through its unchanged production updater.
+  Their contract tests passed; actual installed execution remains below.
 
 ## Remaining sequence
 
-1. Build and sign the four candidates from that source; finalize the Mac
-   installer and updater metadata after notarization. Keep the resulting
-   artifact identities immutable.
+1. Collect the finalized four-target artifact receipts from the completed
+   packaging and signing jobs. Keep the resulting artifact identities immutable.
 2. Generate isolated Sparkle test feeds with the existing native stable key
    and pinned official Sparkle tools. Only the disposable hosted accounts
    receive a test-feed preference; signed application bundles remain unchanged.

--- a/docs/plans/2026-09-11-electron-upgrade-release-closure.md
+++ b/docs/plans/2026-09-11-electron-upgrade-release-closure.md
@@ -1,0 +1,77 @@
+---
+title: Complete the native and Electron update paths
+date: 2026-09-11
+type: plan
+status: in-progress
+---
+
+The public Electron 0.1.20 release did not complete the native update path:
+both native Sparkle feeds still advertise 0.1.18. The owner approved correcting
+the established release process and qualifying the installed update before
+another app publication. This plan records remaining work, not completed
+installed evidence.
+
+## Completed
+
+- Published website source 7b6cfdc9aef269ffc27885d02e8c75e7ff88bdcd restores
+  compact download controls and exact GitHub 0.1.20 asset links. Live desktop,
+  mobile, locale, checksum and metadata checks passed. The approved empty
+  deployment-journal recovery preserved the original journal; deployment
+  completed and released its shared owner.
+- Manual native-state replacement with signed 0.1.20 passed. This does not
+  establish delivery through Sparkle.
+- The canonical incoming Sparkle generator and publisher now have an explicit
+  Electron transition receipt, separate from embedded application updater
+  metadata. Native receipt validation, key continuity, artifact validation and
+  atomic feed replacement remain in use.
+- Corrected application source is frozen at
+  dd9e99f38b3802746de88b76160fdbb56051edeb, version 0.1.21,
+  provenance build 2026091106, Mac bundle version 1028. Previous signed
+  0.1.21 candidates remain historical evidence; they will not be published.
+
+## Remaining sequence
+
+1. Build and sign the four candidates from that source; finalize the Mac
+   installer and updater metadata after notarization. Keep the resulting
+   artifact identities immutable.
+2. Generate isolated Sparkle test feeds with the existing native stable key
+   and pinned official Sparkle tools. Only the disposable hosted accounts
+   receive a test-feed preference; signed application bundles remain unchanged.
+3. On Apple Silicon and Intel, install the exact native 0.1.18 predecessor,
+   retain synthetic records, language, appearance and contribution opt-out,
+   click its actual Check for Updates and Install controls, and verify the
+   updater-created Electron launch, migration and repeated restart.
+   A manual candidate copy, missing safety field or mismatched artifact
+   cannot qualify publication. Existing-credential coverage is recorded
+   separately and is not claimed by this fixture.
+4. Complete canonical publication preflight and coordinate GitHub assets,
+   native Sparkle feeds, Electron stable feeds, Homebrew and website.
+   The previous owner approvals remain applicable; no publication happens
+   merely because a source test or signing step passes.
+5. Immediately after activation, run two production acceptance paths using
+   unchanged signed predecessors: native 0.1.18 with its bundled Sparkle URL,
+   and Electron 0.1.20 with its bundled Electron update URL. Verify the actual
+   replacement and retained state. Record these separately from test-feed proof.
+
+## Version and qualification boundaries
+
+The Mac bundle allocation follows the existing
+[decision](../decisions/2026-09-11-electron-macos-bundle-version-allocation.md).
+Electron update selection uses the marketing version; timestamp provenance
+does not become a new Apple bundle-version grammar.
+
+The public signed 0.1.20 app disables Node CLI inspection through its Electron
+fuses. Its main process cannot be redirected through an inspector without
+altering the signed artifact. We will not weaken that fuse or present a
+modified fixture as the released app. Its unchanged production update is
+therefore a post-activation acceptance step.
+
+The incoming native test uses the documented Sparkle UserDefaults feed override
+only on disposable accounts. Its receipt labels that scope explicitly;
+productionFeedVerified remains false until the later bundled-feed test passes.
+See the [Sparkle customization documentation](https://sparkle-project.org/documentation/customization/)
+and [Electron fuse documentation](https://www.electronjs.org/docs/latest/tutorial/fuses).
+
+Operational owners remain the
+[Mac stable release runbook](../runbooks/macos-stable-release-runbook.md) and
+[cross-platform publication runbook](../runbooks/2026-08-18-cross-platform-release-publication.md).

--- a/docs/runbooks/2026-08-18-cross-platform-release-publication.md
+++ b/docs/runbooks/2026-08-18-cross-platform-release-publication.md
@@ -675,6 +675,23 @@ the user-facing explanation and commands.
 
 ## Normal Electron stable feed preparation
 
+An Electron cutover also has an incoming native update obligation. Follow the
+[native Sparkle transition procedure](macos-stable-release-runbook.md#native-sparkle-to-electron-transition)
+before activation. The writer below intentionally leaves both native appcasts
+unchanged; a green Electron feed publication does not complete that obligation.
+Publish the exact GitHub assets first, then coordinate both native appcasts,
+the four Electron feeds, Homebrew and the website. Verify both native and
+Electron installed update paths against their real production feeds afterwards.
+
+Website manual download buttons use the canonical GitHub release asset URLs.
+The updates host remains the transport for installed updaters. Keep all four
+buttons compact, retain unobtrusive checksum controls, and derive version,
+platform, minimum OS and native trust claims from the final manifest. Only Mac
+artifacts can be described as Developer ID signed and Apple notarized. Verify
+the rendered desktop/mobile and translated pages after deployment, as well as
+live bytes and social metadata. Homebrew must resolve the same Mac installer
+digests before its installation command is shown.
+
 `scripts/prepare-electron-stable-publication.mjs` prepares a local, journaled
 four-target publication contract. It does not upload, sign, deploy, create a
 release or change any feed. Its optional public verification mode performs only

--- a/docs/runbooks/2026-09-07-macos-native-to-electron-handover.md
+++ b/docs/runbooks/2026-09-07-macos-native-to-electron-handover.md
@@ -1,5 +1,5 @@
 ---
-title: macOS native-to-Electron guided handover
+title: macOS native-to-Electron replacement and update transition
 date: 2026-09-07
 type: runbook
 status: draft
@@ -7,10 +7,9 @@ status: draft
 
 # Status and boundary
 
-The automatic replacement path is implemented for the 0.1.20 candidate. Signed
-installed qualification and publication must complete before presenting it as
-available. Released 0.1.19 requires the earlier guided procedure; it is not proof
-of ordinary replacement compatibility.
+Ordinary replacement shipped in 0.1.20. Native Sparkle Check for Updates requires
+the separate installed transition qualification below. Released 0.1.19 required
+the earlier guided procedure; it is not proof of ordinary replacement compatibility.
 
 The required user journey is: quit the old app, replace TiboTattle in Applications
 with the new signed app, and open it. The app transfers compatible retained state
@@ -288,3 +287,75 @@ Electron main process; unknown registration remains untouched. The settings UI
 reads current OS status rather than treating an unapplied local default as a
 confirmed user choice. The helper confirms only writer shutdown and native preferences;
 its `native_writer_prepared` reply carries no startup-setting claims.
+
+## Native 0.1.18 Check for Updates transition
+
+Manual replacement and native Sparkle installation are separate qualification
+journeys. Do not activate `appcast.xml` or `intel/appcast.xml` on the strength of
+manual replacement evidence alone. Electron's outgoing `electron-updater` feeds
+remain separate from these incoming native feeds.
+
+Use the maintained `generate-sparkle-appcast.js --electron-transition` path with
+the existing stable public key, exact signed DMG, actual Apple-compatible
+`CFBundleVersion`, matching short version and pinned Sparkle tools. The generator
+runs official `generate_appcast`, signs the exact archive with official
+`sign_update`, adds that checked enclosure signature, then signs the XML with
+`sign_update`. Both signatures and the content-addressed URL are verified before
+the output is adopted. It never edits the application or notarized archive.
+
+For the Intel Sparkle namespace, copy the final Electron DMG to the native alias
+`TiboTattle-<version>-macOS-x64.dmg` and verify the copy has exactly the same bytes,
+size and SHA-256 as the final `TiboTattle-<version>-mac-x64.dmg`. The alias is not a
+second build. Keep manual GitHub download and Electron updater names unchanged.
+
+Before installed qualification, generate an isolated rehearsal using
+`--electron-transition-test-source <exact-source-commit> --skip-retain` in addition
+to `--electron-transition`. This fixes the enclosure namespace to
+`https://updates.tibotattle.com/electron/test/native-sparkle/<source>/<bundle-version>/<dmg-sha256>/`.
+Only the approved test objects are staged; no stable appcast is activated.
+The rehearsal still uses the native fleet's existing stable verification key.
+The production publisher refuses this test namespace.
+
+Production publication uses the existing `publish-sparkle-update.js` entrypoint,
+previous native 0.1.18 manifest, key-continuity checks and atomic appcast guard.
+Supply a `tibotattle-electron-sparkle-transition-v1` receipt containing:
+
+- `application`: bundle identifier, architecture, actual bundle version and
+  short version; the Mac bundle allocation is validated independently of the
+  timestamp used for build provenance.
+- `artifact`: exact native-alias filename, byte count and final DMG SHA-256.
+- `source` and `channel`: canonical repository, annotated tag, commit and
+  existing stable channel publication contract.
+- `sparkle`: incoming appcast URL and existing public-key fingerprint.
+- `electron`: provenance `buildNumber`, signed `asarSha256`, and
+  `updaterConfigurationSha256` for the packaged outgoing updater configuration.
+- `evidence`: `scope: "local_qualification"` and `nativeSparkleJourney` with a
+  sibling JSON `localPath`, exact bytes and SHA-256 of the retained installed
+  journey receipt. This is local qualification provenance, not a public
+  downloadable path; retain that proof with the release operation.
+
+The journey schema is `tibotattle-signed-macos-sparkle-transition-v1`, with
+`status: "passed"`, exact `target`, `version`, `buildNumber`, `bundleVersion`,
+`sourceRevision`, `dmgSha256`, `asarSha256`, `feedSha256`,
+`feedScope: "isolated_test_feed"`, `productionFeedVerified: false`,
+`candidateCopiedByRunner: false`,
+`nativeVersion: "0.1.18"`, `nativeDmgSha256`, and true results for
+`nativeSparkleUpdateCompleted`, `migrationCompleted`, `retainedRowsPreserved`,
+`saltPreserved`, `preferencesPreserved`, `optOutPreserved`,
+`restartNoDuplicates`, `sourceUntouched`, `ownedProcessesStopped`,
+`signedArtifactVerified`, `disposableAccountVerified`, `checkForUpdatesClicked`,
+`installUpdateClicked`, `updaterRelaunchedCandidate`, and `feedOverrideApplied`.
+The native DMG must match the retained native predecessor manifest. A manual
+replacement receipt cannot substitute for this evidence.
+
+The publisher mounts and inspects final Electron bytes, checks Developer ID,
+hardened runtime, notarization tickets, Gatekeeper, architecture, minimum OS,
+sealed distribution/source metadata, migration helpers and the outgoing updater.
+The transition receipt does not claim an embedded Sparkle framework, native build
+manifest or native updater settings. Native receipt validation remains unchanged.
+
+First run the publisher without `--publish`; retain the local validated plan.
+Only after exact installed qualification and existing release approval use its
+normal protected publication options. Preserve the native prior manifests and
+verify the live signed feeds and downloaded bytes after activation. Do not
+substitute a direct R2 write for the atomic guard.

--- a/docs/runbooks/macos-stable-release-runbook.md
+++ b/docs/runbooks/macos-stable-release-runbook.md
@@ -116,6 +116,64 @@ publication before showing the command on either website tab.
 
 ## 0. Version lockstep and preflight
 
+### Native Sparkle to Electron transition
+
+For the 0.1.21 transition, users of native 0.1.18 must be able to use its
+existing Check for Updates and Install controls and continue with their retained
+history, settings and contribution choice. Publishing Electron installers or its
+YAML feeds alone does not update either native Sparkle feed.
+
+The final application remains the ordinary signed Electron build, with its own
+outgoing updater configuration. Follow the shared
+[Mac bundle-version allocation](../decisions/2026-09-11-electron-macos-bundle-version-allocation.md):
+0.1.21 uses bundle version 1028, above native 0.1.18's 1026. The provenance build
+number is a separate value. Retain the predecessor's exact public SUPublicEDKey
+in the signed Electron Info.plist: Sparkle refuses removal of that key even
+after a valid archive signature. This passive compatibility value does not add
+a Sparkle framework, feed configuration or second running updater. Preserve
+Apple's version grammar and the Electron inspection fuse.
+
+1. Finalize the exact signed/notarized/stapled Mac DMGs and updater ZIPs through
+   the Electron finalizer. Generate the incoming feed with the existing
+   generate-sparkle-appcast.js entrypoint and its explicit --electron-transition
+   option. This uses the pinned official generator and sign_update tool for
+   both enclosure and feed signatures with the existing native stable key.
+2. First generate an isolated feed with --electron-transition-test-source set
+   to the exact application source and --skip-retain. Its only namespace is
+   electron/test/native-sparkle/<source>/<bundleVersion>/<dmgSha256>/.
+   The production publisher refuses this test namespace. Uploading these test
+   objects requires the existing test-publication authority and shared owner.
+3. Run electron-macos-sparkle-transition.yml on both native hosted architectures
+   with exact source, installer, ASAR and feed hashes. The unchanged signed
+   native predecessor receives a test-feed preference only in its disposable
+   account. Sparkle alone installs the candidate. Require successful actual
+   update/relaunch, retained rows, settings, salt, opt-out and repeated restart.
+   A manual replacement or an ARM receipt cannot substitute for the Intel proof.
+4. Bind each passed receipt as a local qualification file in the explicit
+   tibotattle-electron-sparkle-transition-v1 publisher receipt. It includes the
+   incoming key digest and feed URL separately from the Electron ASAR and
+   outgoing updater configuration digest. The publisher revalidates the signed
+   mounted DMG, receipt, previous native manifest and annotated source tag.
+   It does not treat an arbitrary receipt path as successful qualification.
+5. Generate the final stable incoming feeds and use the existing guarded
+   publish-sparkle-update.js operation below for both architectures. Preserve
+   key continuity and atomic replacement. Intel's native route uses a
+   byte-identical TiboTattle-0.1.21-macOS-x64.dmg alias; the public GitHub download
+   retains the ordinary TiboTattle-0.1.21-mac-x64.dmg name and identical digest.
+6. Coordinate activation with the GitHub release, Electron feeds, Homebrew and
+   website through the cross-platform runbook. Then rerun the native journey
+   with production_feed and no override, and run
+   electron-macos-production-update.yml using the unchanged released Electron
+   0.1.20 app. Preserve these production receipts separately from the isolated
+   test proof. Its signed app cannot be redirected with a Node inspector.
+
+Existing-credential coverage remains an explicit receipt field; the synthetic
+opt-out fixture does not claim an existing Keychain credential rehearsal.
+The active closure plan is
+[the installed update sequence](../plans/2026-09-11-electron-upgrade-release-closure.md).
+
+### Common release preflight
+
 Start with `node scripts/release-agent.mjs doctor --json`. Supply an exact-source
 plan for target-specific checks; see [agent release operations](agent-release-operations.md).
 The doctor reads only local evidence and configured references. It does not

--- a/docs/runbooks/release-publication-reconciliation.md
+++ b/docs/runbooks/release-publication-reconciliation.md
@@ -8,8 +8,10 @@ status: maintained
 # Exact release publication reconciliation
 
 Status: maintained operational interface. This tool coordinates publication of
-an **already qualified stable macOS release** for Apple silicon and Intel. It
-does not build, sign, notarize, change consent, run migrations, publish tags, or
+an **already qualified stable release** through its Apple silicon and Intel
+Sparkle feeds, GitHub assets, cask and website. It admits either the existing
+two-Mac native release or the explicit four-platform Electron transition below.
+It does not build, sign, notarize, change consent, run migrations, publish tags, or
 replace the installed-artifact and hardware gates in the
 [macOS release runbook](./macos-stable-release-runbook.md).
 
@@ -22,7 +24,7 @@ explicitly authorized invocation is required for remote changes.
 Keep the plan and operation journal in a private release-staging directory, outside
 tracked source. Freeze final installer bytes before generating the canonical
 cross-platform `release-manifest.json` and `SHA256SUMS` with the existing release
-evidence generator. The manifest, not a hardcoded asset count, determines the
+evidence generator. For the existing native release, the manifest determines the
 GitHub asset set: all checksum-enumerated artifacts and conditional evidence,
 plus `SHA256SUMS` and `verify-release.md`. Files must retain their public basenames
 and share the canonical manifest's staging directory.
@@ -34,17 +36,76 @@ separate inputs to the existing Sparkle publisher, not invented extra GitHub
 assets. Keep those finalization manifests and the corresponding previous stable
 manifests for both architectures.
 
+### Four-platform Electron transition
+
+The Electron branch requires exactly four direct GitHub-release artifact entries:
+macOS arm64, macOS x64, Windows x64 and Linux x64. Every artifact retains
+`updater.mechanism: electron-updater`; each Mac's `updater.metadata` identifies
+`TiboTattle-<version>-darwin-<architecture>-update.yml`. Do not replace that YAML
+with a native appcast or invent a second app artifact to represent an incoming
+update transport.
+
+The incoming native Sparkle XML files are additional immutable GitHub assets.
+Use distinct public basenames, such as
+`TiboTattle-<version>-native-arm64-appcast.xml` and
+`TiboTattle-<version>-native-x64-appcast.xml`. Preserve their signed bytes when
+copying or renaming them. Each must advertise the correct architecture-specific
+stable destination; isolated test feeds cannot be published as stable feeds.
+
+For the current checksum/native-signature profile, the exact public set is:
+
+| Files | Count |
+| --- | --- |
+| Four canonical installers | 4 |
+| Both Mac ZIPs, ZIP blockmaps and DMG blockmaps | 6 |
+| Four Electron updater YAML files | 4 |
+| Two incoming native Sparkle XML files | 2 |
+| Canonical manifest, `SHA256SUMS`, `SHA256SUMS-ALL-RELEASE-FILES`, verification guide | 4 |
+
+The baseline is 20 files. Any conditional evidence already required by the
+canonical manifest remains required. The reconciler rejects arbitrary extras,
+missing XML, aliases inserted as additional public installers, and checksum
+drift. `SHA256SUMS` remains generator-owned. The auxiliary checksum file contains
+one exact `SHA256  filename` line for each installer, updater artifact, YAML and
+incoming XML and conditional manifest evidence, sorted lexicographically by the
+full line with a final newline.
+It excludes the canonical manifest, both checksum files and verification guide;
+those already have their separate manifest/immutable-release bindings.
+
+The Electron successor must retain the predecessor's exact `SUPublicEDKey` in
+its signed Mac Info.plist. This is passive incoming-update compatibility metadata;
+it does not embed or enable a Sparkle runtime in Electron. Keep the incoming
+native and outgoing Electron updater configurations distinct. Each local
+`tibotattle-electron-sparkle-transition-v1` feed manifest must bind the actual
+architecture-specific native installed journey, final DMG and ASAR, key
+continuity, and source. A manual-copy test or a green job status cannot substitute
+for that receipt. A canonical manifest with pending execution acceptance is
+preparable but final validation refuses publication.
+
+This coordinator still reports only its two native Sparkle feed surfaces.
+Publish and read back all four Electron feeds through the existing
+[Electron stable-feed lane](./2026-08-18-cross-platform-release-publication.md).
+A complete reconciliation here does not mean those four outgoing feeds were
+activated. Track both lanes in the same release closure plan, using their existing
+guarded operations; never bypass either publisher with raw storage writes.
+
 Prepare the cask using the first-party tap's existing `scripts/update-cask.rb`.
 Pin the bytes of `.github/workflows/update-tibotattle.yml` reviewed for dispatch;
 the reconciler invokes that existing workflow rather than rewriting the tap or
 duplicating its native installer checks. The expected cask must contain the
-canonical paired architecture/digest declarations and macOS Sonoma floor.
+canonical paired architecture/digest declarations and macOS Sonoma floor. Native
+releases use `macOS-#{arch}` URLs; the Electron branch uses `mac-#{arch}` URLs
+for the standard canonical GitHub installers.
 
 Prepare the website through the existing [web-only lane](./2026-08-17-web-only-release.md)
 in its exact clean source checkout. Retain its web-release receipt and generated
 `release-site-manifest.json`. Both website installer rows must identify the exact
 GitHub assets in the canonical release manifest. Website publication can use a
-different, explicitly receipt-bound source commit from the native release.
+different, explicitly receipt-bound source commit from the application release.
+For the four-platform transition, also inspect the rendered desktop/mobile
+download section and open all four manual download links: each must select the
+matching immutable GitHub release asset. This coordinator checks the two Mac
+installer rows; retain the Windows/Linux rendered-link evidence separately.
 
 ### Closed plan schema
 
@@ -62,7 +123,7 @@ The JSON plan accepts exactly these fields; unknown fields are rejected:
 | `tap` | `{path, sha256, bytes, workflowSha256}` for the prepared canonical cask and reviewed updater workflow |
 | `website` | `{repositoryRoot, receipt, manifest}`; receipt and manifest each use `{path, sha256, bytes}` |
 
-Each target has exactly:
+An existing native target has exactly:
 
 ```json
 {
@@ -74,6 +135,30 @@ Each target has exactly:
   "sparklePublicEdKey": "<canonical base64 public Ed25519 key>"
 }
 ```
+
+For the Electron transition, **both** targets additionally require a
+`sparkleDmg` file spec, and `dmgName` names the standard public Electron DMG:
+
+```json
+{
+  "architecture": "x64",
+  "dmgName": "TiboTattle-1.2.3-mac-x64.dmg",
+  "appcastName": "TiboTattle-1.2.3-native-x64-appcast.xml",
+  "sparkleDmg": {"path": "/absolute/staging/incoming/TiboTattle-1.2.3-macOS-x64.dmg", "sha256": "<same final installer SHA-256>", "bytes": 1234},
+  "feedManifest": {"path": "/absolute/staging/incoming/intel-transition-manifest.json", "sha256": "<64 lowercase hexadecimal characters>", "bytes": 1234},
+  "previousManifest": {"path": "/absolute/staging/previous-stable-x64.json", "sha256": "<64 lowercase hexadecimal characters>", "bytes": 1234},
+  "sparklePublicEdKey": "<canonical base64 public Ed25519 key>"
+}
+```
+
+`sparkleDmg` is a local input to the same native publisher, not a second public
+artifact. The Intel `macOS-x64` alias is required by the native namespace policy;
+make a separate regular-file copy of the final `mac-x64` DMG and verify identical
+size and SHA-256. Never repackage or re-sign an alias. ARM can reference its
+standard final `mac-arm64` file. The reconciler verifies the alias against the
+canonical installer before passing it to the existing Sparkle publisher, which
+checks the manifest, signed archive, key and installed evidence. Native targets
+must not supply `sparkleDmg`; their existing contract remains unchanged.
 
 Use `x64` for Intel. The `1234` sizes and placeholder hashes above are illustrative,
 not valid evidence. Public keys are not signing keys; never put secret values or
@@ -184,7 +269,13 @@ the exact observed state, not installed-app or physical-hardware qualification.
 
 Run `node --test test/release-publication.test.js` for local/synthetic admission,
 adapter-contract, lost-response, ownership, stale-cache, partial publication and
-zero-write rerun coverage. Tests never contact Apple, upload assets, dispatch a
+zero-write rerun coverage, plus four-platform inventory, alias substitution and
+incoming XML versus outgoing YAML separation. Run
+`node --test test/release-evidence.test.js` when changing the canonical evidence
+contract. Keep the coordinator and website verifier on the same reviewed
+contract: final signed-byte evidence and explicit owner acceptance must not be
+replaced with invented unsigned-payload or passed-test claims to satisfy an older
+validator. Pending acceptance remains a final-publication refusal. Tests never contact Apple, upload assets, dispatch a
 workflow, or deploy a Worker. Live GitHub permissions, a real signed candidate,
 Cloudflare guard credentials, native hardware and actual publication remain
 separate owner-authorized gates.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "app-usagemonitor",
-  "version": "0.1.20",
+  "version": "0.1.21",
   "private": true,
   "type": "module",
   "description": "Local-first coding-agent usage analysis with optional privacy-safe community aggregates.",

--- a/packages/accounting/package.json
+++ b/packages/accounting/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@app-usagemonitor/accounting",
-  "version": "0.1.20",
+  "version": "0.1.21",
   "private": true,
   "type": "module",
   "description": "Runtime-neutral exact API-price-equivalent accounting kernel.",

--- a/packages/identity-core/package.json
+++ b/packages/identity-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@app-usagemonitor/identity-core",
-  "version": "0.1.20",
+  "version": "0.1.21",
   "private": true,
   "type": "module",
   "description": "Deterministic pseudonym derivation primitives shared by local Node runtimes.",

--- a/packages/quota-analysis/package.json
+++ b/packages/quota-analysis/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@app-usagemonitor/quota-analysis",
-  "version": "0.1.20",
+  "version": "0.1.21",
   "private": true,
   "type": "module",
   "description": "Runtime-neutral quota track, calibration, and rolling comparison kernel.",

--- a/packages/telemetry-contract/package.json
+++ b/packages/telemetry-contract/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@app-usagemonitor/telemetry-contract",
-  "version": "0.1.20",
+  "version": "0.1.21",
   "private": true,
   "type": "module",
   "description": "Runtime-neutral closed telemetry schemas, normalization, and validation.",

--- a/release-notes/0.1.20.md
+++ b/release-notes/0.1.20.md
@@ -1,34 +1,11 @@
-# TiboTattle 0.1.20 candidate
+# TiboTattle 0.1.20
 
-This candidate fixes the upgrade from the native Mac app to Electron. It is not
-yet a published stable release. Qualification of the final signed replacement
-install remains pending, followed by installer, website and update publication.
+Install the new Mac app and continue with your existing history and settings. You no longer need to create handover folders, save a copy of the old application, or update native 0.1.16 first.
 
-## Replace the app and keep your history
+The app automatically detects compatible retained native data, makes a backup, and carries over history, identity, sharing choices, language, appearance, refresh and tray preferences, and selected activity folders. It also handles installations where the old application has already been replaced. Reopening the app does not repeat the import or duplicate records.
 
-The new migration path detects retained native data even when the old application
-bundle has already been replaced. Users should be able to install the new app,
-open it and continue with their existing history and settings, without creating
-handover folders or copying the old app themselves.
+Existing Electron users receive the update through the app's normal updater. Installers remain available for Apple silicon and Intel Macs, Windows x64 and Linux x86_64. Native Sparkle feeds remain separate.
 
-Migration creates an automatic backup and imports compatible retained data
-through a recoverable transaction. It preserves identity salt, sharing opt-outs,
-language, appearance, refresh and tray preferences, and the selected Codex
-activity roots. Completed imports are recognized on subsequent launches to avoid
-repeating the migration. Unsupported or damaged state is reported for recovery
-rather than replaced with an empty history.
+This patch does not require a social sign-in or change sharing choices. Damaged or incompatible retained data produces a recovery message rather than being replaced with an empty history.
 
-The signed helper checks application identity and handles the old native process
-and startup registration. This change does not broaden Keychain access or require
-social sign-in.
-
-## Qualification and release boundary
-
-Source tests cover missing predecessor bundles, retained-state compatibility,
-recovery and repeat launches. The signed ordinary replacement rehearsal must
-still demonstrate preserved native records, settings, identity salt and opt-out
-state, followed by a restart without duplicate records. Passing source tests or
-signing an installer alone does not complete that gate.
-
-Until those checks and publication finish, the public 0.1.19 release and its
-published migration requirements remain unchanged.
+**Source:** [f518126a05a6d165b9617f6417a87219d7047273](https://github.com/adamallcock/tibotattle/commit/f518126a05a6d165b9617f6417a87219d7047273), build `2026091104`. [Changes since 0.1.19](https://github.com/adamallcock/tibotattle/compare/v0.1.19...v0.1.20). The attached manifest and verification guide identify final artifact hashes and the platform-specific validation boundaries.

--- a/release-notes/0.1.21.md
+++ b/release-notes/0.1.21.md
@@ -1,0 +1,14 @@
+# TiboTattle 0.1.21 candidate
+
+This packaging follow-up records macOS 14.0 as the minimum supported system in
+both signed Mac application bundles. The previous installers declared macOS 12
+in their metadata despite the supported floor being macOS 14, causing Homebrew's
+cask audit to reject them.
+
+The app's usage analysis, automatic native-data migration and sharing choices
+are unchanged. Existing 0.1.20 installers remain immutable; this correction ships
+as a new version for all four desktop targets.
+
+Source configuration and package tests passed. Final signed bundle metadata,
+installer qualification, Homebrew acceptance and public release remain separate
+checks; this candidate is not yet published.

--- a/release-notes/0.1.21.md
+++ b/release-notes/0.1.21.md
@@ -1,14 +1,17 @@
-# TiboTattle 0.1.21 candidate
+# TiboTattle 0.1.21
 
-This packaging follow-up records macOS 14.0 as the minimum supported system in
-both signed Mac application bundles. The previous installers declared macOS 12
-in their metadata despite the supported floor being macOS 14, causing Homebrew's
-cask audit to reject them.
+This release completes the update path from the native Mac app to the unified
+desktop app. Native 0.1.18 users can choose **Check for Updates**, install the
+update and continue with their local history, settings and contribution choice.
+Manual installation also preserves existing local data; no backup-folder setup
+is needed.
 
-The app's usage analysis, automatic native-data migration and sharing choices
-are unchanged. Existing 0.1.20 installers remain immutable; this correction ships
-as a new version for all four desktop targets.
+Both Mac installers now declare the supported minimum of macOS 14 correctly,
+fixing the metadata mismatch that caused Homebrew's cask audit to reject them.
+The Mac app retains the public verification key required by the native updater
+and uses Electron's updater for subsequent releases.
 
-Source configuration and package tests passed. Final signed bundle metadata,
-installer qualification, Homebrew acceptance and public release remain separate
-checks; this candidate is not yet published.
+Downloads are available for Apple Silicon, Intel Macs, Windows and Linux.
+The website's download buttons use GitHub release assets and provide checksums.
+The Mac installers are Developer ID signed and Apple notarized; the Windows
+installer is Authenticode signed and timestamped.

--- a/schemas/release-evidence-v1/manifest.schema.json
+++ b/schemas/release-evidence-v1/manifest.schema.json
@@ -187,10 +187,12 @@
     },
     "build": {
       "type": "object", "additionalProperties": false,
-      "required": ["sourceManifestSha256", "unsignedPayloadSha256"],
+      "required": ["sourceManifestSha256"],
+      "oneOf": [{ "required": ["unsignedPayloadSha256"] }, { "required": ["finalArtifactSha256"] }],
       "properties": {
         "sourceManifestSha256": { "$ref": "#/$defs/sha256" },
-        "unsignedPayloadSha256": { "$ref": "#/$defs/sha256" }
+        "unsignedPayloadSha256": { "$ref": "#/$defs/sha256" },
+        "finalArtifactSha256": { "$ref": "#/$defs/sha256" }
       }
     },
     "store": {
@@ -306,10 +308,40 @@
           ]
         },
         "assurances": { "$ref": "#/$defs/assurances" },
+        "cleanInstallAcceptance": {
+          "type": "object", "additionalProperties": false,
+          "required": ["status", "reason", "sourceCommit"],
+          "properties": {
+            "status": { "enum": ["owner_accepted", "pending"] },
+            "reason": { "type": "string", "minLength": 1, "maxLength": 512 },
+            "sourceCommit": { "$ref": "#/$defs/commit" }
+          }
+        },
         "store": { "anyOf": [{ "type": "null" }, { "$ref": "#/$defs/store" }] },
         "updater": { "$ref": "#/$defs/updater" }
       },
       "allOf": [
+        {
+          "if": { "properties": { "build": { "type": "object", "required": ["finalArtifactSha256"] } }, "required": ["build"] },
+          "then": {
+            "properties": { "channel": { "const": "direct" }, "updater": { "properties": { "enabled": { "const": true }, "mechanism": { "const": "electron-updater" } } } },
+            "oneOf": [
+              { "properties": { "platform": { "const": "macos" }, "architecture": { "enum": ["arm64", "x64"] } } },
+              { "properties": { "platform": { "enum": ["windows", "linux"] }, "architecture": { "const": "x64" } } }
+            ]
+          }
+        },
+        {
+          "if": { "required": ["cleanInstallAcceptance"] },
+          "then": {
+            "properties": { "channel": { "const": "direct" }, "assurances": { "properties": { "cleanInstallSmokePassed": { "const": false } } } },
+            "oneOf": [
+              { "properties": { "platform": { "const": "macos" }, "architecture": { "enum": ["arm64", "x64"] } } },
+              { "properties": { "platform": { "enum": ["windows", "linux"] }, "architecture": { "const": "x64" } } }
+            ]
+          },
+          "else": { "properties": { "assurances": { "properties": { "cleanInstallSmokePassed": { "const": true } } } } }
+        },
         {
           "if": { "properties": { "platform": { "const": "macos" }, "channel": { "const": "direct" } }, "required": ["platform", "channel"] },
           "then": {
@@ -318,8 +350,8 @@
               "build": { "$ref": "#/$defs/build" },
               "store": { "type": "null" },
               "distribution": { "not": { "enum": ["mac-app-store", "microsoft-store", "flathub", "snap", "apt", "rpm"] } },
-              "assurances": { "required": ["cleanInstallSmokePassed", "developerIdSigned", "hardenedRuntime", "notarizationAccepted", "ticketStapled", "gatekeeperAssessmentPassed"], "properties": { "cleanInstallSmokePassed": { "const": true }, "developerIdSigned": { "const": true }, "hardenedRuntime": { "const": true }, "notarizationAccepted": { "const": true }, "ticketStapled": { "const": true }, "gatekeeperAssessmentPassed": { "const": true } } },
-              "updater": { "properties": { "mechanism": { "enum": ["sparkle", "none"] } } }
+              "assurances": { "required": ["cleanInstallSmokePassed", "developerIdSigned", "hardenedRuntime", "notarizationAccepted", "ticketStapled", "gatekeeperAssessmentPassed"], "properties": { "cleanInstallSmokePassed": { "type": "boolean" }, "developerIdSigned": { "const": true }, "hardenedRuntime": { "const": true }, "notarizationAccepted": { "const": true }, "ticketStapled": { "const": true }, "gatekeeperAssessmentPassed": { "const": true } } },
+              "updater": { "properties": { "mechanism": { "enum": ["sparkle", "electron-updater", "none"] } } }
             }
           }
         },
@@ -331,7 +363,7 @@
               "build": { "$ref": "#/$defs/build" },
               "store": { "type": "null" },
               "distribution": { "not": { "enum": ["mac-app-store", "microsoft-store", "flathub", "snap", "apt", "rpm"] } },
-              "assurances": { "required": ["cleanInstallSmokePassed", "authenticodeSigned", "timestamped"], "properties": { "cleanInstallSmokePassed": { "const": true }, "authenticodeSigned": { "const": true }, "timestamped": { "const": true } } },
+              "assurances": { "required": ["cleanInstallSmokePassed", "authenticodeSigned", "timestamped"], "properties": { "cleanInstallSmokePassed": { "type": "boolean" }, "authenticodeSigned": { "const": true }, "timestamped": { "const": true } } },
               "updater": { "properties": { "mechanism": { "enum": ["electron-updater", "none"] } } }
             }
           }
@@ -344,8 +376,8 @@
               "build": { "$ref": "#/$defs/build" },
               "store": { "type": "null" },
               "distribution": { "not": { "enum": ["mac-app-store", "microsoft-store", "flathub", "snap", "apt", "rpm"] } },
-              "assurances": { "required": ["cleanInstallSmokePassed", "artifactIntegrityVerified"], "properties": { "cleanInstallSmokePassed": { "const": true }, "artifactIntegrityVerified": { "const": true } } },
-              "updater": { "properties": { "mechanism": { "enum": ["none"] } } }
+              "assurances": { "required": ["cleanInstallSmokePassed", "artifactIntegrityVerified"], "properties": { "cleanInstallSmokePassed": { "type": "boolean" }, "artifactIntegrityVerified": { "const": true } } },
+              "updater": { "properties": { "mechanism": { "enum": ["electron-updater", "none"] } } }
             }
           }
         },

--- a/scripts/build-electron-runtime.mjs
+++ b/scripts/build-electron-runtime.mjs
@@ -174,6 +174,7 @@ const NATIVE_PATH_MODULE = Object.freeze({
 });
 export const ELECTRON_SHELL_RUNTIME_FILES = Object.freeze([
   "config/electron-production-distribution.cjs",
+  "config/macos-bundle-version-plan.cjs",
   "config/deployment-endpoints.js",
   "native/macos-keychain/contract.js",
   "apps/electron/companion-supervisor.js",

--- a/scripts/electron-sparkle-transition.js
+++ b/scripts/electron-sparkle-transition.js
@@ -135,7 +135,15 @@ export async function validateElectronSparkleDMG(path, { manifest, manifestPath,
   const mount = response['system-entities']?.find(value => typeof value['mount-point'] === 'string');
   if (!mount || typeof mount['dev-entry'] !== 'string') fail('MOUNT_INVALID');
   try {
-    const names = (await readdir(mount['mount-point'])).filter(name => !['.DS_Store', '.background', '.VolumeIcon.icns', '.fseventsd', '.Trashes'].includes(name)).sort();
+    const entries = await readdir(mount['mount-point']);
+    // electron-builder writes its Finder artwork as this regular TIFF file.
+    // Accept that exact non-executable asset, not arbitrary hidden entries.
+    if (entries.includes('.background.tiff')) {
+      const artwork = join(mount['mount-point'], '.background.tiff');
+      await hashFile(artwork, 16 * 1024 ** 2);
+      if (((await lstat(artwork)).mode & 0o111) !== 0) fail('LAYOUT_INVALID');
+    }
+    const names = entries.filter(name => !['.DS_Store', '.background', '.background.tiff', '.VolumeIcon.icns', '.fseventsd', '.Trashes'].includes(name)).sort();
     if (names.join() !== ['Applications', PRODUCT_BRAND.bundleName].sort().join()) fail('LAYOUT_INVALID');
     await validateMacOSApplicationsLink(join(mount['mount-point'], 'Applications'));
     const app = join(mount['mount-point'], PRODUCT_BRAND.bundleName);

--- a/scripts/electron-sparkle-transition.js
+++ b/scripts/electron-sparkle-transition.js
@@ -152,6 +152,10 @@ export async function validateElectronSparkleDMG(path, { manifest, manifestPath,
     distribution.assertProductionElectronMacOSBundleMetadata({ target: `darwin-${manifest.application.architecture}`,
       version: manifest.application.shortVersion, buildNumber: manifest.electron.buildNumber,
       bundleVersion: plist.CFBundleVersion, bundleShortVersion: plist.CFBundleShortVersionString });
+    distribution.assertProductionElectronMacOSIncomingUpgradeMetadata({
+      target: `darwin-${manifest.application.architecture}`, publicEDKey: plist.SUPublicEDKey });
+    if (createHash('sha256').update(Buffer.from(plist.SUPublicEDKey, 'base64')).digest('hex')
+        !== manifest.sparkle.publicEdKeySha256) fail('KEY_MISMATCH');
     const expectedArch = manifest.application.architecture === 'x64' ? 'x86_64' : 'arm64';
     if (run('/usr/bin/lipo', ['-archs', join(app, 'Contents/MacOS/TiboTattle')]).stdout.trim() !== expectedArch) fail('ARCHITECTURE_MISMATCH');
     const asar = join(app, 'Contents/Resources/app.asar');

--- a/scripts/electron-sparkle-transition.js
+++ b/scripts/electron-sparkle-transition.js
@@ -1,0 +1,189 @@
+/** Incoming native Sparkle transport for a signed Electron replacement.
+ * This receipt never claims Electron embeds Sparkle or a native build manifest.
+ */
+import { createHash } from 'node:crypto';
+import { createReadStream } from 'node:fs';
+import { lstat, readFile, realpath, readdir } from 'node:fs/promises';
+import { createRequire } from 'node:module';
+import { basename, dirname, join, resolve } from 'node:path';
+import { PRODUCT_BRAND } from '../config/product-brand.js';
+import distribution from '../config/electron-production-distribution.cjs';
+import { assertReleaseChannelPublication, resolveReleaseChannel } from '../config/release-channels.js';
+import { validateProductionDistributionMetadata } from '../apps/electron/desktop-updater.js';
+import { macOSCredentialApplicationVerificationArguments } from '../apps/electron/desktop-macos-keychain.js';
+import { parseWindowsUpdaterYaml } from './verify-electron-windows-update-artifacts.mjs';
+import { isAppleMacOSBundleVersion, compareAppleMacOSBundleVersions } from './macos-bundle-version.js';
+import { assertStableSparkleKeyContinuity, runMacOSReleaseCommand, validateMacOSApplicationsLink } from './macos-release-core.js';
+
+export const ELECTRON_SPARKLE_TRANSITION_SCHEMA = 'tibotattle-electron-sparkle-transition-v1';
+const HASH = /^[a-f0-9]{64}$/u;
+const exact = (v, keys) => v && Object.getPrototypeOf(v) === Object.prototype
+  && Object.keys(v).sort().join() === [...keys].sort().join();
+const fail = code => { throw Object.assign(new Error(`SPARKLE_ELECTRON_TRANSITION_${code}`), { code: `SPARKLE_ELECTRON_TRANSITION_${code}` }); };
+export const isElectronSparkleTransition = value => value?.schemaVersion === ELECTRON_SPARKLE_TRANSITION_SCHEMA;
+
+export function validateElectronSparkleTransitionManifest(manifest, dmg, sparklePublicKey, selectedChannel) {
+  const channel = resolveReleaseChannel(selectedChannel.name, { architecture: selectedChannel.architecture });
+  const app = manifest?.application, artifact = manifest?.artifact, electron = manifest?.electron;
+  if (!exact(manifest, ['schemaVersion', 'application', 'artifact', 'source', 'channel', 'sparkle', 'electron', 'evidence'])
+      || !isElectronSparkleTransition(manifest) || channel.name !== 'stable'
+      || !exact(app, ['bundleIdentifier', 'architecture', 'bundleVersion', 'shortVersion'])
+      || app.bundleIdentifier !== PRODUCT_BRAND.bundleIdentifier || app.architecture !== channel.architecture
+      || !isAppleMacOSBundleVersion(app.bundleVersion)
+      || !distribution.PRODUCTION_ELECTRON_RELEASE_VERSION_PATTERN.test(app.shortVersion)
+      || !exact(artifact, ['fileName', 'bytes', 'sha256'])
+      || artifact.fileName !== basename(dmg.path) || !/^TiboTattle-[0-9]+\.[0-9]+\.[0-9]+-(?:mac-arm64|macOS-arm64|macOS-x64)\.dmg$/u.test(artifact.fileName)
+      || (app.architecture === 'x64' ? artifact.fileName !== `TiboTattle-${app.shortVersion}-macOS-x64.dmg`
+        : ![`TiboTattle-${app.shortVersion}-mac-arm64.dmg`, `TiboTattle-${app.shortVersion}-macOS-arm64.dmg`].includes(artifact.fileName))
+      || !Number.isSafeInteger(artifact.bytes) || artifact.bytes < 1 || artifact.bytes !== dmg.size || !HASH.test(artifact.sha256)
+      || !exact(manifest.source, ['repository', 'commit', 'tag'])
+      || manifest.source.repository !== 'https://github.com/adamallcock/tibotattle'
+      || !/^[a-f0-9]{40}$/u.test(manifest.source.commit) || manifest.source.tag !== `v${app.shortVersion}`
+      || !exact(manifest.sparkle, ['appcastURL', 'publicEdKeySha256'])
+      || manifest.sparkle.appcastURL !== channel.sparkle.appcastURL
+      || !HASH.test(manifest.sparkle.publicEdKeySha256) || manifest.sparkle.publicEdKeySha256 !== sparklePublicKey.sha256
+      || !exact(electron, ['buildNumber', 'asarSha256', 'updaterConfigurationSha256'])
+      || !distribution.PRODUCTION_ELECTRON_BUILD_NUMBER_PATTERN.test(electron.buildNumber)
+      || !HASH.test(electron.asarSha256) || !HASH.test(electron.updaterConfigurationSha256)
+      || !exact(manifest.evidence, ['scope', 'nativeSparkleJourney']) || manifest.evidence.scope !== 'local_qualification'
+      || !exact(manifest.evidence.nativeSparkleJourney, ['localPath', 'bytes', 'sha256'])) fail('MANIFEST_INVALID');
+  distribution.assertProductionElectronMacOSBundleMetadata({ target: `darwin-${app.architecture}`,
+    version: app.shortVersion, buildNumber: electron.buildNumber, bundleVersion: app.bundleVersion,
+    bundleShortVersion: app.shortVersion });
+  const proof = manifest.evidence.nativeSparkleJourney;
+  if (typeof proof.localPath !== 'string' || !/^[A-Za-z0-9][A-Za-z0-9._-]{0,127}\.json$/u.test(proof.localPath)
+      || !HASH.test(proof.sha256) || !Number.isSafeInteger(proof.bytes) || proof.bytes < 1 || proof.bytes > 1024 * 1024) fail('EVIDENCE_INVALID');
+  assertReleaseChannelPublication(channel, manifest.channel);
+  if (manifest.channel.sparkle.publicEdKeySha256 !== manifest.sparkle.publicEdKeySha256) fail('KEY_MISMATCH');
+  return Object.freeze({ artifactSha256: artifact.sha256, bundleVersion: app.bundleVersion, manifest });
+}
+
+export function validateElectronSparkleJourney(proof, manifest) {
+  const checks = ['nativeSparkleUpdateCompleted', 'migrationCompleted', 'retainedRowsPreserved', 'saltPreserved',
+    'preferencesPreserved', 'optOutPreserved', 'restartNoDuplicates', 'sourceUntouched', 'ownedProcessesStopped',
+    'signedArtifactVerified', 'disposableAccountVerified', 'checkForUpdatesClicked', 'installUpdateClicked',
+    'updaterRelaunchedCandidate', 'feedOverrideApplied'];
+  if (proof?.schemaVersion !== 'tibotattle-signed-macos-sparkle-transition-v1' || proof.status !== 'passed'
+      || proof.target !== `darwin-${manifest.application.architecture}` || proof.version !== manifest.application.shortVersion
+      || proof.buildNumber !== manifest.electron.buildNumber || proof.bundleVersion !== manifest.application.bundleVersion
+      || proof.feedScope !== 'isolated_test_feed' || !HASH.test(proof.feedSha256)
+      || proof.productionFeedVerified !== false || proof.candidateCopiedByRunner !== false
+      || proof.sourceRevision !== manifest.source.commit || proof.dmgSha256 !== manifest.artifact.sha256
+      || proof.asarSha256 !== manifest.electron.asarSha256 || proof.nativeVersion !== '0.1.18'
+      || !HASH.test(proof.nativeDmgSha256) || checks.some(key => proof[key] !== true)) fail('JOURNEY_INCOMPLETE');
+  return proof;
+}
+
+async function hashFile(path, maximum = 2 * 1024 ** 3) {
+  const selected = resolve(path);
+  if (await realpath(selected) !== selected) fail('UNSAFE_PATH');
+  const before = await lstat(selected);
+  if (!before.isFile() || before.nlink !== 1 || before.size < 1 || before.size > maximum) fail('UNSAFE_FILE');
+  const hash = createHash('sha256');
+  for await (const chunk of createReadStream(selected)) hash.update(chunk);
+  const after = await lstat(selected);
+  if (before.ino !== after.ino || before.dev !== after.dev || before.size !== after.size
+      || before.mtimeMs !== after.mtimeMs || before.ctimeMs !== after.ctimeMs) fail('CHANGED_FILE');
+  return { sha256: hash.digest('hex'), bytes: before.size };
+}
+
+export async function readElectronSparkleJourney(manifest, manifestPath) {
+  const spec = manifest.evidence.nativeSparkleJourney;
+  if (!exact(spec, ['localPath', 'bytes', 'sha256']) || typeof spec.localPath !== 'string'
+      || !/^[A-Za-z0-9][A-Za-z0-9._-]{0,127}\.json$/u.test(spec.localPath)
+      || !HASH.test(spec.sha256) || !Number.isSafeInteger(spec.bytes) || spec.bytes < 1 || spec.bytes > 1024 * 1024) fail('EVIDENCE_INVALID');
+  const path = join(dirname(resolve(manifestPath)), spec.localPath);
+  const digest = await hashFile(path, 1024 * 1024);
+  if (digest.sha256 !== spec.sha256 || digest.bytes !== spec.bytes) fail('EVIDENCE_MISMATCH');
+  const bytes = await readFile(path);
+  if (createHash('sha256').update(bytes).digest('hex') !== spec.sha256) fail('EVIDENCE_CHANGED');
+  return validateElectronSparkleJourney(JSON.parse(bytes), manifest);
+}
+
+/** Previous native receipts retain their unchanged native validator. */
+export function assertElectronSparkleContinuity({ manifest, previousManifest, journey = null, stableBootstrap = false }) {
+  if (stableBootstrap || previousManifest === null) fail('PREVIOUS_REQUIRED');
+  if (!isElectronSparkleTransition(previousManifest)) {
+    if (previousManifest.application?.shortVersion !== '0.1.18'
+        || journey?.nativeDmgSha256 !== previousManifest.artifact?.sha256) fail('NATIVE_PREDECESSOR_MISMATCH');
+    return assertStableSparkleKeyContinuity({ architecture: manifest.application.architecture, channel: 'stable',
+      candidateBundleVersion: manifest.application.bundleVersion,
+      candidatePublicEdKeySha256: manifest.sparkle.publicEdKeySha256, previousManifest, stableBootstrap: false });
+  }
+  validateElectronSparkleTransitionManifest(previousManifest,
+    { path: previousManifest.artifact?.fileName, size: previousManifest.artifact?.bytes },
+    { sha256: manifest.sparkle.publicEdKeySha256 }, resolveReleaseChannel('stable', { architecture: manifest.application.architecture }));
+  if (compareAppleMacOSBundleVersions(manifest.application.bundleVersion, previousManifest.application.bundleVersion) <= 0) fail('VERSION_NOT_NEWER');
+  return Object.freeze({ mode: 'previous_manifest', previousBundleVersion: previousManifest.application.bundleVersion,
+    policy: 'previous_stable_manifest_required' });
+}
+
+/** Inspect final signed bytes, without launching the app or touching user state. */
+export async function validateElectronSparkleDMG(path, { manifest, manifestPath,
+  commandRunner = runMacOSReleaseCommand, readAsarPackage = null } = {}) {
+  await readElectronSparkleJourney(manifest, manifestPath);
+  const before = await hashFile(path);
+  if (before.sha256 !== manifest.artifact.sha256 || before.bytes !== manifest.artifact.bytes) fail('DMG_MISMATCH');
+  const run = (command, args, options = {}) => commandRunner(command, args, { timeout: 300_000,
+    failureMessage: 'Electron transition artifact inspection failed', ...options });
+  run('/usr/bin/hdiutil', ['verify', path]);
+  run('/usr/bin/codesign', ['--verify', '--strict', path]);
+  run('/usr/bin/xcrun', ['stapler', 'validate', path]);
+  run('/usr/sbin/spctl', ['--assess', '--type', 'open', '--context', 'context:primary-signature', path]);
+  const attached = run('/usr/bin/hdiutil', ['attach', '-readonly', '-nobrowse', '-plist', path]);
+  const response = JSON.parse(run('/usr/bin/plutil', ['-convert', 'json', '-o', '-', '-'], { input: attached.stdout }).stdout);
+  const mount = response['system-entities']?.find(value => typeof value['mount-point'] === 'string');
+  if (!mount || typeof mount['dev-entry'] !== 'string') fail('MOUNT_INVALID');
+  try {
+    const names = (await readdir(mount['mount-point'])).filter(name => !['.DS_Store', '.background', '.VolumeIcon.icns', '.fseventsd', '.Trashes'].includes(name)).sort();
+    if (names.join() !== ['Applications', PRODUCT_BRAND.bundleName].sort().join()) fail('LAYOUT_INVALID');
+    await validateMacOSApplicationsLink(join(mount['mount-point'], 'Applications'));
+    const app = join(mount['mount-point'], PRODUCT_BRAND.bundleName);
+    run('/usr/bin/codesign', macOSCredentialApplicationVerificationArguments(app));
+    const identity = run('/usr/bin/codesign', ['-dv', '--verbose=4', app]);
+    if (!/flags=.*\bruntime\b/u.test(identity.stderr + identity.stdout)) fail('HARDENED_RUNTIME_REQUIRED');
+    run('/usr/bin/xcrun', ['stapler', 'validate', app]);
+    run('/usr/sbin/spctl', ['--assess', '--type', 'execute', app]);
+    const plist = JSON.parse(run('/usr/bin/plutil', ['-convert', 'json', '-o', '-', join(app, 'Contents/Info.plist')]).stdout);
+    if (plist.CFBundleIdentifier !== manifest.application.bundleIdentifier
+        || plist.CFBundleVersion !== manifest.application.bundleVersion
+        || plist.CFBundleShortVersionString !== manifest.application.shortVersion
+        || plist.CFBundleExecutable !== 'TiboTattle' || plist.LSMinimumSystemVersion !== '14.0') fail('APP_IDENTITY_MISMATCH');
+    distribution.assertProductionElectronMacOSBundleMetadata({ target: `darwin-${manifest.application.architecture}`,
+      version: manifest.application.shortVersion, buildNumber: manifest.electron.buildNumber,
+      bundleVersion: plist.CFBundleVersion, bundleShortVersion: plist.CFBundleShortVersionString });
+    const expectedArch = manifest.application.architecture === 'x64' ? 'x86_64' : 'arm64';
+    if (run('/usr/bin/lipo', ['-archs', join(app, 'Contents/MacOS/TiboTattle')]).stdout.trim() !== expectedArch) fail('ARCHITECTURE_MISMATCH');
+    const asar = join(app, 'Contents/Resources/app.asar');
+    if ((await hashFile(asar, 512 * 1024 ** 2)).sha256 !== manifest.electron.asarSha256) fail('ASAR_MISMATCH');
+    let readPackage = readAsarPackage;
+    if (readPackage === null) {
+      const require = createRequire(import.meta.url), builderRequire = createRequire(require.resolve('electron-builder'));
+      const loaded = builderRequire('@electron/asar'), api = loaded.default ?? loaded;
+      readPackage = file => { if (api.statFile(file, 'package.json').size > 128 * 1024) fail('PACKAGE_TOO_LARGE');
+        return JSON.parse(api.extractFile(file, 'package.json').toString('utf8')); };
+    }
+    const pkg = readPackage(asar), target = `darwin-${manifest.application.architecture}`;
+    const meta = validateProductionDistributionMetadata(pkg?.tibotattleDistribution,
+      { platform: 'darwin', architecture: manifest.application.architecture });
+    if (pkg.name !== 'app-usagemonitor' || pkg.version !== manifest.application.shortVersion
+        || Object.keys(pkg).some(key => key.startsWith('tibotattleAccountless'))
+        || meta.sourceRevision !== manifest.source.commit || meta.buildNumber !== manifest.electron.buildNumber
+        || meta.channel !== distribution.PRODUCTION_ELECTRON_CHANNEL
+        || meta.contributionPolicy !== distribution.PRODUCTION_ELECTRON_CONTRIBUTION_POLICY) fail('DISTRIBUTION_MISMATCH');
+    const updatePath = join(app, 'Contents/Resources/app-update.yml');
+    if ((await hashFile(updatePath, 128 * 1024)).sha256 !== manifest.electron.updaterConfigurationSha256) fail('UPDATER_MISMATCH');
+    const updater = parseWindowsUpdaterYaml(await readFile(updatePath));
+    if (updater.provider !== 'generic' || updater.url !== distribution.PRODUCTION_ELECTRON_TARGETS[target].feedURL
+        || Object.keys(updater).some(key => !['provider', 'url', 'updaterCacheDirName'].includes(key))) fail('UPDATER_MISMATCH');
+    for (const helper of [join(app, 'Contents/MacOS', distribution.PRODUCTION_ELECTRON_NATIVE_HANDOVER_HELPER_RESOURCE_RELATIVE_PATH.at(-1)),
+      join(app, 'Contents/Resources', ...distribution.PRODUCTION_ELECTRON_MACOS_KEYCHAIN_ADAPTER_RESOURCE_RELATIVE_PATH)]) {
+      await hashFile(helper, 8 * 1024 ** 2);
+      if (run('/usr/bin/lipo', ['-archs', helper]).stdout.trim() !== expectedArch) fail('HELPER_ARCHITECTURE_MISMATCH');
+    }
+    return Object.freeze({ source: { commit: manifest.source.commit, tag: manifest.source.tag } });
+  } finally {
+    run('/usr/bin/hdiutil', ['detach', mount['dev-entry']]);
+    if ((await hashFile(path)).sha256 !== before.sha256) fail('DMG_CHANGED');
+  }
+}

--- a/scripts/generate-sparkle-appcast.js
+++ b/scripts/generate-sparkle-appcast.js
@@ -541,9 +541,12 @@ export async function signElectronTransitionFeed({ appcastOutputPath, dmgPath, a
     fail("Transition requires one unsigned official enclosure", "SPARKLE_TRANSITION_FEED_INVALID");
   }
   const enclosure = enclosures[0][0];
-  if (enclosure.endsWith("/>")) fail("Unexpected official enclosure", "SPARKLE_TRANSITION_FEED_INVALID");
+  // The pinned tool emits a self-closing enclosure for unsigned Electron
+  // archives. Normalize it to the existing signed-feed validator's paired
+  // form before the official tool signs the resulting XML.
+  const ending = enclosure.endsWith("/>") ? "/>" : ">";
   await writeFile(appcastOutputPath, text.replace(enclosure,
-    `${enclosure.slice(0, -1)} sparkle:edSignature="${signature}">`));
+    `${enclosure.slice(0, -ending.length)} sparkle:edSignature="${signature}">${ending === "/>" ? "</enclosure>" : ""}`));
   await runSignUpdate(signUpdatePath, [...keys, appcastOutputPath]);
 }
 

--- a/scripts/generate-sparkle-appcast.js
+++ b/scripts/generate-sparkle-appcast.js
@@ -527,6 +527,26 @@ function defaultRunGenerateAppcastTool({
   ], { label: "generate_appcast", timeout: GENERATE_APPCAST_TIMEOUT_MS });
 }
 
+/** Sign an official generated Electron entry without changing the signed app. */
+export async function signElectronTransitionFeed({ appcastOutputPath, dmgPath, account = null,
+  edKeyFile = null, signUpdatePath, runSignUpdate = (path, args) => runTool(path, args,
+    { label: "sign_update transition", timeout: SIGN_TIMEOUT_MS }) }) {
+  const keys = edKeyFile !== null ? ["--ed-key-file", edKeyFile]
+    : account !== null ? ["--account", account] : [];
+  const signature = normalizeSignature(await runSignUpdate(signUpdatePath, [...keys, "-p", dmgPath]), "Transition archive");
+  const text = await readFile(appcastOutputPath, "utf8");
+  const enclosures = [...text.matchAll(/<enclosure\b([^>]*?)>/gu)];
+  if (enclosures.length !== 1 || /sparkle-signatures:|sparkle:edSignature/u.test(text)
+      || /<!DOCTYPE|<!ENTITY/u.test(text)) {
+    fail("Transition requires one unsigned official enclosure", "SPARKLE_TRANSITION_FEED_INVALID");
+  }
+  const enclosure = enclosures[0][0];
+  if (enclosure.endsWith("/>")) fail("Unexpected official enclosure", "SPARKLE_TRANSITION_FEED_INVALID");
+  await writeFile(appcastOutputPath, text.replace(enclosure,
+    `${enclosure.slice(0, -1)} sparkle:edSignature="${signature}">`));
+  await runSignUpdate(signUpdatePath, [...keys, appcastOutputPath]);
+}
+
 /**
  * Produce a named channel's feed-signed appcast by driving the pinned
  * official Sparkle generate_appcast binary, then validating its output
@@ -543,6 +563,7 @@ async function generateOfficialSignedAppcast({
   generateAppcastPath,
   options,
   runGenerateAppcastTool,
+  signUpdatePath,
 }) {
   const downloadURLPrefix = `${channel.sparkle.origin}/${channel.sparkle.objectPrefix}/${options.bundleVersion}/${dmg.sha256}/`;
   const workRoot = await mkdtemp(
@@ -563,6 +584,11 @@ async function generateOfficialSignedAppcast({
       generateAppcastPath,
       stagingDirectory,
     });
+    if (options.electronTransition) {
+      await signElectronTransitionFeed({ appcastOutputPath, dmgPath: join(stagingDirectory, dmgFileName),
+        account: options.account, edKeyFile: options.edKeyFile, signUpdatePath,
+        runSignUpdate: options.runSignUpdate });
+    }
     const bytes = await readFile(appcastOutputPath).catch(() => null);
     if (bytes === null) {
       fail(
@@ -614,9 +640,9 @@ async function generateOfficialSignedAppcast({
     }
     // Self-check with the exact validation the publisher applies, so a
     // generated appcast can never be shaped in a way the publisher rejects.
-    validateCandidateAppcastShape(text, channel.name, {
-      architecture: channel.architecture,
-    });
+    if (!options.electronTransitionTestSource) {
+      validateCandidateAppcastShape(text, channel.name, { architecture: channel.architecture });
+    }
     return Object.freeze({ bytes, validated });
   } finally {
     await rm(workRoot, { recursive: true, force: true });
@@ -666,6 +692,16 @@ ${deltasBlock}</item></channel></rss>
 `;
 }
 
+function validateTransitionOptions(options) {
+  if (options.electronTransition && (options.channel !== "stable" || options.sparklePublicEdKey === null)) {
+    fail("Electron transition requires stable incoming key verification");
+  }
+  if (options.electronTransitionTestSource != null && (!options.electronTransition || !options.skipRetain
+      || !/^[a-f0-9]{40}$/u.test(options.electronTransitionTestSource))) {
+    fail("Transition rehearsal requires exact source, --electron-transition and --skip-retain");
+  }
+}
+
 export function parseGenerateSparkleAppcastArguments(argv) {
   const options = {
     account: null,
@@ -676,6 +712,8 @@ export function parseGenerateSparkleAppcastArguments(argv) {
     channel: null,
     dmgPath: null,
     edKeyFile: null,
+    electronTransition: false,
+    electronTransitionTestSource: null,
     maxDeltas: null,
     output: null,
     replace: false,
@@ -694,6 +732,7 @@ export function parseGenerateSparkleAppcastArguments(argv) {
     ["--channel", "channel"],
     ["--dmg", "dmgPath"],
     ["--ed-key-file", "edKeyFile"],
+    ["--electron-transition-test-source", "electronTransitionTestSource"],
     ["--max-deltas", "maxDeltas"],
     ["--output", "output"],
     ["--short-version", "shortVersion"],
@@ -708,6 +747,8 @@ export function parseGenerateSparkleAppcastArguments(argv) {
         fail(`${argument} must be supplied exactly once with a value`);
       }
       options[key] = argv[++index];
+    } else if (argument === "--electron-transition" && !options.electronTransition) {
+      options.electronTransition = true;
     } else if (argument === "--replace" && !options.replace) {
       options.replace = true;
     } else if (argument === "--skip-apply-check" && !options.skipApplyCheck) {
@@ -728,6 +769,7 @@ export function parseGenerateSparkleAppcastArguments(argv) {
       fail(`${flag} is required`);
     }
   }
+  validateTransitionOptions(options);
   options.architecture = normalizeReleaseArchitecture(options.architecture ?? "arm64");
   if (!isAppleMacOSBundleVersion(options.bundleVersion)) {
     fail("--bundle-version must be an Apple-compatible CFBundleVersion");
@@ -767,6 +809,7 @@ export function parseGenerateSparkleAppcastArguments(argv) {
 }
 
 export async function generateSparkleAppcast(options) {
+  validateTransitionOptions(options);
   const channel = resolveReleaseChannel(options.channel, {
     architecture: options.architecture,
   });
@@ -825,9 +868,13 @@ export async function generateSparkleAppcast(options) {
       ]);
     }
     const official = await generateOfficialSignedAppcast({
-      channel,
+      channel: options.electronTransitionTestSource
+        ? { ...channel, sparkle: { ...channel.sparkle,
+          objectPrefix: `electron/test/native-sparkle/${options.electronTransitionTestSource}` } }
+        : channel,
       dmg,
       dmgFileName,
+      signUpdatePath: injectedGenerateAppcastTool === null ? toolPath("sign_update") : null,
       generateAppcastPath: injectedGenerateAppcastTool === null
         ? toolPath("generate_appcast")
         : null,

--- a/scripts/generate-sparkle-appcast.js
+++ b/scripts/generate-sparkle-appcast.js
@@ -529,24 +529,34 @@ function defaultRunGenerateAppcastTool({
 
 /** Sign an official generated Electron entry without changing the signed app. */
 export async function signElectronTransitionFeed({ appcastOutputPath, dmgPath, account = null,
-  edKeyFile = null, signUpdatePath, runSignUpdate = (path, args) => runTool(path, args,
+  edKeyFile = null, sparklePublicEdKey, signUpdatePath, runSignUpdate = (path, args) => runTool(path, args,
     { label: "sign_update transition", timeout: SIGN_TIMEOUT_MS }) }) {
   const keys = edKeyFile !== null ? ["--ed-key-file", edKeyFile]
     : account !== null ? ["--account", account] : [];
-  const signature = normalizeSignature(await runSignUpdate(signUpdatePath, [...keys, "-p", dmgPath]), "Transition archive");
   const text = await readFile(appcastOutputPath, "utf8");
+  // A successor retaining the native public key lets the official generator
+  // sign its enclosure. A fully signed feed is adopted unchanged and both
+  // signatures are checked by validateSignedSparkleFeed below.
+  if (text.includes("sparkle-signatures:")) return;
   const enclosures = [...text.matchAll(/<enclosure\b([^>]*?)>/gu)];
-  if (enclosures.length !== 1 || /sparkle-signatures:|sparkle:edSignature/u.test(text)
-      || /<!DOCTYPE|<!ENTITY/u.test(text)) {
-    fail("Transition requires one unsigned official enclosure", "SPARKLE_TRANSITION_FEED_INVALID");
+  if (enclosures.length !== 1 || /<!DOCTYPE|<!ENTITY/u.test(text)) {
+    fail("Transition requires one official enclosure", "SPARKLE_TRANSITION_FEED_INVALID");
   }
   const enclosure = enclosures[0][0];
-  // The pinned tool emits a self-closing enclosure for unsigned Electron
-  // archives. Normalize it to the existing signed-feed validator's paired
-  // form before the official tool signs the resulting XML.
+  const signatures = [...enclosure.matchAll(/sparkle:edSignature="([^"]+)"/gu)];
+  if (signatures.length > 1 || (text.match(/sparkle:edSignature=/gu) ?? []).length !== signatures.length) {
+    fail("Unexpected official enclosure signature", "SPARKLE_TRANSITION_FEED_INVALID");
+  }
+  const signature = normalizeSignature(signatures.length === 1 ? signatures[0][1]
+    : await runSignUpdate(signUpdatePath, [...keys, "-p", dmgPath]), "Transition archive");
+  const publicKey = importPublicEdKey(sparklePublicEdKey);
+  if (publicKey === null) fail("Transition requires the pinned public key", "SPARKLE_TRANSITION_FEED_INVALID");
+  assertLocalSignature({ bytes: await readFile(dmgPath), signature, publicKey, label: "Transition archive" });
+  // Normalize self-closing unsigned output before the official feed signature.
   const ending = enclosure.endsWith("/>") ? "/>" : ">";
+  const attributes = enclosure.slice(0, -ending.length);
   await writeFile(appcastOutputPath, text.replace(enclosure,
-    `${enclosure.slice(0, -ending.length)} sparkle:edSignature="${signature}">${ending === "/>" ? "</enclosure>" : ""}`));
+    `${attributes}${signatures.length === 0 ? ` sparkle:edSignature="${signature}"` : ""}>${ending === "/>" ? "</enclosure>" : ""}`));
   await runSignUpdate(signUpdatePath, [...keys, appcastOutputPath]);
 }
 
@@ -589,7 +599,7 @@ async function generateOfficialSignedAppcast({
     });
     if (options.electronTransition) {
       await signElectronTransitionFeed({ appcastOutputPath, dmgPath: join(stagingDirectory, dmgFileName),
-        account: options.account, edKeyFile: options.edKeyFile, signUpdatePath,
+        account: options.account, edKeyFile: options.edKeyFile, sparklePublicEdKey: options.sparklePublicEdKey, signUpdatePath,
         runSignUpdate: options.runSignUpdate });
     }
     const bytes = await readFile(appcastOutputPath).catch(() => null);

--- a/scripts/lib/macos-transition-ui-diagnostics.mjs
+++ b/scripts/lib/macos-transition-ui-diagnostics.mjs
@@ -1,0 +1,142 @@
+import { spawnSync } from "node:child_process";
+
+const SCHEMA = "tibotattle-macos-transition-ui-diagnostics-v1";
+const AX_STATUSES = ["ok", "failure", "illegal_argument", "invalid_element", "cannot_complete",
+  "unsupported", "not_implemented", "api_disabled", "no_value", "other"];
+const LIMIT = 512;
+
+function assertPID(pid) {
+  if (!Number.isSafeInteger(pid) || pid < 2 || pid > 2_147_483_647) {
+    throw new TypeError("Mac transition diagnostic PID is invalid");
+  }
+}
+
+// Executed by the existing /usr/bin/osascript identity, not a new helper binary.
+// Apple APIs: AXUIElementGetAttributeValueCount, AXUIElementCopyAttributeValue,
+// AXUIElementSetMessagingTimeout, NSRunningApplication, CGWindowListCopyWindowInfo.
+// The timeout applies only to this newly-created AX object. No UI attribute,
+// permission, preference, application state, activation or action is changed.
+function inspectOwnedApplication(pid) {
+  ObjC.import("AppKit");
+  ObjC.import("ApplicationServices");
+  const cap = 512;
+  function axStatus(code) {
+    const known = {0:"ok", "-25200":"failure", "-25201":"illegal_argument",
+      "-25202":"invalid_element", "-25204":"cannot_complete", "-25205":"unsupported",
+      "-25208":"not_implemented", "-25211":"api_disabled", "-25212":"no_value"};
+    return known[String(code)] || "other";
+  }
+  const result = {
+    schemaVersion:"tibotattle-macos-transition-ui-diagnostics-v1", status:"observed",
+    accessibilityTrusted:Boolean($.AXIsProcessTrusted()),
+    application:{found:false, hidden:null, active:null, terminated:null, activationPolicy:null},
+    ax:{timeoutStatus:null, windows:{status:"api_disabled", count:null}, menuBar:{status:"api_disabled", present:null}},
+    coreGraphics:{status:"unavailable", windows:null, onScreenWindows:null, truncated:false},
+  };
+  const app = $.NSRunningApplication.runningApplicationWithProcessIdentifier(pid);
+  if (!app.isNil()) {
+    const policies = {0:"regular", 1:"accessory", 2:"prohibited"};
+    result.application = {found:true, hidden:Boolean(app.hidden), active:Boolean(app.active),
+      terminated:Boolean(app.terminated), activationPolicy:policies[String(app.activationPolicy)] || "unknown"};
+  }
+  if (result.accessibilityTrusted) {
+    const element = $.AXUIElementCreateApplication(pid);
+    result.ax.timeoutStatus = axStatus($.AXUIElementSetMessagingTimeout(element, 0.5));
+    // Do not start potentially long default-timeout queries if the bound failed.
+    if (result.ax.timeoutStatus === "ok") {
+      const count = Ref();
+      const code = $.AXUIElementGetAttributeValueCount(element, $("AXWindows"), count);
+      result.ax.windows.status = axStatus(code);
+      if (code === 0) result.ax.windows.count = Math.min(cap, Math.max(0, Number(count[0])));
+      const menu = Ref();
+      const menuCode = $.AXUIElementCopyAttributeValue(element, $("AXMenuBar"), menu);
+      result.ax.menuBar = {status:axStatus(menuCode), present:menuCode === 0 ? true : null};
+    } else {
+      result.ax.windows.status = "other";
+      result.ax.menuBar.status = "other";
+    }
+  }
+  // Only inspect numeric owner/visibility properties. Never read window names,
+  // app names, paths, accessibility titles, text, children or arbitrary values.
+  const windows = ObjC.castRefToObject($.CGWindowListCopyWindowInfo(0, 0));
+  if (!windows.isNil()) {
+    const total = Number(windows.count);
+    if (!Number.isSafeInteger(total) || total < 0) return JSON.stringify(result);
+    const inspectCount = Math.min(total, 4096);
+    let owned = 0, onScreen = 0;
+    for (let index = 0; index < inspectCount; index++) {
+      const entry = windows.objectAtIndex(index);
+      if (Number(ObjC.unwrap(entry.objectForKey(ObjC.castRefToObject($.kCGWindowOwnerPID)))) !== pid) continue;
+      owned++;
+      if (ObjC.unwrap(entry.objectForKey(ObjC.castRefToObject($.kCGWindowIsOnscreen))) === true) onScreen++;
+    }
+    result.coreGraphics = {status:"observed", windows:Math.min(cap, owned),
+      onScreenWindows:Math.min(cap, onScreen), truncated:total > inspectCount || owned > cap};
+  }
+  return JSON.stringify(result);
+}
+
+export function macOSTransitionUIDiagnosticScript(pid) {
+  assertPID(pid);
+  return `(${inspectOwnedApplication.toString()})(${pid})`;
+}
+
+function exactKeys(value, keys) {
+  return value !== null && typeof value === "object" && !Array.isArray(value)
+    && Object.keys(value).sort().join("\n") === [...keys].sort().join("\n");
+}
+function count(value) { return Number.isSafeInteger(value) && value >= 0 && value <= LIMIT; }
+
+// Reject unknown fields/text rather than forwarding even a bounded subprocess
+// response into a durable release receipt.
+export function parseMacOSTransitionUIDiagnostics(output) {
+  if (typeof output !== "string" || Buffer.byteLength(output) > 4096) throw new TypeError("Invalid Mac UI diagnostic");
+  let value;
+  try { value = JSON.parse(output); } catch { throw new TypeError("Invalid Mac UI diagnostic"); }
+  const invalid = () => { throw new TypeError("Invalid Mac UI diagnostic"); };
+  if (!exactKeys(value, ["schemaVersion", "status", "accessibilityTrusted", "application", "ax", "coreGraphics"])
+      || value.schemaVersion !== SCHEMA || value.status !== "observed"
+      || typeof value.accessibilityTrusted !== "boolean") invalid();
+  const app = value.application, ax = value.ax, cg = value.coreGraphics;
+  if (!exactKeys(app, ["found", "hidden", "active", "terminated", "activationPolicy"])
+      || typeof app.found !== "boolean") invalid();
+  if (app.found ? (![app.hidden, app.active, app.terminated].every(v => typeof v === "boolean")
+      || !["regular", "accessory", "prohibited", "unknown"].includes(app.activationPolicy))
+    : [app.hidden, app.active, app.terminated, app.activationPolicy].some(v => v !== null)) invalid();
+  if (!exactKeys(ax, ["timeoutStatus", "windows", "menuBar"])
+      || !(ax.timeoutStatus === null || AX_STATUSES.includes(ax.timeoutStatus))
+      || !exactKeys(ax.windows, ["status", "count"]) || !AX_STATUSES.includes(ax.windows.status)
+      || !exactKeys(ax.menuBar, ["status", "present"]) || !AX_STATUSES.includes(ax.menuBar.status)
+      || (ax.windows.status === "ok" ? !count(ax.windows.count) : ax.windows.count !== null)
+      || (ax.menuBar.status === "ok" ? ax.menuBar.present !== true : ax.menuBar.present !== null)) invalid();
+  if ((!value.accessibilityTrusted && (ax.timeoutStatus !== null || ax.windows.status !== "api_disabled" || ax.menuBar.status !== "api_disabled"))
+      || (value.accessibilityTrusted && ax.timeoutStatus === null)) invalid();
+  if (!exactKeys(cg, ["status", "windows", "onScreenWindows", "truncated"])
+      || typeof cg.truncated !== "boolean" || !["observed", "unavailable"].includes(cg.status)
+      || (cg.status === "observed" ? (!count(cg.windows) || !count(cg.onScreenWindows) || cg.onScreenWindows > cg.windows)
+        : (cg.windows !== null || cg.onScreenWindows !== null || cg.truncated))) invalid();
+  return value;
+}
+
+/** Caller must revalidate its previously captured executable/PID/start-time
+ * fingerprint; never use a process name or a stale PID as ownership evidence. */
+export function collectMacOSTransitionUIDiagnostics({ pid, verifyOwnedProcess } = {}, {
+  run = spawnSync, platform = process.platform,
+} = {}) {
+  assertPID(pid);
+  if (typeof verifyOwnedProcess !== "function") throw new TypeError("Mac UI diagnostic ownership check is required");
+  const unavailable = reason => ({ schemaVersion:SCHEMA, status:"unavailable", reason });
+  if (platform !== "darwin") return unavailable("unsupported_host");
+  const owned = () => { try { return verifyOwnedProcess(pid) === true; } catch { return false; } };
+  if (!owned()) return unavailable("ownership_unverified");
+  let response;
+  try {
+    response = run("/usr/bin/osascript", ["-l", "JavaScript", "-e", macOSTransitionUIDiagnosticScript(pid)], {
+      encoding:"utf8", timeout:5000, killSignal:"SIGKILL", maxBuffer:4096, windowsHide:true,
+    });
+  } catch { return unavailable("probe_failed"); }
+  if (!owned()) return unavailable("ownership_changed");
+  if (response?.error || response?.status !== 0 || response?.signal) return unavailable("probe_failed");
+  try { return parseMacOSTransitionUIDiagnostics(response.stdout); }
+  catch { return unavailable("invalid_response"); }
+}

--- a/scripts/macos-bundle-version.js
+++ b/scripts/macos-bundle-version.js
@@ -1,3 +1,5 @@
+import bundleVersionPlan from "../config/macos-bundle-version-plan.cjs";
+
 // Apple's release-build grammar for CFBundleVersion: a positive first
 // component of at most four digits, followed by up to two components of at
 // most two digits each. Release artifacts do not use development suffixes.
@@ -13,31 +15,7 @@ export const LEGACY_STABLE_MACOS_BUNDLE_VERSION = "0.1.16";
 // marketing majors through 7999.
 export const MACOS_BUNDLE_VERSION_EPOCH = 2_000;
 
-// Signed releases keep the production bundle identifier, so their build
-// numbers must advance from the last installed shared-identity dogfood build.
-// Freeze the owner-reviewed allocations per marketing version and channel;
-// adding a future release is an explicit policy change, never an implicit
-// timestamp or environment-controlled counter.
-// The 0.1.17 RC2 used 1023, RC3 used 1023.1, installed startup-recovery RC4
-// used 1023.2, installed integrated RC5 used 1023.3, and installed accounting-
-// deadline RC6 used 1023.4, and the retired-checkpoint RC7 used 1023.5. The
-// fitted-transition correction used RC8 allocation 1023.6. RC9 reserves 1023.7
-// for refresh-policy, selected-plan Trends, and last-good snapshot corrections,
-// preserving allocated stable 1024. Allocation is not built/installed evidence.
-export const SIGNED_MACOS_BUNDLE_VERSION_PLAN = Object.freeze({
-  "0.1.17": Object.freeze({
-    "internal-dogfood": "1023.7",
-    stable: "1024",
-  }),
-  // Separate ARM and Intel installers share the same source and build ordering.
-  // Preserve signed Intel RC1 1025 and combined Astra/Intel RC2 1025.1.
-  // RC3 reserves 1025.2 for parser-upgrade deadlines and paginated seed isolation.
-  // Allocation does not establish signing, installation, or publication.
-  "0.1.18": Object.freeze({
-    "internal-dogfood": "1025.2",
-    stable: "1026",
-  }),
-});
+export const { SIGNED_MACOS_BUNDLE_VERSION_PLAN } = bundleVersionPlan;
 
 export function resolveSignedMacOSBundleVersion(releaseVersion, channel) {
   if (typeof releaseVersion !== "string"

--- a/scripts/publish-sparkle-update.js
+++ b/scripts/publish-sparkle-update.js
@@ -47,6 +47,11 @@ import {
   validateSignedSparkleFeed,
 } from "./sparkle-signed-feed-validation.js";
 
+import {
+  isElectronSparkleTransition, validateElectronSparkleTransitionManifest,
+  validateElectronSparkleDMG, readElectronSparkleJourney, assertElectronSparkleContinuity,
+} from "./electron-sparkle-transition.js";
+
 const SCRIPT_FILE = fileURLToPath(import.meta.url);
 const REPOSITORY_ROOT = resolve(dirname(SCRIPT_FILE), "..");
 const WRANGLER_PATH = join(
@@ -492,6 +497,9 @@ function validateReleaseManifest(
   sparklePublicKey,
   channel,
 ) {
+  if (isElectronSparkleTransition(manifest)) {
+    return validateElectronSparkleTransitionManifest(manifest, dmg, sparklePublicKey, channel);
+  }
   if (manifest.schemaVersion !== RELEASE_MANIFEST_SCHEMA
       || normalizeReleaseArchitecture(manifest.application?.architecture) !== channel.architecture
       || manifest.application?.bundleIdentifier !== PRODUCT_BRAND.bundleIdentifier
@@ -2135,6 +2143,7 @@ export async function publishSparkleUpdate({
   fetchPublic = defaultPublicFetch,
   fetchGuard = defaultPublicFetch,
   validateDMG = validateMacOSDMG,
+  validateElectronDMG = validateElectronSparkleDMG,
 } = {}) {
   if (typeof publish !== "boolean" || typeof replaceAppcast !== "boolean"
       || typeof stableBootstrap !== "boolean"
@@ -2146,6 +2155,7 @@ export async function publishSparkleUpdate({
       || typeof fetchPublic !== "function"
       || typeof fetchGuard !== "function"
       || typeof validateDMG !== "function"
+      || typeof validateElectronDMG !== "function"
       || typeof sourceRepositoryRoot !== "string"
       || sourceRepositoryRoot.length === 0
       || sourceRepositoryRoot.includes("\0")
@@ -2221,7 +2231,11 @@ export async function publishSparkleUpdate({
       runSourceGit,
     },
   );
-  const validatedDMG = await validateDMG(dmg.path, {
+  const electronTransition = isElectronSparkleTransition(manifest.manifest);
+  const transitionJourney = electronTransition ? await readElectronSparkleJourney(manifest.manifest, releaseManifest.path) : null;
+  const validatedDMG = electronTransition
+    ? await validateElectronDMG(dmg.path, { manifest: manifest.manifest, manifestPath: releaseManifest.path })
+    : await validateDMG(dmg.path, {
     architecture: releaseChannel.architecture,
     expectedBundleIdentifier: manifest.manifest.application.bundleIdentifier,
     expectedBundleVersion: manifest.bundleVersion,
@@ -2290,6 +2304,9 @@ export async function publishSparkleUpdate({
   const previousStableManifest = previousStableManifestPath === null
     ? null
     : await readStableReleaseManifest(previousStableManifestPath);
+  if (electronTransition) {
+    assertElectronSparkleContinuity({ manifest: manifest.manifest, previousManifest: previousStableManifest, journey: transitionJourney, stableBootstrap });
+  } else {
   assertStableSparkleKeyContinuity({
     architecture: releaseChannel.architecture,
     candidateBundleVersion: manifest.bundleVersion,
@@ -2298,6 +2315,7 @@ export async function publishSparkleUpdate({
     previousManifest: previousStableManifest,
     stableBootstrap,
   });
+  }
   const publication = Object.freeze({
     architecture: releaseChannel.architecture,
     appcast: Object.freeze({

--- a/scripts/reconcile-release-publication.mjs
+++ b/scripts/reconcile-release-publication.mjs
@@ -13,6 +13,7 @@ import { isAppleMacOSBundleVersion } from "./macos-bundle-version.js";
 import { publishSparkleUpdate, verifyReleaseManifestSourceProvenance } from "./publish-sparkle-update.js";
 import { deployWebRelease } from "./deploy-web-release.js";
 import { verifyWebReleaseReceipt } from "./web-release-lane.js";
+import { isElectronSparkleTransition } from "./electron-sparkle-transition.js";
 import { buildSha256Sums, validateReleaseEvidenceManifest } from "./release-evidence.js";
 import { PRODUCTION_DEPLOY_CONFIRMATION, recheckProductionHealth } from "../apps/worker/scripts/production-deploy.mjs";
 import { createProductionDeploymentLock } from "../apps/worker/scripts/production-deployment-lock.mjs";
@@ -63,11 +64,13 @@ export function validatePublicationPlan(plan) {
     fail("RELEASE_PUBLICATION_PLAN_INVALID");
   }
   for (const target of plan.targets) {
-    if (!exact(target, ["architecture", "feedManifest", "dmgName", "appcastName", "sparklePublicEdKey", "previousManifest"])
+    if (!exact(target, ["architecture", "feedManifest", "dmgName", "appcastName", "sparklePublicEdKey", "previousManifest", ...(target.sparkleDmg === undefined ? [] : ["sparkleDmg"])])
         || !fileSpec(target.feedManifest) || target.feedManifest.bytes > MAX_SMALL || !fileSpec(target.previousManifest) || target.previousManifest.bytes > MAX_SMALL
         || !/^[A-Za-z0-9+/]{43}=$/.test(target.sparklePublicEdKey)
         || ![target.dmgName, target.appcastName].every((name) => plan.assets.some((asset) => asset.name === name))
-        || target.dmgName !== `TiboTattle-${plan.version}-macOS-${target.architecture}.dmg`) fail("RELEASE_PUBLICATION_TARGET_INVALID");
+        || (target.sparkleDmg === undefined
+          ? target.dmgName !== `TiboTattle-${plan.version}-macOS-${target.architecture}.dmg`
+          : !fileSpec(target.sparkleDmg) || target.dmgName !== `TiboTattle-${plan.version}-mac-${target.architecture}.dmg`)) fail("RELEASE_PUBLICATION_TARGET_INVALID");
   }
   if (new Set(plan.targets.flatMap((target) => [target.dmgName, target.appcastName])).size !== 4) fail("RELEASE_PUBLICATION_TARGET_INVALID");
   return structuredClone(plan);
@@ -111,26 +114,51 @@ export async function preparePublication(plan, { repositoryRoot = ROOT, publishF
   const asset = (name) => plan.assets.find((entry) => entry.name === name);
   const canonical = await jsonFile(asset("release-manifest.json"));
   await validateReleaseEvidenceManifest(canonical, { artifactRoot: dirname(asset("release-manifest.json").path), manifestPath: asset("release-manifest.json").path });
+  const electron = canonical.artifacts.length === 4
+    && canonical.artifacts.every(a => a.updater?.mechanism === "electron-updater")
+    && canonical.artifacts.map(a => `${a.platform}-${a.architecture}`).sort().join() === "linux-x64,macos-arm64,macos-x64,windows-x64";
+  const macArtifacts = canonical.artifacts.filter(a => a.platform === "macos");
   if (canonical.version !== plan.version || canonical.tag !== plan.source.tag || canonical.commit !== plan.source.commit
-      || canonical.repository !== plan.source.repository || canonical.artifacts.length !== 2
-      || canonical.artifacts.some((artifact) => artifact.platform !== "macos" || artifact.channel !== "direct" || artifact.distribution !== "github-release")
-      || canonical.artifacts.map((artifact) => artifact.architecture).sort().join() !== "arm64,x64") fail("RELEASE_PUBLICATION_CANONICAL_IDENTITY_MISMATCH");
+      || canonical.repository !== plan.source.repository || (!electron && canonical.artifacts.length !== 2)
+      || canonical.artifacts.some((artifact) => (!electron && artifact.platform !== "macos") || artifact.channel !== "direct" || artifact.distribution !== "github-release")
+      || macArtifacts.map((artifact) => artifact.architecture).sort().join() !== "arm64,x64") fail("RELEASE_PUBLICATION_CANONICAL_IDENTITY_MISMATCH");
   const sums = buildSha256Sums(canonical);
   const sumsFile = asset("SHA256SUMS");
   if (digest(sums) !== sumsFile.sha256 || Buffer.byteLength(sums) !== sumsFile.bytes) fail("RELEASE_PUBLICATION_CHECKSUM_SET_MISMATCH");
-  const expectedAssets = [...sums.trimEnd().split("\n").map((row) => row.slice(66)), "SHA256SUMS", "verify-release.md"].sort();
+  let expectedAssets = [...sums.trimEnd().split("\n").map((row) => row.slice(66)), "SHA256SUMS", "verify-release.md"].sort();
+  if (electron) {
+    const extra = plan.targets.flatMap(t => [t.appcastName,
+      `TiboTattle-${plan.version}-mac-${t.architecture}.zip`,
+      `TiboTattle-${plan.version}-mac-${t.architecture}.zip.blockmap`,
+      `TiboTattle-${plan.version}-mac-${t.architecture}.dmg.blockmap`]);
+    expectedAssets = [...expectedAssets, ...extra, "SHA256SUMS-ALL-RELEASE-FILES"].sort();
+    if (new Set(expectedAssets).size !== expectedAssets.length) fail("RELEASE_PUBLICATION_CANONICAL_ASSET_SET_MISMATCH");
+    const allSums = asset("SHA256SUMS-ALL-RELEASE-FILES");
+    const summed = expectedAssets.filter(n => !["release-manifest.json", "SHA256SUMS", "SHA256SUMS-ALL-RELEASE-FILES", "verify-release.md"].includes(n));
+    if (!allSums || summed.some(n => !asset(n))) fail("RELEASE_PUBLICATION_CANONICAL_ASSET_SET_MISMATCH");
+    const expected = summed.map(n => `${asset(n).sha256}  ${n}`).sort().join("\n") + "\n";
+    if (allSums.sha256 !== digest(expected) || allSums.bytes !== Buffer.byteLength(expected)) fail("RELEASE_PUBLICATION_CHECKSUM_SET_MISMATCH");
+  }
   if (expectedAssets.join() !== plan.assets.map((entry) => entry.name).sort().join()) fail("RELEASE_PUBLICATION_CANONICAL_ASSET_SET_MISMATCH");
   const feeds = {};
   for (const target of plan.targets) {
-    const artifact = canonical.artifacts.find((entry) => entry.architecture === target.architecture);
-    if (artifact.fileName !== target.dmgName || artifact.updater.enabled !== true || artifact.updater.metadata.fileName !== target.appcastName) fail("RELEASE_PUBLICATION_CANONICAL_TARGET_MISMATCH");
+    const artifact = macArtifacts.find((entry) => entry.architecture === target.architecture);
+    if (artifact.fileName !== target.dmgName || artifact.updater.enabled !== true
+        || (electron ? target.sparkleDmg === undefined || artifact.updater.metadata.fileName !== `TiboTattle-${plan.version}-darwin-${target.architecture}-update.yml`
+          : target.sparkleDmg !== undefined || artifact.updater.metadata.fileName !== target.appcastName)) fail("RELEASE_PUBLICATION_CANONICAL_TARGET_MISMATCH");
     const manifest = await jsonFile(target.feedManifest);
+    const incomingDmg = electron ? target.sparkleDmg : asset(target.dmgName);
+    if (electron) {
+      await verifyFile(incomingDmg);
+      if (incomingDmg.sha256 !== artifact.sha256 || incomingDmg.bytes !== artifact.bytes
+          || !isElectronSparkleTransition(manifest)) fail("RELEASE_PUBLICATION_CANONICAL_TARGET_MISMATCH");
+    } else if (isElectronSparkleTransition(manifest)) fail("RELEASE_PUBLICATION_CANONICAL_TARGET_MISMATCH");
     if (manifest.source?.commit !== plan.source.commit || manifest.source?.tag !== plan.source.tag
         || manifest.application?.shortVersion !== plan.version || manifest.application?.bundleVersion !== plan.build
         || (manifest.application?.architecture ?? "arm64") !== target.architecture) fail("RELEASE_PUBLICATION_MANIFEST_IDENTITY_MISMATCH");
     const channel = resolveReleaseChannel(plan.channel, { architecture: target.architecture });
     const options = { architecture: target.architecture, channel: plan.channel, bucket: channel.sparkle.r2Bucket,
-      dmgPath: asset(target.dmgName).path, appcastPath: asset(target.appcastName).path,
+      dmgPath: incomingDmg.path, appcastPath: asset(target.appcastName).path,
       releaseManifestPath: target.feedManifest.path, sparklePublicEdKey: target.sparklePublicEdKey,
       previousStableManifestPath: target.previousManifest.path, sourceRepositoryRoot: repositoryRoot };
     // Existing validator retains native trust, both Sparkle signatures, key continuity,
@@ -170,7 +198,7 @@ export async function preparePublication(plan, { repositoryRoot = ROOT, publishF
       || !cask.includes('  arch arm: "arm64", intel: "x64"\n')
       || !cask.includes('  depends_on macos: :sonoma\n')
       || !cask.includes(`  sha256 arm:   "${arm.sha256}",\n         intel: "${intel.sha256}"\n`)
-      || !cask.includes('  url "https://github.com/adamallcock/tibotattle/releases/download/v#{version}/TiboTattle-#{version}-macOS-#{arch}.dmg"\n')) fail("RELEASE_PUBLICATION_CASK_IDENTITY_MISMATCH");
+      || !cask.includes(`  url "https://github.com/adamallcock/tibotattle/releases/download/v#{version}/TiboTattle-#{version}-${electron ? 'mac' : 'macOS'}-#{arch}.dmg"\n`)) fail("RELEASE_PUBLICATION_CASK_IDENTITY_MISMATCH");
   return { plan, feeds, siteFiles, websiteSourceCommit: receipt.sourceCommit };
 }
 
@@ -319,6 +347,7 @@ export function createPublicationAdapters({ repositoryRoot = ROOT, spawn = spawn
       const target = prepared.feeds[architecture].target;
       for (const name of [target.dmgName, target.appcastName]) await verifyFile(prepared.plan.assets.find((asset) => asset.name === name));
       await verifyFile(target.previousManifest); await verifyFile(target.feedManifest);
+      if (target.sparkleDmg) await verifyFile(target.sparkleDmg);
       const channel = resolveReleaseChannel("stable", { architecture });
       return publishFeed({ ...options, publish: true, replaceAppcast: true,
         atomicAppcastGuardEndpoint: channel.sparkle.atomicGuardURL, atomicAppcastGuardTokenEnv: "SPARKLE_APPCAST_GUARD_TOKEN" });

--- a/scripts/release-evidence-descriptor.js
+++ b/scripts/release-evidence-descriptor.js
@@ -49,6 +49,7 @@ import {
   validateStoreDeliveryReceipt,
   normalizeUpdater,
   validateAssurances,
+  normalizeCleanInstallAcceptance,
   validateCanonicalManifest,
   validateDistribution,
   validateSpdxJson,
@@ -231,7 +232,7 @@ async function normalizeArtifact(descriptor, release, productName, baseDir, cont
   assertAllowedKeys(selected, [
     "platform", "channel", "architecture", "format", "version", "path", "file", "fileName",
     "bytes", "sha256", "source", "distribution", "downloadUrl", "nativeTrust", "build",
-    "sbom", "provenance", "assurances", "platformAssurances", "store", "updater",
+    "sbom", "provenance", "assurances", "platformAssurances", "store", "updater", "cleanInstallAcceptance",
   ], "artifact", "RELEASE_EVIDENCE_ARTIFACT_INVALID");
   const platform = assertPlatform(selected.platform);
   const channel = assertChannel(selected.channel);
@@ -302,11 +303,13 @@ async function normalizeArtifact(descriptor, release, productName, baseDir, cont
   }
   const updater = normalizeUpdater(updaterInput, platform, channel,
     "updater", updaterMetadata);
+  const cleanInstallAcceptance = normalizeCleanInstallAcceptance(selected.cleanInstallAcceptance, { platform, channel, architecture, source, assurances: selected.assurances ?? selected.platformAssurances });
   const assurances = validateAssurances(
     selected.assurances === undefined ? selected.platformAssurances : selected.assurances,
     platform,
     channel,
     "artifact.assurances",
+    cleanInstallAcceptance,
   );
   let store = normalizeStore(selected.store, platform, channel, "artifact.store", {
     artifactDigest: artifactFile.sha256,
@@ -332,7 +335,7 @@ async function normalizeArtifact(descriptor, release, productName, baseDir, cont
     store,
     label: "artifact.nativeTrust",
   });
-  const build = normalizeBuild(selected.build, channel, "artifact.build");
+  const build = normalizeBuild(selected.build, channel, "artifact.build", artifactFile.sha256, { platform, architecture, updater });
   const distribution = validateDistribution({
     value: selected.distribution,
     channel,
@@ -360,6 +363,7 @@ async function normalizeArtifact(descriptor, release, productName, baseDir, cont
     sbom,
     provenance,
     assurances,
+    ...(cleanInstallAcceptance === undefined ? {} : { cleanInstallAcceptance }),
     store,
     updater,
   };

--- a/scripts/release-evidence-output.js
+++ b/scripts/release-evidence-output.js
@@ -137,6 +137,8 @@ export async function validateReleaseEvidenceManifest(
   { artifactRoot = null, manifestPath = null } = {},
 ) {
   validateCanonicalManifest(manifest);
+  assert(manifest.artifacts.every(artifact => artifact.cleanInstallAcceptance?.status !== "pending"),
+    "RELEASE_EVIDENCE_ACCEPTANCE_PENDING", "release still has pending clean-install acceptance");
   if (artifactRoot !== null) await verifyManifestFiles(manifest, artifactRoot);
   if (manifestPath !== null) {
     assert(basename(resolve(manifestPath)) === RELEASE_EVIDENCE_MANIFEST_FILE_NAME,

--- a/scripts/release-evidence-policy.js
+++ b/scripts/release-evidence-policy.js
@@ -231,7 +231,23 @@ export function normalizeSource({ value, release, label }) {
   return normalized;
 }
 
-export function validateAssurances(value, platform, channel, label) {
+/** Missing native execution stays explicit; an owner decision is never a passed smoke. */
+export function normalizeCleanInstallAcceptance(value, { platform, channel, architecture, source, assurances }) {
+  if (value === undefined) return undefined;
+  const label = "cleanInstallAcceptance";
+  assertPlainObject(value, "RELEASE_EVIDENCE_ACCEPTANCE_INVALID", label);
+  assertAllowedKeys(value, ["status", "reason", "sourceCommit"], label, "RELEASE_EVIDENCE_ACCEPTANCE_INVALID");
+  assert(channel === "direct" && ((platform === "macos" && ["arm64", "x64"].includes(architecture))
+    || (["windows", "linux"].includes(platform) && architecture === "x64")),
+  "RELEASE_EVIDENCE_ACCEPTANCE_INVALID", "acceptance requires a supported direct target");
+  assert(["owner_accepted", "pending"].includes(value.status), "RELEASE_EVIDENCE_ACCEPTANCE_INVALID", "acceptance status is invalid");
+  assertSafeText(value.reason, "RELEASE_EVIDENCE_ACCEPTANCE_INVALID", "acceptance reason", { maximumBytes: 512 });
+  assert(value.sourceCommit === source.commit, "RELEASE_EVIDENCE_SOURCE_MISMATCH", "acceptance must identify the artifact source");
+  assert(assurances?.cleanInstallSmokePassed === false, "RELEASE_EVIDENCE_ACCEPTANCE_INVALID", "unobserved execution must not claim a passed smoke");
+  return { status: value.status, reason: value.reason, sourceCommit: value.sourceCommit };
+}
+
+export function validateAssurances(value, platform, channel, label, acceptance = undefined) {
   const assurances = assertPlainObject(value,
     "RELEASE_EVIDENCE_ASSURANCES_INVALID", label);
   assertAllowedKeys(assurances,
@@ -242,6 +258,7 @@ export function validateAssurances(value, platform, channel, label) {
       `${label}.${key} must be boolean`);
   }
   for (const key of RELEASE_EVIDENCE_PLATFORM_ASSURANCES[platform][channel]) {
+    if (key === "cleanInstallSmokePassed" && acceptance !== undefined) continue;
     assert(assurances[key] === true, "RELEASE_EVIDENCE_ASSURANCES_INCOMPLETE",
       `${label}.${key} must be true for ${platform}/${channel}`);
   }
@@ -496,13 +513,23 @@ export function normalizeNativeTrust({ value, platform, channel, store, label })
   };
 }
 
-export function normalizeBuild(value, channel, label) {
+export function normalizeBuild(value, channel, label, finalArtifactSha256 = undefined, electronTarget = undefined) {
   if (channel === "store") {
     assert(value === null, "RELEASE_EVIDENCE_BUILD_INVALID",
       `${label} must be null for a Store-delivered subject`);
     return null;
   }
   const build = assertPlainObject(value, "RELEASE_EVIDENCE_BUILD_INVALID", label);
+  if (Object.hasOwn(build, "finalArtifactSha256")) {
+    assert(channel === "direct" && electronTarget?.updater?.enabled === true && electronTarget.updater.mechanism === "electron-updater"
+      && ((electronTarget.platform === "macos" && ["arm64", "x64"].includes(electronTarget.architecture))
+        || (["windows", "linux"].includes(electronTarget.platform) && electronTarget.architecture === "x64")),
+    "RELEASE_EVIDENCE_BUILD_INVALID", "final build evidence requires a supported direct Electron updater target");
+    assertAllowedKeys(build, ["sourceManifestSha256", "finalArtifactSha256"], label, "RELEASE_EVIDENCE_BUILD_INVALID");
+    assert(build.finalArtifactSha256 === finalArtifactSha256, "RELEASE_EVIDENCE_BUILD_INVALID", "final build evidence must bind the exact final artifact");
+    return { sourceManifestSha256: assertSha256(build.sourceManifestSha256, `${label}.sourceManifestSha256`),
+      finalArtifactSha256: assertSha256(build.finalArtifactSha256, `${label}.finalArtifactSha256`) };
+  }
   assertAllowedKeys(build, ["sourceManifestSha256", "unsignedPayloadSha256"], label,
     "RELEASE_EVIDENCE_BUILD_INVALID");
   return {
@@ -856,7 +883,7 @@ export function validateCanonicalArtifact(artifact, release, index) {
   assertAllowedKeys(artifact, [
     "platform", "channel", "architecture", "format", "version", "distribution",
     "downloadUrl", "fileName", "bytes", "sha256", "source", "nativeTrust", "build",
-    "sbom", "provenance", "assurances", "store", "updater",
+    "sbom", "provenance", "assurances", "store", "updater", "cleanInstallAcceptance",
   ], label, "RELEASE_EVIDENCE_ARTIFACT_INVALID");
   assert(Object.prototype.hasOwnProperty.call(artifact, "store"),
     "RELEASE_EVIDENCE_ARTIFACT_INVALID",
@@ -907,13 +934,14 @@ export function validateCanonicalArtifact(artifact, release, index) {
   validateCanonicalAttestation(artifact.provenance, {
     label: `${label}.provenance`, release, artifactDigest: artifact.sha256,
   });
-  validateAssurances(artifact.assurances, platform, channel, `${label}.assurances`);
+  const acceptance = normalizeCleanInstallAcceptance(artifact.cleanInstallAcceptance, { platform, channel, architecture: artifact.architecture, source, assurances: artifact.assurances });
+  validateAssurances(artifact.assurances, platform, channel, `${label}.assurances`, acceptance);
   const store = normalizeStore(artifact.store, platform, channel, `${label}.store`, {
     artifactDigest: artifact.sha256,
   });
   normalizeNativeTrust({ value: artifact.nativeTrust, platform, channel, store,
     label: `${label}.nativeTrust` });
-  normalizeBuild(artifact.build, channel, `${label}.build`);
+  normalizeBuild(artifact.build, channel, `${label}.build`, artifact.sha256, artifact);
   validateDistribution({ value: artifact.distribution, channel, platform, store,
     source: release, fileName: artifact.fileName, downloadUrl, label: `${label}.distribution` });
   const updater = assertPlainObject(artifact.updater,

--- a/scripts/smoke-electron-macos-empty-profile.mjs
+++ b/scripts/smoke-electron-macos-empty-profile.mjs
@@ -44,13 +44,32 @@ export function assertEmptyProfileSharing(value, { optedOut = false } = {}) {
     || (optedOut && value.transportStatus !== 'off') || value.lastAcceptedAt !== null) fail(optedOut ? 'opt_out' : 'fresh_projection');
   return true;
 }
-export function emptyProfileSettingsScript(tab) {
-  if (!['general', 'data', 'about'].includes(tab)) fail('settings_tab');
+export function emptyProfileSettingsScript(tab, operation = 'selected') {
+  if (!['general', 'data', 'about'].includes(tab) || !['ready', 'click', 'selected'].includes(operation)) fail('settings_tab');
   return `(() => { const button = document.getElementById('settings-tab-${tab}');
     const panel = document.getElementById('settings-panel-${tab}');
-    if (!button || !panel || button.disabled) return false;
-    button.click(); return button.getAttribute('aria-selected') === 'true' && panel.hidden === false;
+    if (document.readyState !== 'complete' || !button || !panel || button.disabled) return false;
+    ${operation === 'ready' ? "return true;" : operation === 'click' ? "button.click(); return true;"
+      : "return button.getAttribute('aria-selected') === 'true' && panel.hidden === false;"}
   })()`;
+}
+export async function exerciseEmptyProfileSettings(settings, { now = Date.now, wait = delay } = {}) {
+  const until = async (expression, stage) => {
+    const deadline = now() + 10000;
+    do {
+      if (await settings.evaluate(expression) === true) return;
+      await wait(100);
+    } while (now() < deadline);
+    fail(stage);
+  };
+  for (const tab of ['about', 'general', 'data']) {
+    // Preload exists before the deferred Settings module has installed its handlers.
+    // Complete document readiness precedes the one actual click; polling never clicks.
+    await until(emptyProfileSettingsScript(tab, 'ready'), 'settings_ready');
+    if (await settings.evaluate(emptyProfileSettingsScript(tab, 'click')) !== true) fail('settings_click');
+    await until(emptyProfileSettingsScript(tab, 'selected'), 'settings_effect');
+  }
+  return true;
 }
 async function absent(path) { try { await lstat(path); } catch (error) { if (error.code === 'ENOENT') return; throw error; } fail('profile_not_empty'); }
 async function safeDirectory(path) {
@@ -127,7 +146,7 @@ export async function runEmptyProfileSmoke({ intake, execute = false }) {
     assertSignedStagingFreshProjection(sharing, await smallJson(join(profile, 'desktop-settings', 'desktop-first-run-v1.json')));
     proof.freshDefaultSharingObserved = true;
     stage = 'settings';
-    for (const tab of ['about', 'general', 'data']) if (await active.settings.evaluate(emptyProfileSettingsScript(tab)) !== true) fail('settings_interaction');
+    await exerciseEmptyProfileSettings(active.settings);
     proof.settingsTabsInteractive = true;
     await absent(codex);
     await stopOwnedMacSharingApp(active); active = null;

--- a/scripts/smoke-electron-macos-empty-profile.mjs
+++ b/scripts/smoke-electron-macos-empty-profile.mjs
@@ -1,0 +1,164 @@
+#!/usr/bin/env node
+// Separate clean-install evidence: no predecessor, fixtures, or upload success claims.
+import { createHash } from 'node:crypto';
+import { execFileSync } from 'node:child_process';
+import { lstat, mkdir, readFile } from 'node:fs/promises';
+import { userInfo } from 'node:os';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { setTimeout as delay } from 'node:timers/promises';
+import { assertExtractedSignedMacBundle, verifySparkleTransitionCandidate,
+  validateSparkleTransitionHost, signedMacTransitionEnvironment } from './smoke-electron-macos-sparkle-transition.mjs';
+import { launchVerifiedMacSharingApp, stopOwnedMacSharingApp,
+  assertSignedStagingFreshProjection } from './run-signed-electron-staging.mjs';
+
+export const EMPTY_PROFILE_CONFIRMATION = 'RUN_DISPOSABLE_EMPTY_PROFILE';
+const SOURCE = 'a651ea130dd1460e4443a037c4434f57b911fec4';
+const CANDIDATES = Object.freeze({
+  'darwin-arm64': Object.freeze({ architecture: 'arm64',
+    dmgSha256: '0afab510adf250775e1401307b547cee1a7955e1d7ec8dce9852cc4ca143c7e2',
+    asarSha256: '11d053d35ae6e971adc27b3a30a8bb94592e09f5f1466cfb5d9c008634950175', filename: 'TiboTattle-0.1.21-mac-arm64.dmg' }),
+  'darwin-x64': Object.freeze({ architecture: 'x64',
+    dmgSha256: '50960e1aac65eb2673a7634a18bf123b604680f2a526822a0ccccc1d3b0b52e4',
+    asarSha256: '8222cd3119e42b24d87adaee6d1a264514517504a12e2b7d728fb53ac81722e1', filename: 'TiboTattle-0.1.21-macOS-x64.dmg' }),
+});
+function fail(stage) { const error = new Error('Empty-profile qualification failed'); error.emptyProfileStage = stage; throw error; }
+export function validateEmptyProfileIntake(input) {
+  if (!input || typeof input !== 'object' || Array.isArray(input)
+    || Object.keys(input).sort().join(',') !== 'runnerRevision,target'
+    || typeof input.runnerRevision !== 'string' || !/^[a-f0-9]{40}$/u.test(input.runnerRevision)
+    || typeof input.target !== 'string' || !Object.hasOwn(CANDIDATES, input.target)) fail('intake');
+  const candidate = CANDIDATES[input.target];
+  return Object.freeze({ ...input, ...candidate, sourceRevision: SOURCE, version: '0.1.21', buildNumber: '2026091107', bundleVersion: '1028',
+    url: `https://updates.tibotattle.com/electron/test/native-sparkle/${SOURCE}/1028/${candidate.dmgSha256}/${candidate.filename}` });
+}
+export function parseEmptyProfileArguments(args) {
+  if (!Array.isArray(args) || ![1, 3].includes(args.length) || !['--plan', '--execute'].includes(args[0])) fail('arguments');
+  const execute = args[0] === '--execute';
+  if (execute ? args.length !== 3 || args[1] !== '--confirm' || args[2] !== EMPTY_PROFILE_CONFIRMATION : args.length !== 1) fail('confirmation');
+  return { execute };
+}
+export function assertEmptyProfileSharing(value, { optedOut = false } = {}) {
+  if (value?.available !== true || value.current !== true || value.enabled !== !optedOut
+    || (!optedOut && value.basis !== 'default_on')
+    || (optedOut && value.transportStatus !== 'off') || value.lastAcceptedAt !== null) fail(optedOut ? 'opt_out' : 'fresh_projection');
+  return true;
+}
+export function emptyProfileSettingsScript(tab) {
+  if (!['general', 'data', 'about'].includes(tab)) fail('settings_tab');
+  return `(() => { const button = document.getElementById('settings-tab-${tab}');
+    const panel = document.getElementById('settings-panel-${tab}');
+    if (!button || !panel || button.disabled) return false;
+    button.click(); return button.getAttribute('aria-selected') === 'true' && panel.hidden === false;
+  })()`;
+}
+async function absent(path) { try { await lstat(path); } catch (error) { if (error.code === 'ENOENT') return; throw error; } fail('profile_not_empty'); }
+async function safeDirectory(path) {
+  const info = await lstat(path);
+  if (!info.isDirectory() || info.isSymbolicLink() || info.uid !== process.getuid() || (info.mode & 0o022)) fail('unsafe_directory');
+  if (path !== '/Users/runner' && path.startsWith('/Users/runner/')) await safeDirectory(dirname(path));
+}
+function command(executable, args, timeout = 90000) {
+  return execFileSync(executable, args, { encoding: 'utf8', timeout, maxBuffer: 1024 * 1024, stdio: ['ignore', 'pipe', 'ignore'] }).trim();
+}
+async function smallJson(path) {
+  const stat = await lstat(path);
+  if (!stat.isFile() || stat.isSymbolicLink() || stat.nlink !== 1 || stat.uid !== process.getuid() || stat.size > 4096) fail('first_run_receipt');
+  return JSON.parse(await readFile(path, 'utf8'));
+}
+async function sharingReady(active) {
+  const deadline = Date.now() + 30000;
+  while (Date.now() < deadline) {
+    const value = await active.readSharing();
+    if (value?.available === true && value.current === true) return value;
+    await delay(250);
+  }
+  fail('sharing_unavailable');
+}
+export async function runEmptyProfileSmoke({ intake, execute = false }) {
+  const proof = { schemaVersion: 'tibotattle-signed-macos-empty-profile-v1', status: 'failed',
+    disposableAccountVerified: false, emptyProfileVerified: false, signedArtifactVerified: false,
+    nativeIntroContinued: false, freshDefaultSharingObserved: false, settingsTabsInteractive: false,
+    controlledRestart: false, defaultSharingPreserved: false, persistentOptOut: false,
+    codexHomeAbsentThroughout: false, ownedProcessesStopped: false, nativeCleanQuitQualified: false,
+    usageUploadQualified: false, credentialPersistenceQualified: false, failureStage: null };
+  let active, stage = 'intake';
+  try {
+    const input = validateEmptyProfileIntake(intake);
+    Object.assign(proof, { target: input.target, sourceRevision: input.sourceRevision, runnerRevision: input.runnerRevision,
+      version: input.version, buildNumber: input.buildNumber, dmgSha256: input.dmgSha256, asarSha256: input.asarSha256 });
+    if (!execute) return { ...proof, status: 'planned' };
+    stage = 'host';
+    const home = validateSparkleTransitionHost({ target: input.target, platform: process.platform,
+      architecture: process.arch, nodeVersion: process.version, environment: process.env, account: userInfo() });
+    if (process.env.GITHUB_SHA !== input.runnerRevision) fail('runner_revision');
+    proof.disposableAccountVerified = true;
+    const appData = join(home, 'Library', 'Application Support');
+    const profile = join(appData, 'TiboTattle'), codex = join(home, '.codex');
+    const installed = join(home, 'Applications', 'TiboTattle.app');
+    stage = 'empty_profile';
+    for (const path of [codex, join(home, '.claude'), profile, installed, '/Applications/TiboTattle.app',
+      join(appData, 'Usage Monitor'), join(appData, 'TiboTattle Native Handover'), join(appData, 'app-usagemonitor'),
+      join(home, 'Library', 'Preferences', 'com.usagemonitor.local.plist')]) await absent(path);
+    proof.emptyProfileVerified = true;
+    const directory = join(process.env.RUNNER_TEMP, 'tibotattle-empty-profile');
+    await mkdir(directory, { mode: 0o700 }); await safeDirectory(directory);
+    const environment = signedMacTransitionEnvironment({ target: input.target, home, temporaryDirectory: directory });
+    stage = 'artifact';
+    const dmg = join(directory, 'candidate.dmg');
+    const response = command('/usr/bin/curl', ['--disable', '--fail', '--silent', '--show-error', '--proto', '=https',
+      '--max-time', '180', '--max-filesize', String(1024 ** 3), '--output', dmg, '--write-out', '%{http_code}', input.url], 190000);
+    if (response !== '200') fail('download');
+    const bytes = await readFile(dmg);
+    if (bytes.length === 0 || bytes.length > 1024 ** 3 || createHash('sha256').update(bytes).digest('hex') !== input.dmgSha256) fail('dmg_digest');
+    const mount = join(directory, 'mount'); await mkdir(mount, { mode: 0o700 });
+    await mkdir(dirname(installed), { recursive: true, mode: 0o700 }); await safeDirectory(dirname(installed));
+    command('/usr/bin/hdiutil', ['attach', '-readonly', '-nobrowse', '-noautoopen', '-mountpoint', mount, dmg]);
+    try { command('/usr/bin/ditto', [join(mount, 'TiboTattle.app'), installed], 120000); }
+    finally { command('/usr/bin/hdiutil', ['detach', mount]); }
+    const candidateCodeDirectoryHash = await assertExtractedSignedMacBundle(dmg, installed, join(directory, 'verification-mount'));
+    const verified = await verifySparkleTransitionCandidate({ ...input, candidateCodeDirectoryHash }, installed);
+    proof.signedArtifactVerified = true;
+    stage = 'first_launch';
+    active = await launchVerifiedMacSharingApp(verified, environment, { untouched: true });
+    proof.nativeIntroContinued = active.nativeIntroContinued === true;
+    const sharing = await sharingReady(active);
+    assertEmptyProfileSharing(sharing);
+    assertSignedStagingFreshProjection(sharing, await smallJson(join(profile, 'desktop-settings', 'desktop-first-run-v1.json')));
+    proof.freshDefaultSharingObserved = true;
+    stage = 'settings';
+    for (const tab of ['about', 'general', 'data']) if (await active.settings.evaluate(emptyProfileSettingsScript(tab)) !== true) fail('settings_interaction');
+    proof.settingsTabsInteractive = true;
+    await absent(codex);
+    await stopOwnedMacSharingApp(active); active = null;
+    stage = 'default_restart';
+    active = await launchVerifiedMacSharingApp(verified, environment);
+    assertEmptyProfileSharing(await sharingReady(active));
+    proof.controlledRestart = true; proof.defaultSharingPreserved = true;
+    stage = 'opt_out';
+    await active.settings.evaluate('globalThis.tibotattleDesktop.setSharingEnabled(false)');
+    assertEmptyProfileSharing(await sharingReady(active), { optedOut: true });
+    await absent(codex);
+    await stopOwnedMacSharingApp(active); active = null;
+    stage = 'opt_out_restart';
+    active = await launchVerifiedMacSharingApp(verified, environment);
+    assertEmptyProfileSharing(await sharingReady(active), { optedOut: true });
+    await absent(codex);
+    proof.persistentOptOut = true; proof.codexHomeAbsentThroughout = true;
+    await stopOwnedMacSharingApp(active); active = null;
+    proof.ownedProcessesStopped = true; proof.status = 'passed';
+  } catch (error) {
+    proof.failureStage = error.emptyProfileStage ?? stage;
+    if (error.ownedMacProcessesStopped === true) proof.ownedProcessesStopped = true;
+  } finally {
+    if (active) { try { proof.ownedProcessesStopped = await stopOwnedMacSharingApp(active); } catch { proof.ownedProcessesStopped = false; proof.status = 'failed'; } }
+  }
+  return proof;
+}
+if (process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  let proof;
+  try { proof = await runEmptyProfileSmoke({ ...parseEmptyProfileArguments(process.argv.slice(2)), intake: JSON.parse(process.env.EMPTY_PROFILE_INTAKE ?? '{}') }); }
+  catch { proof = { schemaVersion: 'tibotattle-signed-macos-empty-profile-v1', status: 'failed', failureStage: 'arguments' }; }
+  process.stdout.write(JSON.stringify(proof) + '\n');
+  if (proof.status === 'failed') process.exitCode = 1;
+}

--- a/scripts/smoke-electron-macos-production-update.mjs
+++ b/scripts/smoke-electron-macos-production-update.mjs
@@ -8,7 +8,8 @@ import { userInfo } from 'node:os';
 import { dirname, isAbsolute, join, relative, resolve, sep } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { validateSparkleTransitionHost, captureMacTransitionProcesses, stopVerifiedMacTransitionProcesses,
-  assertExtractedSignedMacBundle, verifySparkleTransitionCandidate, signedMacTransitionEnvironment } from './smoke-electron-macos-sparkle-transition.mjs';
+  assertExtractedSignedMacBundle, verifySparkleTransitionCandidate, signedMacTransitionEnvironment,
+  findMacTransitionApplicationProcess } from './smoke-electron-macos-sparkle-transition.mjs';
 import { launchVerifiedMacSharingApp, stopOwnedMacSharingApp } from './run-signed-electron-staging.mjs';
 import { seedSignedReplacementNativeState, readSignedReplacementState,
   assertSignedReplacementContinuity } from './smoke-electron-macos-replacement.mjs';
@@ -106,10 +107,7 @@ async function until(check, timeout, stage) {
   fail(stage);
 }
 function appPid(app) {
-  const executable = join(app, 'Contents', 'MacOS', 'TiboTattle');
-  const matches = command('/bin/ps', ['-axo', 'pid=,comm=']).split('\n')
-    .map(line => /^\s*(\d+)\s+(.+)$/u.exec(line)).filter(m => m && m[2] === executable);
-  if (matches.length > 1) fail('duplicate_process'); return matches.length ? +matches[0][1] : null;
+  return findMacTransitionApplicationProcess(join(app, 'Contents', 'MacOS', 'TiboTattle'))?.pid ?? null;
 }
 async function verifyPredecessor(input, appPath) {
   const asar = join(appPath, 'Contents', 'Resources', 'app.asar');

--- a/scripts/smoke-electron-macos-production-update.mjs
+++ b/scripts/smoke-electron-macos-production-update.mjs
@@ -1,0 +1,271 @@
+#!/usr/bin/env node
+// Post-activation acceptance only. No feed overrides, signing changes or candidate installation by this runner.
+import { execFileSync } from 'node:child_process';
+import { createHash } from 'node:crypto';
+import { mkdir, lstat, readFile, writeFile, realpath } from 'node:fs/promises';
+import { createRequire } from 'node:module';
+import { userInfo } from 'node:os';
+import { dirname, isAbsolute, join, relative, resolve, sep } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { validateSparkleTransitionHost, captureMacTransitionProcesses, stopVerifiedMacTransitionProcesses,
+  assertExtractedSignedMacBundle, verifySparkleTransitionCandidate, signedMacTransitionEnvironment } from './smoke-electron-macos-sparkle-transition.mjs';
+import { launchVerifiedMacSharingApp, stopOwnedMacSharingApp } from './run-signed-electron-staging.mjs';
+import { seedSignedReplacementNativeState, readSignedReplacementState,
+  assertSignedReplacementContinuity } from './smoke-electron-macos-replacement.mjs';
+import { parseWindowsUpdaterYaml } from './verify-electron-windows-update-artifacts.mjs';
+import { validateProductionDistributionMetadata } from '../apps/electron/desktop-updater.js';
+import { macOSCredentialApplicationVerificationArguments } from '../apps/electron/desktop-macos-keychain.js';
+import { inspectNativeElectronHandoverCompletion } from '../apps/electron/desktop-native-migration.js';
+
+export const ELECTRON_PRODUCTION_UPDATE_SCHEMA = 'tibotattle-signed-macos-production-update-v1';
+export const ELECTRON_020_SOURCE = 'f518126a05a6d165b9617f6417a87219d7047273';
+export const ELECTRON_020_DMG = Object.freeze({
+  'darwin-arm64': '50a1b89aff696ef3323ab48284aa820af7aad504397fbe88831c29ace2479f30',
+  'darwin-x64': 'a63ec06036ddbc5a0e70dc59c6520a8ad5baa8c7a3a0fc4d3713a7f1f1523ecd',
+});
+const require = createRequire(import.meta.url), SHA = /^[0-9a-f]{64}$/u;
+const fail = stage => { throw Object.assign(new Error('SIGNED_PRODUCTION_UPDATE_REFUSED'), { updateStage: stage }); };
+const hash = (bytes, algorithm = 'sha256', encoding = 'hex') => createHash(algorithm).update(bytes).digest(encoding);
+const command = (file, args, timeout = 30000) => execFileSync(file, args,
+  { encoding: 'utf8', timeout, maxBuffer: 4 * 1024 ** 2, stdio: ['ignore', 'pipe', 'ignore'] }).trim();
+export function parseProductionUpdateArguments(argv) {
+  const execute = argv[0] === '--execute';
+  if (!['--plan', '--execute'].includes(argv[0]) || argv[1] !== '--intake' || !isAbsolute(argv[2] ?? '')
+    || (execute ? argv.length !== 5 || argv[3] !== '--confirm' || argv[4] !== 'RUN_DISPOSABLE_PRODUCTION_ELECTRON_UPDATE'
+      : argv.length !== 3)) fail('arguments');
+  return { execute, intakePath: resolve(argv[2]) };
+}
+export function validateProductionUpdateIntake(value) {
+  const keys = ['schemaVersion', 'target', 'sourceRevision', 'buildNumber', 'version', 'bundleVersion',
+    'dmgSha256', 'asarSha256', 'zipSha256', 'feedSha256', 'predecessorAsarSha256', 'directory'];
+  if (!value || typeof value !== 'object' || Array.isArray(value)
+    || Object.keys(value).sort().join('|') !== keys.sort().join('|')
+    || value.schemaVersion !== 'tibotattle-production-electron-update-intake-v1'
+    || !Object.hasOwn(ELECTRON_020_DMG, value.target) || value.version !== '0.1.21' || value.bundleVersion !== '1028'
+    || typeof value.sourceRevision !== 'string' || !/^[0-9a-f]{40}$/u.test(value.sourceRevision)
+    || typeof value.buildNumber !== 'string' || !/^[1-9][0-9]{0,9}$/u.test(value.buildNumber)
+    || !['dmgSha256', 'asarSha256', 'zipSha256', 'feedSha256', 'predecessorAsarSha256'].every(k => typeof value[k] === 'string' && SHA.test(value[k]))
+    || !isAbsolute(value.directory ?? '') || /[\0\r\n]/u.test(value.directory)) fail('intake');
+  const architecture = value.target === 'darwin-arm64' ? 'arm64' : 'x64';
+  const feedBase = 'https://updates.tibotattle.com/electron/stable/' + value.target;
+  const file = version => 'TiboTattle-' + version + '-mac-' + architecture;
+  return { ...value, architecture, directory: resolve(value.directory), feedBase,
+    feedUrl: feedBase + '/latest-mac.yml', zipFileName: file(value.version) + '.zip',
+    dmgFileName: file(value.version) + '.dmg', predecessorDmgSha256: ELECTRON_020_DMG[value.target],
+    predecessorUrl: 'https://github.com/adamallcock/tibotattle/releases/download/v0.1.20/' + file('0.1.20') + '.dmg',
+    candidateUrl: 'https://github.com/adamallcock/tibotattle/releases/download/v0.1.21/' + file(value.version) + '.dmg' };
+}
+export function validateProductionMacUpdateFeed(input, manifest, zip, dmg) {
+  const entries = manifest?.files;
+  if (manifest?.version !== '0.1.21' || !Array.isArray(entries) || entries.length !== 2
+    || manifest.path !== input.zipFileName || Object.hasOwn(manifest, 'packages')) fail('feed_identity');
+  for (const [name, bytes] of [[input.zipFileName, zip], [input.dmgFileName, dmg]]) {
+    const selected = entries.filter(entry => entry.url === name);
+    if (selected.length !== 1 || selected[0].size !== bytes.length
+      || selected[0].sha512 !== hash(bytes, 'sha512', 'base64')) fail('feed_artifact');
+  }
+  if (manifest.sha512 !== hash(zip, 'sha512', 'base64') || hash(zip) !== input.zipSha256
+    || hash(dmg) !== input.dmgSha256) fail('feed_artifact');
+  return true;
+}
+async function safePath(path) {
+  for (let p = resolve(path);;) {
+    if ((await lstat(p)).isSymbolicLink()) fail('unsafe_path');
+    const parent = dirname(p); if (parent === p) break; p = parent;
+  }
+  if (await realpath(path) !== resolve(path)) fail('unsafe_path');
+}
+async function absent(path) {
+  try { await lstat(path); } catch (error) { if (error.code === 'ENOENT') return; throw error; } fail('preexisting_state');
+}
+async function bytes(path, limit = 1024 ** 3) {
+  await safePath(path); const s = await lstat(path);
+  if (!s.isFile() || s.nlink !== 1 || s.uid !== process.getuid() || s.size < 1 || s.size > limit) fail('unsafe_file');
+  return readFile(path);
+}
+async function fetchBytes(url, limit, github = false) {
+  let selected = new URL(url);
+  for (let redirect = 0; redirect < 4; redirect++) {
+    if (selected.protocol !== 'https:' || selected.username || selected.password
+      || !(github ? ['github.com', 'release-assets.githubusercontent.com', 'objects.githubusercontent.com'].includes(selected.hostname)
+        : selected.origin === 'https://updates.tibotattle.com')) fail('download_url');
+    const response = await fetch(selected, { redirect: 'manual', signal: AbortSignal.timeout(120000) });
+    if ([301, 302, 303, 307, 308].includes(response.status) && github) {
+      selected = new URL(response.headers.get('location'), selected); await response.body?.cancel(); continue;
+    }
+    if (!response.ok || +response.headers.get('content-length') > limit) fail('download');
+    const chunks = []; let length = 0;
+    for await (const chunk of response.body) { length += chunk.length; if (length > limit) fail('download_size'); chunks.push(chunk); }
+    if (!length) fail('download_empty'); return Buffer.concat(chunks);
+  }
+  fail('download_redirect');
+}
+async function until(check, timeout, stage) {
+  const deadline = Date.now() + timeout;
+  do { const result = await check(); if (result) return result; await new Promise(r => setTimeout(r, 300)); } while (Date.now() < deadline);
+  fail(stage);
+}
+function appPid(app) {
+  const executable = join(app, 'Contents', 'MacOS', 'TiboTattle');
+  const matches = command('/bin/ps', ['-axo', 'pid=,comm=']).split('\n')
+    .map(line => /^\s*(\d+)\s+(.+)$/u.exec(line)).filter(m => m && m[2] === executable);
+  if (matches.length > 1) fail('duplicate_process'); return matches.length ? +matches[0][1] : null;
+}
+async function verifyPredecessor(input, appPath) {
+  const asar = join(appPath, 'Contents', 'Resources', 'app.asar');
+  if (hash(await bytes(asar, 512 * 1024 ** 2)) !== input.predecessorAsarSha256) fail('predecessor_asar');
+  command('/usr/bin/codesign', macOSCredentialApplicationVerificationArguments(appPath));
+  command('/usr/sbin/spctl', ['--assess', '--type', 'execute', appPath]);
+  const loaded = createRequire(require.resolve('electron-builder'))('@electron/asar'), api = loaded?.default ?? loaded;
+  if (api.statFile(asar, 'package.json').size > 128 * 1024) fail('predecessor_metadata');
+  const pkg = JSON.parse(api.extractFile(asar, 'package.json').toString('utf8'));
+  const distribution = validateProductionDistributionMetadata(pkg.tibotattleDistribution, { platform: 'darwin', architecture: input.architecture });
+  const plist = JSON.parse(command('/usr/bin/plutil', ['-convert', 'json', '-o', '-', join(appPath, 'Contents', 'Info.plist')]));
+  if (pkg.name !== 'app-usagemonitor' || pkg.version !== '0.1.20' || distribution.sourceRevision !== ELECTRON_020_SOURCE
+    || distribution.buildNumber !== '2026091104' || distribution.target !== input.target || distribution.channel !== 'stable'
+    || plist.CFBundleIdentifier !== 'com.usagemonitor.local' || plist.CFBundleShortVersionString !== '0.1.20'
+    || plist.CFBundleVersion !== '2026091104') fail('predecessor_identity');
+  const executable = join(appPath, 'Contents', 'MacOS', 'TiboTattle');
+  if (command('/usr/bin/lipo', ['-archs', executable]) !== (input.architecture === 'arm64' ? 'arm64' : 'x86_64')) fail('predecessor_architecture');
+  return { appPath, executable, distribution };
+}
+async function copyPredecessor(dmg, app, mount) {
+  await mkdir(mount, { mode: 0o700 });
+  command('/usr/bin/hdiutil', ['attach', '-readonly', '-nobrowse', '-noautoopen', '-mountpoint', mount, dmg], 90000);
+  try { command('/usr/bin/ditto', [join(mount, 'TiboTattle.app'), app], 120000); }
+  finally { command('/usr/bin/hdiutil', ['detach', mount], 90000); }
+}
+export async function runProductionUpdate(options) {
+  const proof = { schemaVersion: ELECTRON_PRODUCTION_UPDATE_SCHEMA, status: 'failed', predecessorVersion: '0.1.20',
+    predecessorBundleVersion: '2026091104', feedScope: 'production_feed', feedOverrideApplied: false,
+    productionFeedVerified: false, signedArtifactVerified: false, disposableAccountVerified: false,
+    checkForUpdatesInvoked: false, updateDiscoveredAutomatically: false, downloadUpdateInvoked: false, installUpdateInvoked: false,
+    updaterRelaunchedCandidate: false, candidateCopiedByRunner: false, retainedRowsPreserved: false,
+    preferencesPreserved: false, saltPreserved: false, optOutPreserved: false, restartNoDuplicates: false,
+    ownedProcessesStopped: false, existingCredentialFixture: false, failureStage: null };
+  let input, app, active, stage = 'intake'; const knownProcesses = new Map();
+  try {
+    input = validateProductionUpdateIntake(JSON.parse(await bytes(options.intakePath, 16384)));
+    for (const key of ['target', 'sourceRevision', 'version', 'buildNumber', 'bundleVersion', 'dmgSha256', 'asarSha256',
+      'zipSha256', 'feedSha256', 'predecessorAsarSha256', 'predecessorDmgSha256']) proof[key] = input[key];
+    if (!options.execute) return { ...proof, status: 'planned' };
+    const home = validateSparkleTransitionHost({ target: input.target, platform: process.platform, architecture: process.arch,
+      nodeVersion: process.version, environment: process.env, account: userInfo() });
+    const root = await realpath(process.env.RUNNER_TEMP), child = relative(root, input.directory);
+    if (!child || child === '..' || child.startsWith('..' + sep) || isAbsolute(child)) fail('intake_location');
+    await safePath(input.directory); proof.disposableAccountVerified = true;
+    stage = 'fixed_production_feed';
+    const feed = await fetchBytes(input.feedUrl, 65536);
+    if (hash(feed) !== input.feedSha256) fail('production_feed_digest');
+    const zip = await fetchBytes(input.feedBase + '/' + input.zipFileName, 1024 ** 3);
+    const candidate = await fetchBytes(input.candidateUrl, 1024 ** 3, true);
+    validateProductionMacUpdateFeed(input, parseWindowsUpdaterYaml(feed), zip, candidate);
+    const predecessor = await fetchBytes(input.predecessorUrl, 1024 ** 3, true);
+    if (hash(predecessor) !== input.predecessorDmgSha256) fail('predecessor_digest');
+    const predecessorDmg = join(input.directory, 'predecessor.dmg'), candidateDmg = join(input.directory, 'candidate.dmg');
+    await writeFile(predecessorDmg, predecessor, { flag: 'wx', mode: 0o600 });
+    await writeFile(candidateDmg, candidate, { flag: 'wx', mode: 0o600 });
+    proof.productionFeedVerified = true;
+    const support = join(home, 'Library', 'Application Support'), native = join(support, 'Usage Monitor');
+    const profile = join(support, 'TiboTattle'), codex = join(home, '.codex'), applications = join(home, 'Applications');
+    app = join(applications, 'TiboTattle.app');
+    stage = 'fresh_host';
+    for (const path of [native, profile, codex, app, '/Applications/TiboTattle.app', join(support, 'TiboTattle Native Handover'),
+      join(support, 'app-usagemonitor')]) await absent(path);
+    if (/\/TiboTattle[^/]*\.app\//u.test(command('/bin/ps', ['-axo', 'comm=']))) fail('preexisting_process');
+    await mkdir(applications, { recursive: true, mode: 0o700 }); await safePath(applications);
+    const folder = await lstat(applications);
+    if (folder.uid !== process.getuid() || (folder.mode & 0o022)) fail('application_location');
+    await copyPredecessor(predecessorDmg, app, join(input.directory, 'install-mount'));
+    await assertExtractedSignedMacBundle(predecessorDmg, app, join(input.directory, 'predecessor-verification-mount'));
+    const verified = await verifyPredecessor(input, app); proof.signedArtifactVerified = true;
+    command('/System/Library/Frameworks/CoreServices.framework/Frameworks/LaunchServices.framework/Support/lsregister', ['-f', app]);
+    await mkdir(codex, { mode: 0o700 }); await mkdir(join(codex, 'sessions'), { mode: 0o700 });
+    const seeded = await seedSignedReplacementNativeState(native, codex);
+    for (const [key, kind, value] of [['tibotattle.language-preference.v1', '-string', 'es'],
+      ['tibotattle.appearance.v1', '-string', 'dark'], ['tibotattle.refresh-interval.v1', '-int', '900']]) {
+      command('/usr/bin/defaults', ['write', 'com.usagemonitor.local', key, kind, value]);
+    }
+    const temporary = join(input.directory, 'runtime'); await mkdir(temporary, { mode: 0o700 });
+    const environment = signedMacTransitionEnvironment({ target: input.target, home, temporaryDirectory: temporary });
+    stage = 'predecessor_baseline';
+    active = await launchVerifiedMacSharingApp(verified, environment, { launchServices: true });
+    captureMacTransitionProcesses(app, active.pid, knownProcesses);
+    await until(async () => (await inspectNativeElectronHandoverCompletion({ userDataRoot: profile })).status === 'completed', 120000, 'predecessor_migration');
+    const stateRoot = join(profile, 'companion-state'), settingsFile = join(profile, 'desktop-settings', 'desktop-settings-v1.json');
+    const sharing = await until(async () => { const value = await active.readSharing(); return value?.available && value?.current ? value : null; }, 30000, 'sharing');
+    const before = await readSignedReplacementState(stateRoot);
+    assertSignedReplacementContinuity(seeded, before, JSON.parse(await readFile(settingsFile)), sharing);
+    await absent(join(stateRoot, 'accountless-device-binding-v1.json'));
+    // Invoke the ordinary Settings APIs; only the signed main process owns the updater/feed.
+    stage = 'check_update';
+    const ready = await until(async () => {
+      const value = (await active.settings.evaluate('globalThis.tibotattleDesktop.getSettings()'))?.about?.update;
+      return value?.canCheck || value?.canInstall ? value : null;
+    }, 180000, 'check_ready');
+    if (ready.canInstall) proof.updateDiscoveredAutomatically = true;
+    else {
+      await active.settings.evaluate('void globalThis.tibotattleDesktop.checkForUpdates().catch(() => {}); true');
+      proof.checkForUpdatesInvoked = true;
+    }
+    await until(async () => {
+      const value = await active.settings.evaluate('globalThis.tibotattleDesktop.getSettings()');
+      if (value?.about?.update?.status === 'error') fail('updater_error');
+      return value?.about?.update?.canDownload || value?.about?.update?.canInstall;
+    }, 90000, 'update_offer');
+    let snapshot = await active.settings.evaluate('globalThis.tibotattleDesktop.getSettings()');
+    if (!snapshot.about.update.canInstall) {
+      await active.settings.evaluate('void globalThis.tibotattleDesktop.downloadUpdate().catch(() => {}); true'); proof.downloadUpdateInvoked = true;
+    }
+    await until(async () => (await active.settings.evaluate('globalThis.tibotattleDesktop.getSettings()'))?.about?.update?.canInstall,
+      180000, 'update_download');
+    // A changed production feed invalidates this exact-candidate acceptance before installation.
+    if (hash(await fetchBytes(input.feedUrl, 65536)) !== input.feedSha256) fail('production_feed_changed');
+    stage = 'install_update'; const oldPid = active.pid;
+    captureMacTransitionProcesses(app, oldPid, knownProcesses);
+    // The call can lose its CDP response when the updater exits the predecessor.
+    const request = active.settings.evaluate('globalThis.tibotattleDesktop.installUpdateAndRestart()');
+    proof.installUpdateInvoked = true; request.catch(() => {});
+    const successor = await until(() => {
+      captureMacTransitionProcesses(app, oldPid, knownProcesses); const pid = appPid(app);
+      return pid && pid !== oldPid ? pid : null;
+    }, 180000, 'updater_relaunch');
+    input.candidateCodeDirectoryHash = await assertExtractedSignedMacBundle(candidateDmg, app, join(input.directory, 'successor-verification-mount'));
+    await verifySparkleTransitionCandidate(input, app);
+    captureMacTransitionProcesses(app, successor, knownProcesses);
+    proof.updaterRelaunchedCandidate = true;
+    for (const session of active.sessions) { try { session.close(); } catch {} } active = null;
+    // The updater-created launch must preserve state before any controlled restart.
+    assertSignedReplacementContinuity(before, await readSignedReplacementState(stateRoot), JSON.parse(await readFile(settingsFile)), sharing);
+    await absent(join(stateRoot, 'accountless-device-binding-v1.json'));
+    await stopVerifiedMacTransitionProcesses({ appPath: app, knownProcesses, verifyApp: path => verifySparkleTransitionCandidate(input, path) });
+    stage = 'controlled_restart';
+    active = await launchVerifiedMacSharingApp(await verifySparkleTransitionCandidate(input, app), environment, { launchServices: true });
+    captureMacTransitionProcesses(app, active.pid, knownProcesses);
+    const afterSharing = await until(async () => { const value = await active.readSharing(); return value?.available && value?.current ? value : null; }, 30000, 'sharing_after');
+    assertSignedReplacementContinuity(before, await readSignedReplacementState(stateRoot), JSON.parse(await readFile(settingsFile)), afterSharing);
+    await absent(join(stateRoot, 'accountless-device-binding-v1.json'));
+    await stopOwnedMacSharingApp(active); active = null;
+    Object.assign(proof, { retainedRowsPreserved: true, saltPreserved: true, preferencesPreserved: true,
+      optOutPreserved: true, restartNoDuplicates: true, status: 'passed' });
+  } catch (error) { proof.failureStage = error?.updateStage ?? error?.transitionStage ?? stage; }
+  finally {
+    if (active) { try { await stopOwnedMacSharingApp(active); } catch { proof.status = 'failed'; proof.failureStage ??= 'cleanup'; } }
+    if (app && input && knownProcesses.size) {
+      try {
+        proof.ownedProcessesStopped = await stopVerifiedMacTransitionProcesses({ appPath: app, knownProcesses,
+          verifyApp: async path => {
+            try { return await verifySparkleTransitionCandidate(input, path); }
+            catch { return verifyPredecessor(input, path); }
+          } });
+      } catch { proof.ownedProcessesStopped = false; proof.status = 'failed'; proof.failureStage ??= 'cleanup'; }
+    }
+  }
+  return proof;
+}
+if (process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  try {
+    const result = await runProductionUpdate(parseProductionUpdateArguments(process.argv.slice(2)));
+    process.stdout.write(JSON.stringify(result) + '\n'); process.exitCode = ['planned', 'passed'].includes(result.status) ? 0 : 1;
+  } catch { process.stdout.write(JSON.stringify({ schemaVersion: ELECTRON_PRODUCTION_UPDATE_SCHEMA, status: 'failed', failureStage: 'arguments' }) + '\n'); process.exitCode = 1; }
+}

--- a/scripts/smoke-electron-macos-sparkle-transition.mjs
+++ b/scripts/smoke-electron-macos-sparkle-transition.mjs
@@ -161,19 +161,21 @@ export function sparkleTransitionUiScript(pid, action) {
   if (!Number.isSafeInteger(pid) || pid < 2 || !['activate', 'openmenu', 'about', 'check', 'install', 'relaunch', 'quit', 'inspect'].includes(action)) fail('ui_arguments');
   return [
     'function run() {',
+    'let actionAttempted = false;',
+    'try {',
     'const matches = Application("System Events").applicationProcesses.whose({unixId:' + pid + '})();',
     'if (matches.length !== 1) return "process_absent";',
     'const p = matches[0];',
     'const action = ' + JSON.stringify(action) + ';',
     'function label(e) { try { return String(e.name()); } catch (_) { try { return String(e.title()); } catch (_) { return ""; } } }',
-    'function press(e) { e.click(); return "clicked"; }',
-    'if (action === "activate") { p.frontmost = true; return p.frontmost() ? "activated" : "target_absent"; }',
+    'function press(e) { actionAttempted = true; e.click(); return "clicked"; }',
+    'if (action === "activate") { actionAttempted = true; p.frontmost = true; return p.frontmost() ? "activated" : "target_absent"; }',
     'if (action === "openmenu" || action === "about" || action === "quit") {',
     '  const bars = p.menuBars(); if (bars.length < 1) return "menu_absent";',
     '  const items = bars.flatMap(b => b.menuBarItems()).filter(e => label(e) === "TiboTattle");',
     '  if (items.length !== 1) return "menu_absent";',
     '  if (action === "openmenu") return press(items[0]);',
-    '  if (action === "quit") { p.frontmost = true; items[0].click(); }',
+    '  if (action === "quit") { actionAttempted = true; p.frontmost = true; items[0].click(); }',
     '  const menus = items[0].menus(); if (menus.length !== 1) return "menu_absent";',
     '  const names = action === "about" ? ["About TiboTattle","Acerca de TiboTattle"] : ["Quit TiboTattle","Salir de TiboTattle"];',
     '  const targets = menus[0].menuItems().filter(e => names.includes(label(e)));',
@@ -192,6 +194,7 @@ export function sparkleTransitionUiScript(pid, action) {
     'if (/up.to.date|versión más reciente/i.test(text)) return "no_update";',
     'if (/Keychain|keychain|llavero/.test(text)) return "keychain_dialog";',
     'return "target_absent";',
+    '} catch (_) { return actionAttempted ? "action_unconfirmed" : "snapshot_unavailable"; }',
     '}',
   ].join('\n');
 }
@@ -200,9 +203,9 @@ function ui(executable, pid, action) {
   if (!current || current.pid !== pid) return 'process_absent';
   const result = command('/usr/bin/osascript', ['-l', 'JavaScript', '-e', sparkleTransitionUiScript(pid, action)], 10000);
   const allowed = ['clicked', 'activated', 'process_absent', 'menu_absent', 'target_absent', 'ambiguous_target',
-    'signature_error', 'no_update', 'keychain_dialog'];
+    'signature_error', 'no_update', 'keychain_dialog', 'snapshot_unavailable', 'action_unconfirmed'];
   if (!allowed.includes(result)) fail('ui_result');
-  if (['ambiguous_target', 'signature_error', 'no_update', 'keychain_dialog'].includes(result)) fail(result);
+  if (['ambiguous_target', 'signature_error', 'no_update', 'keychain_dialog', 'action_unconfirmed'].includes(result)) fail(result);
   return result;
 }
 
@@ -458,7 +461,7 @@ export async function runSparkleTransition(options) {
       captureMacTransitionProcesses(installedApp, original.pid, knownProcesses);
       const current = appProcess(installedExecutable);
       if (current && current.pid !== original.pid) return current;
-      if (current) ui(installedExecutable, original.pid, 'relaunch');
+      if (current) interact('relaunch');
       return null;
     }, 180000, 'sparkle_relaunch');
     const relaunched = appProcess(installedExecutable);

--- a/scripts/smoke-electron-macos-sparkle-transition.mjs
+++ b/scripts/smoke-electron-macos-sparkle-transition.mjs
@@ -11,6 +11,7 @@ import { dirname, isAbsolute, join, relative, resolve, sep } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { seedSignedReplacementNativeState,
   readSignedReplacementState, assertSignedReplacementContinuity } from './smoke-electron-macos-replacement.mjs';
+import { retireAutomaticContributionState } from '../src/automatic-contribution-retirement.js';
 import { launchVerifiedMacSharingApp, stopOwnedMacSharingApp } from './run-signed-electron-staging.mjs';
 import { validateSignedSparkleFeed } from './sparkle-signed-feed-validation.js';
 import { inspectNativeElectronHandoverCompletion } from '../apps/electron/desktop-native-migration.js';
@@ -159,7 +160,7 @@ export function sparkleTransitionUiScript(pid, action) {
     '}',
     'let elements = []; for (const w of p.windows()) elements = elements.concat(w.entireContents());',
     'const labels = {check:["Check for Updates…","Buscar actualizaciones…"],',
-    '  install:["Install Update","Instalar actualización"], relaunch:["Install and Relaunch","Instalar y reiniciar"]};',
+    '  install:["Install Update","Instalar actualización"], relaunch:["Install and Relaunch","Instalar y volver a abrir"]};',
     'if (action !== "inspect") {',
     '  const targets = elements.filter(e => { try { return e.role() === "AXButton" && labels[action].includes(label(e)) && e.enabled(); } catch (_) { return false; } });',
     '  if (targets.length === 1) return press(targets[0]);',
@@ -301,6 +302,18 @@ export async function verifySparkleTransitionCandidate(input, appPath) {
 }
 const verifyCandidate = verifySparkleTransitionCandidate;
 
+export async function seedNativeSparkleTransitionState(nativeRoot, codexHome) {
+  await seedSignedReplacementNativeState(nativeRoot, codexHome);
+  // A running native 0.1.18 has already retired the older scheduler settings.
+  // Preserve that disabled intent in its real schema before measuring continuity.
+  const retired = await retireAutomaticContributionState({
+    settingsFile: join(nativeRoot, 'private', 'automatic-contribution-v0.1.json'),
+    now: () => new Date('2026-09-01T00:00:00.000Z'),
+  });
+  if (retired.priorState !== 'disabled' || retired.networkActivity !== false) fail('fixture_opt_out');
+  return readSignedReplacementState(nativeRoot);
+}
+
 export async function runSparkleTransition(options) {
   const proof = { schemaVersion: NATIVE_SPARKLE_TRANSITION_SCHEMA, status: 'failed', nativeVersion: '0.1.18',
     nativeSparkleUpdateCompleted: false, productionFeedVerified: false,
@@ -347,7 +360,7 @@ export async function runSparkleTransition(options) {
     command('/usr/bin/codesign', macOSCredentialApplicationVerificationArguments(installedApp));
     command('/System/Library/Frameworks/CoreServices.framework/Frameworks/LaunchServices.framework/Support/lsregister', ['-f', installedApp]);
     await mkdir(codex, { mode: 0o700 }); await mkdir(join(codex, 'sessions'), { mode: 0o700 });
-    const seeded = await seedSignedReplacementNativeState(nativeRoot, codex);
+    const seeded = await seedNativeSparkleTransitionState(nativeRoot, codex);
     const domain = 'com.usagemonitor.local';
     for (const [key, kind, value] of [['tibotattle.language-preference.v1', '-string', 'es'],
       ['tibotattle.appearance.v1', '-string', 'dark'], ['tibotattle.refresh-interval.v1', '-int', '900'],

--- a/scripts/smoke-electron-macos-sparkle-transition.mjs
+++ b/scripts/smoke-electron-macos-sparkle-transition.mjs
@@ -1,0 +1,451 @@
+#!/usr/bin/env node
+// Real native Check for Updates -> signed Electron replacement, on a disposable hosted Mac.
+// The runner never copies the candidate into Applications and never alters either signed bundle.
+import { execFileSync, spawnSync } from 'node:child_process';
+import { createHash } from 'node:crypto';
+import { createReadStream } from 'node:fs';
+import { lstat, mkdir, readFile, realpath } from 'node:fs/promises';
+import { createRequire } from 'node:module';
+import { userInfo } from 'node:os';
+import { dirname, isAbsolute, join, relative, resolve, sep } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { seedSignedReplacementNativeState,
+  readSignedReplacementState, assertSignedReplacementContinuity } from './smoke-electron-macos-replacement.mjs';
+import { launchVerifiedMacSharingApp, stopOwnedMacSharingApp, signedStagingChildEnvironment } from './run-signed-electron-staging.mjs';
+import { validateSignedSparkleFeed } from './sparkle-signed-feed-validation.js';
+import { inspectNativeElectronHandoverCompletion } from '../apps/electron/desktop-native-migration.js';
+import { macOSCredentialApplicationVerificationArguments } from '../apps/electron/desktop-macos-keychain.js';
+import { validateProductionDistributionMetadata } from '../apps/electron/desktop-updater.js';
+import distributionPolicy from '../config/electron-production-distribution.cjs';
+
+export const NATIVE_SPARKLE_TRANSITION_SCHEMA = 'tibotattle-signed-macos-sparkle-transition-v1';
+export const NATIVE_018_DMG_SHA256 = '2ea8eca02df7cc5210b6b6ce3d6e44016bffd9d081544a4efc6fa1afeeb0f1ae';
+export const NATIVE_018_INTEL_DMG_SHA256 = '70630ba90e92a1cd8cb904e66e1aebe85b04e9d23a50bef7e4e41aca84c4d2f6';
+const require = createRequire(import.meta.url);
+const CONFIRMATION = 'RUN_DISPOSABLE_NATIVE_SPARKLE_TRANSITION';
+const SHA = /^[0-9a-f]{64}$/u;
+const SOURCE = /^[0-9a-f]{40}$/u;
+const hash = (bytes) => createHash('sha256').update(bytes).digest('hex');
+const fail = (stage) => { throw Object.assign(new Error('SIGNED_SPARKLE_TRANSITION_REFUSED'), { transitionStage: stage }); };
+const sleep = (ms) => new Promise((done) => setTimeout(done, ms));
+
+export function parseSparkleTransitionArguments(argv) {
+  const executing = argv[0] === '--execute';
+  if (!['--plan', '--execute'].includes(argv[0]) || argv[1] !== '--intake'
+    || !isAbsolute(argv[2] ?? '') || (executing
+      ? argv.length !== 5 || argv[3] !== '--confirm' || argv[4] !== CONFIRMATION
+      : argv.length !== 3)) fail('arguments');
+  return { execute: executing, intakePath: resolve(argv[2]) };
+}
+
+export function validateSparkleTransitionIntake(value) {
+  const keys = ['schemaVersion', 'target', 'feedScope', 'sourceRevision', 'version', 'buildNumber', 'bundleVersion',
+    'dmgSha256', 'asarSha256', 'feedSha256', 'nativeDmgSha256', 'directory'];
+  if (!value || Object.keys(value).sort().join('|') !== keys.sort().join('|')
+    || value.schemaVersion !== 'tibotattle-native-sparkle-test-intake-v1'
+    || !['darwin-arm64', 'darwin-x64'].includes(value.target)
+    || !['isolated_test_feed', 'production_feed'].includes(value.feedScope)
+    || typeof value.sourceRevision !== 'string' || !SOURCE.test(value.sourceRevision) || value.version !== '0.1.21'
+    || value.bundleVersion !== '1028' || typeof value.buildNumber !== 'string' || !/^[1-9][0-9]{0,9}$/u.test(value.buildNumber)
+    || ![value.dmgSha256, value.asarSha256, value.feedSha256].every((v) => typeof v === 'string' && SHA.test(v))
+    || value.nativeDmgSha256 !== (value.target === 'darwin-arm64' ? NATIVE_018_DMG_SHA256 : NATIVE_018_INTEL_DMG_SHA256)
+    || !isAbsolute(value.directory ?? '')) fail('intake');
+  const directory = resolve(value.directory);
+  const architecture = value.target === 'darwin-arm64' ? 'arm64' : 'x64';
+  const production = value.feedScope === 'production_feed';
+  const prefix = production ? (architecture === 'arm64' ? 'releases' : 'intel/releases')
+    : 'electron/test/native-sparkle/' + value.sourceRevision;
+  const baseUrl = 'https://updates.tibotattle.com/' + prefix + '/' + value.bundleVersion + '/' + value.dmgSha256;
+  return { ...value, directory, architecture, objectPrefix: prefix,
+    feedUrl: production ? 'https://updates.tibotattle.com/' + (architecture === 'arm64' ? '' : 'intel/') + 'appcast.xml' : baseUrl + '/appcast.xml',
+    dmgFileName: 'TiboTattle-' + value.version + (architecture === 'arm64' ? '-mac-arm64.dmg' : '-macOS-x64.dmg'),
+    dmgPath: join(directory, 'candidate.dmg'), nativeDmgPath: join(directory, 'native.dmg'),
+    feedPath: join(directory, 'appcast.xml'), appPath: join(directory, 'candidate', 'TiboTattle.app'),
+    nativeAppPath: join(directory, 'native', 'TiboTattle.app') };
+}
+
+export function validateSparkleTransitionHost({ target, platform, architecture, nodeVersion, environment, account }) {
+  const expected = target === 'darwin-arm64' ? 'arm64' : target === 'darwin-x64' ? 'x64' : null;
+  if (!expected || platform !== 'darwin' || architecture !== expected || nodeVersion !== 'v26.2.0'
+    || environment.GITHUB_ACTIONS !== 'true' || environment.RUNNER_ENVIRONMENT !== 'github-hosted'
+    || environment.RUNNER_OS !== 'macOS' || environment.RUNNER_ARCH !== (expected === 'arm64' ? 'ARM64' : 'X64')
+    || account.uid !== 501 || account.username !== 'runner' || account.homedir !== '/Users/runner'
+    || !isAbsolute(environment.RUNNER_TEMP ?? '')) fail('disposable_account');
+  return account.homedir;
+}
+
+async function safePath(path) {
+  let cursor = resolve(path);
+  while (true) {
+    if ((await lstat(cursor)).isSymbolicLink()) fail('unsafe_path');
+    const parent = dirname(cursor);
+    if (parent === cursor) break;
+    cursor = parent;
+  }
+  if (await realpath(path) !== resolve(path)) fail('unsafe_path');
+}
+async function absent(path) {
+  try { await lstat(path); } catch (error) { if (error.code === 'ENOENT') return; throw error; }
+  fail('preexisting_state');
+}
+async function fileHash(path, maximum = 1024 ** 3) {
+  await safePath(path);
+  const before = await lstat(path);
+  if (!before.isFile() || before.nlink !== 1 || before.uid !== process.getuid()
+    || before.size < 1 || before.size > maximum) fail('unsafe_file');
+  const digest = createHash('sha256');
+  for await (const part of createReadStream(path)) digest.update(part);
+  const after = await lstat(path);
+  if (before.ino !== after.ino || before.dev !== after.dev || before.size !== after.size
+    || before.mtimeMs !== after.mtimeMs) fail('changed_file');
+  return digest.digest('hex');
+}
+function command(file, args, timeout = 30000) {
+  return execFileSync(file, args, { encoding: 'utf8', timeout, maxBuffer: 4 * 1024 * 1024,
+    stdio: ['ignore', 'pipe', 'ignore'] }).trim();
+}
+function plist(app) {
+  return JSON.parse(command('/usr/bin/plutil', ['-convert', 'json', '-o', '-', join(app, 'Contents', 'Info.plist')]));
+}
+function processes() {
+  return command('/bin/ps', ['-axo', 'pid=,ppid=,pgid=,comm=']).split('\n').map((line) => {
+    const m = /^\s*(\d+)\s+(\d+)\s+(\d+)\s+(.+)$/u.exec(line);
+    if (!m) fail('process_inventory');
+    return { pid: +m[1], parent: +m[2], group: +m[3], command: m[4] };
+  });
+}
+function appProcess(executable) {
+  const found = processes().filter((row) => row.command === executable);
+  if (found.length > 1) fail('multiple_owned_apps');
+  return found[0] ?? null;
+}
+async function until(check, timeout, stage) {
+  const deadline = Date.now() + timeout;
+  while (Date.now() < deadline) { const result = await check(); if (result) return result; await sleep(500); }
+  fail(stage);
+}
+
+// Targets only the already identity-checked synthetic process. No global keystrokes or prompt approval.
+export function sparkleTransitionUiScript(pid, action) {
+  if (!Number.isSafeInteger(pid) || pid < 2 || !['about', 'check', 'install', 'relaunch', 'quit', 'inspect'].includes(action)) fail('ui_arguments');
+  return [
+    'function run() {',
+    'const matches = Application("System Events").applicationProcesses.whose({unixId:' + pid + '})();',
+    'if (matches.length !== 1) return "process_absent";',
+    'const p = matches[0];',
+    'const action = ' + JSON.stringify(action) + ';',
+    'function label(e) { try { return String(e.name()); } catch (_) { try { return String(e.title()); } catch (_) { return ""; } } }',
+    'function press(e) { e.click(); return "clicked"; }',
+    'if (action === "about" || action === "quit") {',
+    '  p.frontmost = true;',
+    '  const bars = p.menuBars(); if (bars.length < 1) return "menu_absent";',
+    '  const items = bars[0].menuBarItems().filter(e => label(e) === "TiboTattle");',
+    '  if (items.length !== 1) return "menu_absent"; items[0].click();',
+    '  const menus = items[0].menus(); if (menus.length !== 1) return "menu_absent";',
+    '  const names = action === "about" ? ["About TiboTattle","Acerca de TiboTattle"] : ["Quit TiboTattle","Salir de TiboTattle"];',
+    '  const targets = menus[0].menuItems().filter(e => names.includes(label(e)));',
+    '  return targets.length === 1 ? press(targets[0]) : "target_absent";',
+    '}',
+    'let elements = []; for (const w of p.windows()) elements = elements.concat(w.entireContents());',
+    'const labels = {check:["Check for Updates…","Buscar actualizaciones…"],',
+    '  install:["Install Update","Instalar actualización"], relaunch:["Install and Relaunch","Instalar y reiniciar"]};',
+    'if (action !== "inspect") {',
+    '  const targets = elements.filter(e => { try { return e.role() === "AXButton" && labels[action].includes(label(e)) && e.enabled(); } catch (_) { return false; } });',
+    '  if (targets.length === 1) return press(targets[0]);',
+    '  if (targets.length > 1) return "ambiguous_target";',
+    '}',
+    'const text = elements.map(e => {try{return String(e.value());}catch(_){return "";}}).join(" ");',
+    'if (/improperly signed|could not be validated/i.test(text)) return "signature_error";',
+    'if (/up.to.date|versión más reciente/i.test(text)) return "no_update";',
+    'if (/Keychain|keychain|llavero/.test(text)) return "keychain_dialog";',
+    'return "target_absent";',
+    '}',
+  ].join('\n');
+}
+function ui(executable, pid, action) {
+  const current = appProcess(executable);
+  if (!current || current.pid !== pid) return 'process_absent';
+  const result = command('/usr/bin/osascript', ['-l', 'JavaScript', '-e', sparkleTransitionUiScript(pid, action)], 10000);
+  const allowed = ['clicked', 'process_absent', 'menu_absent', 'target_absent', 'ambiguous_target',
+    'signature_error', 'no_update', 'keychain_dialog'];
+  if (!allowed.includes(result)) fail('ui_result');
+  if (['ambiguous_target', 'signature_error', 'no_update', 'keychain_dialog'].includes(result)) fail(result);
+  return result;
+}
+function processFingerprint(row) {
+  try { return row.command + '\n' + command('/bin/ps', ['-p', String(row.pid), '-o', 'lstart=']); }
+  catch { return null; }
+}
+export function captureMacTransitionProcesses(appPath, verifiedPid, registry) {
+  const rows = processes(), executable = join(appPath, 'Contents', 'MacOS', 'TiboTattle');
+  if (verifiedPid !== null) {
+    const main = rows.find((row) => row.pid === verifiedPid && row.command === executable);
+    if (main) registry.set(main.pid, processFingerprint(main));
+  }
+  const owned = new Set(rows.filter((row) => registry.has(row.pid)
+    && registry.get(row.pid) !== null && registry.get(row.pid) === processFingerprint(row)).map((row) => row.pid));
+  let changed = true;
+  while (changed) {
+    changed = false;
+    for (const row of rows) if (!owned.has(row.pid) && owned.has(row.parent)) {
+      registry.set(row.pid, processFingerprint(row)); owned.add(row.pid); changed = true;
+    }
+  }
+}
+export async function stopVerifiedMacTransitionProcesses({ appPath, knownProcesses, verifyApp }) {
+  const executable = join(appPath, 'Contents', 'MacOS', 'TiboTattle');
+  const current = appProcess(executable);
+  if (current) {
+    // A Sparkle-created successor is admitted only after checking its actual signed bytes.
+    await verifyApp(appPath);
+    captureMacTransitionProcesses(appPath, current.pid, knownProcesses);
+    try { ui(executable, current.pid, 'quit'); } catch { /* Controlled owned-process cleanup follows. */ }
+  } else captureMacTransitionProcesses(appPath, null, knownProcesses);
+  const remaining = () => processes().filter((row) => knownProcesses.has(row.pid)
+    && knownProcesses.get(row.pid) !== null && knownProcesses.get(row.pid) === processFingerprint(row));
+  for (const signal of ['SIGTERM', 'SIGKILL']) {
+    for (const row of remaining()) {
+      try { process.kill(row.pid, signal); } catch (error) { if (error.code !== 'ESRCH') throw error; }
+    }
+    try { await until(() => remaining().length === 0, 10000, 'owned_processes_remaining'); break; }
+    catch { if (signal === 'SIGKILL') fail('owned_processes_remaining'); }
+  }
+  // Never equate the vanished predecessor PID with a stopped replacement/helper.
+  if (appProcess(executable) || processes().some((row) => row.command.startsWith(appPath + '/')
+    || /\/(?:TiboTattle[^/]*\.app|Sparkle\.framework)\//u.test(row.command))) fail('untracked_transition_process');
+  return true;
+}
+
+function codeDirectoryHash(app) {
+  const result = spawnSync('/usr/bin/codesign', ['--display', '--verbose=4', app],
+    { encoding: 'utf8', timeout: 30000, maxBuffer: 16384 });
+  const matched = /^CDHash=([0-9a-f]{40,64})$/mu.exec(result.stderr ?? '');
+  if (result.status !== 0 || result.error || !matched) fail('code_directory');
+  return matched[1];
+}
+export async function assertExtractedSignedMacBundle(dmgPath, appPath, mount) {
+  await mkdir(mount, { mode: 0o700 });
+  command('/usr/bin/hdiutil', ['attach', '-readonly', '-nobrowse', '-noautoopen', '-mountpoint', mount, dmgPath], 90000);
+  try {
+    const archived = join(mount, 'TiboTattle.app');
+    command('/usr/bin/codesign', macOSCredentialApplicationVerificationArguments(archived));
+    const digest = codeDirectoryHash(archived);
+    if (digest !== codeDirectoryHash(appPath)) fail('extracted_archive_mismatch');
+    return digest;
+  } finally { command('/usr/bin/hdiutil', ['detach', mount], 90000); }
+}
+async function verifyInputs(input) {
+  if (await fileHash(input.nativeDmgPath) !== input.nativeDmgSha256
+    || await fileHash(input.dmgPath) !== input.dmgSha256
+    || await fileHash(input.feedPath, 1024 * 1024) !== input.feedSha256) fail('artifact_digest');
+  const native = plist(input.nativeAppPath);
+  if (native.CFBundleIdentifier !== 'com.usagemonitor.local' || native.CFBundleShortVersionString !== '0.1.18'
+    || native.CFBundleVersion !== '1026' || native.SURequireSignedFeed !== true
+    || typeof native.SUPublicEDKey !== 'string'
+    || native.SUFeedURL !== 'https://updates.tibotattle.com/' + (input.architecture === 'arm64' ? '' : 'intel/') + 'appcast.xml') fail('native_identity');
+  command('/usr/bin/codesign', macOSCredentialApplicationVerificationArguments(input.nativeAppPath));
+  command('/usr/sbin/spctl', ['--assess', '--type', 'execute', input.nativeAppPath]);
+  input.nativeCodeDirectoryHash = await assertExtractedSignedMacBundle(input.nativeDmgPath, input.nativeAppPath,
+    join(input.directory, 'predecessor-verification-mount'));
+  input.candidateCodeDirectoryHash = await assertExtractedSignedMacBundle(input.dmgPath, input.appPath,
+    join(input.directory, 'candidate-verification-mount'));
+  const verified = await verifyCandidate(input, input.appPath);
+  const feed = validateSignedSparkleFeed({ architecture: input.architecture, appcastBytes: await readFile(input.feedPath),
+    dmg: { bytes: await readFile(input.dmgPath), fileName: input.dmgFileName, sha256: input.dmgSha256 },
+    objectPrefix: input.objectPrefix, updateOrigin: 'https://updates.tibotattle.com', publicEdKey: native.SUPublicEDKey });
+  if (feed.bundleVersion !== input.bundleVersion || feed.shortVersion !== input.version
+    || feed.minimumSystemVersion !== '14.0') fail('feed_identity');
+  // Fresh read binds the URL the native updater will actually request.
+  const response = await fetch(input.feedUrl, { redirect: 'error', signal: AbortSignal.timeout(30000) });
+  if (!response.ok || Number(response.headers.get('content-length') ?? 0) > 1024 * 1024
+    || hash(Buffer.from(await response.arrayBuffer())) !== input.feedSha256) fail('live_test_feed');
+  return verified;
+}
+export async function verifySparkleTransitionCandidate(input, appPath) {
+  const asar = join(appPath, 'Contents', 'Resources', 'app.asar');
+  if (await fileHash(asar, 512 * 1024 ** 2) !== input.asarSha256) fail('asar_digest');
+  command('/usr/bin/codesign', macOSCredentialApplicationVerificationArguments(appPath));
+  command('/usr/sbin/spctl', ['--assess', '--type', 'execute', appPath]);
+  if (input.candidateCodeDirectoryHash && codeDirectoryHash(appPath) !== input.candidateCodeDirectoryHash) fail('candidate_archive_mismatch');
+  const builderRequire = createRequire(require.resolve('electron-builder'));
+  const loaded = builderRequire('@electron/asar'), api = loaded?.default ?? loaded;
+  if (api.statFile(asar, 'package.json').size > 128 * 1024) fail('package_metadata');
+  const manifest = JSON.parse(api.extractFile(asar, 'package.json').toString('utf8'));
+  const distribution = validateProductionDistributionMetadata(manifest.tibotattleDistribution,
+    { platform: 'darwin', architecture: input.architecture });
+  if (manifest.name !== 'app-usagemonitor' || manifest.version !== input.version
+    || distribution.sourceRevision !== input.sourceRevision || distribution.target !== input.target
+    || distribution.channel !== distributionPolicy.PRODUCTION_ELECTRON_CHANNEL
+    || distribution.contributionPolicy !== distributionPolicy.PRODUCTION_ELECTRON_CONTRIBUTION_POLICY
+    || Object.keys(manifest).some((k) => k.startsWith('tibotattleAccountless'))) fail('distribution');
+  const verified = { appPath, executable: join(appPath, 'Contents', 'MacOS', 'TiboTattle'), distribution };
+  if (command('/usr/bin/lipo', ['-archs', verified.executable]) !== (input.architecture === 'arm64' ? 'arm64' : 'x86_64')) fail('architecture');
+  const value = plist(appPath);
+  distributionPolicy.assertProductionElectronMacOSBundleMetadata({ target: input.target,
+    version: input.version, buildNumber: input.buildNumber, bundleVersion: value.CFBundleVersion,
+    bundleShortVersion: value.CFBundleShortVersionString });
+  if (value.CFBundleIdentifier !== 'com.usagemonitor.local' || value.LSMinimumSystemVersion !== '14.0'
+    || verified.distribution.buildNumber !== input.buildNumber) fail('candidate_identity');
+  return verified;
+}
+const verifyCandidate = verifySparkleTransitionCandidate;
+
+export async function runSparkleTransition(options) {
+  const proof = { schemaVersion: NATIVE_SPARKLE_TRANSITION_SCHEMA, status: 'failed', nativeVersion: '0.1.18',
+    nativeSparkleUpdateCompleted: false, productionFeedVerified: false,
+    signedArtifactVerified: false, disposableAccountVerified: false, checkForUpdatesClicked: false,
+    installUpdateClicked: false, updaterRelaunchedCandidate: false, candidateCopiedByRunner: false,
+    migrationCompleted: false, retainedRowsPreserved: false, saltPreserved: false,
+    preferencesPreserved: false, optOutPreserved: false, restartNoDuplicates: false,
+    sourceUntouched: false, ownedProcessesStopped: false, existingCredentialFixture: false, failureStage: null };
+  let active, installedExecutable, ownedPid, installedApp, selectedInput, stage = 'intake';
+  const knownProcesses = new Map();
+  try {
+    await fileHash(options.intakePath, 16384);
+    const input = validateSparkleTransitionIntake(JSON.parse(await readFile(options.intakePath, 'utf8')));
+    selectedInput = input;
+    let home;
+    if (options.execute) home = validateSparkleTransitionHost({ target: input.target, platform: process.platform,
+      architecture: process.arch, nodeVersion: process.version, environment: process.env, account: userInfo() });
+    Object.assign(proof, { target: input.target, sourceRevision: input.sourceRevision, dmgSha256: input.dmgSha256,
+      asarSha256: input.asarSha256, feedSha256: input.feedSha256, version: input.version, bundleVersion: input.bundleVersion,
+      buildNumber: input.buildNumber, nativeDmgSha256: input.nativeDmgSha256, feedScope: input.feedScope, feedOverrideApplied: false });
+    if (options.execute) {
+      const temporaryRoot = await realpath(process.env.RUNNER_TEMP);
+      const child = relative(temporaryRoot, input.directory);
+      if (!child || child === '..' || child.startsWith('..' + sep) || isAbsolute(child)) fail('intake_location');
+      proof.disposableAccountVerified = true;
+    }
+    stage = 'artifact';
+    await verifyInputs(input);
+    proof.signedArtifactVerified = true;
+    if (!options.execute) return { ...proof, status: 'prepared' };
+    const appData = join(home, 'Library', 'Application Support'), nativeRoot = join(appData, 'Usage Monitor');
+    const profile = join(appData, 'TiboTattle'), codex = join(home, '.codex');
+    const applications = join(home, 'Applications'); installedApp = join(applications, 'TiboTattle.app');
+    stage = 'fresh_host';
+    for (const path of [nativeRoot, profile, codex, installedApp, '/Applications/TiboTattle.app',
+      join(appData, 'TiboTattle Native Handover'), join(appData, 'app-usagemonitor')]) await absent(path);
+    if (processes().some((p) => /\/(?:TiboTattle[^/]*\.app|Sparkle\.framework)\//u.test(p.command))) fail('preexisting_process');
+    await mkdir(applications, { recursive: true, mode: 0o700 });
+    await safePath(applications);
+    const parent = await lstat(applications);
+    if (parent.uid !== process.getuid() || (parent.mode & 0o022) !== 0) fail('application_location');
+    // Only the verified predecessor is copied. Sparkle alone must place the candidate here.
+    command('/usr/bin/ditto', [input.nativeAppPath, installedApp], 120000);
+    command('/usr/bin/codesign', macOSCredentialApplicationVerificationArguments(installedApp));
+    command('/System/Library/Frameworks/CoreServices.framework/Frameworks/LaunchServices.framework/Support/lsregister', ['-f', installedApp]);
+    await mkdir(codex, { mode: 0o700 }); await mkdir(join(codex, 'sessions'), { mode: 0o700 });
+    const seeded = await seedSignedReplacementNativeState(nativeRoot, codex);
+    const domain = 'com.usagemonitor.local';
+    for (const [key, kind, value] of [['tibotattle.language-preference.v1', '-string', 'es'],
+      ['tibotattle.appearance.v1', '-string', 'dark'], ['tibotattle.refresh-interval.v1', '-int', '900'],
+      ['SUEnableAutomaticChecks', '-bool', 'false'],
+      ['SUAutomaticallyUpdate', '-bool', 'false']]) command('/usr/bin/defaults', ['write', domain, key, kind, value]);
+    if (input.feedScope === 'isolated_test_feed') {
+      command('/usr/bin/defaults', ['write', domain, 'SUFeedURL', '-string', input.feedUrl]);
+      proof.feedOverrideApplied = true;
+    } else {
+      const prior = spawnSync('/usr/bin/defaults', ['read', domain, 'SUFeedURL'], { encoding: 'utf8', timeout: 10000, maxBuffer: 16384 });
+      if (prior.error || prior.status !== 1 || prior.stdout?.trim()) fail('preexisting_feed_override');
+    }
+    stage = 'native_launch';
+    installedExecutable = join(installedApp, 'Contents', 'MacOS', 'TiboTattle');
+    command('/usr/bin/open', ['-n', installedApp]);
+    const original = await until(() => appProcess(installedExecutable), 60000, 'native_process');
+    ownedPid = original.pid;
+    captureMacTransitionProcesses(installedApp, ownedPid, knownProcesses);
+    await until(() => ui(installedExecutable, ownedPid, 'about') === 'clicked', 60000, 'about_menu');
+    stage = 'check_for_updates';
+    await until(() => ui(installedExecutable, ownedPid, 'check') === 'clicked', 60000, 'check_button');
+    proof.checkForUpdatesClicked = true;
+    // Let the native startup collector settle before measuring retained rows.
+    stage = 'update_offer';
+    await until(() => {
+      captureMacTransitionProcesses(installedApp, ownedPid, knownProcesses);
+      return ui(installedExecutable, ownedPid, 'install') === 'clicked';
+    }, 90000, 'update_offer');
+    proof.installUpdateClicked = true;
+    const before = await readSignedReplacementState(nativeRoot);
+    if (JSON.stringify(seeded) !== JSON.stringify(before)) fail('native_seed_changed');
+    // Native shutdown can checkpoint SQLite; compare records and hash the other files.
+    const sourceFiles = ['local-unified-index-device-salt-v1',
+      'launcher-settings-v1.json', 'first-run-v1.json', 'private/automatic-contribution-v0.1.json'];
+    const sourceHashes = await Promise.all(sourceFiles.map((name) => fileHash(join(nativeRoot, name))));
+    stage = 'sparkle_install';
+    await until(() => {
+      captureMacTransitionProcesses(installedApp, original.pid, knownProcesses);
+      const current = appProcess(installedExecutable);
+      if (current && current.pid !== original.pid) return current;
+      if (current) ui(installedExecutable, original.pid, 'relaunch');
+      return null;
+    }, 180000, 'sparkle_relaunch');
+    const relaunched = appProcess(installedExecutable);
+    if (!relaunched || relaunched.pid === original.pid) fail('candidate_not_relaunched');
+    ownedPid = relaunched.pid;
+    await verifyCandidate(input, installedApp);
+    captureMacTransitionProcesses(installedApp, ownedPid, knownProcesses);
+    proof.updaterRelaunchedCandidate = true;
+    stage = 'first_migration';
+    await until(async () => (await inspectNativeElectronHandoverCompletion({ userDataRoot: profile })).status === 'completed', 120000, 'migration_incomplete');
+    // Observe the first updater-created launch before a separately recorded controlled restart.
+    const settingsPath = join(profile, 'desktop-settings', 'desktop-settings-v1.json');
+    const settings = JSON.parse(await readFile(settingsPath, 'utf8'));
+    const after = await readSignedReplacementState(join(profile, 'companion-state'));
+    for (const key of ['usageRows', 'quotaRows', 'tokensInUncached', 'recordDigest', 'saltDigest', 'optOutDigest']) {
+      if (before[key] !== after[key]) fail('first_launch_continuity');
+    }
+    if (settings.language !== 'es' || settings.appearance !== 'dark' || settings.refreshIntervalSeconds !== 900) fail('first_launch_preferences');
+    await absent(join(profile, 'companion-state', 'accountless-device-binding-v1.json'));
+    proof.migrationCompleted = true; proof.nativeSparkleUpdateCompleted = true;
+    await stopVerifiedMacTransitionProcesses({ appPath: installedApp, knownProcesses,
+      verifyApp: (path) => verifyCandidate(input, path) }); ownedPid = null;
+    const temporary = join(input.directory, 'runtime'); await mkdir(temporary, { mode: 0o700 });
+    const environment = signedStagingChildEnvironment(process.env, home, temporary);
+    const verified = await verifyCandidate(input, installedApp);
+    for (let iteration = 0; iteration < 2; iteration += 1) {
+      stage = 'electron_restart';
+      active = await launchVerifiedMacSharingApp(verified, environment, { launchServices: true });
+      const sharing = await until(async () => {
+        const value = await active.readSharing(); return value?.available && value?.current ? value : null;
+      }, 30000, 'sharing_state');
+      assertSignedReplacementContinuity(before, await readSignedReplacementState(join(profile, 'companion-state')),
+        JSON.parse(await readFile(settingsPath, 'utf8')), sharing);
+      await absent(join(profile, 'companion-state', 'accountless-device-binding-v1.json'));
+      await stopOwnedMacSharingApp(active); active = null;
+    }
+    proof.retainedRowsPreserved = true; proof.saltPreserved = true; proof.preferencesPreserved = true;
+    proof.optOutPreserved = true; proof.restartNoDuplicates = true;
+    if (JSON.stringify(before) !== JSON.stringify(await readSignedReplacementState(nativeRoot))) fail('native_records_changed');
+    if (JSON.stringify(sourceHashes) !== JSON.stringify(await Promise.all(sourceFiles.map((name) => fileHash(join(nativeRoot, name)))))) fail('native_source_changed');
+    proof.sourceUntouched = true; proof.ownedProcessesStopped = true;
+    proof.productionFeedVerified = input.feedScope === 'production_feed'; proof.status = 'passed';
+  } catch (error) { proof.failureStage = error?.transitionStage ?? stage; }
+  finally {
+    if (active) {
+      try { proof.ownedProcessesStopped = await stopOwnedMacSharingApp(active); }
+      catch { proof.ownedProcessesStopped = false; proof.status = 'failed'; }
+    }
+    if (installedApp && selectedInput && knownProcesses.size) {
+      try {
+        proof.ownedProcessesStopped = await stopVerifiedMacTransitionProcesses({ appPath: installedApp, knownProcesses,
+          verifyApp: async (path) => {
+            if (plist(path).CFBundleShortVersionString === '0.1.18') {
+              command('/usr/bin/codesign', macOSCredentialApplicationVerificationArguments(path));
+              if (codeDirectoryHash(path) !== selectedInput.nativeCodeDirectoryHash) fail('native_cleanup_identity');
+            } else await verifyCandidate(selectedInput, path);
+          } });
+      }
+      catch { proof.ownedProcessesStopped = false; proof.status = 'failed'; }
+    }
+  }
+  return proof;
+}
+
+if (process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  try {
+    const proof = await runSparkleTransition(parseSparkleTransitionArguments(process.argv.slice(2)));
+    process.stdout.write(JSON.stringify(proof) + '\n');
+    if (!['passed', 'prepared'].includes(proof.status)) process.exitCode = 1;
+  } catch { process.stderr.write('SIGNED_SPARKLE_TRANSITION_REFUSED\n'); process.exitCode = 1; }
+}

--- a/scripts/smoke-electron-macos-sparkle-transition.mjs
+++ b/scripts/smoke-electron-macos-sparkle-transition.mjs
@@ -18,6 +18,7 @@ import { inspectNativeElectronHandoverCompletion } from '../apps/electron/deskto
 import { macOSCredentialApplicationVerificationArguments } from '../apps/electron/desktop-macos-keychain.js';
 import { validateProductionDistributionMetadata } from '../apps/electron/desktop-updater.js';
 import distributionPolicy from '../config/electron-production-distribution.cjs';
+import { collectMacOSTransitionUIDiagnostics } from './lib/macos-transition-ui-diagnostics.mjs';
 
 export const NATIVE_SPARKLE_TRANSITION_SCHEMA = 'tibotattle-signed-macos-sparkle-transition-v1';
 export const NATIVE_018_DMG_SHA256 = '2ea8eca02df7cc5210b6b6ce3d6e44016bffd9d081544a4efc6fa1afeeb0f1ae';
@@ -126,11 +127,29 @@ function processes() {
     return { pid: +m[1], parent: +m[2], group: +m[3], command: m[4] };
   });
 }
-function appProcess(executable) {
-  const found = processes().filter((row) => row.command === executable);
-  if (found.length > 1) fail('multiple_owned_apps');
-  return found[0] ?? null;
+export function selectMacTransitionApplicationProcess(rows, executable) {
+  const inventory = new Map(rows.map(row => [row.pid, row]));
+  if (inventory.size !== rows.length) fail('process_inventory');
+  const matches = rows.filter(row => row.command === executable);
+  // The signed Electron companion uses the same executable in Node mode.
+  // It is an owned descendant, not a second independently launched app.
+  const roots = matches.filter(row => {
+    const visited = new Set([row.pid]);
+    let parent = row.parent;
+    while (inventory.has(parent)) {
+      if (visited.has(parent)) fail('process_inventory');
+      visited.add(parent);
+      const ancestor = inventory.get(parent);
+      if (ancestor.command === executable) return false;
+      parent = ancestor.parent;
+    }
+    return true;
+  });
+  if (roots.length > 1 || (matches.length && roots.length === 0)) fail('multiple_owned_apps');
+  return roots[0] ?? null;
 }
+export const findMacTransitionApplicationProcess = executable => selectMacTransitionApplicationProcess(processes(), executable);
+const appProcess = findMacTransitionApplicationProcess;
 async function until(check, timeout, stage) {
   const deadline = Date.now() + timeout;
   while (Date.now() < deadline) { const result = await check(); if (result) return result; await sleep(500); }
@@ -321,6 +340,8 @@ export async function verifySparkleTransitionCandidate(input, appPath) {
   distributionPolicy.assertProductionElectronMacOSBundleMetadata({ target: input.target,
     version: input.version, buildNumber: input.buildNumber, bundleVersion: value.CFBundleVersion,
     bundleShortVersion: value.CFBundleShortVersionString });
+  distributionPolicy.assertProductionElectronMacOSIncomingUpgradeMetadata({ target: input.target,
+    publicEDKey: value.SUPublicEDKey });
   if (value.CFBundleIdentifier !== 'com.usagemonitor.local' || value.LSMinimumSystemVersion !== '14.0'
     || verified.distribution.buildNumber !== input.buildNumber) fail('candidate_identity');
   return verified;
@@ -482,6 +503,13 @@ export async function runSparkleTransition(options) {
     proof.productionFeedVerified = input.feedScope === 'production_feed'; proof.status = 'passed';
   } catch (error) {
     proof.failureStage = error?.transitionStage ?? stage;
+    if (ownedPid) {
+      proof.uiState = collectMacOSTransitionUIDiagnostics({ pid: ownedPid, verifyOwnedProcess: pid => {
+        const expected = knownProcesses.get(pid);
+        const row = processes().find(p => p.pid === pid && p.command === installedExecutable);
+        return typeof expected === 'string' && Boolean(row) && processFingerprint(row) === expected;
+      } });
+    }
     try {
       if (installedExecutable && ownedPid && appProcess(installedExecutable)?.pid === ownedPid) {
         proof.uiDiagnostic = JSON.parse(command('/usr/bin/osascript', ['-l', 'JavaScript', '-e', sparkleTransitionDiagnosticScript(ownedPid)], 10000));

--- a/scripts/smoke-electron-macos-sparkle-transition.mjs
+++ b/scripts/smoke-electron-macos-sparkle-transition.mjs
@@ -157,10 +157,29 @@ async function until(check, timeout, stage) {
 }
 
 // Targets only the already identity-checked synthetic process. No global keystrokes or prompt approval.
+function nativeWindowElements(windows) {
+  const queue = windows.map(element => ({ element, depth: 0 })), elements = [];
+  const started = Date.now();
+  const limited = () => { throw Object.assign(new Error('Native UI tree limit'), { uiTreeLimit: true }); };
+  if (queue.length > 8) limited();
+  for (let index = 0; index < queue.length; index++) {
+    if (index >= 512 || Date.now() - started > 6000) limited();
+    const { element, depth } = queue[index], role = String(element.role());
+    // Sparkle and About controls are native. The dashboard and release notes
+    // are web content; enumerating their entire DOM can stall System Events.
+    if (role === 'AXWebArea') continue;
+    if (role === 'AXButton' || role === 'AXStaticText') { elements.push(element); continue; }
+    const children = element.uiElements();
+    if (children.length && (depth >= 8 || queue.length + children.length > 512)) limited();
+    queue.push(...children.map(child => ({ element: child, depth: depth + 1 })));
+  }
+  return elements;
+}
 export function sparkleTransitionUiScript(pid, action) {
   if (!Number.isSafeInteger(pid) || pid < 2 || !['activate', 'openmenu', 'about', 'check', 'install', 'relaunch', 'quit', 'inspect'].includes(action)) fail('ui_arguments');
   return [
     'function run() {',
+    nativeWindowElements.toString(),
     'let actionAttempted = false;',
     'try {',
     'const matches = Application("System Events").applicationProcesses.whose({unixId:' + pid + '})();',
@@ -181,7 +200,7 @@ export function sparkleTransitionUiScript(pid, action) {
     '  const targets = menus[0].menuItems().filter(e => names.includes(label(e)));',
     '  return targets.length === 1 ? press(targets[0]) : "target_absent";',
     '}',
-    'let elements = []; for (const w of p.windows()) elements = elements.concat(w.entireContents());',
+    'const elements = nativeWindowElements(p.windows());',
     'const labels = {check:["Check for Updates…","Buscar actualizaciones…"],',
     '  install:["Install Update","Instalar actualización"], relaunch:["Install and Relaunch","Instalar y volver a abrir"]};',
     'if (action !== "inspect") {',
@@ -194,18 +213,20 @@ export function sparkleTransitionUiScript(pid, action) {
     'if (/up.to.date|versión más reciente/i.test(text)) return "no_update";',
     'if (/Keychain|keychain|llavero/.test(text)) return "keychain_dialog";',
     'return "target_absent";',
-    '} catch (_) { return actionAttempted ? "action_unconfirmed" : "snapshot_unavailable"; }',
+    '} catch (error) { return actionAttempted ? "action_unconfirmed" : error.uiTreeLimit ? "ui_tree_limit" : "snapshot_unavailable"; }',
     '}',
   ].join('\n');
 }
 function ui(executable, pid, action) {
   const current = appProcess(executable);
   if (!current || current.pid !== pid) return 'process_absent';
-  const result = command('/usr/bin/osascript', ['-l', 'JavaScript', '-e', sparkleTransitionUiScript(pid, action)], 10000);
+  let result;
+  try { result = command('/usr/bin/osascript', ['-l', 'JavaScript', '-e', sparkleTransitionUiScript(pid, action)], 10000); }
+  catch (error) { fail(error.code === 'ETIMEDOUT' ? 'ui_command_timeout' : 'ui_command_failed'); }
   const allowed = ['clicked', 'activated', 'process_absent', 'menu_absent', 'target_absent', 'ambiguous_target',
-    'signature_error', 'no_update', 'keychain_dialog', 'snapshot_unavailable', 'action_unconfirmed'];
+    'signature_error', 'no_update', 'keychain_dialog', 'snapshot_unavailable', 'action_unconfirmed', 'ui_tree_limit'];
   if (!allowed.includes(result)) fail('ui_result');
-  if (['ambiguous_target', 'signature_error', 'no_update', 'keychain_dialog', 'action_unconfirmed'].includes(result)) fail(result);
+  if (['ambiguous_target', 'signature_error', 'no_update', 'keychain_dialog', 'action_unconfirmed', 'ui_tree_limit'].includes(result)) fail(result);
   return result;
 }
 
@@ -213,6 +234,7 @@ export function sparkleTransitionDiagnosticScript(pid) {
   if (!Number.isSafeInteger(pid) || pid < 2) fail('ui_arguments');
   return [
     'function run() {',
+    nativeWindowElements.toString(),
     'const matches = Application("System Events").applicationProcesses.whose({unixId:' + pid + '})();',
     'if (matches.length !== 1) return JSON.stringify({processPresent:false});',
     'const p=matches[0], bars=p.menuBars(), windows=p.windows();',
@@ -221,7 +243,7 @@ export function sparkleTransitionDiagnosticScript(pid) {
     'const known={"About TiboTattle":"about","Acerca de TiboTattle":"about","Check for Updates…":"check","Buscar actualizaciones…":"check","Install Update":"install","Instalar actualización":"install","Install and Relaunch":"relaunch","Instalar y volver a abrir":"relaunch","Get Started":"first_run"};',
     'let elements=[];',
     'for(const b of bars.slice(0,8)){for(const i of b.menuBarItems()){if(label(i)==="TiboTattle"){result.appMenus++;for(const m of i.menus())elements=elements.concat(m.menuItems());}}}',
-    'for(const w of windows.slice(0,8))elements=elements.concat(w.entireContents());',
+    'elements=elements.concat(nativeWindowElements(windows));',
     'let text="";',
     'for(const e of elements.slice(0,2000)){const name=label(e),id=known[name];if(id){const c=result.controls[id]??{count:0,enabled:0};c.count++;try{if(e.enabled())c.enabled++;}catch(_){}result.controls[id]=c;}else if(name)result.unknownLabelCount++;try{text+=" "+String(e.value());}catch(_){}}',
     'result.keychainDialog=/Keychain|keychain|llavero/.test(text);',

--- a/scripts/smoke-electron-macos-sparkle-transition.mjs
+++ b/scripts/smoke-electron-macos-sparkle-transition.mjs
@@ -11,7 +11,7 @@ import { dirname, isAbsolute, join, relative, resolve, sep } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { seedSignedReplacementNativeState,
   readSignedReplacementState, assertSignedReplacementContinuity } from './smoke-electron-macos-replacement.mjs';
-import { launchVerifiedMacSharingApp, stopOwnedMacSharingApp, signedStagingChildEnvironment } from './run-signed-electron-staging.mjs';
+import { launchVerifiedMacSharingApp, stopOwnedMacSharingApp } from './run-signed-electron-staging.mjs';
 import { validateSignedSparkleFeed } from './sparkle-signed-feed-validation.js';
 import { inspectNativeElectronHandoverCompletion } from '../apps/electron/desktop-native-migration.js';
 import { macOSCredentialApplicationVerificationArguments } from '../apps/electron/desktop-macos-keychain.js';
@@ -72,6 +72,17 @@ export function validateSparkleTransitionHost({ target, platform, architecture, 
     || account.uid !== 501 || account.username !== 'runner' || account.homedir !== '/Users/runner'
     || !isAbsolute(environment.RUNNER_TEMP ?? '')) fail('disposable_account');
   return account.homedir;
+}
+
+export function signedMacTransitionEnvironment({ target, home, temporaryDirectory }) {
+  const selectedHome = validateSparkleTransitionHost({ target, platform: process.platform, architecture: process.arch,
+    nodeVersion: process.version, environment: process.env, account: userInfo() });
+  if (home !== selectedHome || !isAbsolute(temporaryDirectory ?? '')) fail('runtime_environment');
+  const child = relative(resolve(process.env.RUNNER_TEMP), resolve(temporaryDirectory));
+  if (!child || child === '..' || child.startsWith('..' + sep) || isAbsolute(child)) fail('runtime_environment');
+  return { PATH: '/usr/bin:/bin:/usr/sbin:/sbin', HOME: home, TMPDIR: temporaryDirectory, LANG: 'en_US.UTF-8',
+    GITHUB_ACTIONS: 'true', RUNNER_ARCH: target === 'darwin-arm64' ? 'ARM64' : 'X64',
+    RUNNER_ENVIRONMENT: 'github-hosted', RUNNER_OS: 'macOS' };
 }
 
 async function safePath(path) {
@@ -401,7 +412,7 @@ export async function runSparkleTransition(options) {
     await stopVerifiedMacTransitionProcesses({ appPath: installedApp, knownProcesses,
       verifyApp: (path) => verifyCandidate(input, path) }); ownedPid = null;
     const temporary = join(input.directory, 'runtime'); await mkdir(temporary, { mode: 0o700 });
-    const environment = signedStagingChildEnvironment(process.env, home, temporary);
+    const environment = signedMacTransitionEnvironment({ target: input.target, home, temporaryDirectory: temporary });
     const verified = await verifyCandidate(input, installedApp);
     for (let iteration = 0; iteration < 2; iteration += 1) {
       stage = 'electron_restart';

--- a/scripts/smoke-electron-macos-sparkle-transition.mjs
+++ b/scripts/smoke-electron-macos-sparkle-transition.mjs
@@ -139,7 +139,7 @@ async function until(check, timeout, stage) {
 
 // Targets only the already identity-checked synthetic process. No global keystrokes or prompt approval.
 export function sparkleTransitionUiScript(pid, action) {
-  if (!Number.isSafeInteger(pid) || pid < 2 || !['about', 'check', 'install', 'relaunch', 'quit', 'inspect'].includes(action)) fail('ui_arguments');
+  if (!Number.isSafeInteger(pid) || pid < 2 || !['activate', 'openmenu', 'about', 'check', 'install', 'relaunch', 'quit', 'inspect'].includes(action)) fail('ui_arguments');
   return [
     'function run() {',
     'const matches = Application("System Events").applicationProcesses.whose({unixId:' + pid + '})();',
@@ -148,11 +148,13 @@ export function sparkleTransitionUiScript(pid, action) {
     'const action = ' + JSON.stringify(action) + ';',
     'function label(e) { try { return String(e.name()); } catch (_) { try { return String(e.title()); } catch (_) { return ""; } } }',
     'function press(e) { e.click(); return "clicked"; }',
-    'if (action === "about" || action === "quit") {',
-    '  p.frontmost = true;',
+    'if (action === "activate") { p.frontmost = true; return p.frontmost() ? "activated" : "target_absent"; }',
+    'if (action === "openmenu" || action === "about" || action === "quit") {',
     '  const bars = p.menuBars(); if (bars.length < 1) return "menu_absent";',
-    '  const items = bars[0].menuBarItems().filter(e => label(e) === "TiboTattle");',
-    '  if (items.length !== 1) return "menu_absent"; items[0].click();',
+    '  const items = bars.flatMap(b => b.menuBarItems()).filter(e => label(e) === "TiboTattle");',
+    '  if (items.length !== 1) return "menu_absent";',
+    '  if (action === "openmenu") return press(items[0]);',
+    '  if (action === "quit") { p.frontmost = true; items[0].click(); }',
     '  const menus = items[0].menus(); if (menus.length !== 1) return "menu_absent";',
     '  const names = action === "about" ? ["About TiboTattle","Acerca de TiboTattle"] : ["Quit TiboTattle","Salir de TiboTattle"];',
     '  const targets = menus[0].menuItems().filter(e => names.includes(label(e)));',
@@ -178,11 +180,34 @@ function ui(executable, pid, action) {
   const current = appProcess(executable);
   if (!current || current.pid !== pid) return 'process_absent';
   const result = command('/usr/bin/osascript', ['-l', 'JavaScript', '-e', sparkleTransitionUiScript(pid, action)], 10000);
-  const allowed = ['clicked', 'process_absent', 'menu_absent', 'target_absent', 'ambiguous_target',
+  const allowed = ['clicked', 'activated', 'process_absent', 'menu_absent', 'target_absent', 'ambiguous_target',
     'signature_error', 'no_update', 'keychain_dialog'];
   if (!allowed.includes(result)) fail('ui_result');
   if (['ambiguous_target', 'signature_error', 'no_update', 'keychain_dialog'].includes(result)) fail(result);
   return result;
+}
+
+export function sparkleTransitionDiagnosticScript(pid) {
+  if (!Number.isSafeInteger(pid) || pid < 2) fail('ui_arguments');
+  return [
+    'function run() {',
+    'const matches = Application("System Events").applicationProcesses.whose({unixId:' + pid + '})();',
+    'if (matches.length !== 1) return JSON.stringify({processPresent:false});',
+    'const p=matches[0], bars=p.menuBars(), windows=p.windows();',
+    'const result={processPresent:true,frontmost:Boolean(p.frontmost()),menuBars:Math.min(bars.length,8),windows:Math.min(windows.length,8),appMenus:0,controls:{},unknownLabelCount:0};',
+    'function label(e){try{return String(e.name());}catch(_){return "";}}',
+    'const known={"About TiboTattle":"about","Acerca de TiboTattle":"about","Check for Updates…":"check","Buscar actualizaciones…":"check","Install Update":"install","Instalar actualización":"install","Install and Relaunch":"relaunch","Instalar y volver a abrir":"relaunch","Get Started":"first_run"};',
+    'let elements=[];',
+    'for(const b of bars.slice(0,8)){for(const i of b.menuBarItems()){if(label(i)==="TiboTattle"){result.appMenus++;for(const m of i.menus())elements=elements.concat(m.menuItems());}}}',
+    'for(const w of windows.slice(0,8))elements=elements.concat(w.entireContents());',
+    'let text="";',
+    'for(const e of elements.slice(0,2000)){const name=label(e),id=known[name];if(id){const c=result.controls[id]??{count:0,enabled:0};c.count++;try{if(e.enabled())c.enabled++;}catch(_){}result.controls[id]=c;}else if(name)result.unknownLabelCount++;try{text+=" "+String(e.value());}catch(_){}}',
+    'result.keychainDialog=/Keychain|keychain|llavero/.test(text);',
+    'result.signatureError=/improperly signed|could not be validated/i.test(text);',
+    'result.noUpdate=/up.to.date|versión más reciente/i.test(text);',
+    'return JSON.stringify(result);',
+    '}',
+  ].join('\n');
 }
 function processFingerprint(row) {
   try { return row.command + '\n' + command('/bin/ps', ['-p', String(row.pid), '-o', 'lstart=']); }
@@ -379,15 +404,26 @@ export async function runSparkleTransition(options) {
     const original = await until(() => appProcess(installedExecutable), 60000, 'native_process');
     ownedPid = original.pid;
     captureMacTransitionProcesses(installedApp, ownedPid, knownProcesses);
-    await until(() => ui(installedExecutable, ownedPid, 'about') === 'clicked', 60000, 'about_menu');
+    proof.uiResultCounts = {};
+    const interact = (action) => {
+      const result = ui(installedExecutable, ownedPid, action);
+      proof.lastUiResult = result;
+      proof.uiResultCounts[result] = (proof.uiResultCounts[result] ?? 0) + 1;
+      return result;
+    };
+    // Open once, then wait for AX to expose the menu. Repeated clicks can
+    // toggle it closed on slower hosts before the About item is available.
+    await until(() => interact('activate') === 'activated', 30000, 'native_activate');
+    await until(() => interact('openmenu') === 'clicked', 30000, 'app_menu');
+    await until(() => interact('about') === 'clicked', 60000, 'about_menu');
     stage = 'check_for_updates';
-    await until(() => ui(installedExecutable, ownedPid, 'check') === 'clicked', 60000, 'check_button');
+    await until(() => interact('check') === 'clicked', 60000, 'check_button');
     proof.checkForUpdatesClicked = true;
     // Let the native startup collector settle before measuring retained rows.
     stage = 'update_offer';
     await until(() => {
       captureMacTransitionProcesses(installedApp, ownedPid, knownProcesses);
-      return ui(installedExecutable, ownedPid, 'install') === 'clicked';
+      return interact('install') === 'clicked';
     }, 90000, 'update_offer');
     proof.installUpdateClicked = true;
     const before = await readSignedReplacementState(nativeRoot);
@@ -444,7 +480,14 @@ export async function runSparkleTransition(options) {
     if (JSON.stringify(sourceHashes) !== JSON.stringify(await Promise.all(sourceFiles.map((name) => fileHash(join(nativeRoot, name)))))) fail('native_source_changed');
     proof.sourceUntouched = true; proof.ownedProcessesStopped = true;
     proof.productionFeedVerified = input.feedScope === 'production_feed'; proof.status = 'passed';
-  } catch (error) { proof.failureStage = error?.transitionStage ?? stage; }
+  } catch (error) {
+    proof.failureStage = error?.transitionStage ?? stage;
+    try {
+      if (installedExecutable && ownedPid && appProcess(installedExecutable)?.pid === ownedPid) {
+        proof.uiDiagnostic = JSON.parse(command('/usr/bin/osascript', ['-l', 'JavaScript', '-e', sparkleTransitionDiagnosticScript(ownedPid)], 10000));
+      }
+    } catch { proof.uiDiagnostic = { unavailable: true }; }
+  }
   finally {
     if (active) {
       try { proof.ownedProcessesStopped = await stopOwnedMacSharingApp(active); }

--- a/test/electron-production-distribution.test.js
+++ b/test/electron-production-distribution.test.js
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict";
+import { createHash } from "node:crypto";
 import { execFileSync, spawn } from "node:child_process";
 import { readFileSync } from "node:fs";
 import { createRequire } from "node:module";
@@ -42,6 +43,26 @@ const BUILD_NUMBER = "20260906";
 const REHEARSAL_VERSION_CORE = RELEASE_VERSION.replace(/\d+$/u, (patch) => String(Number(patch) + 1));
 const REHEARSAL_CURRENT_VERSION = `${REHEARSAL_VERSION_CORE}-native-to-electron-handover.1`;
 const REHEARSAL_NEXT_VERSION = `${REHEARSAL_VERSION_CORE}-native-to-electron-handover.2`;
+
+test("stable Mac incoming upgrades retain the verified native 018 public key exactly", () => {
+  const publicEDKey = POLICY.PRODUCTION_ELECTRON_NATIVE_SPARKLE_PUBLIC_ED_KEY;
+  // Both hash-verified native 0.1.18 DMGs contain this decoded public-key digest.
+  assert.equal(createHash("sha256").update(Buffer.from(publicEDKey, "base64")).digest("hex"),
+    "ae8a8e00311a4cfc1e7e7f2eedcf7fa53d6bc197997c912a0b8f908e54a28fbf");
+  for (const target of ["darwin-arm64", "darwin-x64"]) {
+    assert.deepEqual(POLICY.assertProductionElectronMacOSIncomingUpgradeMetadata({ target, publicEDKey }),
+      { publicEDKey });
+    for (const invalid of [undefined, null, "", publicEDKey + "\n", "A".repeat(43) + "=", [publicEDKey]]) {
+      assert.throws(() => POLICY.assertProductionElectronMacOSIncomingUpgradeMetadata({
+        target, publicEDKey: invalid,
+      }), /retain the native stable public key/u);
+    }
+  }
+  for (const target of [undefined, "darwin", "win32-x64", "linux-x64", ["darwin-arm64"]]) {
+    assert.throws(() => POLICY.assertProductionElectronMacOSIncomingUpgradeMetadata({ target, publicEDKey }),
+      /retain the native stable public key/u);
+  }
+});
 
 test("signed Mac allocation is independent of candidate provenance and advances native 018", () => {
   const nativeVersion = resolveSignedMacOSBundleVersion("0.1.18", "stable");
@@ -463,6 +484,12 @@ test("production builder source config binds app identity, target-specific build
       assert.equal(config.mac.bundleShortVersion, RELEASE_VERSION, target);
       assert.equal(config.mac.bundleVersion, config.buildVersion, target);
       assert.equal(config.mac.minimumSystemVersion, "14.0", target);
+      assert.deepEqual(config.mac.extendInfo, {
+        SUPublicEDKey: POLICY.PRODUCTION_ELECTRON_NATIVE_SPARKLE_PUBLIC_ED_KEY,
+      }, target);
+      POLICY.assertProductionElectronMacOSIncomingUpgradeMetadata({
+        target, publicEDKey: config.mac.extendInfo.SUPublicEDKey,
+      });
       assert.equal(config.mac.sign, "./scripts/electron-macos-sign-order.mjs", target);
       assert.deepEqual(config.mac.target, [
         { target: "dmg", arch: [spec.architecture] },
@@ -481,6 +508,7 @@ test("production builder source config binds app identity, target-specific build
       assert.match(config.extraResources[0].from,
         new RegExp(`electron-production[\\\\/]${target}[\\\\/]native[\\\\/]macos-keychain\\.node$`, "u"), target);
     } else if (target === "win32-x64") {
+      assert.doesNotMatch(JSON.stringify(config), /SUPublicEDKey|SUFeedURL/u);
       assert.deepEqual(config.win.target, [{ target: "nsis", arch: ["x64"] }]);
       assert.equal(config.win.verifyUpdateCodeSignature, true);
       assert.equal(config.win.signExecutable, true);
@@ -489,6 +517,7 @@ test("production builder source config binds app identity, target-specific build
       assert.equal(config.extraMetadata.shortVersionWindows, config.buildVersion);
       assertWindowsResourceVersion(config.buildVersion);
     } else {
+      assert.doesNotMatch(JSON.stringify(config), /SUPublicEDKey|SUFeedURL/u);
       assert.deepEqual(config.linux.target, [{ target: "AppImage", arch: ["x64"] }]);
       assert.deepEqual(config.linux.executableArgs, []);
       assert.equal(Object.hasOwn(config.extraMetadata, "shortVersion"), false);
@@ -553,6 +582,7 @@ test("rehearsal builder config binds semantic updater versions to numeric macOS 
     assert.deepEqual(config.extraMetadata.tibotattleDistribution, metadata, candidate);
     assert.equal(config.mac.bundleShortVersion, REHEARSAL_VERSION_CORE, candidate);
     assert.equal(config.mac.bundleVersion, buildNumber, candidate);
+    assert.equal(config.mac.extendInfo, undefined, candidate);
     assert.equal(config.buildVersion, buildNumber, candidate);
     assert.deepEqual(config.publish, [{
       provider: "generic",
@@ -583,6 +613,7 @@ test("development builder retains the adapter contract but excludes the producti
     assert.ok(filter.includes("native/macos-keychain/contract.js"), target);
     assert.equal(filter.includes("native/macos-keychain.node"), false, target);
     assert.equal(Object.hasOwn(config, "extraResources"), false, target);
+    assert.doesNotMatch(JSON.stringify(config), /SUPublicEDKey|SUFeedURL/u, target);
   }
 });
 
@@ -725,6 +756,7 @@ test("signed staging source binds the hosted macOS account and disables the upda
   assert.equal(config.appId, POLICY.PRODUCTION_ELECTRON_APP_ID);
   assert.equal(config.forceCodeSigning, true);
   assert.equal(config.publish, undefined);
+  assert.equal(config.mac.extendInfo, undefined);
   assert.equal(Object.hasOwn(config.extraMetadata, "tibotattleDistribution"), false);
   assert.equal(config.directories.app, resolve(plan.stagingDirectory));
   assert.throws(() => loadSignedStagingBuilderConfig({ expectedTestUsername: "ci runner" }));

--- a/test/electron-production-distribution.test.js
+++ b/test/electron-production-distribution.test.js
@@ -406,6 +406,7 @@ test("production builder source config binds app identity, target-specific build
     if (target.startsWith("darwin-")) {
       assert.equal(config.mac.bundleShortVersion, RELEASE_VERSION, target);
       assert.equal(config.mac.bundleVersion, config.buildVersion, target);
+      assert.equal(config.mac.minimumSystemVersion, "14.0", target);
       assert.equal(config.mac.sign, "./scripts/electron-macos-sign-order.mjs", target);
       assert.deepEqual(config.mac.target, [
         { target: "dmg", arch: [spec.architecture] },
@@ -437,6 +438,16 @@ test("production builder source config binds app identity, target-specific build
       assert.equal(Object.hasOwn(config.extraMetadata, "shortVersion"), false);
     }
   }
+});
+
+test("pinned macOS packager writes the configured supported system floor into Info.plist", () => {
+  const macPackagerSource = readFileSync(
+    ELECTRON_BUILDER_REQUIRE.resolve("app-builder-lib/out/macPackager"), "utf8",
+  );
+  assert.match(macPackagerSource,
+    /const minimumSystemVersion = this\.platformSpecificBuildOptions\.minimumSystemVersion/u);
+  assert.match(macPackagerSource,
+    /appPlist\.LSMinimumSystemVersion = minimumSystemVersion/u);
 });
 
 test("production macOS builder resolves the isolated signing-order hook before signing", async () => {

--- a/test/electron-production-distribution.test.js
+++ b/test/electron-production-distribution.test.js
@@ -21,6 +21,11 @@ import {
 } from "../scripts/package-electron-production.mjs";
 import { DEPLOYMENT_ENDPOINTS } from "../config/deployment-endpoints.js";
 import { RELEASE_VERSION } from "../config/release-manifest.js";
+import {
+  resolveSignedMacOSBundleVersion,
+  isAppleMacOSBundleVersion,
+  compareAppleMacOSBundleVersions,
+} from "../scripts/macos-bundle-version.js";
 
 const require = createRequire(import.meta.url);
 const POLICY = require("../config/electron-production-distribution.cjs");
@@ -37,6 +42,57 @@ const BUILD_NUMBER = "20260906";
 const REHEARSAL_VERSION_CORE = RELEASE_VERSION.replace(/\d+$/u, (patch) => String(Number(patch) + 1));
 const REHEARSAL_CURRENT_VERSION = `${REHEARSAL_VERSION_CORE}-native-to-electron-handover.1`;
 const REHEARSAL_NEXT_VERSION = `${REHEARSAL_VERSION_CORE}-native-to-electron-handover.2`;
+
+test("signed Mac allocation is independent of candidate provenance and advances native 018", () => {
+  const nativeVersion = resolveSignedMacOSBundleVersion("0.1.18", "stable");
+  assert.equal(nativeVersion, "1026");
+  assert.equal(resolveSignedMacOSBundleVersion("0.1.21", "stable"), "1028");
+  assert.equal(compareAppleMacOSBundleVersions(nativeVersion, "1028"), -1);
+  assert.equal(isAppleMacOSBundleVersion("1028"), true);
+  assert.equal(isAppleMacOSBundleVersion("2026091105"), false);
+  for (const target of ["darwin-arm64", "darwin-x64"]) {
+    for (const buildNumber of ["2026091105", "2026091106"]) {
+      const input = { target, version: "0.1.21", buildNumber };
+      assert.equal(POLICY.productionElectronBuildVersionForTarget(input), "1028");
+      assert.deepEqual(POLICY.assertProductionElectronMacOSBundleMetadata({
+        ...input, bundleVersion: "1028", bundleShortVersion: "0.1.21",
+      }), { bundleVersion: "1028", bundleShortVersion: "0.1.21" });
+      for (const bundleVersion of [undefined, "1026", "1028.0", buildNumber]) {
+        assert.throws(() => POLICY.assertProductionElectronMacOSBundleMetadata({
+          ...input, bundleVersion, bundleShortVersion: "0.1.21",
+        }), /reviewed production allocation/u);
+      }
+      for (const bundleShortVersion of [undefined, "0.1.20", "1028"]) {
+        assert.throws(() => POLICY.assertProductionElectronMacOSBundleMetadata({
+          ...input, bundleVersion: "1028", bundleShortVersion,
+        }), /reviewed production allocation/u);
+      }
+      assert.throws(() => POLICY.productionElectronBuildVersionForTarget({
+        ...input, version: "0.1.22",
+      }), /explicit signed bundle version allocation/u);
+    }
+  }
+});
+
+test("historical Electron receipts keep their frozen bundle ordering without allocating future stable releases", () => {
+  for (const version of ["0.1.19", "0.1.20", REHEARSAL_CURRENT_VERSION]) {
+    assert.equal(POLICY.productionElectronBuildVersionForTarget({
+      target: "darwin-arm64", version, buildNumber: "2026091104",
+    }), "2026091104");
+  }
+  assert.equal(resolveSignedMacOSBundleVersion("0.1.19", "stable"), null);
+  assert.equal(resolveSignedMacOSBundleVersion("0.1.20", "stable"), null);
+  assert.equal(resolveSignedMacOSBundleVersion("0.1.22", "stable"), null);
+  const { AppUpdater } = require("electron-updater/out/AppUpdater");
+  const updaterRequire = createRequire(require.resolve("electron-updater/package.json"));
+  const updaterSemver = updaterRequire("semver");
+  return AppUpdater.prototype.isUpdateAvailable.call({
+    currentVersion: updaterSemver.parse("0.1.20"),
+    allowDowngrade: false,
+    isUpdateSupported: async () => true,
+    isUserWithinRollout: async () => true,
+  }, { version: "0.1.21" }).then((available) => assert.equal(available, true));
+});
 
 async function withTemporaryDirectory(run) {
   const root = await mkdtemp(join(tmpdir(), "tibotattle-electron-production-"));
@@ -561,7 +617,7 @@ test("Windows candidate mapping is lossless, ordered, and accepted by the pinned
   assert.equal(POLICY.productionElectronWindowsFileVersion(BUILD_NUMBER), "0.0.309.10282");
   assert.equal(POLICY.productionElectronBuildVersionForTarget({
     target: "darwin-arm64", version: RELEASE_VERSION, buildNumber: BUILD_NUMBER,
-  }), BUILD_NUMBER);
+  }), resolveSignedMacOSBundleVersion(RELEASE_VERSION, "stable"));
 
   const config = loadProductionBuilderConfig("win32-x64");
   const appInfo = new AppInfo({

--- a/test/electron-sparkle-transition.test.js
+++ b/test/electron-sparkle-transition.test.js
@@ -1,7 +1,7 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
 import { createHash } from 'node:crypto';
-import { mkdtemp, mkdir, symlink, writeFile, readFile, rm, realpath } from 'node:fs/promises';
+import { mkdtemp, mkdir, symlink, writeFile, readFile, rm, realpath, chmod, truncate } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { resolveReleaseChannel } from '../config/release-channels.js';
@@ -149,6 +149,21 @@ test('mounted Electron inspector binds signed identity, architecture, ASAR, upda
     wrongArch = false; pkg.tibotattleDistribution = { ...pkg.tibotattleDistribution, sourceRevision: 'd'.repeat(40) };
     await assert.rejects(validateElectronSparkleDMG(dmgPath, options), { code: 'SPARKLE_ELECTRON_TRANSITION_DISTRIBUTION_MISMATCH' });
     assert.equal(calls.filter(call => call.includes('detach')).length, detachedAfterKeys + 2);
+    pkg.tibotattleDistribution = { ...pkg.tibotattleDistribution, sourceRevision: manifest.source.commit };
+    const artwork = join(mount, '.background.tiff');
+    await writeFile(artwork, 'II*\0standard Finder artwork', { mode: 0o644 });
+    assert.deepEqual(await validateElectronSparkleDMG(dmgPath, options), { source: { commit: manifest.source.commit, tag: 'v0.1.21' } });
+    await chmod(artwork, 0o755);
+    await assert.rejects(validateElectronSparkleDMG(dmgPath, options), { code: 'SPARKLE_ELECTRON_TRANSITION_LAYOUT_INVALID' });
+    await chmod(artwork, 0o644); await truncate(artwork, 16 * 1024 ** 2 + 1);
+    await assert.rejects(validateElectronSparkleDMG(dmgPath, options), { code: 'SPARKLE_ELECTRON_TRANSITION_UNSAFE_FILE' });
+    await rm(artwork); await symlink(join(app, 'Contents/Resources/app.asar'), artwork);
+    await assert.rejects(validateElectronSparkleDMG(dmgPath, options), { code: 'SPARKLE_ELECTRON_TRANSITION_UNSAFE_PATH' });
+    await rm(artwork); await mkdir(artwork);
+    await assert.rejects(validateElectronSparkleDMG(dmgPath, options), { code: 'SPARKLE_ELECTRON_TRANSITION_UNSAFE_FILE' });
+    await rm(artwork, { recursive: true }); await writeFile(join(mount, '.unexpected'), 'unknown');
+    await assert.rejects(validateElectronSparkleDMG(dmgPath, options), { code: 'SPARKLE_ELECTRON_TRANSITION_LAYOUT_INVALID' });
+    assert.equal(calls.filter(call => call.includes('detach')).length, detachedAfterKeys + 8);
   } finally { await rm(root, { recursive: true, force: true }); }
 });
 

--- a/test/electron-sparkle-transition.test.js
+++ b/test/electron-sparkle-transition.test.js
@@ -1,0 +1,155 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { createHash } from 'node:crypto';
+import { mkdtemp, mkdir, symlink, writeFile, readFile, rm, realpath } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { resolveReleaseChannel } from '../config/release-channels.js';
+import { ELECTRON_SPARKLE_TRANSITION_SCHEMA, validateElectronSparkleTransitionManifest,
+  validateElectronSparkleJourney, readElectronSparkleJourney, assertElectronSparkleContinuity,
+  validateElectronSparkleDMG } from '../scripts/electron-sparkle-transition.js';
+import { createProductionDistributionMetadata } from '../apps/electron/desktop-updater.js';
+const hash = value => createHash('sha256').update(value).digest('hex');
+const key = 'a'.repeat(64);
+function fixture(architecture = 'arm64') {
+  const channel = resolveReleaseChannel('stable', { architecture });
+  const manifest = { schemaVersion: ELECTRON_SPARKLE_TRANSITION_SCHEMA,
+    application: { architecture, bundleIdentifier: 'com.usagemonitor.local', bundleVersion: '1028', shortVersion: '0.1.21' },
+    artifact: { fileName: `TiboTattle-0.1.21-${architecture === 'x64' ? 'macOS-x64' : 'mac-arm64'}.dmg`, bytes: 3, sha256: hash('dmg') },
+    source: { repository: 'https://github.com/adamallcock/tibotattle', commit: 'b'.repeat(40), tag: 'v0.1.21' },
+    channel: { ...channel, sparkle: { ...channel.sparkle, publicEdKeySha256: key } },
+    sparkle: { appcastURL: channel.sparkle.appcastURL, publicEdKeySha256: key },
+    electron: { buildNumber: '2026091105', asarSha256: 'c'.repeat(64), updaterConfigurationSha256: 'd'.repeat(64) },
+    evidence: { scope: 'local_qualification', nativeSparkleJourney: { localPath: 'journey.json', bytes: 1, sha256: 'e'.repeat(64) } } };
+  const proof = { schemaVersion: 'tibotattle-signed-macos-sparkle-transition-v1', status: 'passed',
+    target: 'darwin-arm64', version: '0.1.21', buildNumber: '2026091105', bundleVersion: '1028',
+    feedScope: 'isolated_test_feed', feedSha256: '1'.repeat(64), feedOverrideApplied: true, productionFeedVerified: false,
+    candidateCopiedByRunner: false, signedArtifactVerified: true, disposableAccountVerified: true,
+    checkForUpdatesClicked: true, installUpdateClicked: true, updaterRelaunchedCandidate: true,
+    sourceRevision: manifest.source.commit, dmgSha256: manifest.artifact.sha256, asarSha256: manifest.electron.asarSha256,
+    nativeVersion: '0.1.18', nativeDmgSha256: 'f'.repeat(64), nativeSparkleUpdateCompleted: true,
+    migrationCompleted: true, retainedRowsPreserved: true, saltPreserved: true, preferencesPreserved: true,
+    optOutPreserved: true, restartNoDuplicates: true, sourceUntouched: true, ownedProcessesStopped: true };
+  const validate = value => validateElectronSparkleTransitionManifest(value,
+    { path: value.artifact.fileName, size: value.artifact.bytes }, { sha256: key }, channel);
+  return { manifest, proof, validate };
+}
+
+test('transition receipt separates timestamp provenance, Apple bundle version and incoming updater', () => {
+  for (const architecture of ['arm64', 'x64']) {
+    const { manifest, validate } = fixture(architecture);
+    assert.equal(validate(manifest).bundleVersion, '1028');
+    assert.equal(manifest.electron.buildNumber, '2026091105');
+    assert.equal(Object.hasOwn(manifest, 'updater'), false);
+    assert.equal(Object.hasOwn(manifest, 'assurances'), false);
+  }
+});
+
+test('receipt rejects key/channel/source/architecture confusion, native assertions and invalid versions', () => {
+  const changes = [m => { m.sparkle.publicEdKeySha256 = 'f'.repeat(64); },
+    m => { m.sparkle.appcastURL = 'https://updates.tibotattle.com/electron/test/appcast.xml'; },
+    m => { m.source.tag = 'v0.1.20'; }, m => { m.application.architecture = 'x64'; },
+    m => { m.application.bundleVersion = '2026091105'; }, m => { m.application.bundleVersion = '0.1.21'; },
+    m => { m.updater = { frameworkVersion: '2.9.3' }; },
+    m => { m.evidence.nativeSparkleJourney.localPath = '../journey.json'; }];
+  for (const change of changes) { const { manifest, validate } = fixture(); change(manifest); assert.throws(() => validate(manifest)); }
+  const { manifest, validate } = fixture('x64'); manifest.artifact.fileName = 'TiboTattle-0.1.21-mac-x64.dmg';
+  assert.throws(() => validate(manifest));
+});
+
+test('manual replacement evidence cannot qualify the native Sparkle transition', () => {
+  const { manifest, proof } = fixture();
+  assert.equal(validateElectronSparkleJourney(proof, manifest), proof);
+  for (const field of ['nativeSparkleUpdateCompleted', 'migrationCompleted', 'retainedRowsPreserved', 'saltPreserved',
+    'preferencesPreserved', 'optOutPreserved', 'restartNoDuplicates', 'sourceUntouched', 'ownedProcessesStopped',
+    'signedArtifactVerified', 'disposableAccountVerified', 'checkForUpdatesClicked', 'installUpdateClicked', 'updaterRelaunchedCandidate', 'feedOverrideApplied']) {
+    assert.throws(() => validateElectronSparkleJourney({ ...proof, [field]: false }, manifest));
+  }
+  for (const change of [{ schemaVersion: 'tibotattle-signed-replacement-v1' }, { status: 'failed' },
+    { sourceRevision: 'a'.repeat(40) }, { dmgSha256: 'a'.repeat(64) }, { asarSha256: 'a'.repeat(64) }, { nativeVersion: '0.1.17' }, { target: 'darwin-x64' }, { version: '0.1.20' }, { buildNumber: '2026091104' },
+    { bundleVersion: '1026' }, { feedScope: 'production_feed' }, { productionFeedVerified: true }, { candidateCopiedByRunner: true }, { feedSha256: null }]) {
+    assert.throws(() => validateElectronSparkleJourney({ ...proof, ...change }, manifest));
+  }
+});
+
+test('journey evidence is bound to exact bytes; missing proof prevents any native command', async () => {
+  const root = await mkdtemp(join(await realpath(tmpdir()), 'sparkle-transition-proof-'));
+  try {
+    const { manifest, proof } = fixture();
+    const path = join(root, 'receipt.json'), bytes = Buffer.from(JSON.stringify(proof));
+    manifest.evidence.nativeSparkleJourney = { localPath: 'journey.json', bytes: bytes.length, sha256: hash(bytes) };
+    await writeFile(join(root, 'journey.json'), bytes);
+    assert.deepEqual(await readElectronSparkleJourney(manifest, path), proof);
+    await writeFile(join(root, 'journey.json'), Buffer.from(JSON.stringify({ ...proof, optOutPreserved: false })));
+    await assert.rejects(readElectronSparkleJourney(manifest, path));
+    let calls = 0;
+    await assert.rejects(validateElectronSparkleDMG(join(root, 'missing.dmg'), { manifest, manifestPath: path,
+      commandRunner: () => { calls++; throw Error('unexpected'); } }));
+    assert.equal(calls, 0);
+  } finally { await rm(root, { recursive: true, force: true }); }
+});
+
+test('subsequent transition continuity rejects bootstrap, downgrade, key and architecture drift', () => {
+  const { manifest } = fixture();
+  const previous = structuredClone(manifest); previous.application.bundleVersion = '2026091001'; previous.application.shortVersion = '0.1.20'; previous.source.tag = 'v0.1.20'; previous.artifact.fileName = 'TiboTattle-0.1.20-mac-arm64.dmg';
+  assert.throws(() => assertElectronSparkleContinuity({ manifest, previousManifest: previous }));
+  for (const options of [{ previousManifest: null }, { previousManifest: previous, stableBootstrap: true },
+    { previousManifest: manifest }, { previousManifest: { ...previous, sparkle: { ...previous.sparkle, publicEdKeySha256: 'f'.repeat(64) } } },
+    { previousManifest: fixture('x64').manifest }]) assert.throws(() => assertElectronSparkleContinuity({ manifest, ...options }));
+});
+
+
+test('mounted Electron inspector binds signed identity, architecture, ASAR, updater and detaches on rejection', async () => {
+  const root = await mkdtemp(join(await realpath(tmpdir()), 'sparkle-transition-inspection-'));
+  try {
+    const { manifest, proof } = fixture();
+    const mount = join(root, 'volume'), app = join(mount, 'TiboTattle.app');
+    await mkdir(join(app, 'Contents/Resources/native'), { recursive: true });
+    await mkdir(join(app, 'Contents/MacOS'), { recursive: true });
+    await symlink('/Applications', join(mount, 'Applications'));
+    const asar = Buffer.from('signed-asar'), updater = Buffer.from('provider: generic\nurl: https://updates.tibotattle.com/electron/stable/darwin-arm64\n');
+    await writeFile(join(app, 'Contents/Resources/app.asar'), asar);
+    await writeFile(join(app, 'Contents/Resources/app-update.yml'), updater);
+    await writeFile(join(app, 'Contents/MacOS/TiboTattleNativeHandover'), 'helper');
+    await writeFile(join(app, 'Contents/Resources/native/macos-keychain.node'), 'adapter');
+    const dmgPath = join(root, manifest.artifact.fileName);
+    await writeFile(dmgPath, 'dmg');
+    manifest.electron.asarSha256 = hash(asar); manifest.electron.updaterConfigurationSha256 = hash(updater);
+    proof.asarSha256 = hash(asar);
+    const proofBytes = Buffer.from(JSON.stringify(proof));
+    manifest.evidence.nativeSparkleJourney = { localPath: 'journey.json', bytes: proofBytes.length, sha256: hash(proofBytes) };
+    await writeFile(join(root, 'journey.json'), proofBytes);
+    const pkg = { name: 'app-usagemonitor', version: '0.1.21', tibotattleDistribution:
+      createProductionDistributionMetadata({ target: 'darwin-arm64', sourceRevision: manifest.source.commit, buildNumber: manifest.electron.buildNumber }) };
+    let wrongArch = false; const calls = [];
+    const commandRunner = (command, args) => {
+      calls.push([command, ...args]);
+      if (command.endsWith('plutil')) return { stdout: JSON.stringify(args.at(-1) === '-'
+        ? { 'system-entities': [{ 'mount-point': mount, 'dev-entry': '/dev/synthetic-test' }] }
+        : { CFBundleIdentifier: 'com.usagemonitor.local', CFBundleVersion: '1028', CFBundleShortVersionString: '0.1.21',
+          CFBundleExecutable: 'TiboTattle', LSMinimumSystemVersion: '14.0' }), stderr: '' };
+      if (command.endsWith('lipo')) return { stdout: wrongArch ? 'x86_64' : 'arm64', stderr: '' };
+      return { stdout: '', stderr: args.includes('-dv') ? 'CodeDirectory flags=0x10000(runtime)' : '' };
+    };
+    const options = { manifest, manifestPath: join(root, 'receipt.json'), commandRunner, readAsarPackage: () => pkg };
+    assert.deepEqual(await validateElectronSparkleDMG(dmgPath, options), { source: { commit: manifest.source.commit, tag: 'v0.1.21' } });
+    assert(calls.some(call => call[0].endsWith('codesign') && call.some(arg => arg.startsWith('-R=identifier'))));
+    assert.equal(calls.filter(call => call.includes('detach')).length, 1);
+    wrongArch = true;
+    await assert.rejects(validateElectronSparkleDMG(dmgPath, options), { code: 'SPARKLE_ELECTRON_TRANSITION_ARCHITECTURE_MISMATCH' });
+    assert.equal(calls.filter(call => call.includes('detach')).length, 2);
+    wrongArch = false; pkg.tibotattleDistribution = { ...pkg.tibotattleDistribution, sourceRevision: 'd'.repeat(40) };
+    await assert.rejects(validateElectronSparkleDMG(dmgPath, options), { code: 'SPARKLE_ELECTRON_TRANSITION_DISTRIBUTION_MISMATCH' });
+    assert.equal(calls.filter(call => call.includes('detach')).length, 3);
+  } finally { await rm(root, { recursive: true, force: true }); }
+});
+
+
+test('native predecessor must be exact 0.1.18 archive exercised by the journey', () => {
+  const { manifest, proof } = fixture();
+  for (const previousManifest of [
+    { application: { shortVersion: '0.1.17' }, artifact: { sha256: proof.nativeDmgSha256 } },
+    { application: { shortVersion: '0.1.18' }, artifact: { sha256: '1'.repeat(64) } },
+  ]) assert.throws(() => assertElectronSparkleContinuity({ manifest, previousManifest, journey: proof }),
+    { code: 'SPARKLE_ELECTRON_TRANSITION_NATIVE_PREDECESSOR_MISMATCH' });
+});

--- a/test/electron-sparkle-transition.test.js
+++ b/test/electron-sparkle-transition.test.js
@@ -8,9 +8,10 @@ import { resolveReleaseChannel } from '../config/release-channels.js';
 import { ELECTRON_SPARKLE_TRANSITION_SCHEMA, validateElectronSparkleTransitionManifest,
   validateElectronSparkleJourney, readElectronSparkleJourney, assertElectronSparkleContinuity,
   validateElectronSparkleDMG } from '../scripts/electron-sparkle-transition.js';
+import distribution from '../config/electron-production-distribution.cjs';
 import { createProductionDistributionMetadata } from '../apps/electron/desktop-updater.js';
 const hash = value => createHash('sha256').update(value).digest('hex');
-const key = 'a'.repeat(64);
+const key = hash(Buffer.from(distribution.PRODUCTION_ELECTRON_NATIVE_SPARKLE_PUBLIC_ED_KEY, 'base64'));
 function fixture(architecture = 'arm64') {
   const channel = resolveReleaseChannel('stable', { architecture });
   const manifest = { schemaVersion: ELECTRON_SPARKLE_TRANSITION_SCHEMA,
@@ -121,13 +122,13 @@ test('mounted Electron inspector binds signed identity, architecture, ASAR, upda
     await writeFile(join(root, 'journey.json'), proofBytes);
     const pkg = { name: 'app-usagemonitor', version: '0.1.21', tibotattleDistribution:
       createProductionDistributionMetadata({ target: 'darwin-arm64', sourceRevision: manifest.source.commit, buildNumber: manifest.electron.buildNumber }) };
-    let wrongArch = false; const calls = [];
+    let wrongArch = false, publicEDKey = distribution.PRODUCTION_ELECTRON_NATIVE_SPARKLE_PUBLIC_ED_KEY; const calls = [];
     const commandRunner = (command, args) => {
       calls.push([command, ...args]);
       if (command.endsWith('plutil')) return { stdout: JSON.stringify(args.at(-1) === '-'
         ? { 'system-entities': [{ 'mount-point': mount, 'dev-entry': '/dev/synthetic-test' }] }
         : { CFBundleIdentifier: 'com.usagemonitor.local', CFBundleVersion: '1028', CFBundleShortVersionString: '0.1.21',
-          CFBundleExecutable: 'TiboTattle', LSMinimumSystemVersion: '14.0' }), stderr: '' };
+          CFBundleExecutable: 'TiboTattle', LSMinimumSystemVersion: '14.0', SUPublicEDKey: publicEDKey }), stderr: '' };
       if (command.endsWith('lipo')) return { stdout: wrongArch ? 'x86_64' : 'arm64', stderr: '' };
       return { stdout: '', stderr: args.includes('-dv') ? 'CodeDirectory flags=0x10000(runtime)' : '' };
     };
@@ -135,12 +136,19 @@ test('mounted Electron inspector binds signed identity, architecture, ASAR, upda
     assert.deepEqual(await validateElectronSparkleDMG(dmgPath, options), { source: { commit: manifest.source.commit, tag: 'v0.1.21' } });
     assert(calls.some(call => call[0].endsWith('codesign') && call.some(arg => arg.startsWith('-R=identifier'))));
     assert.equal(calls.filter(call => call.includes('detach')).length, 1);
+    for (const invalid of [undefined, '', Buffer.alloc(32).toString('base64')]) {
+      publicEDKey = invalid;
+      await assert.rejects(validateElectronSparkleDMG(dmgPath, options));
+    }
+    publicEDKey = distribution.PRODUCTION_ELECTRON_NATIVE_SPARKLE_PUBLIC_ED_KEY;
+    const detachedAfterKeys = calls.filter(call => call.includes('detach')).length;
+    assert.equal(detachedAfterKeys, 4);
     wrongArch = true;
     await assert.rejects(validateElectronSparkleDMG(dmgPath, options), { code: 'SPARKLE_ELECTRON_TRANSITION_ARCHITECTURE_MISMATCH' });
-    assert.equal(calls.filter(call => call.includes('detach')).length, 2);
+    assert.equal(calls.filter(call => call.includes('detach')).length, detachedAfterKeys + 1);
     wrongArch = false; pkg.tibotattleDistribution = { ...pkg.tibotattleDistribution, sourceRevision: 'd'.repeat(40) };
     await assert.rejects(validateElectronSparkleDMG(dmgPath, options), { code: 'SPARKLE_ELECTRON_TRANSITION_DISTRIBUTION_MISMATCH' });
-    assert.equal(calls.filter(call => call.includes('detach')).length, 3);
+    assert.equal(calls.filter(call => call.includes('detach')).length, detachedAfterKeys + 2);
   } finally { await rm(root, { recursive: true, force: true }); }
 });
 

--- a/test/generate-sparkle-appcast-stable-feed.test.js
+++ b/test/generate-sparkle-appcast-stable-feed.test.js
@@ -497,3 +497,48 @@ test("Intel generation retains the ARM archive and signs its own namespace", asy
     assert.throws(() => validateCandidateAppcastShape(written, "stable"));
   } finally { await fixture.cleanup(); }
 });
+
+test('Electron transition uses official signing tools for archive and feed without changing app bytes', async () => {
+  const fixture = await createStableFixture({ bundleVersion: '1028', shortVersion: '0.1.21' });
+  const calls = [];
+  try {
+    const plistPath = join(fixture.appPath, 'Contents/Info.plist');
+    const plist = (await readFile(plistPath, 'utf8')).replace('<key>SURequireSignedFeed</key><true/>', '');
+    await writeFile(plistPath, plist);
+    const options = stableOptions(fixture, ['--electron-transition', '--account', 'ed25519', '--skip-retain',
+      '--electron-transition-test-source', 'b'.repeat(40)]);
+    const result = await generateSparkleAppcast({ ...options,
+      runGenerateAppcastTool: fakeGenerateAppcastTool(fixture, { mutateOutput: text => text
+        .replace(/<!-- sparkle-sign-warning:[\s\S]*?-->/u, '')
+        .replace(/<!-- sparkle-signatures:[\s\S]*$/u, '')
+        .replace(/ sparkle:edSignature="[^"]+"/u, '') }),
+      runSignUpdate: async (_path, args) => {
+        calls.push(args);
+        const path = args.at(-1);
+        if (args.includes('-p')) return sign(null, await readFile(path), TEST_KEY_PAIR.privateKey).toString('base64');
+        const text = (await readFile(path, 'utf8')).replace('<?xml version="1.0" standalone="yes"?>',
+          '<?xml version="1.0" standalone="yes"?><!-- sparkle-sign-warning:\nOfficial fixture signing warning\n-->');
+        const signature = sign(null, Buffer.from(text), TEST_KEY_PAIR.privateKey).toString('base64');
+        await writeFile(path, `${text}<!-- sparkle-signatures:\nedSignature: ${signature}\nlength: ${Buffer.byteLength(text)}\n-->\n`);
+      } });
+    assert.equal(result.feedSigned, true);
+    assert.equal(result.retained, null);
+    assert.equal(calls.length, 2);
+    assert.deepEqual(calls.map(call => call.slice(0, 2)), [['--account', 'ed25519'], ['--account', 'ed25519']]);
+    assert.equal(result.full.url, `https://updates.tibotattle.com/electron/test/native-sparkle/${'b'.repeat(40)}/1028/${sha256(fixture.dmgBytes)}/${fixture.dmgFileName}`);
+    assert.equal(await readFile(plistPath, 'utf8'), plist);
+    assert.deepEqual(await readFile(fixture.dmgPath), fixture.dmgBytes);
+  } finally { await fixture.cleanup(); }
+});
+
+test('transition rehearsal refuses arbitrary destinations, missing stable key, retention and non-Apple version', async () => {
+  const fixture = await createStableFixture();
+  try {
+    for (const args of [['--electron-transition-test-source', 'b'.repeat(40)],
+      ['--electron-transition', '--electron-transition-test-source', 'b'.repeat(40)],
+      ['--electron-transition', '--skip-retain', '--electron-transition-test-source', '../stable'],
+      ['--electron-transition', '--download-url-prefix', 'https://elsewhere.invalid']]) {
+      assert.throws(() => stableOptions(fixture, args));
+    }
+  } finally { await fixture.cleanup(); }
+});

--- a/test/generate-sparkle-appcast-stable-feed.test.js
+++ b/test/generate-sparkle-appcast-stable-feed.test.js
@@ -498,7 +498,7 @@ test("Intel generation retains the ARM archive and signs its own namespace", asy
   } finally { await fixture.cleanup(); }
 });
 
-test('Electron transition uses official signing tools for archive and feed without changing app bytes', async () => {
+for (const selfClosing of [false, true]) test(`Electron transition signs ${selfClosing ? 'self-closing' : 'paired'} official enclosure without changing app bytes`, async () => {
   const fixture = await createStableFixture({ bundleVersion: '1028', shortVersion: '0.1.21' });
   const calls = [];
   try {
@@ -511,7 +511,8 @@ test('Electron transition uses official signing tools for archive and feed witho
       runGenerateAppcastTool: fakeGenerateAppcastTool(fixture, { mutateOutput: text => text
         .replace(/<!-- sparkle-sign-warning:[\s\S]*?-->/u, '')
         .replace(/<!-- sparkle-signatures:[\s\S]*$/u, '')
-        .replace(/ sparkle:edSignature="[^"]+"/u, '') }),
+        .replace(/ sparkle:edSignature="[^"]+"/u, '')
+        .replace(/(<enclosure\b[^>]*?)><\/enclosure>/u, selfClosing ? '$1/>' : '$1></enclosure>') }),
       runSignUpdate: async (_path, args) => {
         calls.push(args);
         const path = args.at(-1);

--- a/test/generate-sparkle-appcast-stable-feed.test.js
+++ b/test/generate-sparkle-appcast-stable-feed.test.js
@@ -543,3 +543,40 @@ test('transition rehearsal refuses arbitrary destinations, missing stable key, r
     }
   } finally { await fixture.cleanup(); }
 });
+
+for (const mode of ['archive_signed', 'feed_signed', 'invalid_archive_signature', 'invalid_feed_signature']) {
+  test(`Electron successor official ${mode} output is verified without redundant signing`, async () => {
+    const fixture = await createStableFixture({ bundleVersion: '1028', shortVersion: '0.1.21' });
+    const calls = [];
+    try {
+      const options = stableOptions(fixture, ['--electron-transition', '--skip-retain']);
+      const operation = generateSparkleAppcast({ ...options,
+        runGenerateAppcastTool: fakeGenerateAppcastTool(fixture, { mutateOutput: text => {
+          if (mode === 'feed_signed') return text;
+          if (mode === 'invalid_feed_signature') return text.replace('IMPORTANT:', 'IMPORXANT:');
+          const unsignedFeed = text.replace(/<!-- sparkle-sign-warning:[\s\S]*?-->/u, '')
+            .replace(/<!-- sparkle-signatures:[\s\S]*$/u, '');
+          return mode === 'invalid_archive_signature'
+            ? unsignedFeed.replace(/sparkle:edSignature="[^"]+"/u, `sparkle:edSignature="${Buffer.alloc(64).toString('base64')}"`)
+            : unsignedFeed;
+        } }),
+        runSignUpdate: async (_path, args) => {
+          calls.push(args); assert.equal(args.includes('-p'), false, 'existing archive signature must be reused');
+          const path = args.at(-1);
+          const text = (await readFile(path, 'utf8')).replace('<?xml version="1.0" standalone="yes"?>',
+            '<?xml version="1.0" standalone="yes"?><!-- sparkle-sign-warning:\nOfficial fixture signing warning\n-->');
+          const signature = sign(null, Buffer.from(text), TEST_KEY_PAIR.privateKey).toString('base64');
+          await writeFile(path, `${text}<!-- sparkle-signatures:\nedSignature: ${signature}\nlength: ${Buffer.byteLength(text)}\n-->\n`);
+        } });
+      if (mode.startsWith('invalid_')) {
+        await assert.rejects(operation, { code: mode === 'invalid_archive_signature'
+          ? 'SPARKLE_APPCAST_SIGNATURE_INVALID' : 'SPARKLE_SIGNED_FEED_ENVELOPE_SIGNATURE_INVALID' });
+        assert.equal(calls.length, 0);
+      } else {
+        const result = await operation; assert.equal(result.feedSigned, true);
+        assert.equal(calls.length, mode === 'feed_signed' ? 0 : 1);
+      }
+      assert.deepEqual(await readFile(fixture.dmgPath), fixture.dmgBytes);
+    } finally { await fixture.cleanup(); }
+  });
+}

--- a/test/macos-transition-ui-diagnostics.test.mjs
+++ b/test/macos-transition-ui-diagnostics.test.mjs
@@ -1,0 +1,123 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import test from "node:test";
+import vm from "node:vm";
+import { collectMacOSTransitionUIDiagnostics, macOSTransitionUIDiagnosticScript,
+  parseMacOSTransitionUIDiagnostics } from "../scripts/lib/macos-transition-ui-diagnostics.mjs";
+
+function fixture({ trusted = true, windowsCode = 0, menuCode = 0, timeoutCode = 0, rows = [] } = {}) {
+  const calls = [];
+  const $ = value => value;
+  Object.assign($, {
+    AXIsProcessTrusted: () => trusted,
+    NSRunningApplication: {runningApplicationWithProcessIdentifier: pid => {
+      calls.push(["app", pid]);
+      return {isNil:() => false, hidden:false, active:true, terminated:false, activationPolicy:0};
+    }},
+    AXUIElementCreateApplication: pid => { calls.push(["ax", pid]); return pid; },
+    AXUIElementSetMessagingTimeout: (element, seconds) => { calls.push(["timeout", element, seconds]); return timeoutCode; },
+    AXUIElementGetAttributeValueCount: (element, attribute, out) => {
+      calls.push(["count", element, attribute]); out[0] = 3; return windowsCode;
+    },
+    AXUIElementCopyAttributeValue: (element, attribute, out) => {
+      calls.push(["menu", element, attribute]); out[0] = {}; return menuCode;
+    },
+    kCGWindowOwnerPID:"owner", kCGWindowIsOnscreen:"onScreen",
+    CGWindowListCopyWindowInfo: () => ({isNil:() => false, count:rows.length,
+      objectAtIndex:index => ({objectForKey:key => {
+        assert.ok(["owner", "onScreen"].includes(key), "No window text may be read");
+        return rows[index][key];
+      }})}),
+  });
+  const output = vm.runInNewContext(macOSTransitionUIDiagnosticScript(1234), {
+    $, ObjC:{import() {}, unwrap:value => value, castRefToObject:value => value}, Ref:() => [],
+  });
+  return {calls, output, value:parseMacOSTransitionUIDiagnostics(output)};
+}
+
+test("read-only JXA inspects exact PID, bounded AX calls and only owned numeric window properties", () => {
+  const {value,calls} = fixture({rows:[{owner:1234,onScreen:true},{owner:1234,onScreen:false},{owner:999,onScreen:true}]});
+  assert.deepEqual(value.ax.windows, {status:"ok",count:3});
+  assert.deepEqual(value.ax.menuBar, {status:"ok",present:true});
+  assert.deepEqual(value.coreGraphics, {status:"observed",windows:2,onScreenWindows:1,truncated:false});
+  assert.deepEqual(calls, [["app",1234],["ax",1234],["timeout",1234,0.5],["count",1234,"AXWindows"],["menu",1234,"AXMenuBar"]]);
+});
+
+test("AX connection failure is distinct from zero visible windows and missing menu", () => {
+  const {value} = fixture({windowsCode:-25204,menuCode:-25212});
+  assert.deepEqual(value.ax.windows,{status:"cannot_complete",count:null});
+  assert.deepEqual(value.ax.menuBar,{status:"no_value",present:null});
+  assert.equal(value.coreGraphics.windows,0);
+  assert.equal(fixture({windowsCode:-999}).value.ax.windows.status,"other");
+});
+
+test("untrusted caller never prompts or queries AX; failed timeout setup skips AX requests", () => {
+  const noTrust=fixture({trusted:false});
+  assert.deepEqual(noTrust.calls,[["app",1234]]);
+  assert.equal(noTrust.value.ax.windows.status,"api_disabled");
+  const noBound=fixture({timeoutCode:-25201});
+  assert.deepEqual(noBound.calls,[["app",1234],["ax",1234],["timeout",1234,0.5]]);
+  assert.equal(noBound.value.ax.timeoutStatus,"illegal_argument");
+  assert.equal(noBound.value.ax.windows.count,null);
+});
+
+test("CG window inventory is capped and cannot include other process counts or labels", () => {
+  const {value} = fixture({rows:Array.from({length:4100},()=>({owner:1234,onScreen:true}))});
+  assert.deepEqual(value.coreGraphics,{status:"observed",windows:512,onScreenWindows:512,truncated:true});
+  const script=macOSTransitionUIDiagnosticScript(1234);
+  assert.doesNotMatch(script,/AXUIElementPerformAction|AXUIElementSetAttributeValue|AXIsProcessTrustedWithOptions|\.activate|\.click|\.frontmost|kCGWindowName|bundleIdentifier|executableURL|AXTitle|AXValue|AXChildren/u);
+});
+
+test("rejects invalid PIDs and arbitrary response data instead of retaining content", () => {
+  for(const pid of [undefined,0,1,-1,1.5,"1234",[1234],2147483648,NaN]) assert.throws(()=>macOSTransitionUIDiagnosticScript(pid));
+  const base=fixture().value;
+  for(const change of [v=>{v.title="PRIVATE";},v=>{v.application.path="PRIVATE";},v=>{v.ax.windows.status="PRIVATE";},v=>{v.ax.windows.count=-1;},v=>{v.coreGraphics.onScreenWindows=1;},v=>{v.ax.menuBar.present="yes";}]) {
+    const next=structuredClone(base);change(next);assert.throws(()=>parseMacOSTransitionUIDiagnostics(JSON.stringify(next)),/Invalid Mac UI diagnostic/);
+  }
+  for(const output of [null,"PRIVATE","x".repeat(5000),"[]"]) assert.throws(()=>parseMacOSTransitionUIDiagnostics(output));
+});
+
+test("collector fences ownership before and after fixed osascript invocation", () => {
+  const output=fixture().output; let checks=0;
+  const value=collectMacOSTransitionUIDiagnostics({pid:1234,verifyOwnedProcess:pid=>{assert.equal(pid,1234);checks++;return true;}}, {
+    platform:"darwin",run:(file,args,options)=>{
+      assert.equal(file,"/usr/bin/osascript");assert.deepEqual(args.slice(0,3),["-l","JavaScript","-e"]);
+      assert.equal(args[3],macOSTransitionUIDiagnosticScript(1234));
+      assert.deepEqual(options,{encoding:"utf8",timeout:5000,killSignal:"SIGKILL",maxBuffer:4096,windowsHide:true});
+      return {status:0,stdout:output,stderr:"PRIVATE"};
+    },
+  });
+  assert.equal(checks,2);assert.equal(value.status,"observed");
+  let call=0;
+  const changed=collectMacOSTransitionUIDiagnostics({pid:1234,verifyOwnedProcess:()=>++call===1}, {platform:"darwin",run:()=>({status:0,stdout:output})});
+  assert.equal(changed.reason,"ownership_changed");
+});
+
+test("collector failures retain only fixed reasons, never stderr or exception text", () => {
+  const args={pid:1234,verifyOwnedProcess:()=>true};
+  for(const run of [()=>{throw Error("PRIVATE");},()=>({status:1,stderr:"PRIVATE"}),()=>({status:0,error:Error("PRIVATE")}),()=>({status:0,stdout:"PRIVATE"})]) {
+    const result=collectMacOSTransitionUIDiagnostics(args,{platform:"darwin",run});
+    assert.equal(result.status,"unavailable");assert.doesNotMatch(JSON.stringify(result),/PRIVATE/);
+  }
+  const never=()=>{assert.fail("Must not execute");};
+  assert.equal(collectMacOSTransitionUIDiagnostics(args,{platform:"linux",run:never}).reason,"unsupported_host");
+  assert.equal(collectMacOSTransitionUIDiagnostics({...args,verifyOwnedProcess:()=>false},{platform:"darwin",run:never}).reason,"ownership_unverified");
+  assert.throws(()=>collectMacOSTransitionUIDiagnostics({pid:1234},{platform:"darwin",run:never}),/ownership/);
+});
+
+test("real JXA CF bridge reads only synthetic window dictionaries with exact PID filtering", {
+  skip:process.platform !== "darwin",
+}, () => {
+  // No real window inventory or AX query: exercise the real CF/NSNumber bridge
+  // with synthetic data, retaining exact production owner-key handling.
+  const script=macOSTransitionUIDiagnosticScript(process.pid)
+    .replace("Boolean($.AXIsProcessTrusted())","false")
+    .replace("$.CGWindowListCopyWindowInfo(0, 0)",
+      `ObjC.castObjectToRef($([{kCGWindowOwnerPID:${process.pid},kCGWindowIsOnscreen:true},{kCGWindowOwnerPID:1,kCGWindowIsOnscreen:true}]))`);
+  const result=spawnSync("/usr/bin/osascript",["-l","JavaScript","-e",script],{
+    encoding:"utf8",timeout:5000,killSignal:"SIGKILL",maxBuffer:4096,
+  });
+  assert.equal(result.status,0,"Synthetic native bridge must execute");
+  assert.deepEqual(parseMacOSTransitionUIDiagnostics(result.stdout).coreGraphics,
+    {status:"observed",windows:1,onScreenWindows:1,truncated:false});
+});

--- a/test/publish-sparkle-update.test.js
+++ b/test/publish-sparkle-update.test.js
@@ -3319,3 +3319,44 @@ test("Intel first publication bootstraps only its empty feed and cannot reuse AR
     ]);
   } finally { await arm.cleanup(); await intel.cleanup(); }
 });
+
+test('canonical publisher accepts explicit Electron transition only with bound Sparkle journey and native predecessor', async () => {
+  const previous = await createReleaseFixture({ bundleVersion: '1026', shortVersion: '0.1.18' });
+  const fixture = await createReleaseFixture({ bundleVersion: '1028', shortVersion: '0.1.21' });
+  try {
+    const native = JSON.parse(await readFile(fixture.releaseManifestPath));
+    const proof = { schemaVersion: 'tibotattle-signed-macos-sparkle-transition-v1', status: 'passed',
+    target: 'darwin-arm64', version: '0.1.21', buildNumber: '2026091105', bundleVersion: '1028',
+    feedScope: 'isolated_test_feed', feedSha256: '1'.repeat(64), feedOverrideApplied: true, productionFeedVerified: false,
+    candidateCopiedByRunner: false, signedArtifactVerified: true, disposableAccountVerified: true,
+    checkForUpdatesClicked: true, installUpdateClicked: true, updaterRelaunchedCandidate: true,
+      sourceRevision: native.source.commit, dmgSha256: native.artifact.sha256, asarSha256: 'c'.repeat(64),
+      nativeVersion: '0.1.18', nativeDmgSha256: sha256(previous.dmgBytes), nativeSparkleUpdateCompleted: true,
+      migrationCompleted: true, retainedRowsPreserved: true, saltPreserved: true, preferencesPreserved: true,
+      optOutPreserved: true, restartNoDuplicates: true, sourceUntouched: true, ownedProcessesStopped: true };
+    const proofPath = join(dirname(fixture.releaseManifestPath), 'sparkle-journey.json');
+    const bytes = Buffer.from(JSON.stringify(proof));
+    await writeFile(proofPath, bytes);
+    const receipt = { schemaVersion: 'tibotattle-electron-sparkle-transition-v1',
+      application: { ...native.application, architecture: 'arm64' }, artifact: native.artifact,
+      source: native.source, channel: native.channel,
+      sparkle: { appcastURL: native.updater.appcastURL, publicEdKeySha256: native.updater.publicEdKeySha256 },
+      electron: { buildNumber: '2026091105', asarSha256: proof.asarSha256, updaterConfigurationSha256: 'd'.repeat(64) },
+      evidence: { scope: 'local_qualification', nativeSparkleJourney: { localPath: 'sparkle-journey.json', bytes: bytes.length, sha256: sha256(bytes) } } };
+    await writeFile(fixture.releaseManifestPath, JSON.stringify(receipt));
+    let inspections = 0, remoteCalls = 0;
+    const options = { channel: 'stable', bucket: APPROVED_R2_BUCKET, dmgPath: fixture.dmgPath,
+      appcastPath: fixture.appcastPath, releaseManifestPath: fixture.releaseManifestPath,
+      previousStableManifestPath: previous.releaseManifestPath, stableBootstrap: false, sparklePublicEdKey: TEST_PUBLIC_ED_KEY,
+      validateDMG: async () => { throw Error('Native payload validator must not inspect Electron'); },
+      validateElectronDMG: async (_path, input) => { inspections++; assert.deepEqual(input.manifest, receipt);
+        return { source: { commit: receipt.source.commit, tag: receipt.source.tag } }; },
+      runWrangler: async () => { remoteCalls++; throw Error('No remote writes in validation'); } };
+    const result = await publishSparkleUpdate(options);
+    assert.equal(result.status, 'validated'); assert.equal(result.published, false);
+    assert.equal(inspections, 1); assert.equal(remoteCalls, 0);
+    await writeFile(proofPath, JSON.stringify({ ...proof, nativeSparkleUpdateCompleted: false }));
+    await assert.rejects(publishSparkleUpdate(options), { code: 'SPARKLE_ELECTRON_TRANSITION_EVIDENCE_MISMATCH' });
+    assert.equal(inspections, 1); assert.equal(remoteCalls, 0);
+  } finally { await previous.cleanup(); await fixture.cleanup(); }
+});

--- a/test/release-evidence.test.js
+++ b/test/release-evidence.test.js
@@ -1179,3 +1179,67 @@ test("bounded JSON reads fail before accepting oversized metadata", async () => 
     await value.close();
   }
 });
+
+test("Mac and Linux Electron updater metadata validates without relaxing native trust", async () => {
+  const v = await buildBaseFixture();
+  try {
+    const schema = JSON.parse(await readFile(new URL("../schemas/release-evidence-v1/manifest.schema.json", import.meta.url), "utf8"));
+    const validate = new Ajv2020({ strict: false }).compile(schema);
+    for (const [platform, architecture] of [["macos", "arm64"], ["macos", "x64"], ["linux", "x64"]]) {
+      const input = structuredClone(v.input), a = input.artifacts[0]; a.platform = platform; a.architecture = architecture; a.updater.mechanism = "electron-updater";
+      if (platform === "linux") { a.nativeTrust = { scheme: "none" }; a.assurances = { ...ASSURANCES.linux.direct }; }
+      const manifest = await generateReleaseEvidence({ descriptor: input, baseDir: v.root });
+      assert.equal(manifest.artifacts[0].updater.mechanism, "electron-updater"); assert.equal(validate(manifest), true, JSON.stringify(validate.errors));
+      await validateReleaseEvidenceManifest(manifest, { artifactRoot: v.root });
+      delete a.assurances[platform === "linux" ? "artifactIntegrityVerified" : "developerIdSigned"];
+      await assert.rejects(generateReleaseEvidence({ descriptor: input, baseDir: v.root }), { code: "RELEASE_EVIDENCE_ASSURANCES_INCOMPLETE" });
+    }
+  } finally { await v.close(); }
+});
+test("owner acceptance is explicit, source-bound and never a passed smoke", async () => {
+  const v = await buildBaseFixture();
+  try {
+    const input = structuredClone(v.input), a = input.artifacts[0]; a.architecture = "x64"; a.assurances.cleanInstallSmokePassed = false;
+    a.cleanInstallAcceptance = { status: "owner_accepted", reason: "Owner accepts unobserved physical Intel execution for this exact candidate.", sourceCommit: RELEASE.commit };
+    const manifest = await generateReleaseEvidence({ descriptor: input, baseDir: v.root });
+    assert.equal(manifest.artifacts[0].assurances.cleanInstallSmokePassed, false); assert.deepEqual(manifest.artifacts[0].cleanInstallAcceptance, a.cleanInstallAcceptance);
+    await validateReleaseEvidenceManifest(manifest, { artifactRoot: v.root });
+    const schema = JSON.parse(await readFile(new URL("../schemas/release-evidence-v1/manifest.schema.json", import.meta.url), "utf8"));
+    assert.equal(new Ajv2020({ strict: false }).compile(schema)(manifest), true);
+    for (const mutate of [x => x.cleanInstallAcceptance.sourceCommit = "f".repeat(40), x => x.cleanInstallAcceptance.reason = "", x => x.assurances.cleanInstallSmokePassed = true, x => x.cleanInstallAcceptance.status = "passed", x => x.architecture = "unreviewed"]) {
+      const changed = structuredClone(input); mutate(changed.artifacts[0]); await assert.rejects(generateReleaseEvidence({ descriptor: changed, baseDir: v.root }));
+    }
+    delete a.cleanInstallAcceptance; await assert.rejects(generateReleaseEvidence({ descriptor: input, baseDir: v.root }), { code: "RELEASE_EVIDENCE_ASSURANCES_INCOMPLETE" });
+  } finally { await v.close(); }
+});
+test("pending evidence can be prepared but final release validation refuses it", async () => {
+  const v = await buildBaseFixture();
+  try {
+    const input = structuredClone(v.input), a = input.artifacts[0]; a.assurances.cleanInstallSmokePassed = false;
+    a.cleanInstallAcceptance = { status: "pending", reason: "Exact signed ARM production canary has not completed.", sourceCommit: RELEASE.commit };
+    const manifest = await generateReleaseEvidence({ descriptor: input, baseDir: v.root });
+    await assert.rejects(validateReleaseEvidenceManifest(manifest, { artifactRoot: v.root }), { code: "RELEASE_EVIDENCE_ACCEPTANCE_PENDING" });
+    const output = await writeReleaseEvidenceFiles({ manifest, manifestPath: join(v.root, "release-manifest.json"), sumsPath: join(v.root, "SHA256SUMS") });
+    assert.equal(JSON.parse(await readFile(output.manifestPath, "utf8")).artifacts[0].cleanInstallAcceptance.status, "pending");
+  } finally { await v.close(); }
+});
+test("final Electron build evidence binds final bytes without claiming an unsigned payload", async () => {
+  const v = await buildBaseFixture();
+  try {
+    const input = structuredClone(v.input), a = input.artifacts[0];
+    a.updater.mechanism = "electron-updater";
+    a.build = { sourceManifestSha256: "2".repeat(64), finalArtifactSha256: digest(await readFile(join(v.root, a.path))) };
+    const manifest = await generateReleaseEvidence({ descriptor: input, baseDir: v.root });
+    assert.deepEqual(manifest.artifacts[0].build, a.build);
+    await validateReleaseEvidenceManifest(manifest, { artifactRoot: v.root });
+    const schema = JSON.parse(await readFile(new URL("../schemas/release-evidence-v1/manifest.schema.json", import.meta.url), "utf8"));
+    assert.equal(new Ajv2020({ strict: false }).compile(schema)(manifest), true);
+    a.updater.mechanism = "sparkle";
+    await assert.rejects(generateReleaseEvidence({ descriptor: input, baseDir: v.root }), { code: "RELEASE_EVIDENCE_BUILD_INVALID" });
+    const nonElectron = structuredClone(manifest); nonElectron.artifacts[0].updater.mechanism = "sparkle";
+    assert.equal(new Ajv2020({ strict: false }).compile(schema)(nonElectron), false);
+    a.updater.mechanism = "electron-updater";
+    a.build.finalArtifactSha256 = "f".repeat(64);
+    await assert.rejects(generateReleaseEvidence({ descriptor: input, baseDir: v.root }), { code: "RELEASE_EVIDENCE_BUILD_INVALID" });
+  } finally { await v.close(); }
+});

--- a/test/release-publication.test.js
+++ b/test/release-publication.test.js
@@ -355,3 +355,61 @@ test("website readback checks every prepared file and current healthy deployment
   assert.deepEqual(reads, ["/release-site-manifest.json", "/", "/api/health"]);
   healthySource = "e".repeat(40); assert.equal((await adapter.website(prepared)).status, "pending");
 });
+
+async function electronFixture(t) {
+  const f = await fixture(t), { plan, file } = f;
+  const canonical = JSON.parse(await readFile(plan.assets.find(a => a.name === 'release-manifest.json').path));
+  const put = async (name, bytes) => { const entry = { name, ...await file(name, bytes) }; const i = plan.assets.findIndex(a => a.name === name); if (i < 0) plan.assets.push(entry); else plan.assets[i] = entry; return entry; };
+  for (const target of plan.targets) {
+    const old = plan.assets.find(a => a.name === target.dmgName), bytes = await readFile(old.path);
+    target.sparkleDmg = { path: old.path, bytes: old.bytes, sha256: old.sha256 };
+    plan.assets.splice(plan.assets.indexOf(old), 1);
+    target.dmgName = `TiboTattle-1.2.3-mac-${target.architecture}.dmg`;
+    const dmg = await put(target.dmgName, bytes);
+    const a = canonical.artifacts.find(a => a.architecture === target.architecture);
+    a.fileName = dmg.name; a.downloadUrl = `${source.repository}/releases/download/v1.2.3/${dmg.name}`;
+    a.build = { sourceManifestSha256: sha('synthetic source'), finalArtifactSha256: dmg.sha256 };
+    const metadata = await put(`TiboTattle-1.2.3-darwin-${target.architecture}-update.yml`, 'synthetic Electron updater metadata');
+    a.updater = { enabled: true, mechanism: 'electron-updater', metadata: { fileName: metadata.name, bytes: metadata.bytes, sha256: metadata.sha256, subjectSha256: dmg.sha256 } };
+    for (const suffix of ['zip', 'zip.blockmap', 'dmg.blockmap']) await put(`TiboTattle-1.2.3-mac-${target.architecture}.${suffix}`, `synthetic ${suffix}`);
+    const manifest = JSON.parse(await readFile(target.feedManifest.path));manifest.schemaVersion = 'tibotattle-electron-sparkle-transition-v1';
+    target.feedManifest = await file(`feed-manifest-${target.architecture}.json`, JSON.stringify(manifest));
+  }
+  for (const platform of ['windows', 'linux']) {
+    const windows = platform === 'windows', target = windows ? 'win32-x64' : 'linux-x64';
+    const dmg = await put(`TiboTattle-1.2.3-${windows ? 'Windows-x64.exe' : 'linux-x86_64.AppImage'}`, `synthetic ${platform}`);
+    const metadata = await put(`TiboTattle-1.2.3-${target}-update.yml`, `synthetic ${platform} metadata`);
+    canonical.artifacts.push({ ...structuredClone(canonical.artifacts[0]), platform, architecture:'x64', format:windows?'exe':'appimage', fileName:dmg.name, bytes:dmg.bytes, sha256:dmg.sha256,
+      downloadUrl:`${source.repository}/releases/download/v1.2.3/${dmg.name}`,
+      nativeTrust:windows?{publisher:'Synthetic',certificateSha256:sha('certificate')}:{scheme:'none'},
+      assurances:windows?{cleanInstallSmokePassed:true,authenticodeSigned:true,timestamped:true}:{cleanInstallSmokePassed:true,artifactIntegrityVerified:true},
+      build:{sourceManifestSha256:sha('source'),finalArtifactSha256:dmg.sha256},
+      updater:{enabled:true,mechanism:'electron-updater',metadata:{fileName:metadata.name,bytes:metadata.bytes,sha256:metadata.sha256,subjectSha256:dmg.sha256}} });
+  }
+  const { compareArtifactIdentity } = await import('../scripts/release-evidence.js');canonical.artifacts.sort(compareArtifactIdentity);
+  await put('release-manifest.json', `${stableStringify(canonical)}\n`);await put('SHA256SUMS',buildSha256Sums(canonical));
+  const all = plan.assets.filter(a => !['release-manifest.json','SHA256SUMS','verify-release.md'].includes(a.name)).map(a => `${a.sha256}  ${a.name}`).sort().join('\n')+'\n';await put('SHA256SUMS-ALL-RELEASE-FILES',all);
+  const site = JSON.parse(await readFile(plan.website.manifest.path));for(const row of [site.installer,site.intelInstaller])row.url=row.url.replace('-macOS-','-mac-');
+  plan.website.manifest=await file('release-site-manifest.json',JSON.stringify(site));plan.website.receipt=await file('web-release-receipt.json',JSON.stringify({sourceCommit:'c'.repeat(40),site:{manifestSha256:plan.website.manifest.sha256}}));
+  plan.tap={...await file('tibotattle.rb',(await readFile(plan.tap.path,'utf8')).replace('-macOS-','-mac-')),workflowSha256:plan.tap.workflowSha256};
+  return {...f,put};
+}
+
+test('Electron transition admits four platforms, exact auxiliary files, incoming alias and outgoing YAML separately', async t => {
+  const f = await electronFixture(t);assert.equal(f.plan.assets.length,20);
+  const calls=[];const prepared=await preparePublication(f.plan,{...f.prepareOptions,publishFeed:async options=>{calls.push(options);return f.prepareOptions.publishFeed(options);}});
+  assert.equal(calls.length,2);assert.equal(calls[1].dmgPath,f.plan.targets[1].sparkleDmg.path);
+  assert.equal(prepared.plan.assets.some(a=>a.name==='TiboTattle-1.2.3-darwin-arm64-update.yml'),true);
+});
+
+test('Electron transition refuses alias substitution, missing incoming XML, unsigned inventory and wrong feed discriminator', async t => {
+  for(const change of ['alias','missing_xml','extra','sums','discriminator']) {
+    const f=await electronFixture(t);
+    if(change==='alias')f.plan.targets[1].sparkleDmg=await f.file('wrong.dmg','unrelated signed bytes');
+    if(change==='missing_xml')f.plan.assets=f.plan.assets.filter(a=>a.name!==f.plan.targets[0].appcastName);
+    if(change==='extra')await f.put('unreviewed.txt','extra');
+    if(change==='sums')await f.put('SHA256SUMS-ALL-RELEASE-FILES','wrong');
+    if(change==='discriminator'){const m=JSON.parse(await readFile(f.plan.targets[0].feedManifest.path));delete m.schemaVersion;f.plan.targets[0].feedManifest=await f.file('feed-manifest-arm64.json',JSON.stringify(m));}
+    await assert.rejects(preparePublication(f.plan,f.prepareOptions),/RELEASE_PUBLICATION_/);
+  }
+});

--- a/test/smoke-electron-macos-empty-profile.test.mjs
+++ b/test/smoke-electron-macos-empty-profile.test.mjs
@@ -3,7 +3,7 @@ import { readFile } from 'node:fs/promises';
 import test from 'node:test';
 import vm from 'node:vm';
 import { validateEmptyProfileIntake, parseEmptyProfileArguments, assertEmptyProfileSharing,
-  emptyProfileSettingsScript, runEmptyProfileSmoke, EMPTY_PROFILE_CONFIRMATION } from '../scripts/smoke-electron-macos-empty-profile.mjs';
+  emptyProfileSettingsScript, exerciseEmptyProfileSettings, runEmptyProfileSmoke, EMPTY_PROFILE_CONFIRMATION } from '../scripts/smoke-electron-macos-empty-profile.mjs';
 const intake = { runnerRevision: 'e'.repeat(40), target: 'darwin-arm64' };
 test('intake pins candidate bytes and rejects caller-selected source, paths, origins or extra fields', () => {
   const value = validateEmptyProfileIntake(intake);
@@ -36,18 +36,45 @@ test('fresh projection refuses stale, unavailable, implicit prior choice or acce
   assert.equal(assertEmptyProfileSharing({ ...value, enabled: false, transportStatus: 'off' }, { optedOut: true }), true);
   assert.throws(() => assertEmptyProfileSharing({ ...value, enabled: false, transportStatus: 'uploading' }, { optedOut: true }));
 });
-test('settings interaction executes existing tab handler and verifies its effect', () => {
-  for (const tab of ['about', 'general', 'data']) {
-    const panel = { hidden: true };
-    let selected = 'false', clicks = 0;
-    const button = { disabled: false, click() { clicks++; selected = 'true'; panel.hidden = false; }, getAttribute() { return selected; } };
-    const document = { getElementById(id) { return id === `settings-tab-${tab}` ? button : panel; } };
-    assert.equal(vm.runInNewContext(emptyProfileSettingsScript(tab), { document }), true);
-    assert.equal(clicks, 1);
-    button.click = () => {}; panel.hidden = true;
-    assert.equal(vm.runInNewContext(emptyProfileSettingsScript(tab), { document }), false);
+test('settings waits for deferred module readiness, clicks once, and polls the real tab effect', async () => {
+  let time = 0;
+  const clicks = { about: 0, general: 0, data: 0 }, panels = {}, buttons = {};
+  for (const tab of Object.keys(clicks)) {
+    panels[tab] = { hidden: true };
+    buttons[tab] = { disabled: false, selected: 'false',
+      click() { assert.ok(time >= 200); clicks[tab]++; this.applyAt = time + 200; },
+      getAttribute() { return this.selected; } };
   }
+  const document = { readyState: 'loading', getElementById(id) {
+    const tab = id.split('-').at(-1); return id.startsWith('settings-tab-') ? buttons[tab] : panels[tab];
+  } };
+  const settings = { evaluate: async expression => vm.runInNewContext(expression, { document }) };
+  const wait = async milliseconds => {
+    time += milliseconds;
+    if (time >= 200) document.readyState = 'complete';
+    for (const tab of Object.keys(clicks)) if (buttons[tab].applyAt <= time) {
+      buttons[tab].selected = 'true'; panels[tab].hidden = false;
+    }
+  };
+  assert.equal(await exerciseEmptyProfileSettings(settings, { now: () => time, wait }), true);
+  assert.deepEqual(clicks, { about: 1, general: 1, data: 1 });
+  assert.ok(time >= 800);
   assert.throws(() => emptyProfileSettingsScript("data');process.exit()"));
+  assert.throws(() => emptyProfileSettingsScript('about', 'mutate'));
+});
+test('missing readiness or a broken tab effect fails within the budget without retrying clicks', async () => {
+  for (const ready of [false, true]) {
+    let time = 0, clicks = 0;
+    const button = { disabled: false, click() { clicks++; }, getAttribute() { return 'false'; } };
+    const panel = { hidden: true };
+    const document = { readyState: ready ? 'complete' : 'loading',
+      getElementById(id) { return id.startsWith('settings-tab-') ? button : panel; } };
+    const settings = { evaluate: async expression => vm.runInNewContext(expression, { document }) };
+    await assert.rejects(exerciseEmptyProfileSettings(settings, {
+      now: () => time, wait: async milliseconds => { time += milliseconds; },
+    }), error => error.emptyProfileStage === (ready ? 'settings_effect' : 'settings_ready'));
+    assert.equal(time, 10000); assert.equal(clicks, ready ? 1 : 0);
+  }
 });
 test('manual workflow has static architecture hosts and no native fixtures or publication', async () => {
   const workflow = await readFile(new URL('../.github/workflows/electron-macos-empty-profile.yml', import.meta.url), 'utf8');

--- a/test/smoke-electron-macos-empty-profile.test.mjs
+++ b/test/smoke-electron-macos-empty-profile.test.mjs
@@ -1,0 +1,64 @@
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import test from 'node:test';
+import vm from 'node:vm';
+import { validateEmptyProfileIntake, parseEmptyProfileArguments, assertEmptyProfileSharing,
+  emptyProfileSettingsScript, runEmptyProfileSmoke, EMPTY_PROFILE_CONFIRMATION } from '../scripts/smoke-electron-macos-empty-profile.mjs';
+const intake = { runnerRevision: 'e'.repeat(40), target: 'darwin-arm64' };
+test('intake pins candidate bytes and rejects caller-selected source, paths, origins or extra fields', () => {
+  const value = validateEmptyProfileIntake(intake);
+  assert.equal(value.sourceRevision, 'a651ea130dd1460e4443a037c4434f57b911fec4');
+  assert.equal(value.buildNumber, '2026091107');
+  assert.equal(value.bundleVersion, '1028');
+  assert.match(value.url, /^https:\/\/updates\.tibotattle\.com\/electron\/test\/native-sparkle\//u);
+  for (const field of ['sourceRevision', 'directory', 'url', 'dmgSha256', 'asarSha256']) assert.throws(() => validateEmptyProfileIntake({ ...intake, [field]: 'different' }));
+  for (const target of [[], {}, null, 'darwin-ia32', 'toString']) assert.throws(() => validateEmptyProfileIntake({ ...intake, target }));
+  for (const runnerRevision of [[], null, 'main', 'E'.repeat(40)]) assert.throws(() => validateEmptyProfileIntake({ ...intake, runnerRevision }));
+  const intel = validateEmptyProfileIntake({ ...intake, target: 'darwin-x64' });
+  assert.equal(intel.architecture, 'x64');
+  assert.notEqual(intel.dmgSha256, value.dmgSha256);
+  assert.match(intel.url, /TiboTattle-0\.1\.21-macOS-x64\.dmg$/u);
+});
+test('execution requires exact explicit confirmation; plan cannot smuggle arguments', () => {
+  assert.deepEqual(parseEmptyProfileArguments(['--plan']), { execute: false });
+  assert.deepEqual(parseEmptyProfileArguments(['--execute', '--confirm', EMPTY_PROFILE_CONFIRMATION]), { execute: true });
+  for (const args of [[], ['--execute'], ['--execute', '--confirm', 'yes'], ['--plan', '--confirm', EMPTY_PROFILE_CONFIRMATION], ['--plan', '--intake', '/tmp/a']]) assert.throws(() => parseEmptyProfileArguments(args));
+});
+test('plan has no host, download, installation or sharing side effects and claims no qualification', async () => {
+  const value = await runEmptyProfileSmoke({ intake });
+  assert.equal(value.status, 'planned');
+  for (const [key, flag] of Object.entries(value)) if (typeof flag === 'boolean') assert.equal(flag, false, key);
+});
+test('fresh projection refuses stale, unavailable, implicit prior choice or accepted payload', () => {
+  const value = { available: true, current: true, enabled: true, basis: 'default_on', lastAcceptedAt: null };
+  assert.equal(assertEmptyProfileSharing(value), true);
+  for (const change of [{ available: false }, { current: false }, { enabled: false }, { basis: 'explicit_on' }, { lastAcceptedAt: '2026-09-11T00:00:00Z' }]) assert.throws(() => assertEmptyProfileSharing({ ...value, ...change }));
+  assert.equal(assertEmptyProfileSharing({ ...value, enabled: false, transportStatus: 'off' }, { optedOut: true }), true);
+  assert.throws(() => assertEmptyProfileSharing({ ...value, enabled: false, transportStatus: 'uploading' }, { optedOut: true }));
+});
+test('settings interaction executes existing tab handler and verifies its effect', () => {
+  for (const tab of ['about', 'general', 'data']) {
+    const panel = { hidden: true };
+    let selected = 'false', clicks = 0;
+    const button = { disabled: false, click() { clicks++; selected = 'true'; panel.hidden = false; }, getAttribute() { return selected; } };
+    const document = { getElementById(id) { return id === `settings-tab-${tab}` ? button : panel; } };
+    assert.equal(vm.runInNewContext(emptyProfileSettingsScript(tab), { document }), true);
+    assert.equal(clicks, 1);
+    button.click = () => {}; panel.hidden = true;
+    assert.equal(vm.runInNewContext(emptyProfileSettingsScript(tab), { document }), false);
+  }
+  assert.throws(() => emptyProfileSettingsScript("data');process.exit()"));
+});
+test('manual workflow has static architecture hosts and no native fixtures or publication', async () => {
+  const workflow = await readFile(new URL('../.github/workflows/electron-macos-empty-profile.yml', import.meta.url), 'utf8');
+  assert.match(workflow, /workflow_dispatch:/u);
+  assert.match(workflow, /runs-on: macos-26\n/u);
+  assert.match(workflow, /runs-on: macos-15-intel\n/u);
+  assert.doesNotMatch(workflow, /pull_request_target|contents: write|id-token: write|runs-on: \$\{\{|macos-26-intel/u);
+  assert.match(workflow, /default: plan/u);
+  const script = await readFile(new URL('../scripts/smoke-electron-macos-empty-profile.mjs', import.meta.url), 'utf8');
+  assert.doesNotMatch(script, /seedNativeSparkleTransitionState|signedStagingFixture|prepareSignedStagingDisposableProfile|writeFile\(/u);
+  assert.match(script, /untouched: true/u);
+  assert.match(script, /usageUploadQualified: false/u);
+  assert.match(script, /setSharingEnabled\(false\)/u);
+});

--- a/test/smoke-electron-macos-empty-profile.test.mjs
+++ b/test/smoke-electron-macos-empty-profile.test.mjs
@@ -52,6 +52,8 @@ test('settings interaction executes existing tab handler and verifies its effect
 test('manual workflow has static architecture hosts and no native fixtures or publication', async () => {
   const workflow = await readFile(new URL('../.github/workflows/electron-macos-empty-profile.yml', import.meta.url), 'utf8');
   assert.match(workflow, /workflow_dispatch:/u);
+  assert.match(workflow, /registration:\n    if: github\.event_name == 'push'/u);
+  assert.equal((workflow.match(/if: github\.event_name == 'workflow_dispatch' && inputs\.target/g) ?? []).length, 2);
   assert.match(workflow, /runs-on: macos-26\n/u);
   assert.match(workflow, /runs-on: macos-15-intel\n/u);
   assert.doesNotMatch(workflow, /pull_request_target|contents: write|id-token: write|runs-on: \$\{\{|macos-26-intel/u);

--- a/test/smoke-electron-macos-production-update.test.mjs
+++ b/test/smoke-electron-macos-production-update.test.mjs
@@ -1,0 +1,80 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { execFileSync } from 'node:child_process';
+import { createHash } from 'node:crypto';
+import { mkdtemp, readFile, writeFile, rm, realpath } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import * as runner from '../scripts/smoke-electron-macos-production-update.mjs';
+const hash = (b, algorithm = 'sha256', encoding = 'hex') => createHash(algorithm).update(b).digest(encoding);
+const fixture = (target = 'darwin-arm64') => ({ schemaVersion: 'tibotattle-production-electron-update-intake-v1',
+  target, sourceRevision: 'a'.repeat(40), buildNumber: '2026091106', version: '0.1.21', bundleVersion: '1028',
+  dmgSha256: 'b'.repeat(64), asarSha256: 'c'.repeat(64), zipSha256: 'd'.repeat(64), feedSha256: 'e'.repeat(64),
+  predecessorAsarSha256: 'f'.repeat(64), directory: '/tmp/qualified-production-update' });
+test('only exact confirmed execute can run an installed production update', () => {
+  assert.deepEqual(runner.parseProductionUpdateArguments(['--plan', '--intake', '/tmp/input.json']), { execute: false, intakePath: '/tmp/input.json' });
+  assert.equal(runner.parseProductionUpdateArguments(['--execute', '--intake', '/tmp/input.json', '--confirm', 'RUN_DISPOSABLE_PRODUCTION_ELECTRON_UPDATE']).execute, true);
+  for (const args of [[], ['--execute', '--intake', '/tmp/input.json'], ['--plan', '--intake', 'relative'],
+    ['--plan', '--intake', '/tmp/input.json', '--confirm', 'RUN_DISPOSABLE_PRODUCTION_ELECTRON_UPDATE'],
+    ['--execute', '--intake', '/tmp/input.json', '--confirm', 'yes']]) assert.throws(() => runner.parseProductionUpdateArguments(args));
+});
+test('both targets bind immutable 020 and exact 021 identities to fixed stable transport', () => {
+  for (const target of ['darwin-arm64', 'darwin-x64']) {
+    const input = runner.validateProductionUpdateIntake(fixture(target));
+    assert.equal(input.predecessorDmgSha256, runner.ELECTRON_020_DMG[target]);
+    assert.equal(input.feedUrl, 'https://updates.tibotattle.com/electron/stable/' + target + '/latest-mac.yml');
+    assert.equal(input.predecessorUrl, 'https://github.com/adamallcock/tibotattle/releases/download/v0.1.20/TiboTattle-0.1.20-mac-' + input.architecture + '.dmg');
+    assert.equal(input.zipFileName, 'TiboTattle-0.1.21-mac-' + input.architecture + '.zip');
+  }
+  for (const key of Object.keys(fixture())) { const bad = fixture(); delete bad[key]; assert.throws(() => runner.validateProductionUpdateIntake(bad)); }
+  for (const bad of [{ feedUrl: 'https://example.com' }, { feedScope: 'isolated_test_feed' }, { version: '0.1.22' },
+    { bundleVersion: '2026091106' }, { sourceRevision: 'main' }, { buildNumber: 1028 }, { target: 'linux-x64' },
+    { directory: 'relative' }, { predecessorAsarSha256: 'A'.repeat(64) }]) assert.throws(() => runner.validateProductionUpdateIntake({ ...fixture(), ...bad }));
+});
+test('live feed must bind both exact artifacts and cannot redirect the updater', () => {
+  const zip = Buffer.from('signed ZIP'), dmg = Buffer.from('signed DMG');
+  const input = runner.validateProductionUpdateIntake({ ...fixture(), zipSha256: hash(zip), dmgSha256: hash(dmg) });
+  const manifest = { version: '0.1.21', files: [[input.zipFileName, zip], [input.dmgFileName, dmg]].map(([url, b]) => ({ url, size: b.length, sha512: hash(b, 'sha512', 'base64') })),
+    path: input.zipFileName, sha512: hash(zip, 'sha512', 'base64') };
+  assert.equal(runner.validateProductionMacUpdateFeed(input, manifest, zip, dmg), true);
+  for (const change of [m => m.version = '0.1.20', m => m.path = '../candidate.zip', m => m.files[0].url = 'https://example.com/candidate.zip',
+    m => m.files[0].size++, m => m.files[0].sha512 = m.files[1].sha512, m => m.sha512 = m.files[1].sha512,
+    m => m.files.push(m.files[0]), m => m.packages = {}]) {
+    const bad = structuredClone(manifest); change(bad); assert.throws(() => runner.validateProductionMacUpdateFeed(input, bad, zip, dmg));
+  }
+  assert.throws(() => runner.validateProductionMacUpdateFeed(input, manifest, Buffer.from('altered'), dmg));
+});
+test('plan reads intake only and makes no artifact, feed, process or signed-app acceptance claim', async () => {
+  const directory = await realpath(await mkdtemp(join(tmpdir(), 'production-update-plan-')));
+  try {
+    const intakePath = join(directory, 'intake.json'); await writeFile(intakePath, JSON.stringify(fixture()), { mode: 0o600 });
+    const result = await runner.runProductionUpdate({ execute: false, intakePath });
+    assert.equal(result.status, 'planned');
+    for (const key of ['productionFeedVerified', 'signedArtifactVerified', 'disposableAccountVerified', 'updaterRelaunchedCandidate', 'candidateCopiedByRunner', 'ownedProcessesStopped']) assert.equal(result[key], false);
+  } finally { await rm(directory, { recursive: true, force: true }); }
+});
+test('runner leaves the signed application and production feed under their actual owners', async () => {
+  const source = await readFile(new URL('../scripts/smoke-electron-macos-production-update.mjs', import.meta.url), 'utf8');
+  assert.match(source, /copyPredecessor\(predecessorDmg/);
+  assert.doesNotMatch(source, /copyPredecessor\(candidate|setFeedURL|--inspect|codesign[^\n]*--sign|process\.env\.[A-Z_]+\s*=/);
+  assert.match(source, /assertExtractedSignedMacBundle\(candidateDmg, app/);
+  assert.match(source, /verifySparkleTransitionCandidate\(input, app\)/);
+  assert.match(source, /installUpdateAndRestart\(\)/);
+  assert.match(source, /stopVerifiedMacTransitionProcesses/);
+  assert.match(source, /assertSignedReplacementContinuity\(seeded, before/);
+});
+
+test('both workflow bodies parse as JavaScript and preserve fixed targets without shell interpolation', async () => {
+  const workflow = await readFile(new URL('../.github/workflows/electron-macos-production-update.yml', import.meta.url), 'utf8');
+  const scripts = [...workflow.matchAll(/node --input-type=module <<'NODE'\n([\s\S]*?)          NODE/g)].map(m => m[1].replace(/^          /gm, ''));
+  assert.equal(scripts.length, 2);
+  for (const script of scripts) {
+    execFileSync(process.execPath, ['--input-type=module', '--check'], { input: script, stdio: ['pipe', 'pipe', 'pipe'] });
+    assert.match(script, /env\.SELECTED_TARGET/);
+    assert.match(script, /env\.SELECTED_RUNNER !== env\.GITHUB_SHA/);
+    assert.doesNotMatch(script, /\$\{\{/);
+  }
+  assert.match(workflow, /runs-on: macos-26-intel/);
+  assert.match(workflow, /runs-on: macos-26\n/);
+  assert.doesNotMatch(workflow, /contents: write|secrets\.|pull_request_target/);
+});

--- a/test/smoke-electron-macos-sparkle-transition.test.mjs
+++ b/test/smoke-electron-macos-sparkle-transition.test.mjs
@@ -58,6 +58,20 @@ test('both Mac architectures require matching hosted runner identity', () => {
   }
 });
 
+test('same-executable companions belong to one app; independent app roots remain ambiguous', () => {
+  const executable = '/Users/runner/Applications/TiboTattle.app/Contents/MacOS/TiboTattle';
+  const process = (pid, parent, command = executable) => ({ pid, parent, group: pid, command });
+  const main = process(30, 1);
+  const rows = [process(1, 0, '/sbin/launchd'), main, process(31, 30),
+    process(32, 31, '/synthetic/helper'), process(33, 32)];
+  assert.deepEqual(runner.selectMacTransitionApplicationProcess(rows, executable), main);
+  assert.deepEqual(runner.selectMacTransitionApplicationProcess([...rows].reverse(), executable), main);
+  assert.equal(runner.selectMacTransitionApplicationProcess([], executable), null);
+  assert.throws(() => runner.selectMacTransitionApplicationProcess([...rows, process(50, 1)], executable));
+  assert.throws(() => runner.selectMacTransitionApplicationProcess([...rows, main], executable));
+  assert.throws(() => runner.selectMacTransitionApplicationProcess([process(30, 31), process(31, 30)], executable));
+});
+
 test('intake binds the architecture, exact native predecessor and closed feed scope', () => {
   for (const target of Object.keys(nativeDigests)) for (const scope of ['isolated_test_feed', 'production_feed']) {
     const value = intake(target, scope), result = runner.validateSparkleTransitionIntake(value);

--- a/test/smoke-electron-macos-sparkle-transition.test.mjs
+++ b/test/smoke-electron-macos-sparkle-transition.test.mjs
@@ -147,6 +147,19 @@ test('waiting for a delayed About item does not toggle its menu closed', () => {
   ready = true; assert.equal(run('about'), 'clicked'); assert.equal(presses, 1);
 });
 
+test('closing updater windows can be reread, but an uncertain click is never retried as a read', () => {
+  let clicks = 0, closing = true, rejectClick = false;
+  const button = { name: () => 'Install and Relaunch', role: () => 'AXButton', enabled: () => true,
+    click: () => { clicks++; if (rejectClick) throw new Error('Action outcome unavailable'); } };
+  const context = { Application: () => ({ applicationProcesses: { whose: () => () => [{ windows: () => [
+    { entireContents: () => { if (closing) throw new Error('Window no longer exists'); return [button]; } },
+  ] }] } }) };
+  const run = () => runInNewContext(runner.sparkleTransitionUiScript(321, 'relaunch') + '\nrun();', context);
+  assert.equal(run(), 'snapshot_unavailable'); assert.equal(clicks, 0);
+  closing = false; assert.equal(run(), 'clicked'); assert.equal(clicks, 1);
+  rejectClick = true; assert.equal(run(), 'action_unconfirmed'); assert.equal(clicks, 2);
+});
+
 test('synthetic UI diagnostics return closed counts rather than unknown labels or text', () => {
   const element = (name, value) => ({ name: () => name, value: () => value, enabled: () => true });
   const context = { Application: () => ({ applicationProcesses: { whose: () => () => [{

--- a/test/smoke-electron-macos-sparkle-transition.test.mjs
+++ b/test/smoke-electron-macos-sparkle-transition.test.mjs
@@ -120,6 +120,32 @@ test('the runner never installs the candidate directly or changes either signed 
   assert.match(script, /await verifyCandidate\(input, installedApp\)/u);
 });
 
+test('waiting for a delayed About item does not toggle its menu closed', () => {
+  let expanded = false, ready = false, opens = 0, presses = 0;
+  const about = { name: () => 'Acerca de TiboTattle', click: () => { presses++; } };
+  const menu = { name: () => 'TiboTattle', click: () => { expanded = !expanded; opens++; },
+    menus: () => expanded ? [{ menuItems: () => ready ? [about] : [] }] : [] };
+  const context = { Application: () => ({ applicationProcesses: { whose: () => () => [{ menuBars: () => [{ menuBarItems: () => [menu] }] }] } }) };
+  const run = action => runInNewContext(runner.sparkleTransitionUiScript(321, action) + '\nrun();', context);
+  assert.equal(run('openmenu'), 'clicked');
+  for (let i = 0; i < 3; i++) assert.equal(run('about'), 'target_absent');
+  assert.equal(opens, 1); assert.equal(expanded, true);
+  ready = true; assert.equal(run('about'), 'clicked'); assert.equal(presses, 1);
+});
+
+test('synthetic UI diagnostics return closed counts rather than unknown labels or text', () => {
+  const element = (name, value) => ({ name: () => name, value: () => value, enabled: () => true });
+  const context = { Application: () => ({ applicationProcesses: { whose: () => () => [{
+    frontmost: () => true, menuBars: () => [], windows: () => [{ entireContents: () => [
+      element('Private session name', 'Private arbitrary text'), element('Install Update', '')] }],
+  }] } }) };
+  const text = runInNewContext(runner.sparkleTransitionDiagnosticScript(321) + '\nrun();', context);
+  const value = JSON.parse(text);
+  assert.equal(value.processPresent, true); assert.equal(value.unknownLabelCount, 1);
+  assert.deepEqual(value.controls.install, { count: 1, enabled: 1 });
+  assert.doesNotMatch(text, /Private|session|arbitrary/u);
+});
+
 test('production proof refuses a user feed override instead of silently testing a different feed', async () => {
   const script = await readFile(new URL('../scripts/smoke-electron-macos-sparkle-transition.mjs', import.meta.url), 'utf8');
   const body = script.slice(script.indexOf("    if (input.feedScope === 'isolated_test_feed') {"),

--- a/test/smoke-electron-macos-sparkle-transition.test.mjs
+++ b/test/smoke-electron-macos-sparkle-transition.test.mjs
@@ -186,6 +186,33 @@ test('workflow download planning matches the runner for both architectures and s
         : `https://updates.tibotattle.com/electron/test/native-sparkle/${source}/1028/${value.dmgSha256}/`;
       assert.equal(files[1][1], candidatePrefix + normalized.dmgFileName);
       assert.ok(files[0][1].startsWith(`https://updates.tibotattle.com/${prefix}releases/1026/${nativeDigests[target]}/`));
+      // Exercise the actual extraction and JSON-writing block with only OS commands
+      // substituted. This catches an architecture variable overwritten by a Path.
+      const extraction = [
+        'import pathlib,json,shutil',
+        'root=pathlib.Path(' + JSON.stringify(root) + ')',
+        'e=' + JSON.stringify({ SELECTED_DMG: value.dmgSha256, SELECTED_ASAR: value.asarSha256,
+          SELECTED_FEED: value.feedSha256, SELECTED_BUILD: value.buildNumber }),
+        'source=' + JSON.stringify(source), 'runner=source',
+        'target=' + JSON.stringify(target), 'scope=' + JSON.stringify(scope),
+        'native=' + JSON.stringify(nativeDigests[target]),
+        "pathlib.Path('sparkle-transition-receipts').mkdir()",
+        'class Commands:',
+        '  DEVNULL=None',
+        '  def run(self,args,**options):',
+        "    if args[:2]==['/usr/bin/hdiutil','attach']:",
+        "      (pathlib.Path(args[args.index('-mountpoint')+1])/'TiboTattle.app').mkdir()",
+        "    elif args[0]=='/usr/bin/ditto': shutil.copytree(args[1],args[2])",
+        "    elif args[:2]!=['/usr/bin/hdiutil','detach']: raise AssertionError('unexpected command')",
+        'subprocess=Commands()',
+        python.slice(python.indexOf("for name in ['native','candidate']:")),
+      ].join('\n');
+      execFileSync('python3', ['-c', extraction], { cwd: root, encoding: 'utf8' });
+      const generated = JSON.parse(await readFile(join(root, 'intake.json'), 'utf8'));
+      assert.equal(generated.target, target);
+      assert.equal(runner.validateSparkleTransitionIntake(generated).target, target);
+      const receipt = JSON.parse(await readFile(join(root, 'sparkle-transition-receipts', 'intake.json'), 'utf8'));
+      assert.equal(receipt.target, target);
     } finally { await rm(root, { recursive: true, force: true }); }
   }
 });

--- a/test/smoke-electron-macos-sparkle-transition.test.mjs
+++ b/test/smoke-electron-macos-sparkle-transition.test.mjs
@@ -113,7 +113,7 @@ test('UI automation is PID-scoped, refuses ambiguous buttons, and returns fixed 
       assert.equal(name, 'System Events');
       return { applicationProcesses: { whose(filter) {
         assert.equal(filter.unixId, 321);
-        return () => [{ windows: () => [{ entireContents: () => buttons }] }];
+        return () => [{ windows: () => [{ role: () => 'AXWindow', uiElements: () => buttons }] }];
       } } };
     },
   });
@@ -122,6 +122,22 @@ test('UI automation is PID-scoped, refuses ambiguous buttons, and returns fixed 
   assert.equal(evaluate([]), 'target_absent');
   assert.equal(evaluate([button('Instalar y volver a abrir')], runner.sparkleTransitionUiScript(321, 'relaunch')), 'clicked');
   assert.doesNotMatch(code, /keystroke|keyCode|System Settings|security authorizationdb/u);
+});
+
+test('native updater controls exclude web trees and refuse incomplete native traversals', () => {
+  let clicks = 0, webReads = 0;
+  const button = { name: () => 'Install and Relaunch', role: () => 'AXButton', enabled: () => true,
+    click: () => { clicks++; } };
+  const group = children => ({ role: () => 'AXGroup', uiElements: () => children });
+  const web = { role: () => 'AXWebArea', uiElements: () => { webReads++; throw new Error('Web tree must not be read'); } };
+  const run = children => runInNewContext(runner.sparkleTransitionUiScript(321, 'relaunch') + '\nrun();', {
+    Application: () => ({ applicationProcesses: { whose: () => () => [{ windows: () => [group(children)] }] } }),
+  });
+  assert.equal(run([web, group([button])]), 'clicked'); assert.equal(clicks, 1); assert.equal(webReads, 0);
+  assert.equal(run([web, group([button, button])]), 'ambiguous_target'); assert.equal(clicks, 1);
+  const cycle = group([]); cycle.uiElements = () => [cycle];
+  assert.equal(run([button, cycle]), 'ui_tree_limit'); assert.equal(clicks, 1);
+  assert.equal(run(Array.from({ length: 513 }, () => group([]))), 'ui_tree_limit'); assert.equal(clicks, 1);
 });
 
 test('the runner never installs the candidate directly or changes either signed bundle', async () => {
@@ -152,7 +168,7 @@ test('closing updater windows can be reread, but an uncertain click is never ret
   const button = { name: () => 'Install and Relaunch', role: () => 'AXButton', enabled: () => true,
     click: () => { clicks++; if (rejectClick) throw new Error('Action outcome unavailable'); } };
   const context = { Application: () => ({ applicationProcesses: { whose: () => () => [{ windows: () => [
-    { entireContents: () => { if (closing) throw new Error('Window no longer exists'); return [button]; } },
+    { role: () => 'AXWindow', uiElements: () => { if (closing) throw new Error('Window no longer exists'); return [button]; } },
   ] }] } }) };
   const run = () => runInNewContext(runner.sparkleTransitionUiScript(321, 'relaunch') + '\nrun();', context);
   assert.equal(run(), 'snapshot_unavailable'); assert.equal(clicks, 0);
@@ -161,9 +177,9 @@ test('closing updater windows can be reread, but an uncertain click is never ret
 });
 
 test('synthetic UI diagnostics return closed counts rather than unknown labels or text', () => {
-  const element = (name, value) => ({ name: () => name, value: () => value, enabled: () => true });
+  const element = (name, value) => ({ role: () => 'AXStaticText', name: () => name, value: () => value, enabled: () => true });
   const context = { Application: () => ({ applicationProcesses: { whose: () => () => [{
-    frontmost: () => true, menuBars: () => [], windows: () => [{ entireContents: () => [
+    frontmost: () => true, menuBars: () => [], windows: () => [{ role: () => 'AXWindow', uiElements: () => [
       element('Private session name', 'Private arbitrary text'), element('Install Update', '')] }],
   }] } }) };
   const text = runInNewContext(runner.sparkleTransitionDiagnosticScript(321) + '\nrun();', context);

--- a/test/smoke-electron-macos-sparkle-transition.test.mjs
+++ b/test/smoke-electron-macos-sparkle-transition.test.mjs
@@ -1,11 +1,13 @@
 import assert from 'node:assert/strict';
 import { execFileSync } from 'node:child_process';
-import { mkdtemp, readFile, rm } from 'node:fs/promises';
+import { mkdtemp, readFile, realpath, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import test from 'node:test';
 import { runInNewContext } from 'node:vm';
 import * as runner from '../scripts/smoke-electron-macos-sparkle-transition.mjs';
+import { retireAutomaticContributionState } from '../src/automatic-contribution-retirement.js';
+import { readSignedReplacementState } from '../scripts/smoke-electron-macos-replacement.mjs';
 
 const source = 'a'.repeat(40);
 const nativeDigests = {
@@ -90,9 +92,9 @@ test('UI automation is PID-scoped, refuses ambiguous buttons, and returns fixed 
   }
   const code = runner.sparkleTransitionUiScript(321, 'check');
   let clicks = 0;
-  const button = () => ({ name: () => 'Check for Updates…', role: () => 'AXButton', enabled: () => true,
+  const button = (name = 'Check for Updates…') => ({ name: () => name, role: () => 'AXButton', enabled: () => true,
     click: () => { clicks++; } });
-  const evaluate = (buttons) => runInNewContext(code + '\nrun();', {
+  const evaluate = (buttons, selectedCode = code) => runInNewContext(selectedCode + '\nrun();', {
     Application(name) {
       assert.equal(name, 'System Events');
       return { applicationProcesses: { whose(filter) {
@@ -104,6 +106,7 @@ test('UI automation is PID-scoped, refuses ambiguous buttons, and returns fixed 
   assert.equal(evaluate([button()]), 'clicked'); assert.equal(clicks, 1);
   assert.equal(evaluate([button(), button()]), 'ambiguous_target'); assert.equal(clicks, 1);
   assert.equal(evaluate([]), 'target_absent');
+  assert.equal(evaluate([button('Instalar y volver a abrir')], runner.sparkleTransitionUiScript(321, 'relaunch')), 'clicked');
   assert.doesNotMatch(code, /keystroke|keyCode|System Settings|security authorizationdb/u);
 });
 
@@ -142,6 +145,21 @@ test('production proof refuses a user feed override instead of silently testing 
     { error: new Error('failed'), status: null }]) {
     assert.throws(() => evaluate('production_feed', previous), /preexisting_feed_override/u);
   }
+});
+
+test('a running native 0.1.18 keeps the seeded opt-out tombstone unchanged', async () => {
+  const root = await mkdtemp(join(await realpath(tmpdir()), 'sparkle-native-seed-'));
+  try {
+    const nativeRoot = join(root, 'native');
+    const before = await runner.seedNativeSparkleTransitionState(nativeRoot, join(root, 'codex'));
+    assert.equal(before.usageRows, 2); assert.equal(before.quotaRows, 2); assert.equal(before.tokensInUncached, 203);
+    const settingsFile = join(nativeRoot, 'private', 'automatic-contribution-v0.1.json');
+    const retired = await retireAutomaticContributionState({ settingsFile, now: () => new Date('2026-09-11T00:00:00.000Z') });
+    assert.equal(retired.status, 'already_retired'); assert.equal(retired.priorState, 'disabled');
+    assert.equal(retired.networkActivity, false);
+    assert.equal(retired.retiredAt, '2026-09-01T00:00:00.000Z');
+    assert.deepEqual(await readSignedReplacementState(nativeRoot), before);
+  } finally { await rm(root, { recursive: true, force: true }); }
 });
 
 test('workflow download planning matches the runner for both architectures and scopes', async () => {

--- a/test/smoke-electron-macos-sparkle-transition.test.mjs
+++ b/test/smoke-electron-macos-sparkle-transition.test.mjs
@@ -1,0 +1,191 @@
+import assert from 'node:assert/strict';
+import { execFileSync } from 'node:child_process';
+import { mkdtemp, readFile, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import test from 'node:test';
+import { runInNewContext } from 'node:vm';
+import * as runner from '../scripts/smoke-electron-macos-sparkle-transition.mjs';
+
+const source = 'a'.repeat(40);
+const nativeDigests = {
+  'darwin-arm64': '2ea8eca02df7cc5210b6b6ce3d6e44016bffd9d081544a4efc6fa1afeeb0f1ae',
+  'darwin-x64': '70630ba90e92a1cd8cb904e66e1aebe85b04e9d23a50bef7e4e41aca84c4d2f6',
+};
+const intake = (target = 'darwin-arm64', feedScope = 'isolated_test_feed') => ({
+  schemaVersion: 'tibotattle-native-sparkle-test-intake-v1', sourceRevision: source,
+  target, feedScope, version: '0.1.21', buildNumber: '2026091106', bundleVersion: '1028',
+  dmgSha256: 'b'.repeat(64), asarSha256: 'c'.repeat(64), feedSha256: 'd'.repeat(64),
+  nativeDmgSha256: nativeDigests[target], directory: '/Users/runner/work/_temp/native-sparkle-intake',
+});
+const host = (target = 'darwin-arm64') => ({
+  target, platform: 'darwin', architecture: target === 'darwin-x64' ? 'x64' : 'arm64', nodeVersion: 'v26.2.0',
+  environment: { GITHUB_ACTIONS: 'true', RUNNER_ENVIRONMENT: 'github-hosted', RUNNER_OS: 'macOS',
+    RUNNER_ARCH: target === 'darwin-x64' ? 'X64' : 'ARM64', RUNNER_TEMP: '/Users/runner/work/_temp' },
+  account: { uid: 501, username: 'runner', homedir: '/Users/runner' },
+});
+
+test('only an explicit confirmed execution can install into the disposable account', () => {
+  assert.deepEqual(runner.parseSparkleTransitionArguments(['--plan', '--intake', '/tmp/intake.json']),
+    { execute: false, intakePath: '/tmp/intake.json' });
+  assert.deepEqual(runner.parseSparkleTransitionArguments(['--execute', '--intake', '/tmp/intake.json',
+    '--confirm', 'RUN_DISPOSABLE_NATIVE_SPARKLE_TRANSITION']), { execute: true, intakePath: '/tmp/intake.json' });
+  for (const args of [[], ['--execute', '--intake', '/tmp/intake.json'],
+    ['--plan', '--intake', 'relative.json'], ['--plan', '--intake', '/tmp/intake.json', '--execute'],
+    ['--execute', '--intake', '/tmp/intake.json', '--confirm', 'yes'],
+    ['--execute', '--intake', '/tmp/intake.json', '--confirm', 'RUN_DISPOSABLE_NATIVE_SPARKLE_TRANSITION', '--force']]) {
+    assert.throws(() => runner.parseSparkleTransitionArguments(args));
+  }
+});
+
+test('both Mac architectures require matching hosted runner identity', () => {
+  for (const target of Object.keys(nativeDigests)) {
+    const value = host(target);
+    assert.equal(runner.validateSparkleTransitionHost(value), '/Users/runner');
+    for (const patch of [{ target: 'linux-x64' }, { platform: 'linux' },
+      { architecture: target === 'darwin-x64' ? 'arm64' : 'x64' }, { nodeVersion: 'v26.3.0' },
+      { account: { ...value.account, uid: 0 } }, { account: { ...value.account, username: 'adam' } },
+      { account: { ...value.account, homedir: '/Users/adam' } },
+      { environment: { ...value.environment, RUNNER_ENVIRONMENT: 'self-hosted', HOME: '/Users/runner' } },
+      { environment: { ...value.environment, GITHUB_ACTIONS: 'false' } },
+      { environment: { ...value.environment, RUNNER_OS: 'Linux' } },
+      { environment: { ...value.environment, RUNNER_ARCH: target === 'darwin-x64' ? 'ARM64' : 'X64' } },
+      { environment: { ...value.environment, RUNNER_TEMP: 'relative' } }]) {
+      assert.throws(() => runner.validateSparkleTransitionHost({ ...value, ...patch }));
+    }
+  }
+});
+
+test('intake binds the architecture, exact native predecessor and closed feed scope', () => {
+  for (const target of Object.keys(nativeDigests)) for (const scope of ['isolated_test_feed', 'production_feed']) {
+    const value = intake(target, scope), result = runner.validateSparkleTransitionIntake(value);
+    const prefix = target === 'darwin-x64' ? 'intel/' : '';
+    const base = 'https://updates.tibotattle.com';
+    assert.equal(result.nativeDmgSha256, nativeDigests[target]);
+    assert.equal(result.feedUrl, scope === 'isolated_test_feed'
+      ? `${base}/electron/test/native-sparkle/${source}/1028/${value.dmgSha256}/appcast.xml`
+      : `${base}/${prefix}appcast.xml`);
+    assert.equal(result.dmgFileName, target === 'darwin-x64'
+      ? 'TiboTattle-0.1.21-macOS-x64.dmg' : 'TiboTattle-0.1.21-mac-arm64.dmg');
+    assert.equal(result.appPath, value.directory + '/candidate/TiboTattle.app');
+    for (const patch of [{ target: 'linux-x64' }, { feedScope: 'https://attacker.example/appcast.xml' },
+      { sourceRevision: 'a'.repeat(39) }, { sourceRevision: '../source' }, { sourceRevision: [source] }, { version: '0.1.20' },
+      { bundleVersion: '2026091106' }, { bundleVersion: '1026' }, { buildNumber: '0' }, { buildNumber: 2026091106 },
+      { dmgSha256: 'B'.repeat(64) }, { asarSha256: '' }, { feedSha256: 'd'.repeat(63) },
+      { dmgSha256: [value.dmgSha256] }, { asarSha256: [value.asarSha256] }, { feedSha256: [value.feedSha256] },
+      { nativeDmgSha256: nativeDigests[target === 'darwin-x64' ? 'darwin-arm64' : 'darwin-x64'] },
+      { directory: 'relative' }, { feedUrl: 'https://attacker.example/appcast.xml' }]) {
+      assert.throws(() => runner.validateSparkleTransitionIntake({ ...value, ...patch }));
+    }
+    for (const key of Object.keys(value)) {
+      const missing = { ...value }; delete missing[key];
+      assert.throws(() => runner.validateSparkleTransitionIntake(missing), key);
+    }
+  }
+});
+
+test('UI automation is PID-scoped, refuses ambiguous buttons, and returns fixed classifications', () => {
+  for (const [pid, action] of [[0, 'check'], [1, 'check'], [3.5, 'check'], ['4;evil()', 'check'], [4, 'approve']]) {
+    assert.throws(() => runner.sparkleTransitionUiScript(pid, action));
+  }
+  const code = runner.sparkleTransitionUiScript(321, 'check');
+  let clicks = 0;
+  const button = () => ({ name: () => 'Check for Updates…', role: () => 'AXButton', enabled: () => true,
+    click: () => { clicks++; } });
+  const evaluate = (buttons) => runInNewContext(code + '\nrun();', {
+    Application(name) {
+      assert.equal(name, 'System Events');
+      return { applicationProcesses: { whose(filter) {
+        assert.equal(filter.unixId, 321);
+        return () => [{ windows: () => [{ entireContents: () => buttons }] }];
+      } } };
+    },
+  });
+  assert.equal(evaluate([button()]), 'clicked'); assert.equal(clicks, 1);
+  assert.equal(evaluate([button(), button()]), 'ambiguous_target'); assert.equal(clicks, 1);
+  assert.equal(evaluate([]), 'target_absent');
+  assert.doesNotMatch(code, /keystroke|keyCode|System Settings|security authorizationdb/u);
+});
+
+test('the runner never installs the candidate directly or changes either signed bundle', async () => {
+  const script = await readFile(new URL('../scripts/smoke-electron-macos-sparkle-transition.mjs', import.meta.url), 'utf8');
+  assert.match(script, /command\('\/usr\/bin\/ditto', \[input\.nativeAppPath, installedApp\]/u);
+  assert.doesNotMatch(script, /command\('\/usr\/bin\/ditto', \[input\.appPath, installedApp\]/u);
+  assert.doesNotMatch(script, /codesign[^\n]*--sign|writeFile[^\n]*Info\.plist|cp[^\n]*candidate[^\n]*Applications/u);
+  assert.match(script, /candidateCopiedByRunner: false/u);
+  assert.match(script, /assertProductionElectronMacOSBundleMetadata/u);
+  assert.match(script, /await verifyCandidate\(input, installedApp\)/u);
+});
+
+test('production proof refuses a user feed override instead of silently testing a different feed', async () => {
+  const script = await readFile(new URL('../scripts/smoke-electron-macos-sparkle-transition.mjs', import.meta.url), 'utf8');
+  const body = script.slice(script.indexOf("    if (input.feedScope === 'isolated_test_feed') {"),
+    script.indexOf("    stage = 'native_launch';"));
+  assert.ok(body.startsWith("    if (input.feedScope === 'isolated_test_feed') {"));
+  const evaluate = (scope, previous) => {
+    const writes = [], proof = { feedOverrideApplied: false };
+    runInNewContext(body, {
+      input: { feedScope: scope, feedUrl: 'https://updates.tibotattle.com/appcast.xml' }, proof,
+      domain: 'com.usagemonitor.local', command: (...args) => writes.push(args),
+      spawnSync: () => previous,
+      fail: (stage) => { throw new Error(stage); },
+    });
+    return { writes, proof };
+  };
+  const production = evaluate('production_feed', { status: 1, stdout: '' });
+  assert.equal(production.writes.length, 0); assert.equal(production.proof.feedOverrideApplied, false);
+  const isolated = evaluate('isolated_test_feed', null);
+  assert.equal(isolated.writes.length, 1); assert.equal(isolated.writes[0][1][2], 'SUFeedURL');
+  assert.equal(isolated.proof.feedOverrideApplied, true);
+  for (const previous of [{ status: 0, stdout: 'https://test.example/appcast.xml' },
+    { status: 0, stdout: '' }, { status: 2, stdout: '' }, { status: 1, stdout: 'unexpected' },
+    { error: new Error('failed'), status: null }]) {
+    assert.throws(() => evaluate('production_feed', previous), /preexisting_feed_override/u);
+  }
+});
+
+test('workflow download planning matches the runner for both architectures and scopes', async () => {
+  const workflow = await readFile(new URL('../.github/workflows/electron-macos-sparkle-transition.yml', import.meta.url), 'utf8');
+  const inputBlock = workflow.split('    inputs:\n')[1].split('\npermissions:')[0];
+  assert.equal([...inputBlock.matchAll(/^      [a-z0-9_]+:$/gmu)].length, 10);
+  assert.match(workflow, /runs-on: macos-26-intel/u);
+  assert.match(workflow, /runs-on: macos-26\n/u);
+  assert.match(workflow, /architecture: x64/u);
+  assert.match(workflow, /architecture: arm64/u);
+  assert.doesNotMatch(workflow, /runs-on:.*\$\{\{/u);
+  for (const target of ['darwin-arm64', 'darwin-x64']) {
+    assert.ok(workflow.includes("if: github.event_name == 'workflow_dispatch' && inputs.target == '" + target + "'"));
+  }
+  assert.match(workflow, /persist-credentials: false/u);
+  assert.match(workflow, /^permissions:\n  contents: read/mu);
+  assert.doesNotMatch(workflow, /secrets\.|pull_request_target|--location|curl[^\n]* -L/u);
+  const pythonBlocks = workflow.split("          python3 - <<'PY'\n").slice(1)
+    .map((block) => block.split('\n          PY')[0].split('\n').map((line) => line.slice(10)).join('\n'));
+  assert.equal(pythonBlocks.length, 2);
+  assert.equal(pythonBlocks[0], pythonBlocks[1], 'both static runner jobs must use identical intake validation');
+  const python = pythonBlocks[0];
+  execFileSync('python3', ['-c', 'import ast,sys; ast.parse(sys.stdin.read())'], { input: python });
+  const planning = python.split('for name,url,digest,limit in files:')[0] + '\nprint(json.dumps(files))\n';
+  for (const target of Object.keys(nativeDigests)) for (const scope of ['isolated_test_feed', 'production_feed']) {
+    const root = await mkdtemp(join(tmpdir(), 'sparkle-download-plan-'));
+    try {
+      const value = intake(target, scope), normalized = runner.validateSparkleTransitionIntake(value);
+      const files = JSON.parse(execFileSync('python3', ['-c', planning], { encoding: 'utf8', env: {
+        ...process.env, SELECTED_SOURCE: source, SELECTED_RUNNER: source, GITHUB_SHA: source,
+        SELECTED_BUILD: value.buildNumber, SELECTED_DMG: value.dmgSha256, SELECTED_ASAR: value.asarSha256,
+        SELECTED_FEED: value.feedSha256, SELECTED_MODE: 'plan', SELECTED_CONFIRMATION: '',
+        SELECTED_TARGET: target, SELECTED_FEED_SCOPE: scope, RUNNER_TEMP: root,
+      } }));
+      assert.equal(files[0][2], nativeDigests[target]);
+      assert.equal(files[1][2], value.dmgSha256);
+      assert.equal(files[2][1], normalized.feedUrl);
+      assert.ok(files[1][1].endsWith('/' + normalized.dmgFileName));
+      const prefix = target === 'darwin-x64' ? 'intel/' : '';
+      const candidatePrefix = scope === 'production_feed'
+        ? `https://updates.tibotattle.com/${prefix}releases/1028/${value.dmgSha256}/`
+        : `https://updates.tibotattle.com/electron/test/native-sparkle/${source}/1028/${value.dmgSha256}/`;
+      assert.equal(files[1][1], candidatePrefix + normalized.dmgFileName);
+      assert.ok(files[0][1].startsWith(`https://updates.tibotattle.com/${prefix}releases/1026/${nativeDigests[target]}/`));
+    } finally { await rm(root, { recursive: true, force: true }); }
+  }
+});


### PR DESCRIPTION
Native 0.1.18 currently reports itself as the latest version because publishing Electron did not activate its Sparkle feed. This change completes the ordinary Check for Updates path into Electron, preserves retained history, settings and opt-out, and retains the public key required by Sparkle. It also corrects both Mac installers' declared minimum OS to macOS 14.

The incoming native updater and Electron's outgoing updater use their existing publication lanes. The maintained reconciliation tooling now understands the exact four-platform, 20-file release inventory and keeps the native feeds separate from Electron metadata.

Application bytes are frozen at a651ea130dd1460e4443a037c4434f57b911fec4, version 0.1.21, provenance build 2026091107, Mac bundle 1028. Later commits in this PR are qualification and publication tooling.

Validation:

- Actual signed native 0.1.18 to Electron upgrade, retained state and repeated restart: Apple Silicon run 34563532865 and Intel macOS 15 run 34565510661 passed.
- Separate signed empty-profile startup, Settings interaction, sharing defaults, restart and durable opt-out: runs 34565550609 and 34565564597 passed.
- Both full native publisher preparations and final canonical release-manifest validation passed. No signing, updater or privacy check was relaxed.
- Windows signed install, data processing, restart and uninstall passed in run 34561980268. Linux packaging passed in run 34561981708; physical Linux acceptance remains the previously recorded owner decision.
- Focused runner, publication, evidence and release-trust tests passed. Release-trust CI passed after publication of the exact annotated source tag.

Native tests above use an explicitly isolated feed and do not contain an existing credential fixture. Checks using unchanged predecessors and their actual production feeds follow activation. GitHub assets, four Electron feeds, both native feeds, Homebrew and website are separate publication/readback steps.
