### PR TITLE
Restore Homebrew installation controls for both Mac downloads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,9 +20,10 @@ version labels; it does not imply API stability before 1.0.
   bodies on 2026-08-23. Their body text is verbatim, with only a conventional
   terminal newline normalized for checked-in Markdown; no retrospective claims
   were added. Existing v0.1.13-v0.1.16 notes were left unchanged.
-- Releases v0.1.13 and later publish a DMG together with an appcast, release
-  manifest, `SHA256SUMS`, and a verification guide. Earlier release pages
-  preserve the DMG that was actually published at the time.
+- Native releases v0.1.13-v0.1.18 publish a DMG together with an appcast,
+  release manifest, `SHA256SUMS`, and a verification guide. Electron releases
+  publish platform installers, updater metadata and their verification evidence.
+  Earlier release pages preserve the artifacts actually published at the time.
 
 Thanks to the early pilot users who shared observations and reproduction steps.
 To preserve privacy and avoid invented attribution, people are named here only
@@ -34,10 +35,68 @@ remains accountable for release wording, validation, signing, and publication.
 
 ## [Unreleased]
 
-Adds customizable menu-bar/tray displays and popup sections, with immediate
-preview, undo and defaults. The Electron implementation remains on its
-[development branch](https://github.com/adamallcock/tibotattle/pull/111);
-these controls are not part of the installed 0.1.18 release.
+No changes yet.
+
+## [0.1.22](./release-notes/0.1.22.md) - 2026-09-11
+
+**Provenance:** [GitHub release](https://github.com/adamallcock/tibotattle/releases/tag/v0.1.22) ·
+[annotated source tag](https://github.com/adamallcock/tibotattle/tree/v0.1.22) ·
+[changes since v0.1.21](https://github.com/adamallcock/tibotattle/compare/v0.1.21...v0.1.22)
+
+Add Projects & threads and local model-performance views, with scoped cached
+results during refresh. Repair large-history contribution preparation and
+resumption, current-parser accounting compatibility, completed-history status
+and cache-drop thread links. Keep refresh and allowance-history controls stable.
+See the [release notes](./release-notes/0.1.22.md).
+
+## [0.1.21](./release-notes/0.1.21.md) - 2026-09-11
+
+**Provenance:** [GitHub release](https://github.com/adamallcock/tibotattle/releases/tag/v0.1.21) ·
+[annotated source tag](https://github.com/adamallcock/tibotattle/tree/v0.1.21) ·
+[changes since v0.1.20](https://github.com/adamallcock/tibotattle/compare/v0.1.20...v0.1.21)
+
+Complete native 0.1.18's update path to Electron, preserving local history,
+settings and contribution choice. Retain the public key needed by the incoming
+native update and declare macOS 14 correctly in both Mac installers. Restore
+compact website download controls with GitHub asset links. See the
+[release notes](./release-notes/0.1.21.md).
+
+## [0.1.20](./release-notes/0.1.20.md) - 2026-09-11
+
+**Provenance:** [GitHub release](https://github.com/adamallcock/tibotattle/releases/tag/v0.1.20) ·
+[annotated source tag](https://github.com/adamallcock/tibotattle/tree/v0.1.20) ·
+[exact application source](https://github.com/adamallcock/tibotattle/commit/f518126a05a6d165b9617f6417a87219d7047273) ·
+[changes since v0.1.19](https://github.com/adamallcock/tibotattle/compare/v0.1.19...v0.1.20)
+
+- Replacing the native Mac application automatically imports compatible retained
+  history and settings, without manually preserving the old application bundle.
+- Makes a recoverable backup and preserves identity, sharing choices and selected
+  activity folders; reopening the app does not duplicate the import.
+- Keeps recovery explicit for damaged or incompatible data and preserves unknown
+  startup registration without changing it.
+
+## [0.1.19](./release-notes/0.1.19.md) - 2026-09-10
+
+**Provenance:** [GitHub release](https://github.com/adamallcock/tibotattle/releases/tag/v0.1.19) ·
+[annotated source tag](https://github.com/adamallcock/tibotattle/tree/v0.1.19) ·
+[exact application source](https://github.com/adamallcock/tibotattle/commit/178315c49f432c8c1ed84f8c982d1c57aed8a094) ·
+[changes since v0.1.18](https://github.com/adamallcock/tibotattle/compare/v0.1.18...v0.1.19)
+
+- Introduces the shared Electron desktop app for Apple silicon and Intel Macs,
+  Windows x64 and Linux x86_64, with customizable tray displays, notifications
+  and automatic updates.
+- Improves usage summaries, model icons, allowance history and cache-detail
+  limits; retained tray observations show when they are stale.
+- Enables accountless, content-free contributions with persistent sharing
+  choices and opt-out controls. Existing unselected installations receive three
+  visible notices before delayed automatic activation.
+- Publishes application build `2026091002`; the release manifest and verification
+  guide identify the final artifacts and platform acceptance boundaries.
+
+This release's native Mac handover requires preserving the old app and does not
+provide an ordinary replacement upgrade. Native Sparkle updates remain separate.
+The 0.1.20 candidate above addresses that limitation; the checked-in 0.1.19 notes
+preserve the published release wording.
 
 ## [0.1.18](./release-notes/0.1.18.md) - 2026-09-05
 

--- a/apps/web/public/styles.css
+++ b/apps/web/public/styles.css
@@ -3181,7 +3181,8 @@ footer p { margin: 0; }
   font-size: .6rem;
   line-height: 1.35;
   scrollbar-width: none;
-  white-space: nowrap;
+  white-space: normal;
+  overflow-wrap: anywhere;
 }
 .community-site .homebrew-install code::-webkit-scrollbar {
   display: none;

--- a/release-notes/0.1.19.md
+++ b/release-notes/0.1.19.md
@@ -1,0 +1,31 @@
+# TiboTattle 0.1.19
+
+TiboTattle moves to a shared Electron desktop app for Apple silicon and Intel Macs, Windows, and Linux.
+
+### A more useful desktop companion
+
+- Customize the menu-bar or tray display and open allowance details without leaving your work.
+- Get desktop notifications and automatic updates. When a refresh is overdue, retained tray values show that they are stale.
+- Read clearer usage and overhead summaries, with recognizable model icons and improved allowance history. Cache-detail lists now say when they show only the most recent records.
+
+### Sharing without a social account
+
+Fresh Electron installations explain automatic sharing at first launch. Content-free measurements can be contributed without signing in to Apple or Google; prompts, responses and raw session content are excluded. Analysis remains local.
+
+You can keep sharing off in Settings. Existing explicit sharing choices are preserved. Existing installations that have never chosen receive three visible notices before delayed automatic activation; choosing **Keep sharing off** stops that transition. An installation is not counted as a unique person. Turning sharing off stops future uploads; it does not erase data already accepted by the service.
+
+### Moving from the native Mac app
+
+**Preserve the old app before replacing it.** Follow the website's guided handover for native 0.1.17 or 0.1.18 so the new app can carry over your history and settings. Native 0.1.16 users should first use **Check for Updates** in the old app to reach native 0.1.18. If that update is unavailable, or migration is blocked, keep the old app and data and contact support.
+
+Existing native downloads remain available. Their Sparkle updates do not automatically replace the native app with Electron.
+
+### Downloads and verification
+
+Choose the installer for your system: macOS 14 or later on Apple silicon or Intel, Windows 10 or later on x64, or the Linux x86_64 AppImage. AppImage mounting requires FUSE 2 support.
+
+Mac installers are Developer ID signed and Apple notarized; the Windows installer is signed. Linux is supplied with checksum verification. See `release-manifest.json`, `SHA256SUMS`, `SHA256SUMS-ALL-RELEASE-FILES` and `verify-release.md` for exact bytes, platform evidence and any explicit acceptance limits. Checksums and signing evidence do not imply that every physical platform has been exercised.
+
+App source: [`178315c4`](https://github.com/adamallcock/tibotattle/commit/178315c49f432c8c1ed84f8c982d1c57aed8a094), build `2026091002`. Verification tooling is pinned separately in `verify-release.md`; it does not change the app's source or version tag.
+
+[Changes since 0.1.18](https://github.com/adamallcock/tibotattle/compare/v0.1.18...v0.1.19)

--- a/release-notes/0.1.20.md
+++ b/release-notes/0.1.20.md
@@ -1,0 +1,11 @@
+# TiboTattle 0.1.20
+
+Install the new Mac app and continue with your existing history and settings. You no longer need to create handover folders, save a copy of the old application, or update native 0.1.16 first.
+
+The app automatically detects compatible retained native data, makes a backup, and carries over history, identity, sharing choices, language, appearance, refresh and tray preferences, and selected activity folders. It also handles installations where the old application has already been replaced. Reopening the app does not repeat the import or duplicate records.
+
+Existing Electron users receive the update through the app's normal updater. Installers remain available for Apple silicon and Intel Macs, Windows x64 and Linux x86_64. Native Sparkle feeds remain separate.
+
+This patch does not require a social sign-in or change sharing choices. Damaged or incompatible retained data produces a recovery message rather than being replaced with an empty history.
+
+**Source:** [f518126a05a6d165b9617f6417a87219d7047273](https://github.com/adamallcock/tibotattle/commit/f518126a05a6d165b9617f6417a87219d7047273), build `2026091104`. [Changes since 0.1.19](https://github.com/adamallcock/tibotattle/compare/v0.1.19...v0.1.20). The attached manifest and verification guide identify final artifact hashes and the platform-specific validation boundaries.

--- a/release-notes/0.1.21.md
+++ b/release-notes/0.1.21.md
@@ -1,0 +1,17 @@
+# TiboTattle 0.1.21
+
+This release completes the update path from the native Mac app to the unified
+desktop app. Native 0.1.18 users can choose **Check for Updates**, install the
+update and continue with their local history, settings and contribution choice.
+Manual installation also preserves existing local data; no backup-folder setup
+is needed.
+
+Both Mac installers now declare the supported minimum of macOS 14 correctly,
+fixing the metadata mismatch that caused Homebrew's cask audit to reject them.
+The Mac app retains the public verification key required by the native updater
+and uses Electron's updater for subsequent releases.
+
+Downloads are available for Apple Silicon, Intel Macs, Windows and Linux.
+The website's download buttons use GitHub release assets and provide checksums.
+The Mac installers are Developer ID signed and Apple notarized; the Windows
+installer is Authenticode signed and timestamped.

--- a/release-notes/0.1.22.md
+++ b/release-notes/0.1.22.md
@@ -1,0 +1,34 @@
+# TiboTattle 0.1.22
+
+Projects & threads shows where your recorded tokens and API-price equivalent
+go, with project expansion, thread details, model filters and live local search.
+Shared work stays grouped with its parent task without double counting.
+
+Model performance adds output-speed and first-token-latency charts, model and
+date selectors, linked hover readouts and measurement details. These are local
+timing estimates, with missing evidence kept visible. This page is available on
+macOS and Linux; Windows timing support is not available yet. Other local usage
+analysis remains available on Windows.
+
+Automatic contributions can prepare retained histories with more than one
+million quota observations without repeatedly failing before the first upload.
+Large uploads resume validation across bounded passes when their evidence is
+unchanged, while account and source changes still trigger revalidation.
+Existing installation credentials, sharing choices and opt-outs are preserved.
+
+The refresh toolbar keeps its phase, count and timer in fixed positions.
+Allowance-history headings and controls wrap when space is tight. Existing
+model icons, including the fallback icon for unrecognized models, are retained.
+
+Completed history scans no longer claim that older sources are still being
+indexed. Cache-drop and switch-overhead rows resolve local thread titles from
+their own verified history generation, and withdraw links when a match becomes
+ambiguous.
+
+Accounting summaries accept the provenance written by the current history
+scanner, repairing a compatibility mismatch that could leave a finished scan
+without an updated summary.
+
+Model performance and Projects & threads keep their last matching results
+visible during background refresh. Changing a period or filter preserves the
+correct scope, and unavailable results remain clearly identified.

--- a/scripts/lib/electron-public-site.mjs
+++ b/scripts/lib/electron-public-site.mjs
@@ -77,6 +77,13 @@ export async function readElectronSitePublication({ planPath, artifactRoot, appr
 
 const escape = value => String(value).replace(/[&<>"']/gu, c => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' })[c]);
 const text = key => `<span data-i18n="${key}">${escape(EN_US_CATALOG[key])}</span>`;
+function homebrewAction(panel, prefix, published) {
+  // Preserve the source-owned command, localization, accessibility and copy IDs.
+  const pattern = new RegExp(`<div\\b(?=[^>]*\\bid="${prefix}homebrew-install")[^>]*>[\\s\\S]*?<\\/div>\\s*<span\\b(?=[^>]*\\bid="${prefix}homebrew-copy-status")[^>]*>[\\s\\S]*?<\\/span>`, 'u');
+  const action = panel.match(pattern)?.[0];
+  if (!action) throw new TypeError('Missing exact Homebrew install action');
+  return published ? action.replace(/^<div\b[^>]*>/u, tag => tag.replace(/\s+hidden(?=[\s>])/u, '')) : action;
+}
 export function renderElectronSiteDownloads(html, release) {
   if (!supportsAutomaticNativeReplacement(release.version)) fail();
   let output = html.replace('</head>', '<meta name="usage-monitor-electron-stable" content="true">\n</head>');
@@ -93,12 +100,13 @@ export function renderElectronSiteDownloads(html, release) {
     const pattern = new RegExp(`<section\\b[^>]*data-platform-panel="${platform}"[^>]*>[\\s\\S]*?<\\/section>`, 'u');
     if (!pattern.test(output)) throw new TypeError('Missing exact platform panel');
     const prefix = { macos: '', 'macos-intel': 'intel-', windows: 'windows-', linux: 'linux-' }[platform];
+    const homebrew = mac ? homebrewAction(output.match(pattern)[0], prefix, release.publishedInstallersVerified) : '';
     const icon = mac ? '<img class="download-platform-icon" src="./apple.svg" alt="" width="22" height="22">'
       : platform === 'windows' ? '<svg class="download-platform-icon" viewBox="0 0 24 24" aria-hidden="true"><path fill="currentColor" d="M2 3h9v8H2zm11 0h9v8h-9zM2 13h9v8H2zm11 0h9v8h-9z"/></svg>'
         : '<span class="download-platform-icon" aria-hidden="true">🐧</span>';
     output = output.replace(pattern, `<section class="platform-panel" id="platform-panel-${platform}" role="tabpanel" aria-labelledby="platform-tab-${platform}" data-platform-panel="${platform}" tabindex="0"${platform === 'macos' ? '' : ' hidden'}>
       ${release.publishedInstallersVerified ? '' : '<p><strong>Local preview — publication has not been verified.</strong></p>'}
-      <div class="install-actions"><a class="button mac-download-button" href="${escape(item.url)}" data-electron-download="${item.target}">${icon}${text(`electron.site.download.${platform}`)}</a></div>
+      <div class="install-actions"><a class="button mac-download-button" href="${escape(item.url)}" data-electron-download="${item.target}">${icon}${text(`electron.site.download.${platform}`)}</a>${homebrew}</div>
       <div class="installer-details installer-details-compact">
         <span class="installer-summary">${escape(release.version)} <span class="installer-summary-divider" aria-hidden="true">·</span> ${text(`electron.site.requirements.${platform}`)}</span>
         <button class="installer-checksum-copy electron-checksum-copy" id="${prefix}installer-sha256-copy" type="button" data-checksum="${escape(item.sha256)}" aria-describedby="${prefix}installer-sha256-copy-status"><span id="${prefix}installer-sha256-copy-label" data-i18n="installer.sha256.copy">Copy SHA-256</span></button>

--- a/test/electron-public-site.test.js
+++ b/test/electron-public-site.test.js
@@ -4,7 +4,7 @@ import { createHash } from 'node:crypto';
 import { mkdtemp, mkdir, readFile, writeFile, rm, symlink } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { readElectronSitePublication, renderElectronSiteDocumentation } from '../scripts/lib/electron-public-site.mjs';
+import { readElectronSitePublication, renderElectronSiteDocumentation, renderElectronSiteDownloads } from '../scripts/lib/electron-public-site.mjs';
 import { identityDigest } from '../scripts/lib/release-operation.mjs';
 import { buildPublicReleaseSite, parseArgs } from '../scripts/build-public-release-site.js';
 
@@ -53,12 +53,32 @@ test('actual public generator renders four targets and automatic native replacem
   assert.match(html,/<meta property="og:image:height" content="1024">/u);
   assert.match(html,/<meta name="twitter:card" content="summary">/u);
   assert.match(html,/<meta property="og:image:alt" content="TiboTattle logo">/u);assert.doesNotMatch(html,/Your existing data and credentials are preserved/u);
-  assert.doesNotMatch(html,/brew install|not available yet|src="\.\/app.js"/u);
+  assert.doesNotMatch(html,/not available yet|src="\.\/app.js"/u);
+  assert.equal((html.match(/brew install --cask adamallcock\/tap\/tibotattle/gu)||[]).length,2);
+  for (const platform of ['windows','linux']) {
+    const panel=html.match(new RegExp(`<section\\b[^>]*data-platform-panel="${platform}"[^>]*>[\\s\\S]*?<\\/section>`,'u'))[0];
+    assert.doesNotMatch(panel,/homebrew-|brew install/u);
+  }
   assert.equal(await readFile(join(output,'community.html'),'utf8'),html);
   const privacy=await readFile(join(output,'privacy.html'),'utf8');assert.match(privacy,/<body[^>]*data-i18n-root/u);assert.match(privacy,/<script type="module" src="\.\/localization\.js"><\/script>/u);assert.match(privacy,/data-i18n="community\.privacy\.sample"/u);
   const docs=await readFile(join(output,'docs.html'),'utf8');assert.match(docs,/<body[^>]*data-i18n-root/u);assert.match(docs,/<script type="module" src="\.\/localization\.js"><\/script>/u);assert.match(docs,/Electron downloads are available/u);assert.match(docs,/automatically transfers retained history and settings/u);assert.match(docs,/In native Mac version 0\.1\.18, choose Check for Updates to install the Electron app/u);assert.doesNotMatch(docs,/Signed releases use the Sparkle feed|local-first Mac app/);assert.doesNotMatch(docs,/macOS is the currently available lane/u);
   const manifest=JSON.parse(await readFile(join(output,'release-site-manifest.json'),'utf8'));assert.equal(manifest.electronRelease.downloads.length,4);assert.equal(manifest.electronRelease.publishedInstallersVerified,false);assert.doesNotMatch(JSON.stringify(manifest.electronRelease.verificationScope),/published-installer/u);assert.equal(manifest.installer,undefined);
   await assert.rejects(buildPublicReleaseSite({...args,installerUrl:'https://tibotattle.com/a.dmg'}),/excludes native/u);
+});
+test('verified Electron Mac panels retain the existing visible Homebrew actions and copy wiring', async t => {
+  const f=await fixture(t);
+  const release=await readElectronSitePublication({...f.options,verifyPublishedInstaller:async value=>({bytes:value.expectedBytes,sha256:value.expectedSha256})});
+  const source=await readFile(new URL('../apps/web/public/community.html',import.meta.url),'utf8');
+  for (const published of [true,false]) {
+    const html=renderElectronSiteDownloads(source,{...release,publishedInstallersVerified:published});
+    for (const prefix of ['','intel-']) {
+      const opening=html.match(new RegExp(`<div\\b[^>]*id="${prefix}homebrew-install"[^>]*>`,'u'))[0];
+      assert.equal(/\s+hidden(?=[\s>])/u.test(opening),!published);
+      assert.match(html,new RegExp(`id="${prefix}homebrew-install-command"[^>]*>brew install --cask adamallcock/tap/tibotattle<\\/code>`,'u'));
+      assert.match(html,new RegExp(`id="${prefix}homebrew-copy-button"[\\s\\S]*?aria-describedby="${prefix}homebrew-copy-status"`,'u'));
+    }
+  }
+  assert.throws(()=>renderElectronSiteDownloads(source.replace('id="intel-homebrew-install"','id="missing-homebrew-install"'),release),/Missing exact Homebrew install action/u);
 });
 test('CLI accepts only explicit complete Electron intake flags',()=>{
   const args=parseArgs(['--electron-publication-plan','/plan.json','--electron-publication-root','/root','--electron-approved-plan-sha256','a'.repeat(64)]);


### PR DESCRIPTION
The Electron website generator replaced the Mac download panels and omitted the existing Homebrew controls. Restore those controls for both Apple Silicon and Intel, preserving their command, translations, accessibility status and Copy behavior.

The generated page exposes Homebrew only after installer publication is verified. The command wraps within the existing control when a longer download or translated Copy label leaves less space. Regression checks cover both Mac panels and ensure Windows and Linux do not inherit the command. This website-only change reuses the published 0.1.22 installers.

Synchronize CHANGELOG.md and the 0.1.19–0.1.22 release notes with the already-published release history. The website branch was missing these records, which caused its release-documentation CI check to fail. The five documentation files match the reviewed 0.1.22 release source; the note bodies and dates match GitHub.

Validation: 665 UI tests, 46 release-site tests and 10 web-release lane tests passed. Release documentation, workflow policy and documentation governance checks pass; preflight 20/20 and release-note tests 11/11 pass. Live browser checks passed all 24 platform/language/viewport combinations, including exact command copying, denied-clipboard fallback, wrapping and all four GitHub downloads. The pre-existing Cloudflare analytics beacon CSP warnings remain recorded separately.

The website-only source a85b9214 is deployed and verified at https://tibotattle.com/. The following commit synchronizes release records only; it does not change the deployed public files or app artifacts.
